### PR TITLE
fix(audit batch 2): enrollment count + session cleanup + upcoming filter

### DIFF
--- a/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf, ValidationError, NotFoundError } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseEnrollment } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, sql } from 'drizzle-orm'
 
 export const POST = withCsrf(
   withAuth(
@@ -43,9 +43,21 @@ export const POST = withCsrf(
         throw new ValidationError('Not enrolled in this subject')
       }
 
-      await drizzleDb
-        .delete(courseEnrollment)
-        .where(eq(courseEnrollment.enrollmentId, enrollment.enrollmentId))
+      // Delete the enrollment and release the schedule seat in one transaction so the
+      // cohort capacity counter doesn't drift upward and falsely report "full".
+      await drizzleDb.transaction(async tx => {
+        await tx
+          .delete(courseEnrollment)
+          .where(eq(courseEnrollment.enrollmentId, enrollment.enrollmentId))
+
+        if (enrollment.scheduleId) {
+          await tx.execute(
+            sql`UPDATE "CourseSchedule"
+                SET "enrolledCount" = GREATEST("enrolledCount" - 1, 0)
+                WHERE id = ${enrollment.scheduleId}`
+          )
+        }
+      })
 
       return NextResponse.json({
         success: true,

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -16,6 +16,7 @@ import {
   profile,
   course,
   sessionReplayArtifact,
+  calendarEvent,
 } from '@/lib/db/schema'
 import { eq, and, asc, desc, sql } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
@@ -475,7 +476,20 @@ export const DELETE = withAuth(
         return NextResponse.json({ error: 'Cannot delete a completed class' }, { status: 400 })
       }
 
-      await drizzleDb.delete(liveSession).where(eq(liveSession.sessionId, classId))
+      // Best-effort: tear down the Daily room so it doesn't leak (roomId is the room name).
+      if (liveSessionRow.roomId) {
+        try {
+          await dailyProvider.deleteRoom(liveSessionRow.roomId)
+        } catch (roomErr) {
+          console.warn('[Class Delete] Failed to delete Daily room:', roomErr)
+        }
+      }
+
+      // Remove the LiveSession and its calendar projection (linked by externalId).
+      await drizzleDb.transaction(async tx => {
+        await tx.delete(calendarEvent).where(eq(calendarEvent.externalId, classId))
+        await tx.delete(liveSession).where(eq(liveSession.sessionId, classId))
+      })
 
       return NextResponse.json({ message: 'Class deleted successfully' })
     } catch (error) {

--- a/tutorme-app/src/app/api/tutor/classes/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextResponse } from 'next/server'
-import { eq, or, and, gte, asc } from 'drizzle-orm'
+import { eq, or, and, gte, asc, ne } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession as liveSessionTable } from '@/lib/db/schema'
@@ -24,9 +24,12 @@ export const GET = withAuth(
     const sessions = await drizzleDb.query.liveSession.findMany({
       where: includeEnded
         ? eq(liveSessionTable.tutorId, tutorId)
-        : or(
-            and(eq(liveSessionTable.tutorId, tutorId), gte(liveSessionTable.scheduledAt, now)),
-            and(eq(liveSessionTable.tutorId, tutorId), eq(liveSessionTable.status, 'active'))
+        : // Upcoming = future or in-progress, but never an ended/cancelled session
+          // (an ended session with a future scheduledAt must not show as "upcoming").
+          and(
+            eq(liveSessionTable.tutorId, tutorId),
+            ne(liveSessionTable.status, 'ended'),
+            or(gte(liveSessionTable.scheduledAt, now), eq(liveSessionTable.status, 'active'))
           ),
       with: {
         participants: {


### PR DESCRIPTION
## **User description**
Second safe batch from the flow audit.

- **unenroll** decrements `CourseSchedule.enrolledCount` (atomic, floored at 0) so
  cohort capacity stops drifting up and falsely reporting "full".
- **class DELETE** now tears down the Daily room and the linked `CalendarEvent`
  (previously leaked an orphaned room + calendar entry).
- **tutor upcoming classes** excludes `status='ended'` so cancelled future sessions
  don't appear as upcoming.

Builds clean (typecheck + next build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix class cleanup, enrollment counts, and upcoming class listings

### What Changed
- Unenrolling now also reduces the course’s open seat count, so classes stop showing as full after a student leaves
- Deleting a tutor class now also removes its calendar entry and shuts down the linked live room, preventing leftover class records
- Upcoming classes no longer include sessions marked as ended, even if their scheduled time is still in the future

### Impact
`✅ Fewer false "full class" messages`
`✅ Fewer leftover class entries after deletion`
`✅ Clearer upcoming class lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
