### PR TITLE
fix(docker): handle both local and CI standalone output paths

### DIFF
--- a/tutorme-app/Dockerfile.production
+++ b/tutorme-app/Dockerfile.production
@@ -37,13 +37,17 @@ RUN adduser --system --uid 1001 nextjs
 
 # Copy necessary files
 COPY --from=builder /app/public ./public
-# Standalone output has nested structure due to monorepo layout - copy contents to root
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone/ADK_WORKSPACE/TutorMekimi/tutorme-app/ ./
+# Try nested path first (local dev), fallback to flat structure (CI)
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/pg ./node_modules/pg
+# Move server.js from nested path if it exists (local dev structure)
+RUN if [ -f "ADK_WORKSPACE/TutorMekimi/tutorme-app/server.js" ]; then \
+      cp -r ADK_WORKSPACE/TutorMekimi/tutorme-app/* . && rm -rf ADK_WORKSPACE; \
+    fi
 
 USER nextjs
 


### PR DESCRIPTION
## **User description**
Next.js standalone output has different directory structures:
- Local dev: nested under ADK_WORKSPACE/TutorMekimi/tutorme-app/
- CI build: flat structure directly in standalone/

- Copy entire standalone directory first
- Add RUN command to move files if nested path exists
- Works for both local and CI environments


___

## **CodeAnt-AI Description**
**Keep the production Docker image working with both local and CI builds**

### What Changed
- The production image now works with either standalone file layout, so the app can start after both local development builds and CI builds.
- When the app is packaged in the nested local path, the Docker image copies those files into the expected place before startup.
- When the app is packaged in the flat CI path, the same image setup still works without extra changes.

### Impact
`✅ Fewer Docker build failures`
`✅ Reliable app startup from local and CI artifacts`
`✅ Smoother production deploys`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
