### PR TITLE
feat(recording): wire session cloud recording end-to-end

### DIFF
--- a/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/transcription/start/route.ts
+++ b/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/transcription/start/route.ts
@@ -4,6 +4,7 @@ import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { ensureDailyWebhook } from '@/lib/video/daily-webhook'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -24,28 +25,6 @@ async function fetchDaily(endpoint: string, options: RequestInit = {}) {
     throw new Error(`Daily API error: ${res.status} ${text}`)
   }
   return res.json().catch(() => ({}))
-}
-
-async function ensureDailyWebhook() {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL
-  const basicAuth = process.env.DAILY_WEBHOOK_BASIC_AUTH
-  if (!baseUrl || !basicAuth) return
-
-  const url = `${baseUrl.replace(/\/$/, '')}/api/webhooks/daily`
-
-  const list = await fetchDaily('/webhooks', { method: 'GET' })
-  const hooks: any[] = Array.isArray(list?.data) ? list.data : Array.isArray(list) ? list : []
-  const exists = hooks.some(h => String(h?.url || '') === url)
-  if (exists) return
-
-  await fetchDaily('/webhooks', {
-    method: 'POST',
-    body: JSON.stringify({
-      url,
-      basicAuth,
-      eventTypes: ['transcript.started', 'transcript.ready-to-download', 'transcript.error'],
-    }),
-  })
 }
 
 export async function POST(req: NextRequest, { params }: { params: any }) {

--- a/tutorme-app/src/app/api/webhooks/daily/route.ts
+++ b/tutorme-app/src/app/api/webhooks/daily/route.ts
@@ -3,6 +3,7 @@ import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession, courseEnrollment } from '@/lib/db/schema'
 import { eq, desc, and, isNotNull } from 'drizzle-orm'
 import { notify } from '@/lib/notifications/notify'
+import { getRecordingDownloadLink } from '@/lib/video/daily-webhook'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -84,17 +85,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true })
   }
 
-  // ── recording.ready ─────────────────────────────────────────────────
-  if (type === 'recording.ready') {
+  // ── recording.ready-to-download ─────────────────────────────────────
+  if (type === 'recording.ready-to-download' || type === 'recording.ready') {
     const roomName = body?.payload?.room_name
-    const recordingId = body?.payload?.id
-    const downloadUrl = body?.payload?.download_url as string | undefined
+    const recordingId = (body?.payload?.recording_id || body?.payload?.id) as string | undefined
     const duration = body?.payload?.duration as number | undefined
 
     if (!roomName || !recordingId) return NextResponse.json({ ok: true })
 
     const sessionRow = await findSessionByRoom(roomName)
     if (!sessionRow?.sessionId) return NextResponse.json({ ok: true })
+
+    // The webhook doesn't include the file URL — fetch a temporary access link.
+    const downloadUrl = await getRecordingDownloadLink(recordingId)
 
     // Persist recording URL on the live session
     if (downloadUrl) {

--- a/tutorme-app/src/lib/sessions/create-session.ts
+++ b/tutorme-app/src/lib/sessions/create-session.ts
@@ -11,6 +11,7 @@ import { eq, and, isNull, not } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession, calendarEvent } from '@/lib/db/schema'
 import { dailyProvider } from '@/lib/video/daily-provider'
+import { ensureDailyWebhook } from '@/lib/video/daily-webhook'
 import type { LiveSessionStatus } from '@/lib/db/schema/enums'
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
 import type * as schema from '@/lib/db/schema'
@@ -63,6 +64,10 @@ export async function createSession(input: CreateSessionInput, tx?: DbClient) {
       maxParticipants: input.maxStudents ?? 50,
       durationMinutes: input.durationMinutes,
     }))
+
+  // Make sure the Daily webhook (recording + transcript) is registered. Fire-and-forget
+  // so it never blocks or fails session creation.
+  void ensureDailyWebhook()
 
   // 2. Insert LiveSession (source of truth)
   const [liveSessionRow] = await db

--- a/tutorme-app/src/lib/video/daily-provider.ts
+++ b/tutorme-app/src/lib/video/daily-provider.ts
@@ -77,7 +77,9 @@ export class DailyCoProvider implements VideoProvider {
         // Auto-join with mic/video off for students
         start_audio_off: true,
         start_video_off: true,
-        // Note: Recording is not supported on current Daily.co plan
+        // Cloud recording: the tutor's client starts it on join (autoRecord); the
+        // recording.ready-to-download webhook then persists the download link.
+        enable_recording: 'cloud',
       },
     }
     console.log('[Daily.co] createRoom payload:', payload)

