### PR TITLE
feat(enroll): view course schedules + pick one at signup (UI)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
@@ -24,6 +24,14 @@ interface CourseDetail {
   enrolled?: boolean
 }
 
+interface CourseScheduleOption {
+  scheduleId: string
+  name: string
+  slots: Array<{ dayOfWeek: string; startTime: string; durationMinutes: number }>
+  spotsLeft: number | null
+  isFull: boolean
+}
+
 function CourseEnrollPageInner() {
   const params = useParams()
   const router = useRouter()
@@ -38,6 +46,8 @@ function CourseEnrollPageInner() {
   const [paying, setPaying] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [startDate, setStartDate] = useState<string | null>(null)
+  const [schedules, setSchedules] = useState<CourseScheduleOption[]>([])
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
 
   const coursesUrl = `/student/subjects/${encodeURIComponent(subjectCode)}/courses`
   const isFree = course != null && (course.price == null || course.price === 0)
@@ -67,6 +77,27 @@ function CourseEnrollPageInner() {
     }
   }, [courseId])
 
+  useEffect(() => {
+    if (!courseId) return
+    let cancelled = false
+    fetch(`/api/courses/${encodeURIComponent(courseId)}/schedules`, { credentials: 'include' })
+      .then(res => (res.ok ? res.json() : { schedules: [] }))
+      .then(data => {
+        if (cancelled) return
+        const list: CourseScheduleOption[] = Array.isArray(data?.schedules) ? data.schedules : []
+        setSchedules(list)
+        // Preselect the first schedule that still has room.
+        const firstOpen = list.find(s => !s.isFull)
+        if (firstOpen) setSelectedScheduleId(firstOpen.scheduleId)
+      })
+      .catch(() => {
+        if (!cancelled) setSchedules([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [courseId])
+
   const getCsrf = async () => {
     const res = await fetch('/api/csrf', { credentials: 'include' })
     const data = await res.json().catch(() => ({}))
@@ -79,11 +110,16 @@ function CourseEnrollPageInner() {
       toast.error('Please select a start date')
       return
     }
+    if (schedules.length > 0 && !selectedScheduleId) {
+      toast.error('Please choose a schedule')
+      return
+    }
     setEnrolling(true)
     try {
       const csrf = await getCsrf()
       const bodyPayload: any = { startDate }
       if (batchId) bodyPayload.batchId = batchId
+      if (selectedScheduleId) bodyPayload.scheduleId = selectedScheduleId
 
       const res = await fetch(`/api/courses/${encodeURIComponent(courseId)}/enroll`, {
         method: 'POST',
@@ -111,6 +147,10 @@ function CourseEnrollPageInner() {
       toast.error('Please select a start date')
       return
     }
+    if (schedules.length > 0 && !selectedScheduleId) {
+      toast.error('Please choose a schedule')
+      return
+    }
     setPaying(true)
     try {
       const csrf = await getCsrf()
@@ -118,7 +158,10 @@ function CourseEnrollPageInner() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...(csrf && { 'X-CSRF-Token': csrf }) },
         credentials: 'include',
-        body: JSON.stringify({ courseId, metadata: { startDate } }),
+        body: JSON.stringify({
+          courseId,
+          metadata: { startDate, scheduleId: selectedScheduleId ?? undefined },
+        }),
       })
       const json = await res.json().catch(() => ({}))
       if (!res.ok) {
@@ -241,6 +284,60 @@ function CourseEnrollPageInner() {
                     />
                   </div>
                 </div>
+
+                {schedules.length > 0 && (
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Choose a schedule</label>
+                    <div className="space-y-2">
+                      {schedules.map(s => {
+                        const selected = selectedScheduleId === s.scheduleId
+                        return (
+                          <label
+                            key={s.scheduleId}
+                            className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
+                              s.isFull
+                                ? 'cursor-not-allowed opacity-60'
+                                : selected
+                                  ? 'border-indigo-500 bg-indigo-50'
+                                  : 'hover:bg-muted/50'
+                            }`}
+                          >
+                            <input
+                              type="radio"
+                              name="schedule"
+                              className="mt-1"
+                              disabled={s.isFull}
+                              checked={selected}
+                              onChange={() => setSelectedScheduleId(s.scheduleId)}
+                            />
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2 text-sm font-medium">
+                                {s.name}
+                                {s.isFull ? (
+                                  <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">
+                                    Full
+                                  </span>
+                                ) : s.spotsLeft != null ? (
+                                  <span className="text-muted-foreground text-xs">
+                                    {s.spotsLeft} left
+                                  </span>
+                                ) : null}
+                              </div>
+                              <p className="text-muted-foreground mt-0.5 text-xs">
+                                {s.slots.length > 0
+                                  ? s.slots
+                                      .map(slot => `${slot.dayOfWeek} ${slot.startTime}`)
+                                      .join(' · ')
+                                  : 'Times arranged with the tutor'}
+                              </p>
+                            </div>
+                          </label>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
                 {isFree ? (
                   <Button className="w-full sm:w-auto" onClick={handleEnroll} disabled={enrolling}>
                     {enrolling ? (

--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/page.tsx
@@ -13,11 +13,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { BookOpen, Loader2, FileText, GraduationCap, Users, Clock } from 'lucide-react'
+import {
+  BookOpen,
+  Loader2,
+  FileText,
+  GraduationCap,
+  Users,
+  Clock,
+  CalendarClock,
+} from 'lucide-react'
 import { useNavigationOverlay } from '@/components/navigation/NavigationOverlay'
 import { TutorList } from './components/TutorList'
 import { DASHBOARD_THEMES, getThemeStyle } from '@/components/dashboard-theme'
 import { BackButton } from '@/components/navigation'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 import { cn } from '@/lib/utils'
 
 interface CourseListItem {
@@ -42,6 +51,7 @@ export default function SubjectCoursesPage() {
   const [courses, setCourses] = useState<CourseListItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
 
   // Theme state with localStorage persistence
   const [themeId, setThemeId] = useState('current')
@@ -236,12 +246,26 @@ export default function SubjectCoursesPage() {
                           <FileText className="mr-2 h-4 w-4 text-[rgba(255,255,255,0.7)]" />
                           View Details
                         </Link>
+                        <button
+                          type="button"
+                          onClick={() => setScheduleCourse({ id: c.id, name: c.name })}
+                          className="inline-flex items-center justify-center rounded-full border border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-medium text-slate-100 transition-colors hover:bg-[rgba(255,255,255,0.15)]"
+                        >
+                          <CalendarClock className="mr-2 h-4 w-4 text-[rgba(255,255,255,0.7)]" />
+                          View Schedule
+                        </button>
                       </div>
                     </div>
                   </li>
                 ))}
               </ul>
             )}
+
+            <ScheduleViewModal
+              courseId={scheduleCourse?.id ?? null}
+              courseName={scheduleCourse?.name}
+              onClose={() => setScheduleCourse(null)}
+            />
           </TabsContent>
 
           <TabsContent value="tutors">

--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -65,8 +65,10 @@ import {
   Tags,
   ExternalLink,
   Settings,
+  CalendarClock,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 import { DEFAULT_LOCALE } from '@/lib/i18n/config'
 import {
   REGIONS,
@@ -168,6 +170,7 @@ interface Course {
 
 function MyCoursesSection() {
   const [courses, setCourses] = useState<Course[]>([])
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   const [loading, setLoading] = useState(true)
   const [activeTab, setActiveTab] = useState<'active' | 'pending' | 'unpublished' | 'catalogued'>('active')
   const [isExpanded, setIsExpanded] = useState(true)
@@ -428,6 +431,15 @@ function MyCoursesSection() {
                   <Edit3 className="mr-1 h-4 w-4" />
                   Edit
                 </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setScheduleCourse({ id: course.id, name: course.name })}
+                  className="text-slate-200 hover:bg-white/10 hover:text-white"
+                >
+                  <CalendarClock className="mr-1 h-4 w-4" />
+                  Schedule
+                </Button>
                 {tab !== 'catalogued' && (
                   <Button
                     variant="ghost"
@@ -549,6 +561,11 @@ function MyCoursesSection() {
           </div>
         </div>
       </CardContent>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </Card>
   )
 }

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Loader2, CalendarClock } from 'lucide-react'
+
+interface ScheduleSlot {
+  dayOfWeek: string
+  startTime: string
+  durationMinutes: number
+}
+
+interface CourseSchedule {
+  scheduleId: string
+  scheduleIndex: number
+  name: string
+  slots: ScheduleSlot[]
+  weeksToSchedule: number
+  maxStudents: number | null
+  enrolledCount: number
+  spotsLeft: number | null
+  isFull: boolean
+}
+
+interface ScheduleViewModalProps {
+  /** When set, the modal is open and loads schedules for this course. */
+  courseId: string | null
+  courseName?: string
+  onClose: () => void
+}
+
+export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleViewModalProps) {
+  const [schedules, setSchedules] = useState<CourseSchedule[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!courseId) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
+      .then(async res => {
+        if (!res.ok) throw new Error('failed')
+        const data = await res.json()
+        if (!cancelled) setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load schedules')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [courseId])
+
+  return (
+    <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarClock className="h-5 w-5" /> Class Schedules
+          </DialogTitle>
+          <DialogDescription>
+            {courseName ? `${courseName} — available class times` : 'Available class times'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] space-y-4 overflow-y-auto p-1">
+          {loading ? (
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="h-6 w-6 animate-spin text-indigo-500" />
+            </div>
+          ) : error ? (
+            <p className="py-8 text-center text-sm text-red-500">{error}</p>
+          ) : schedules.length === 0 ? (
+            <p className="py-8 text-center text-sm text-gray-500">
+              No fixed schedules yet — class times are arranged with the tutor.
+            </p>
+          ) : (
+            schedules.map(s => (
+              <div key={s.scheduleId} className="rounded-lg border bg-gray-50 p-4">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <h4 className="font-semibold text-gray-900">{s.name}</h4>
+                  {s.maxStudents != null && (
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        s.isFull ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700'
+                      }`}
+                    >
+                      {s.isFull ? 'Full' : `${s.spotsLeft} spot${s.spotsLeft === 1 ? '' : 's'} left`}
+                    </span>
+                  )}
+                </div>
+                {s.slots.length > 0 ? (
+                  <ul className="space-y-1.5">
+                    {s.slots.map((slot, i) => (
+                      <li
+                        key={i}
+                        className="flex items-center justify-between rounded-md bg-white px-3 py-2 text-sm"
+                      >
+                        <span className="font-medium text-gray-800">{slot.dayOfWeek}</span>
+                        <span className="text-gray-600">
+                          {slot.startTime} · {slot.durationMinutes} min
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-gray-500">Times to be arranged with the tutor.</p>
+                )}
+                {s.weeksToSchedule ? (
+                  <p className="mt-2 text-xs text-gray-400">Runs for {s.weeksToSchedule} weeks</p>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+
+        <DialogFooter align="end">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## **User description**
UI half of the schedule-selection feature (backend in #101).

## Changes
- **`ScheduleViewModal`** (new) — fetches `GET /api/courses/[id]/schedules` and lists each named schedule's weekly slots + capacity (`N spots left` / `Full`).
- **Student course cards** (subject → courses list) get a **"View Schedule"** button → opens the modal (inline, no navigation).
- **Tutor course rows** (`my-page`) get a **"Schedule"** action → same modal, so tutors can quickly see a course's class times.
- **Student signup page** now:
  - loads the course's named schedules,
  - shows a **radio picker** (preselects the first schedule with room, disables full ones, shows spots-left),
  - requires a choice when schedules exist,
  - sends `scheduleId` on **both** the free path (`/api/courses/[id]/enroll`) and the paid path (`/api/payments/create` metadata → webhook).

Together with #101 this gives the full flow: tutors create named schedules → tutors/students view them → students pick one at signup → enrollment attaches to that schedule (with capacity enforced).

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show course schedules during browsing and at signup**

### What Changed
- Students and tutors can open a schedule view to see a course’s class times, how long it runs, and whether spots are still available
- Course browsing now includes a “View Schedule” action so students can check times without leaving the page
- Tutor course pages now include a “Schedule” action for the same schedule view
- Signup now shows available schedules, blocks full ones, preselects an open schedule, and requires a choice before enrolling when schedules exist
- The chosen schedule is now included in both free enrollment and paid checkout so the student is attached to the right class

### Impact
`✅ Easier schedule checking before signup`
`✅ Fewer enrollments into full classes`
`✅ Fewer missed schedule selections during checkout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
