### PR TITLE
feat(enroll): expose named schedules + thread scheduleId through enrollment

### DIFF
--- a/tutorme-app/src/app/api/courses/[id]/schedules/route.ts
+++ b/tutorme-app/src/app/api/courses/[id]/schedules/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/courses/[id]/schedules
+ *
+ * Public (any authenticated user) read-only list of a course's named schedules,
+ * so students can view the available class times and pick one at signup. Returns
+ * the schedule name, weekly slots, and computed capacity (spotsLeft / isFull).
+ */
+
+import { NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { course, courseSchedule } from '@/lib/db/schema'
+
+export const GET = withAuth(async (req, _session, context) => {
+  const courseId = await getParamAsync(context.params, 'id')
+  if (!courseId) {
+    return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
+  }
+
+  const [courseRow] = await drizzleDb
+    .select({ courseId: course.courseId })
+    .from(course)
+    .where(eq(course.courseId, courseId))
+    .limit(1)
+
+  if (!courseRow) {
+    return NextResponse.json({ error: 'Course not found' }, { status: 404 })
+  }
+
+  const rows = await drizzleDb
+    .select({
+      scheduleId: courseSchedule.scheduleId,
+      scheduleIndex: courseSchedule.scheduleIndex,
+      name: courseSchedule.name,
+      schedule: courseSchedule.schedule,
+      weeksToSchedule: courseSchedule.weeksToSchedule,
+      maxStudents: courseSchedule.maxStudents,
+      enrolledCount: courseSchedule.enrolledCount,
+    })
+    .from(courseSchedule)
+    .where(eq(courseSchedule.courseId, courseId))
+    .orderBy(courseSchedule.scheduleIndex)
+
+  const schedules = rows.map(r => {
+    const spotsLeft =
+      typeof r.maxStudents === 'number' ? Math.max(0, r.maxStudents - (r.enrolledCount ?? 0)) : null
+    return {
+      scheduleId: r.scheduleId,
+      scheduleIndex: r.scheduleIndex,
+      name: r.name ?? `Schedule ${r.scheduleIndex}`,
+      slots: Array.isArray(r.schedule) ? r.schedule : [],
+      weeksToSchedule: r.weeksToSchedule,
+      maxStudents: r.maxStudents,
+      enrolledCount: r.enrolledCount ?? 0,
+      spotsLeft,
+      isFull: spotsLeft === 0,
+    }
+  })
+
+  return NextResponse.json({ schedules })
+})

--- a/tutorme-app/src/app/api/payments/create/route.ts
+++ b/tutorme-app/src/app/api/payments/create/route.ts
@@ -172,6 +172,7 @@ export const POST = withCsrf(
           payerId: session.user.id,
           payerRole: session.user.role,
           startDate: customMetadata?.startDate,
+          scheduleId: customMetadata?.scheduleId,
         },
         successUrl: `${baseUrl}/payment/success?type=course&courseId=${encodeURIComponent(courseId)}`,
         cancelUrl: `${baseUrl}/payment/cancel?type=course&courseId=${encodeURIComponent(courseId)}`,
@@ -196,6 +197,7 @@ export const POST = withCsrf(
             payerId: session.user.id,
             payerRole: session.user.role,
             startDate: customMetadata?.startDate,
+            scheduleId: customMetadata?.scheduleId,
             idempotencyKey: courseIdempotencyKey,
           },
         })

--- a/tutorme-app/src/app/api/student/enrollments/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/route.ts
@@ -7,40 +7,47 @@
 export const dynamic = 'force-dynamic'
 
 import { NextResponse } from 'next/server'
-import { withAuth, NotFoundError } from '@/lib/api/middleware'
+import { withAuth, withCsrf, NotFoundError } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseLesson, courseEnrollment, user } from '@/lib/db/schema'
 import { eq, inArray, desc } from 'drizzle-orm'
 import { sql } from 'drizzle-orm'
 import { enrollStudentInCourse, enrollmentPaymentRequiredResponse } from '@/lib/api/enrollments'
 