--- a/tutorme-app/src/lib/video/daily-webhook.ts
+++ b/tutorme-app/src/lib/video/daily-webhook.ts
@@ -1,0 +1,92 @@
+/**
+ * Daily.co webhook management + recording helpers.
+ *
+ * One global Daily webhook (per domain) delivers transcript AND recording events to
+ * /api/webhooks/daily. ensureDailyWebhook() registers it (idempotently) and upgrades an
+ * older transcript-only hook to also include recording events.
+ */
+
+const DAILY_BASE = 'https://api.daily.co/v1'
+
+const WEBHOOK_EVENT_TYPES = [
+  'transcript.started',
+  'transcript.ready-to-download',
+  'transcript.error',
+  'recording.started',
+  'recording.ready-to-download',
+  'recording.error',
+]
+
+async function fetchDaily(endpoint: string, options: RequestInit = {}) {
+  const apiKey = process.env.DAILY_API_KEY
+  if (!apiKey) throw new Error('DAILY_API_KEY not configured')
+  const res = await fetch(`${DAILY_BASE}${endpoint}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Daily API ${endpoint} failed: ${res.status} ${text.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+/**
+ * Ensure the Daily webhook pointing at /api/webhooks/daily exists and is subscribed to
+ * both transcript and recording events. Safe to call repeatedly; never throws.
+ */
+export async function ensureDailyWebhook(): Promise<void> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+  const basicAuth = process.env.DAILY_WEBHOOK_BASIC_AUTH
+  if (!baseUrl || !basicAuth) return
+
+  const url = `${baseUrl.replace(/\/$/, '')}/api/webhooks/daily`
+
+  try {
+    const list = await fetchDaily('/webhooks', { method: 'GET' })
+    const hooks: Array<{ uuid?: string; url?: string; eventTypes?: string[] }> = Array.isArray(
+      list?.data
+    )
+      ? list.data
+      : Array.isArray(list)
+        ? list
+        : []
+    const existing = hooks.find(h => String(h?.url || '') === url)
+
+    if (existing) {
+      const have = new Set(existing.eventTypes || [])
+      const missing = WEBHOOK_EVENT_TYPES.some(e => !have.has(e))
+      // Older hooks were transcript-only; recreate to add recording events.
+      if (missing && existing.uuid) {
+        await fetchDaily(`/webhooks/${existing.uuid}`, { method: 'DELETE' }).catch(() => {})
+      } else {
+        return
+      }
+    }
+
+    await fetchDaily('/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ url, basicAuth, eventTypes: WEBHOOK_EVENT_TYPES }),
+    })
+  } catch (err) {
+    console.warn('[Daily] ensureDailyWebhook failed:', err)
+  }
+}
+
+/**
+ * Fetch a temporary download link for a finished cloud recording. The
+ * recording.ready-to-download webhook does not include the link directly.
+ */
+export async function getRecordingDownloadLink(recordingId: string): Promise<string | null> {
+  try {
+    const res = await fetchDaily(`/recordings/${recordingId}/access-link`, { method: 'GET' })
+    return (res?.download_link as string) || null
+  } catch (err) {
+    console.warn('[Daily] getRecordingDownloadLink failed:', err)
+    return null
+  }
+}


### PR DESCRIPTION
## **User description**
Enables Daily cloud recording (plan verified): rooms get enable_recording:'cloud' (the tutor client already auto-starts recording on join), shared ensureDailyWebhook subscribes recording+transcript events and registers on session creation, and the webhook handler now handles recording.ready-to-download + fetches the access link. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix Daily cloud recording so session recordings are saved and linked correctly**

### What Changed
- Session rooms now support cloud recording, allowing tutor-recorded sessions to complete the recording flow.
- Daily webhooks now cover both transcript and recording events, and existing transcript-only hooks are upgraded so recording updates are received too.
- When a recording finishes, the app now fetches the temporary download link and saves it on the session record.
- Recording webhook handling now recognizes Daily’s ready-to-download event, so finished recordings are not missed.

### Impact
`✅ Fewer missing session recordings`
`✅ Clearer recording access after class`
`✅ More reliable transcript and recording delivery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
