### PR TITLE
feat(assignments): student submit + tutor grading loop, fix feedback IDOR

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -72,10 +72,35 @@ export default function StudentAssignmentsPage() {
 
   const loadAssignments = useCallback(async () => {
     setLoading(true)
-    // Legacy endpoint removed; show empty state
-    setAssignments([])
-    setStats({ pending: 0, submitted: 0, overdue: 0, total: 0 })
-    setLoading(false)
+    try {
+      const res = await fetch('/api/student/feedback/tasks', { credentials: 'include' })
+      if (!res.ok) throw new Error('failed')
+      const data = await res.json()
+      const tasks: Array<{ id: string; title: string; content?: string; type?: string }> =
+        data?.tasks ?? []
+      const items: AssignmentItem[] = tasks.map(t => ({
+        id: t.id,
+        title: t.title,
+        description: (t.content ?? '').slice(0, 240),
+        type: t.type === 'assessment' ? 'assessment' : 'task',
+        difficulty: 'medium',
+        dueDate: null,
+        maxScore: 100,
+        status: 'pending',
+        score: null,
+        submittedAt: null,
+        questionCount: 0,
+        lessonId: null,
+        batchId: null,
+      }))
+      setAssignments(items)
+      setStats({ pending: items.length, submitted: 0, overdue: 0, total: items.length })
+    } catch {
+      setAssignments([])
+      setStats({ pending: 0, submitted: 0, overdue: 0, total: 0 })
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
   useEffect(() => {
@@ -134,39 +159,23 @@ export default function StudentAssignmentsPage() {
         body: JSON.stringify({
           answers: results.answers,
           timeSpent: timeSpentSec,
+          score: results.score,
+          questionResults: results.questionResults,
         }),
       })
 
       if (submitRes.ok) {
         const data = await submitRes.json()
-        toast.success(`Submitted! Score: ${Math.round(data.submission.score)}%`)
+        const submittedScore = data?.submission?.score
+        toast.success(
+          typeof submittedScore === 'number'
+            ? `Submitted! Score: ${Math.round(submittedScore)}%`
+            : 'Submitted! Awaiting grading.'
+        )
       } else if (submitRes.status === 409) {
         toast.info('Already submitted')
       } else {
         toast.error('Submission failed')
-      }
-
-      // 2. Also call quiz attempt API if this is a quiz type
-      if (activeTask.questions.length > 0) {
-        const attemptRes = await fetch('/api/quiz/attempt', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(csrf && { 'X-CSRF-Token': csrf }),
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            quizId: activeTask.id,
-            score: results.score,
-            maxScore: 100,
-            answers: results.answers,
-            timeSpent: timeSpentSec,
-            questionResults: results.questionResults,
-          }),
-        })
-        if (!attemptRes.ok) {
-          console.warn('Quiz attempt recording failed (non-critical)')
-        }
       }
     } catch {
       toast.error('Failed to submit')

--- a/tutorme-app/src/app/api/feedback/[id]/review/route.ts
+++ b/tutorme-app/src/app/api/feedback/[id]/review/route.ts
@@ -42,7 +42,9 @@ async function postHandler(
       return NextResponse.json({ error: '无效的审核决定' }, { status: 400 })
     }
 
-    const result = await reviewFeedback(id, decision, session.user.id, modifications)
+    const result = await reviewFeedback(id, decision, session.user.id, modifications, {
+      bypassOwnership: session.user.role === 'ADMIN',
+    })
 
     if (!result.success) {
       return NextResponse.json({ error: result.error || '审核失败' }, { status: 400 })

--- a/tutorme-app/src/app/api/feedback/batch-approve/route.ts
+++ b/tutorme-app/src/app/api/feedback/batch-approve/route.ts
@@ -28,7 +28,9 @@ async function postHandler(request: NextRequest, session: Session) {
       return NextResponse.json({ error: '单次最多审核50条反馈' }, { status: 400 })
     }
 
-    const result = await batchApproveFeedback(ids, session.user.id)
+    const result = await batchApproveFeedback(ids, session.user.id, {
+      bypassOwnership: session.user.role === 'ADMIN',
+    })
 
     return NextResponse.json({
       success: result.success,

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -1,0 +1,128 @@
+/**
+ * GET /api/student/assignments/[taskId]
+ *
+ * Returns a single assignable task for the logged-in student so they can start it:
+ * task metadata, the question set (mapped from the task's DMI items), and whether
+ * the student has already submitted (with their existing score).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { getParamAsync } from '@/lib/api/params'
+import { handleApiError } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, builderTaskDmi, taskSubmission } from '@/lib/db/schema'
+
+interface AssignmentQuestion {
+  id: string
+  type: 'multiple_choice' | 'short_answer'
+  question: string
+  options?: string[]
+  correctAnswer?: string
+  points: number
+}
+
+/** Map a task's stored DMI items / metadata questions into the quiz question shape. */
+function mapQuestions(dmiItems: unknown, metadata: unknown): AssignmentQuestion[] {
+  const fromItems = Array.isArray(dmiItems) ? dmiItems : []
+  if (fromItems.length > 0) {
+    return fromItems.map((raw, i) => {
+      const item = (raw ?? {}) as Record<string, unknown>
+      const options = Array.isArray(item.options) ? (item.options as string[]) : undefined
+      return {
+        id: String(item.id ?? item.questionNumber ?? i + 1),
+        type: options && options.length > 0 ? 'multiple_choice' : 'short_answer',
+        question: String(item.questionText ?? item.question ?? ''),
+        options,
+        correctAnswer:
+          item.answer != null
+            ? String(item.answer)
+            : item.correctAnswer != null
+              ? String(item.correctAnswer)
+              : undefined,
+        points: typeof item.points === 'number' ? item.points : 10,
+      }
+    })
+  }
+
+  // Fallback: questions embedded in builderTask.metadata
+  const meta = (metadata ?? {}) as Record<string, unknown>
+  const metaQuestions = Array.isArray(meta.questions) ? meta.questions : []
+  return metaQuestions.map((raw, i) => {
+    const item = (raw ?? {}) as Record<string, unknown>
+    const options = Array.isArray(item.options) ? (item.options as string[]) : undefined
+    return {
+      id: String(item.id ?? i + 1),
+      type: options && options.length > 0 ? 'multiple_choice' : 'short_answer',
+      question: String(item.question ?? item.questionText ?? ''),
+      options,
+      correctAnswer: item.correctAnswer != null ? String(item.correctAnswer) : undefined,
+      points: typeof item.points === 'number' ? item.points : 10,
+    }
+  })
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<Record<string, string | string[]>> }
+) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const studentId = session.user.id
+
+    const taskId = await getParamAsync(context.params, 'taskId')
+    if (!taskId || !/^[a-zA-Z0-9\-_]+$/.test(taskId) || taskId.length > 100) {
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
+    }
+
+    const [task] = await drizzleDb
+      .select({
+        taskId: builderTask.taskId,
+        title: builderTask.title,
+        type: builderTask.type,
+        status: builderTask.status,
+        metadata: builderTask.metadata,
+      })
+      .from(builderTask)
+      .where(and(eq(builderTask.taskId, taskId), isNull(builderTask.deletedAt)))
+      .limit(1)
+
+    if (!task || task.status !== 'published') {
+      return NextResponse.json({ error: 'Task not available' }, { status: 404 })
+    }
+
+    // Existing submission (if any) for this student
+    const [existing] = await drizzleDb
+      .select({ score: taskSubmission.score, status: taskSubmission.status })
+      .from(taskSubmission)
+      .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
+      .limit(1)
+
+    // Latest DMI question set for this task
+    const [dmi] = await drizzleDb
+      .select({ items: builderTaskDmi.items })
+      .from(builderTaskDmi)
+      .where(eq(builderTaskDmi.taskId, taskId))
+      .orderBy(desc(builderTaskDmi.updatedAt))
+      .limit(1)
+
+    const questions = mapQuestions(dmi?.items, task.metadata)
+
+    return NextResponse.json({
+      alreadySubmitted: existing != null,
+      existingScore: existing?.score ?? null,
+      task: {
+        id: task.taskId,
+        title: task.title,
+        type: task.type,
+        questions,
+      },
+    })
+  } catch (error) {
+    return handleApiError(error, 'Failed to load task', 'api/student/assignments/[taskId]/route.ts')
+  }
+}

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -1,0 +1,145 @@
+/**
+ * POST /api/student/assignments/[taskId]/submit
+ *
+ * Persists a student's answers to an assignable task as a TaskSubmission, then
+ * kicks off (best-effort) AI feedback for the tutor's review queue. Enforces:
+ *  - authenticated student
+ *  - CSRF (double-submit token)
+ *  - task is published
+ *  - student is enrolled in the task's course
+ *  - one submission per (task, student) — duplicate returns 409
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import { randomUUID } from 'crypto'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { getParamAsync } from '@/lib/api/params'
+import { handleApiError, requireCsrf } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, courseEnrollment, taskSubmission } from '@/lib/db/schema'
+import { generateFeedback, submitFeedbackForReview } from '@/lib/feedback/workflow'
+
+const MAX_SCORE = 100
+
+function clampScore(value: unknown): number | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null
+  return Math.max(0, Math.min(MAX_SCORE, value))
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<Record<string, string | string[]>> }
+) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const studentId = session.user.id
+
+    const csrfError = await requireCsrf(request)
+    if (csrfError) return csrfError
+
+    const taskId = await getParamAsync(context.params, 'taskId')
+    if (!taskId || !/^[a-zA-Z0-9\-_]+$/.test(taskId) || taskId.length > 100) {
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      answers?: Record<string, unknown>
+      timeSpent?: number
+      score?: number
+      questionResults?: unknown
+    }
+    const answers = body.answers ?? {}
+    const timeSpent = typeof body.timeSpent === 'number' && body.timeSpent >= 0 ? body.timeSpent : 0
+    const score = clampScore(body.score)
+
+    // Task must exist, be published, and not deleted
+    const [task] = await drizzleDb
+      .select({ courseId: builderTask.courseId, status: builderTask.status })
+      .from(builderTask)
+      .where(eq(builderTask.taskId, taskId))
+      .limit(1)
+
+    if (!task || task.status !== 'published') {
+      return NextResponse.json({ error: 'Task not available' }, { status: 404 })
+    }
+
+    // Student must be enrolled in the task's course
+    const [enrollment] = await drizzleDb
+      .select({ enrollmentId: courseEnrollment.enrollmentId })
+      .from(courseEnrollment)
+      .where(
+        and(
+          eq(courseEnrollment.studentId, studentId),
+          eq(courseEnrollment.courseId, task.courseId)
+        )
+      )
+      .limit(1)
+
+    if (!enrollment) {
+      return NextResponse.json({ error: 'Not enrolled in this course' }, { status: 403 })
+    }
+
+    // One submission per (task, student)
+    const [existing] = await drizzleDb
+      .select({ submissionId: taskSubmission.submissionId })
+      .from(taskSubmission)
+      .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
+      .limit(1)
+
+    if (existing) {
+      return NextResponse.json({ error: 'Already submitted' }, { status: 409 })
+    }
+
+    const submissionId = randomUUID()
+    const questionResults =
+      body.questionResults != null && typeof body.questionResults === 'object'
+        ? body.questionResults
+        : null
+
+    await drizzleDb.insert(taskSubmission).values({
+      submissionId,
+      taskId,
+      studentId,
+      answers,
+      timeSpent,
+      attempts: 1,
+      questionResults,
+      score,
+      maxScore: MAX_SCORE,
+      status: 'submitted',
+      tutorApproved: false,
+    })
+
+    // Best-effort: generate AI feedback into the tutor's review queue. Submission
+    // already persisted, so any failure here must not fail the request.
+    try {
+      const request_ = {
+        studentId,
+        submissionId,
+        type: 'task_feedback' as const,
+        context: { taskId, recentPerformance: score ?? undefined },
+        priority: 'medium' as const,
+      }
+      const generated = await generateFeedback(request_)
+      if (generated.success && generated.feedback) {
+        await submitFeedbackForReview(generated.feedback, request_)
+      }
+    } catch (feedbackError) {
+      console.warn('[submit] AI feedback generation failed (non-critical):', feedbackError)
+    }
+
+    return NextResponse.json({
+      submission: { submissionId, score: score ?? 0, status: 'submitted' },
+    })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to submit task',
+      'api/student/assignments/[taskId]/submit/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/app/api/tutor/submissions/[submissionId]/grade/route.ts
+++ b/tutorme-app/src/app/api/tutor/submissions/[submissionId]/grade/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/tutor/submissions/[submissionId]/grade
+ *
+ * Lets the owning tutor (or an admin) record a manual grade for a student's
+ * TaskSubmission: score, optional feedback, and approval. Verifies the tutor owns
+ * the task behind the submission to prevent cross-tutor grading (IDOR).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { getParamAsync } from '@/lib/api/params'
+import { handleApiError, requireCsrf } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, taskSubmission } from '@/lib/db/schema'
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<Record<string, string | string[]>> }
+) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const csrfError = await requireCsrf(request)
+    if (csrfError) return csrfError
+
+    const submissionId = await getParamAsync(context.params, 'submissionId')
+    if (!submissionId || !/^[a-zA-Z0-9\-_]+$/.test(submissionId) || submissionId.length > 100) {
+      return NextResponse.json({ error: 'Invalid submission ID' }, { status: 400 })
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      score?: number
+      maxScore?: number
+      feedback?: string
+      approved?: boolean
+    }
+
+    if (typeof body.score !== 'number' || Number.isNaN(body.score) || body.score < 0) {
+      return NextResponse.json({ error: 'A numeric score is required' }, { status: 400 })
+    }
+
+    // Submission must exist and be owned (via its task) by this tutor (admins bypass)
+    const [row] = await drizzleDb
+      .select({
+        submissionId: taskSubmission.submissionId,
+        maxScore: taskSubmission.maxScore,
+        tutorId: builderTask.tutorId,
+      })
+      .from(taskSubmission)
+      .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+      .where(eq(taskSubmission.submissionId, submissionId))
+      .limit(1)
+
+    if (!row) {
+      return NextResponse.json({ error: 'Submission not found' }, { status: 404 })
+    }
+    if (session.user.role !== 'ADMIN' && row.tutorId !== session.user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const maxScore =
+      typeof body.maxScore === 'number' && body.maxScore > 0 ? body.maxScore : row.maxScore
+    const score = Math.max(0, Math.min(maxScore, body.score))
+
+    await drizzleDb
+      .update(taskSubmission)
+      .set({
+        score,
+        maxScore,
+        tutorFeedback: body.feedback ?? null,
+        tutorApproved: body.approved ?? true,
+        status: 'graded',
+        gradedAt: new Date(),
+      })
+      .where(eq(taskSubmission.submissionId, submissionId))
+
+    return NextResponse.json({
+      submission: { submissionId, score, maxScore, status: 'graded' },
+    })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to grade submission',
+      'api/tutor/submissions/[submissionId]/grade/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/lib/feedback/workflow.ts
+++ b/tutorme-app/src/lib/feedback/workflow.ts
@@ -5,7 +5,7 @@
 
 import { and, asc, eq, gte, inArray } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { feedbackWorkflow, profile, user } from '@/lib/db/schema'
+import { builderTask, feedbackWorkflow, profile, taskSubmission, user } from '@/lib/db/schema'
 import { generateWithFallback } from '@/lib/agents'
 
 export type FeedbackType = 'task_feedback' | 'progress_report' | 'encouragement' | 'correction'
@@ -399,7 +399,8 @@ export async function reviewFeedback(
     modifiedScore?: number
     modifiedComments?: string
     addedNotes?: string
-  }
+  },
+  options?: { bypassOwnership?: boolean }
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const [workflow] = await drizzleDb
@@ -410,6 +411,22 @@ export async function reviewFeedback(
 
     if (!workflow) {
       return { success: false, error: '反馈记录不存在' }
+    }
+
+    // Ownership: only the tutor who owns the task behind the submission may review
+    // its feedback (admins bypass). Prevents IDOR where any tutor could approve/reject
+    // any feedback by knowing the workflow id.
+    if (!options?.bypassOwnership) {
+      const [owner] = await drizzleDb
+        .select({ tutorId: builderTask.tutorId })
+        .from(taskSubmission)
+        .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+        .where(eq(taskSubmission.submissionId, workflow.submissionId))
+        .limit(1)
+
+      if (!owner || owner.tutorId !== reviewerId) {
+        return { success: false, error: '无权审核此反馈' }
+      }
     }
 
     if (workflow.status === 'sent_to_student' || workflow.status === 'rejected') {
@@ -509,13 +526,14 @@ export async function getFeedbackStats(tutorId?: string): Promise<{
  */
 export async function batchApproveFeedback(
   workflowIds: string[],
-  reviewerId: string
+  reviewerId: string,
+  options?: { bypassOwnership?: boolean }
 ): Promise<{ success: boolean; approved: number; failed: number; error?: string }> {
   let approved = 0
   let failed = 0
 
   for (const id of workflowIds) {
-    const result = await reviewFeedback(id, 'approve', reviewerId)
+    const result = await reviewFeedback(id, 'approve', reviewerId, undefined, options)
     if (result.success) {
       approved++
     } else {


### PR DESCRIPTION
## **User description**
## Summary
Closes the missing **submit → grade** loop. Before this, `TaskSubmission` was never written anywhere and the student assignments page called endpoints that didn't exist.

### New endpoints
- **GET `/api/student/assignments/[taskId]`** — returns task metadata + the question set (mapped from the task's DMI items, falling back to `metadata.questions`) + `alreadySubmitted` / `existingScore`.
- **POST `/api/student/assignments/[taskId]/submit`** — persists a `TaskSubmission`. Enforces: authed student, CSRF, task published, enrolled in the task's course, one submission per `(task, student)` (`409` on duplicate). Then fires **best-effort AI feedback** into the tutor review queue (failure can't fail the submit).
- **POST `/api/tutor/submissions/[submissionId]/grade`** — owning tutor (or admin) records `score` / `feedback` / `approved`; verifies the tutor owns the task behind the submission.

### Security
- **Fix IDOR** in `reviewFeedback` / `batchApproveFeedback`: a tutor may only review feedback for submissions on tasks **they own** (admins bypass). The review + batch-approve routes pass the admin bypass explicitly. Previously any tutor could approve/reject any feedback by knowing the workflow id.

### UI
- Wire the student assignments list to `/api/student/feedback/tasks` (was a hardcoded empty stub, so the flow was unreachable).
- Send the QuizModal-computed `score` / `questionResults` on submit; drop the dead `/api/quiz/attempt` call.

## Verification
- `npm run typecheck` → 0 errors
- `npm run build` → exit 0 (all three routes present in the manifest)
- `npm run lint` → 0 errors (pre-existing warnings only)

## Known follow-ups (not in this PR)
- No dedicated **tutor grading UI** yet — the grade endpoint exists but a tutor surfaces/grades via API or the existing feedback panel. A submissions list/grading page is the natural next step.
- The list endpoint returns published tasks without per-student submission status, so the list shows everything as `pending` (re-submission is still blocked server-side via the `409`).
- Short-answer scoring is provisional (client/AI); authoritative scoring is the tutor grade endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Students can open, submit, and see grading for assignable tasks; tutors can grade submissions, and feedback review is restricted to the task owner**

### What Changed
- The student assignments page now loads real tasks instead of showing an empty list, and students can open a task, answer it, and submit it from the UI
- Task pages now show the task content, questions, and whether the student has already submitted, along with any existing score
- Submissions are saved with the student's answers and score, and duplicate submissions are rejected
- Students must be enrolled in the course before they can submit a task
- Tutors can now record a manual grade, feedback, and approval for a submission
- Feedback review and batch approval now only work for the tutor who owns the task, while admins can still review all feedback

### Impact
`✅ Fewer empty assignment lists`
`✅ Shorter student submission flow`
`✅ Fewer duplicate task submissions`
`✅ Safer tutor feedback approval`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
