### PR TITLE
fix(sessions): tier 2 — unify schedule source + trace sessions to schedule

### DIFF
--- a/tutorme-app/drizzle/0055_add_live_session_schedule_id.sql
+++ b/tutorme-app/drizzle/0055_add_live_session_schedule_id.sql
@@ -1,0 +1,14 @@
+-- Link a materialized LiveSession back to the CourseSchedule it was generated from.
+-- Previously there was no schedule->session linkage, so re-publish relied on a
+-- time-overlap heuristic and sessions could not be traced to their schedule.
+-- Nullable (ad-hoc / 1:1 sessions have no schedule); FK set null on schedule delete.
+ALTER TABLE "LiveSession" ADD COLUMN IF NOT EXISTS "scheduleId" text;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "LiveSession"
+    ADD CONSTRAINT "LiveSession_scheduleId_CourseSchedule_id_fk"
+    FOREIGN KEY ("scheduleId") REFERENCES "CourseSchedule"("id")
+    ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "LiveSession_scheduleId_idx" ON "LiveSession"("scheduleId");

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1751803000000,
       "tag": "0054_fix_tutor_application_nullable",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1751804000000,
+      "tag": "0055_add_live_session_schedule_id",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
@@ -5,6 +5,7 @@ import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession as liveSessionTable, courseEnrollment, course } from '@/lib/db/schema'
 import { generateUpcomingSessions, mergeSessions } from '@/lib/schedule-sessions'
+import { resolveCourseScheduleSlots } from '@/lib/sessions/course-schedule-slots'
 
 export const GET = withAuth(
   async (req, session, context) => {
@@ -64,12 +65,10 @@ export const GET = withAuth(
         maxStudents: s.maxStudents ?? 50,
       }))
 
-      // Generate virtual sessions from schedule
-      const schedule = (courseRow?.schedule || []) as Array<{
-        dayOfWeek: string
-        startTime: string
-        durationMinutes: number
-      }>
+      // Generate virtual sessions from the schedule that publish actually
+      // materializes from (CourseSchedule table), falling back to the legacy
+      // course.schedule JSON for unpublished drafts.
+      const schedule = await resolveCourseScheduleSlots(courseId, courseRow?.schedule)
 
       const virtualSessions = generateUpcomingSessions(
         schedule,

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -449,7 +449,9 @@ export const POST = withCsrf(
               .where(eq(courseSchedule.courseId, publishedCourseId))
               .orderBy(courseSchedule.scheduleIndex)
 
-            // Update or create schedules
+            // Update or create schedules, remembering each row's id so the
+            // sessions we materialize below can be linked back to their schedule.
+            const scheduleIdByPayload = new Map<unknown, string>()
             for (let i = 0; i < schedules.length; i++) {
               const s = schedules[i]
               const existingSch = existingSchedules.find(es => es.scheduleIndex === s.scheduleIndex)
@@ -463,9 +465,11 @@ export const POST = withCsrf(
                     updatedAt: now,
                   })
                   .where(eq(courseSchedule.scheduleId, existingSch.scheduleId))
+                scheduleIdByPayload.set(s, existingSch.scheduleId)
               } else {
+                const newScheduleId = crypto.randomUUID()
                 await tx.insert(courseSchedule).values({
-                  scheduleId: crypto.randomUUID(),
+                  scheduleId: newScheduleId,
                   courseId: publishedCourseId,
                   scheduleIndex: s.scheduleIndex || i + 1,
                   schedule: s.schedule || [],
@@ -475,6 +479,7 @@ export const POST = withCsrf(
                   createdAt: now,
                   updatedAt: now,
                 })
+                scheduleIdByPayload.set(s, newScheduleId)
               }
             }
 
@@ -727,9 +732,10 @@ export const POST = withCsrf(
                       category: v.category,
                       type: 'COURSE',
                       courseId: publishedCourseId,
+                      scheduleId: scheduleIdByPayload.get(s) ?? undefined,
                       description: templateCourse.description ?? undefined,
                       status: 'scheduled',
-                      maxStudents: 50,
+                      maxStudents: s.maxStudents ?? 50,
                       timezone: 'UTC',
                     },
                     tx

--- a/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
@@ -11,6 +11,7 @@ import { eq, and, asc, inArray } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession as liveSessionTable, course } from '@/lib/db/schema'
 import { generateUpcomingSessions, mergeSessions } from '@/lib/schedule-sessions'
+import { resolveCourseScheduleSlots } from '@/lib/sessions/course-schedule-slots'
 
 export const GET = withAuth(
   async (req, session, context) => {
@@ -77,12 +78,10 @@ export const GET = withAuth(
         durationMinutes: s.durationMinutes ?? 120,
       }))
 