-export const POST = withAuth(
-  async (req, session) => {
-    const body = await req.json().catch(() => ({}))
-    const { courseId, startDate } = body
+export const POST = withCsrf(
+  withAuth(
+    async (req, session) => {
+      const body = await req.json().catch(() => ({}))
+      const { courseId, startDate, scheduleId } = body
 
-    if (!courseId || typeof courseId !== 'string') {
-      return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
-    }
+      if (!courseId || typeof courseId !== 'string') {
+        return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
+      }
 
-    try {
-      const result = await enrollStudentInCourse(session.user.id, courseId, startDate)
-      return NextResponse.json(result)
-    } catch (error: unknown) {
-      const err = error as any
-      if (err instanceof NotFoundError) {
-        return NextResponse.json({ error: err.message }, { status: 404 })
+      try {
+        const result = await enrollStudentInCourse(
+          session.user.id,
+          courseId,
+          startDate,
+          typeof scheduleId === 'string' ? scheduleId : null
+        )
+        return NextResponse.json(result)
+      } catch (error: unknown) {
+        const err = error as any
+        if (err instanceof NotFoundError) {
+          return NextResponse.json({ error: err.message }, { status: 404 })
+        }
+        if (err?.requiresPayment) {
+          return enrollmentPaymentRequiredResponse(err)
+        }
+        if (err?.message) {
+          return NextResponse.json({ error: err.message }, { status: 400 })
+        }
+        throw error
       }
-      if (err?.requiresPayment) {
-        return enrollmentPaymentRequiredResponse(err)
-      }
-      if (err?.message) {
-        return NextResponse.json({ error: err.message }, { status: 400 })
-      }
-      throw error
-    }
-  },
-  { role: 'STUDENT' }
+    },
+    { role: 'STUDENT' }
+  )
 )
 
 export const GET = withAuth(

--- a/tutorme-app/src/app/api/student/subjects/enroll/route.ts
+++ b/tutorme-app/src/app/api/student/subjects/enroll/route.ts
@@ -8,6 +8,7 @@ import { withAuth, withCsrf, ValidationError, withRateLimitPreset } from '@/lib/
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseEnrollment, courseLesson } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
+import { enrollStudentInCourse } from '@/lib/api/enrollments'
 
 const subjectCourseMap: Record<string, { name: string; description: string }> = {
   english: {
@@ -126,23 +127,14 @@ export const POST = withCsrf(
         await createDefaultLessons(courseId, subjectCode)
       }
 
-      const enrollmentId = crypto.randomUUID()
-      await drizzleDb.insert(courseEnrollment).values({
-        enrollmentId,
-        studentId: session.user.id,
-        courseId,
-        enrollmentSource: 'browse',
-      })
-
-      const [enrollment] = await drizzleDb
-        .select()
-        .from(courseEnrollment)
-        .where(eq(courseEnrollment.enrollmentId, enrollmentId))
-        .limit(1)
+      // Route through the canonical enrollment helper so capacity, progress
+      // seeding, and (future) schedule handling stay consistent across all
+      // enrollment entry points.
+      const result = await enrollStudentInCourse(session.user.id, courseId)
 
       return NextResponse.json({
         success: true,
-        enrollment: enrollment!,
+        enrollment: result.enrollment,
         message: `Enrolled in ${subjectInfo.name}`,
       })
     },

--- a/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
@@ -32,6 +32,7 @@ export const GET = withAuth(
           scheduleId: courseSchedule.scheduleId,
           courseId: courseSchedule.courseId,
           scheduleIndex: courseSchedule.scheduleIndex,
+          name: courseSchedule.name,
           schedule: courseSchedule.schedule,
           weeksToSchedule: courseSchedule.weeksToSchedule,
           maxStudents: courseSchedule.maxStudents,


### PR DESCRIPTION
## **User description**
Backend half of the "students pick a schedule at signup" feature (UI in a follow-up PR).

## Changes
- **New `GET /api/courses/[id]/schedules`** — student-readable list of a course's named schedules (name, weekly slots, `weeksToSchedule`) with computed capacity (`spotsLeft` / `isFull`). Powers the upcoming "view schedule" modal and the signup picker.
- **`name` added to the tutor schedules GET** — the `courseSchedule.name` column existed but was selected by no route.
- **Paid path now persists `scheduleId`** — `payments/create` includes `scheduleId` in the gateway + stored payment metadata; the hitpay/airwallex webhooks already read `meta.scheduleId` to enroll into the chosen schedule. (Previously dropped, so paid enrollments could never attach to a schedule.)
- **Unified enrollment routes** through `enrollStudentInCourse`:
  - `POST /api/student/enrollments` forwards `scheduleId` and now requires CSRF (no POST callers today, so safe).
  - `POST /api/student/subjects/enroll` routes through the canonical helper instead of a direct insert.

The canonical `enrollStudentInCourse` already enforces per-schedule capacity (atomic `enrolledCount`) and writes `courseEnrollment.scheduleId`, so the UI just needs to send a `scheduleId`.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 (new route in manifest) · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let students view named schedules and keep their selected schedule through enrollment**

### What Changed
- Added a student-facing schedule list for each course, including schedule name, weekly time slots, weeks to schedule, and availability status
- Student enrollment now accepts a selected schedule and sends it through the standard enrollment flow, including paid signups
- Subject-based enrollment now uses the same enrollment path as other signups, keeping capacity checks and enrollment records consistent
- Tutor schedule views now show the schedule name as well

### Impact
`✅ Clearer schedule selection at signup`
`✅ Fewer enrollments attached to the wrong schedule`
`✅ Consistent capacity checks across signup paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
