### PR TITLE
fix(db): drop legacy lessonsCompleted column blocking enrollment in prod

### DIFF
--- a/tutorme-app/drizzle/0056_drop_courseenrollment_lessonscompleted.sql
+++ b/tutorme-app/drizzle/0056_drop_courseenrollment_lessonscompleted.sql
@@ -1,0 +1,7 @@
+-- Re-apply migration 0047's intent. 0047 (dated 2023) dropped the legacy
+-- "lessonsCompleted" column from CourseEnrollment, but its journal timestamp is
+-- far below the migration watermark, so Drizzle's migrator skipped it in prod.
+-- The column is not in the Drizzle schema and in prod is NOT NULL without a
+-- default, so every enrollment INSERT fails with 23502 (not-null violation),
+-- breaking student signup. Dropping it is idempotent and safe.
+ALTER TABLE "CourseEnrollment" DROP COLUMN IF EXISTS "lessonsCompleted";

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1781000000000,
       "tag": "0055_add_live_session_schedule_id",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1781100000000,
+      "tag": "0056_drop_courseenrollment_lessonscompleted",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Problem
Student enrollment **500s in production**. Surfaced while verifying schedule-aware signup end-to-end:
> `null value in column "lessonsCompleted" of relation "CourseEnrollment" violates not-null constraint` (23502)

Every enrollment through `enrollStudentInCourse` (the signup path, `/api/student/enrollments`, payment webhooks) fails.

## Root cause
Prod's `CourseEnrollment` still has a legacy `lessonsCompleted` column (`NOT NULL`, no default) from migration `0032`. Migration `0047` was supposed to `DROP` it, but `0047`'s journal timestamp (2023) is **below the migration watermark** (migration `0049` is dated 2026), so Drizzle's migrator silently skipped it — the same class of drift behind the earlier `scheduleId` issue. The column isn't in the Drizzle schema, so inserts omit it → NOT NULL violation.

## Fix
Migration `0056` re-applies `0047`'s intent with a timestamp **above** the watermark so it actually runs: `ALTER TABLE "CourseEnrollment" DROP COLUMN IF EXISTS "lessonsCompleted";` (idempotent).

## Verification
After deploy I'll re-run the end-to-end enroll-with-schedule test (enroll → `enrolledCount` increments → `courseEnrollment.scheduleId` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix student enrollment failures caused by a legacy CourseEnrollment field**

### What Changed
- Removed the old `lessonsCompleted` field from `CourseEnrollment` so student enrollment can complete again in production
- Made the database change safe to run even if the field is already gone

### Impact
`✅ Fewer signup enrollment failures`
`✅ Restored course enrollment in production`
`✅ Fewer payment-webhook enrollment errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
