### PR TITLE
fix(ai): strip code fences / parse JSON from Gemini responses (PCI + DMI)

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -9,6 +9,7 @@ import { getServerSession, getSessionForRealm, authOptions } from '@/lib/auth'
 import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { generateWithKimi, generateWithKimiVision } from '@/lib/ai/kimi'
+import { stripCodeFences } from '@/lib/ai/llm-response'
 import { z } from 'zod'
 
 export const maxDuration = 60
@@ -135,7 +136,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const questions = parseDmiResponse(aiResponse)
+    const questions = parseDmiResponse(stripCodeFences(aiResponse))
 
     return NextResponse.json({
       response: aiResponse,

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -10,6 +10,7 @@ import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { adkPciMasterChat } from '@/lib/adk-client'
 import { generateWithFallback } from '@/lib/agents'
+import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
 import { z } from 'zod'
 
 const PciMasterRequestSchema = z.object({
@@ -186,7 +187,18 @@ export async function POST(request: NextRequest) {
           maxTokens: 2048,
           skipCache: true,
         })
-        response = { response: fallback.content }
+        {
+          // Gemini wraps JSON in code fences; parse it so we return clean text
+          // (and the structured fields) instead of the raw fenced JSON.
+          const parsedJson = parseLlmJson<{ response?: string }>(fallback.content)
+          response = {
+            response:
+              parsedJson && typeof parsedJson.response === 'string'
+                ? parsedJson.response
+                : stripCodeFences(fallback.content),
+            parsed: parsedJson ?? null,
+          }
+        }
       }
     } else {
       const fallback = await generateWithFallback(`System:\n${SYSTEM_PROMPT}\n\n${userPrompt}`, {

--- a/tutorme-app/src/lib/ai/llm-response.ts
+++ b/tutorme-app/src/lib/ai/llm-response.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers for handling raw LLM text output.
+ *
+ * Gemini (and other models) frequently wrap structured output in Markdown code
+ * fences (```json ... ```), and sometimes add prose around it. The app was originally
+ * built for providers that returned bare content, so consumers that JSON.parse or
+ * pattern-match the response break on fenced output. These helpers normalize that.
+ */
+
+/**
+ * Strip a surrounding Markdown code fence (```json / ``` / ~~~) from an LLM response.
+ * If the whole string isn't a single fenced block, returns it trimmed unchanged.
+ */
+export function stripCodeFences(text: string): string {
+  if (!text) return text
+  const s = text.trim()
+  const fence = s.match(/^(?:```|~~~)[^\n]*\n([\s\S]*?)\n?(?:```|~~~)\s*$/)
+  return fence ? fence[1].trim() : s
+}
+
+/**
+ * Best-effort parse of a JSON object from an LLM response. Handles code fences and a
+ * leading/trailing prose by falling back to the first {...} or [...] block. Returns
+ * null if nothing parseable is found.
+ */
+export function parseLlmJson<T = unknown>(text: string): T | null {
+  if (!text) return null
+  const candidates: string[] = []
+  const stripped = stripCodeFences(text)
+  candidates.push(stripped)
+  // Fallback: first balanced-looking object/array slice.
+  const objMatch = stripped.match(/[{[][\s\S]*[}\]]/)
+  if (objMatch) candidates.push(objMatch[0])
+
+  for (const c of candidates) {
+    try {
+      return JSON.parse(c) as T
+    } catch {
+      // try next candidate
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## **User description**
Gemini wraps structured output in markdown code fences (```json … ```). The app was
built for providers that returned bare content, so:
- **PCI-master** showed the **raw fenced JSON** in the chat panel instead of the
  assistant's `response` text (the reported "Generate DMI shows raw JSON").
- **generate-dmi** Q/A parsing could miss questions if the model fenced its output.

Adds shared `src/lib/ai/llm-response.ts` (`stripCodeFences`, `parseLlmJson`).
pci-master now returns the parsed `.response` text (+ structured fields); generate-dmi
strips fences before parsing Q/A. Verified parsing logic against the actual fenced
sample. Builds clean. Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix AI responses that were showing fenced JSON or missing parsed output

### What Changed
- PCI Master now shows the assistant’s plain response text instead of raw fenced JSON, and also keeps any parsed structured data
- DMI question generation now strips Markdown fences before reading the model output, so fenced responses still produce questions
- Added shared handling for LLM text that comes back wrapped in code fences or with extra surrounding text

### Impact
`✅ Fewer raw JSON responses in PCI Master`
`✅ Fewer missing DMI questions`
`✅ Clearer AI reply display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
