### PR TITLE
fix(db): drop stray NOT NULL on TutorApplication optional columns

### DIFF
--- a/tutorme-app/drizzle/0054_fix_tutor_application_nullable.sql
+++ b/tutorme-app/drizzle/0054_fix_tutor_application_nullable.sql
@@ -1,0 +1,16 @@
+-- Align "TutorApplication" nullable columns with the Drizzle schema.
+--
+-- Production drifted to NOT NULL on these optional columns, which broke tutor
+-- registration: legalName/middleName/certificate*/socialLinks are legitimately
+-- null at signup, so the INSERT failed with 23502 (not-null violation) and the
+-- whole registration transaction rolled back. The code schema declares all of
+-- these nullable. DROP NOT NULL is idempotent (no error if already nullable).
+ALTER TABLE "TutorApplication" ALTER COLUMN "legalName" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "TutorApplication" ALTER COLUMN "middleName" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "TutorApplication" ALTER COLUMN "certificateName" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "TutorApplication" ALTER COLUMN "certificateSubjects" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "TutorApplication" ALTER COLUMN "socialLinks" DROP NOT NULL;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1751802000000,
       "tag": "0053_fix_course_schedule_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1751803000000,
+      "tag": "0054_fix_tutor_application_nullable",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Summary
Tutor registration 500s in production. Root cause (surfaced by the new `error.cause` logging): the prod `TutorApplication` table drifted to **`NOT NULL`** on columns the Drizzle schema declares nullable, so a normal signup — which inserts `null` for an absent legal name etc. — fails with Postgres `23502` and rolls back the whole registration transaction (the `User` row too). **New tutor sign-ups are broken in prod.**

```
code: 23502  column: legalName
null value in column "legalName" of relation "TutorApplication" violates not-null constraint
```

## Fix
Migration `0054_fix_tutor_application_nullable.sql` drops the stray `NOT NULL` on the columns that are nullable in the code schema:
`legalName`, `middleName`, `certificateName`, `certificateSubjects`, `socialLinks`. `DROP NOT NULL` is idempotent.

The same statements have been applied directly to prod to unblock signups immediately; this migration makes the fix tracked so a fresh DB / `db:migrate` won't reintroduce the drift.

## Notes
- No code change — the Drizzle schema already declares these nullable; only prod had drifted.
- Journal entry added (`idx 54`); follows the hand-authored idempotent-fix pattern of 0050–0053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow tutor sign-up to save optional application fields**

### What Changed
- Restores nullable behavior for optional tutor application fields so registration no longer fails when legal name, middle name, certificate details, or social links are left blank
- Adds a tracked database migration to keep the database aligned with the app’s expected sign-up behavior

### Impact
`✅ Fewer tutor signup failures`
`✅ Clearer blank-field handling during registration`
`✅ Reduced registration rollbacks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
