### PR TITLE
fix(api): log error.cause and Postgres detail in API errors

### DIFF
--- a/tutorme-app/src/lib/api/middleware.ts
+++ b/tutorme-app/src/lib/api/middleware.ts
@@ -52,6 +52,54 @@ function createErrorId(): string {
   return nanoid(12)
 }
 
+/**
+ * Pull the underlying cause out of an error for logging. Many libraries (e.g.
+ * Drizzle) set their own generic `.message` ("Failed query: ...") and stash the
+ * real driver error — Postgres code/detail/constraint — on `.cause`. Without
+ * this the actual failure reason never reaches the logs.
+ */
+function extractErrorDetails(error: unknown): Record<string, unknown> {
+  const details: Record<string, unknown> = {}
+  if (!(error instanceof Error)) return details
+
+  // Postgres driver errors expose these fields directly on the error object.
+  const e = error as Error & {
+    code?: unknown
+    detail?: unknown
+    constraint?: unknown
+    column?: unknown
+    table?: unknown
+  }
+  if (e.code != null) details.code = e.code
+  if (e.detail != null) details.detail = e.detail
+  if (e.constraint != null) details.constraint = e.constraint
+  if (e.column != null) details.column = e.column
+  if (e.table != null) details.table = e.table
+
+  const cause = (error as { cause?: unknown }).cause
+  if (cause instanceof Error) {
+    const c = cause as Error & {
+      code?: unknown
+      detail?: unknown
+      constraint?: unknown
+      column?: unknown
+      table?: unknown
+    }
+    details.cause = {
+      message: c.message,
+      code: c.code,
+      detail: c.detail,
+      constraint: c.constraint,
+      column: c.column,
+      table: c.table,
+    }
+  } else if (cause != null) {
+    details.cause = typeof cause === 'string' ? cause : String(cause)
+  }
+
+  return details
+}
+
 function logApiError(
   errorId: string,
   logLabel: string,
@@ -66,6 +114,7 @@ function logApiError(
       label: logLabel,
       message: err?.message ?? 'Unknown error',
       stack: err?.stack,
+      ...extractErrorDetails(error),
       ...meta,
     })
   )


### PR DESCRIPTION
## **User description**
## Summary
API error logs were hiding the real failure reason. Drizzle (and similar libraries) set a generic `.message` like `Failed query: insert into ...` and stash the actual driver error on `.cause`. Since `logApiError` only logged `message` + `stack`, the underlying Postgres `code` / `detail` / `constraint` / `column` never reached the logs — which is exactly what made the tutor-registration 500 undiagnosable from logs.

`logApiError` now extracts those fields from both the error object and its `.cause`.

## Why
Surfaced while verifying the new submission/grading endpoints in prod: tutor signup 500s on the `TutorApplication` insert, but the logs only showed Drizzle's "Failed query" wrapper. With this change the next occurrence will log the real Postgres error (e.g. `invalid input syntax for type json` / `column ... does not exist`), pinpointing the schema drift.

## Verification
- `npm run typecheck` → 0 errors
- `npm run build` → exit 0
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show the real database error in API logs**

### What Changed
- API error logs now include the underlying database error details instead of only the generic wrapper message
- Logs can now show Postgres fields like error code, detail, constraint, column, and table
- When an error is wrapped inside another error, the nested cause is also logged

### Impact
`✅ Clearer API error logs`
`✅ Faster diagnosis of database failures`
`✅ Easier debugging of schema and data issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