-      // Generate virtual sessions from schedule
-      const schedule = (courseRow?.schedule || []) as Array<{
-        dayOfWeek: string
-        startTime: string
-        durationMinutes: number
-      }>
+      // Generate virtual sessions from the schedule that publish actually
+      // materializes from (CourseSchedule table), falling back to the legacy
+      // course.schedule JSON for unpublished drafts.
+      const schedule = await resolveCourseScheduleSlots(courseId, courseRow?.schedule)
 
       const virtualSessions = generateUpcomingSessions(
         schedule,

--- a/tutorme-app/src/lib/db/schema/tables/live.ts
+++ b/tutorme-app/src/lib/db/schema/tables/live.ts
@@ -16,7 +16,7 @@ import {
 } from 'drizzle-orm/pg-core'
 import * as enums from '../enums'
 import { user } from './auth'
-import { course } from './course'
+import { course, courseSchedule } from './course'
 
 export const liveSession = pgTable(
   'LiveSession',
@@ -26,6 +26,11 @@ export const liveSession = pgTable(
       .notNull()
       .references(() => user.userId, { onDelete: 'cascade' }),
     courseId: text('courseId').references(() => course.courseId, { onDelete: 'set null' }),
+    // The CourseSchedule this session was materialized from (null for ad-hoc / 1:1).
+    // Lets a session trace back to its schedule and makes re-publish idempotent.
+    scheduleId: text('scheduleId').references(() => courseSchedule.scheduleId, {
+      onDelete: 'set null',
+    }),
     title: text('title').notNull(),
     category: text('category').notNull(),
     description: text('description'),
@@ -43,6 +48,7 @@ export const liveSession = pgTable(
   table => ({
     LiveSession_tutorId_idx: index('LiveSession_tutorId_idx').on(table.tutorId),
     LiveSession_courseId_idx: index('LiveSession_courseId_idx').on(table.courseId),
+    LiveSession_scheduleId_idx: index('LiveSession_scheduleId_idx').on(table.scheduleId),
     LiveSession_status_idx: index('LiveSession_status_idx').on(table.status),
     LiveSession_scheduledAt_idx: index('LiveSession_scheduledAt_idx').on(table.scheduledAt),
     LiveSession_roomId_idx: index('LiveSession_roomId_idx').on(table.roomId),

--- a/tutorme-app/src/lib/sessions/course-schedule-slots.ts
+++ b/tutorme-app/src/lib/sessions/course-schedule-slots.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve the recurring schedule slots used to generate a course's upcoming
+ * ("virtual") sessions.
+ *
+ * Prefers the CourseSchedule table — the SAME source `publish` materializes real
+ * LiveSession rows from — and falls back to the legacy `course.schedule` JSON only
+ * when no schedule rows exist yet (e.g. an unpublished draft). This keeps the
+ * sessions shown to tutors/students consistent with what actually gets
+ * materialized, instead of reading a separate, drift-prone store.
+ */
+
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseSchedule } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+
+export interface ScheduleSlot {
+  dayOfWeek: string
+  startTime: string
+  durationMinutes: number
+}
+
+export async function resolveCourseScheduleSlots(
+  courseId: string,
+  fallbackJson: unknown
+): Promise<ScheduleSlot[]> {
+  const rows = await drizzleDb
+    .select({ schedule: courseSchedule.schedule })
+    .from(courseSchedule)
+    .where(eq(courseSchedule.courseId, courseId))
+
+  const fromTable = rows.flatMap(r => (Array.isArray(r.schedule) ? r.schedule : []))
+  if (fromTable.length > 0) {
+    return fromTable as ScheduleSlot[]
+  }
+
+  return (Array.isArray(fallbackJson) ? fallbackJson : []) as ScheduleSlot[]
+}

--- a/tutorme-app/src/lib/sessions/create-session.ts
+++ b/tutorme-app/src/lib/sessions/create-session.ts
@@ -26,6 +26,8 @@ export interface CreateSessionInput {
   category: string
   type: SessionType
   courseId?: string
+  /** CourseSchedule this session is materialized from (course sessions only). */
+  scheduleId?: string
   studentId?: string
   maxStudents?: number
   description?: string
@@ -76,6 +78,7 @@ export async function createSession(input: CreateSessionInput, tx?: DbClient) {
       sessionId,
       tutorId: input.tutorId,
       courseId: input.courseId ?? null,
+      scheduleId: input.scheduleId ?? null,
       title: input.title,
       category: input.category,
       description: input.description ?? null,


### PR DESCRIPTION
## **User description**
Second of three PRs from the session-lifecycle audit. Fixes the **core inconsistency**: sessions were driven by two schedule stores that never sync.

## The problem
- **Display** ("upcoming sessions" for tutor + student) generated virtual sessions from `course.schedule` (a JSON column).
- **Publish** materialized real `liveSession` rows from the `courseSchedule` **table**.

These never sync, so editing one didn't affect the other — surfacing as duplicate or mismatched sessions (mergeSessions dedupes virtual-vs-real by timestamp, so any drift shows up).

## Fixes
1. **Trace sessions to their schedule** — new nullable `liveSession.scheduleId` FK → `CourseSchedule` (`set null`) + **migration 0055** + index. A materialized session now knows which schedule it came from.
2. **createSession / publish** — `createSession` takes `scheduleId`; publish passes it and now carries the schedule's own **`maxStudents`** into materialization instead of a hardcoded `50` (per-schedule caps were being dropped).
3. **Unified display source** — new `resolveCourseScheduleSlots()` reads the `CourseSchedule` table (the same source publish materializes from), falling back to `course.schedule` JSON only for unpublished drafts. Both session-display routes use it, so **what's shown as upcoming matches what actually materializes.**

## Safety
- Migration is **additive** (nullable column, idempotent `IF NOT EXISTS` / guarded FK) and the deploy runs migrations **before** the new revision takes traffic, so the existing prod table is safe (no repeat of the earlier drift failure mode).
- Display change is read-only with a JSON fallback, so it cannot empty out displays for drafts.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

## Follow-up (not in this PR)
`student/dashboard-stats` also generates virtuals from `course.schedule`; can be switched to the same resolver in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep scheduled sessions and upcoming session views in sync**

### What Changed
- Upcoming sessions now use the same schedule source that publishing uses, so tutors and students see sessions that match what is actually created.
- Published course sessions now keep a link back to the schedule they came from, which makes repeated publishing track the same schedule instead of treating sessions as unrelated.
- Course sessions now carry each schedule’s own student limit when they are created, instead of always using the default limit.
- Draft courses still fall back to the older schedule data, so unpublished courses continue to show upcoming sessions.

### Impact
`✅ Fewer mismatched upcoming sessions`
`✅ Consistent published class schedules`
`✅ Correct class sizes for scheduled sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
