### PR TITLE
Flow audit: PCI vision + safe fixes (enrollment/sessions/builder)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/details/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/details/page.tsx
@@ -95,10 +95,15 @@ export default function CourseDetailsPage() {
     if (!schedule || !Array.isArray(schedule) || schedule.length === 0) return null
     return schedule
       .map(s => {
+        // dayOfWeek may be a number (0-6) or a string ("Monday") depending on the
+        // writer; handle both so the day never renders blank.
+        const dow: unknown = s.dayOfWeek
         const day =
-          typeof s.dayOfWeek === 'number'
-            ? ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][s.dayOfWeek]
-            : ''
+          typeof dow === 'number'
+            ? (['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][dow] ?? '')
+            : typeof dow === 'string'
+              ? dow.slice(0, 3)
+              : ''
         const time = s.startTime ?? ''
         const mins = s.durationMinutes ?? 0
         return `${day} ${time} (${mins} min)`.trim()

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
@@ -96,7 +96,7 @@ export function VariantScheduleEditor({
   schedule,
   onScheduleChange,
   price,
-  weeksToSchedule = 1,
+  weeksToSchedule = 8,
   onWeeksChange,
   allVariantsSchedules,
   excludedSchedules,
@@ -104,7 +104,8 @@ export function VariantScheduleEditor({
 }: VariantScheduleEditorProps) {
   const calendarScrollRef = useRef<HTMLDivElement>(null)
   const [scheduleWeekOffset, setScheduleWeekOffset] = useState(0)
-  const [numberOfWeeks, setNumberOfWeeks] = useState(Math.max(1, weeksToSchedule || 1))
+  // Default to the DB default (8 weeks) so a new schedule isn't silently collapsed to 1.
+  const [numberOfWeeks, setNumberOfWeeks] = useState(Math.max(1, weeksToSchedule || 8))
   const [modeTab, setModeTab] = useState('schedule')
   const [availabilityData, setAvailabilityData] = useState<AvailabilityData | null>(null)
 
@@ -566,7 +567,7 @@ export function VariantScheduleEditor({
             <div className="relative min-h-0 flex-1 overflow-hidden">
               <div
                 ref={calendarScrollRef}
-                className="absolute inset-0 scrollbar-hide touch-pan-y overflow-y-auto overscroll-contain"
+                className="scrollbar-hide absolute inset-0 touch-pan-y overflow-y-auto overscroll-contain"
               >
                 {availabilityData ? (
                   <div className="grid grid-cols-[150px_repeat(7,_1fr)]">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -346,6 +346,10 @@ interface PreviewCardProps {
 import { MonitoringPanel } from './MonitoringPanel'
 import { SubmissionsPanel } from './SubmissionsPanel'
 
+// Cache of rendered PDF page images keyed by document URL, so PCI vision messages
+// don't re-render the same document on every chat turn.
+const pdfPageCache = new Map<string, string[]>()
+
 export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
   function CourseBuilder(
     {
@@ -2038,6 +2042,27 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             }
           : undefined
 
+        // If a PDF document is attached, render its pages (cached) so the PCI model can
+        // actually SEE the document instead of guessing from the title.
+        let pdfPages: string[] | undefined
+        if (sourceDocData?.mimeType === 'application/pdf' && sourceDocData.fileUrl) {
+          const cacheKey = sourceDocData.fileUrl
+          const cached = pdfPageCache.get(cacheKey)
+          if (cached) {
+            pdfPages = cached
+          } else {
+            try {
+              const rendered = await renderPdfToImages(sourceDocData.fileUrl, 3)
+              if (rendered.length > 0) {
+                pdfPages = rendered
+                pdfPageCache.set(cacheKey, rendered)
+              }
+            } catch {
+              // Vision is best-effort; fall back to text-only on render failure.
+            }
+          }
+        }
+
         const response = await fetch('/api/ai/pci-master', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -2052,6 +2077,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
               extensionName,
               sourceDocument,
             },
+            pdfPages,
           }),
         })
         if (!response.ok) {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2362,7 +2362,8 @@ FEEDBACK: [your explanation]`
         let pdfPages: string[] | undefined
         if (hasPdf) {
           toast.info('Analyzing PDF with AI...')
-          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 3)
+          // Analyze up to 5 pages (the generate-dmi API cap) instead of silently 3.
+          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 5)
         }
 
         const response = await fetch('/api/ai/generate-dmi', {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/useBuilderEditors.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/useBuilderEditors.ts
@@ -792,7 +792,8 @@ export function useBuilderEditors(): UseBuilderEditorsReturn {
         let pdfPages: string[] | undefined
         if (hasPdf) {
           toast.info('Analyzing PDF with AI...')
-          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 3)
+          // Analyze up to 5 pages (the generate-dmi API cap) instead of silently 3.
+          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 5)
         }
 
         const response = await fetch('/api/ai/generate-dmi', {

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -10,8 +10,27 @@ import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { adkPciMasterChat } from '@/lib/adk-client'
 import { generateWithFallback } from '@/lib/agents'
+import { generateWithKimiVision } from '@/lib/ai/kimi'
 import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
 import { z } from 'zod'
+
+/**
+ * Normalize a raw LLM response into clean assistant text + parsed structure.
+ * Gemini wraps JSON in code fences, so parse it and surface the `.response` field.
+ */
+function toCleanResponse(content: string): {
+  response: string
+  parsed: { response?: string } | null
+} {
+  const parsedJson = parseLlmJson<{ response?: string }>(content)
+  return {
+    response:
+      parsedJson && typeof parsedJson.response === 'string'
+        ? parsedJson.response
+        : stripCodeFences(content),
+    parsed: parsedJson ?? null,
+  }
+}
 
 const PciMasterRequestSchema = z.object({
   message: z.string().min(1).max(4000),
@@ -32,6 +51,10 @@ const PciMasterRequestSchema = z.object({
         .optional(),
     })
     .optional(),
+  // Rendered page images (data URLs) of an attached PDF, so the model can SEE the
+  // document instead of being told only its title. Sent by the builder when a PDF
+  // source document is attached.
+  pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
 })
 
 const SYSTEM_PROMPT = `You are a PCI (Pedagogically Correct Instruction) Master - an expert educational AI that crafts and refines Socratic-style instructions.
@@ -107,7 +130,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
 
-    const { message, sessionId, context } = parsed.data
+    const { message, sessionId, context, pdfPages } = parsed.data
     const safeMessage = AISecurityManager.sanitizeAiInput(message)
     if (!safeMessage) {
       return NextResponse.json(
@@ -140,7 +163,8 @@ export async function POST(request: NextRequest) {
       parsed?: { response?: string } | null
     }
 
-    if (adkBaseUrl) {
+    const useVision = !!(pdfPages && pdfPages.length > 0)
+    if (adkBaseUrl && !useVision) {
       const probe = await probeAdk(adkBaseUrl)
       if (!probe.ok) {
         if (!hasLocalProvider) {
@@ -166,7 +190,23 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    if (adkBaseUrl) {
+    if (pdfPages && pdfPages.length > 0) {
+      // Vision path: let the model actually SEE the attached document pages so it can
+      // summarize/critique real content instead of guessing from the title. Bypasses
+      // ADK (text-only) and goes straight to the vision-capable provider (Gemini).
+      const promptItems: Array<
+        { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
+      > = [
+        { type: 'text', text: `${SYSTEM_PROMPT}\n\n${userPrompt}` },
+        ...pdfPages.map(url => ({ type: 'image_url' as const, image_url: { url } })),
+      ]
+      const visionText = await generateWithKimiVision(promptItems, {
+        temperature: 0.7,
+        maxTokens: 2048,
+        timeoutMs: 60000,
+      })
+      response = toCleanResponse(visionText)
+    } else if (adkBaseUrl) {
       try {
         response = await adkPciMasterChat({
           userId: session.user.id,
@@ -187,18 +227,7 @@ export async function POST(request: NextRequest) {
           maxTokens: 2048,
           skipCache: true,
         })
-        {
-          // Gemini wraps JSON in code fences; parse it so we return clean text
-          // (and the structured fields) instead of the raw fenced JSON.
-          const parsedJson = parseLlmJson<{ response?: string }>(fallback.content)
-          response = {
-            response:
-              parsedJson && typeof parsedJson.response === 'string'
-                ? parsedJson.response
-                : stripCodeFences(fallback.content),
-            parsed: parsedJson ?? null,
-          }
-        }
+        response = toCleanResponse(fallback.content)
       }
     } else {
       const fallback = await generateWithFallback(`System:\n${SYSTEM_PROMPT}\n\n${userPrompt}`, {
@@ -206,7 +235,7 @@ export async function POST(request: NextRequest) {
         maxTokens: 2048,
         skipCache: true,
       })
-      response = { response: fallback.content }
+      response = toCleanResponse(fallback.content)
     }
 
     const validation = await AISecurityManager.validateAiResponse(response.response)

--- a/tutorme-app/src/app/api/class/rooms/route.ts
+++ b/tutorme-app/src/app/api/class/rooms/route.ts
@@ -135,18 +135,11 @@ export const POST = withCsrf(
           classSessionResult = result
         } catch (error) {
           const rootError = (error as { cause?: Error }).cause ?? error
-          const msg = rootError instanceof Error ? rootError.message : String(rootError)
+          // Log full detail server-side, but never leak raw DB error text or internal
+          // remediation hints (e.g. psql commands) to API clients.
           console.error('[Class Rooms] createSession failed:', rootError)
-          const isSchemaError =
-            msg.includes('column') || msg.includes('enum') || msg.includes('does not exist')
           return NextResponse.json(
-            {
-              error: 'Failed to create session. Please try again.',
-              details: msg,
-              hint: isSchemaError
-                ? 'If this is a schema mismatch, run: psql -f scripts/apply-schema-changes.sql'
-                : undefined,
-            },
+            { error: 'Failed to create session. Please try again.' },
             { status: 500 }
           )
         }


### PR DESCRIPTION
## **User description**
First batch from the cross-flow audit (scheduling, sessions, publishing, registration,
live sessions, task/assessment, classroom).

### Features / fixes
- **PCI vision**: builder renders attached PDF pages (cached) and pci-master routes them
  to Gemini vision so the assistant reads the real document. Also fixes the non-ADK
  fallback to parse fenced JSON.
- **class/rooms**: stop leaking raw DB error text + internal psql hint to clients (security).
- **VariantScheduleEditor**: default `weeksToSchedule` to 8 (DB default), not 1.
- **course details**: render string OR numeric `dayOfWeek` (was blank for string days).
- **builder DMI**: analyze up to 5 PDF pages (API cap) instead of silently 3.

Builds clean. The larger structural findings (duplicate enrollment/publish/session
modules, whiteboard routing, etc.) are tracked separately and handled with sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make PCI replies use attached PDF pages and remove unsafe error details**

### What Changed
- PCI requests now include rendered PDF pages, so the assistant can read attached documents instead of relying only on the title.
- PDF-based PCI checks reuse cached page images and can fall back to text-only if rendering fails.
- AI responses now strip code fences and return clean text consistently, including the fallback path.
- Session creation errors for classroom rooms now show a single safe message instead of raw database text or internal fix instructions.
- Course schedule details now display day names when the source uses either numbers or strings.
- PDF analysis for AI checks now scans up to 5 pages instead of stopping at 3.
- New schedules keep the expected 8-week default instead of starting at 1 week.

### Impact
`✅ More accurate PCI feedback on attached PDFs`
`✅ Fewer unsafe error messages shown to users`
`✅ Clearer course schedule display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
