### PR TITLE
feat(schedules): side-by-side schedule view on course cards everywhere

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -17,6 +17,7 @@ import {
   PreferenceEnrollmentDialog,
   type ScheduleItem,
 } from '@/components/course/PreferenceEnrollmentDialog'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 import {
   Clock,
   Calendar,
@@ -524,52 +525,12 @@ function CoursePageInner() {
         </DialogContent>
       </Dialog>
 
-      {/* Schedule Modal */}
-      <Dialog open={!!scheduleCourse} onOpenChange={open => !open && setScheduleCourse(null)}>
-        <DialogContent className="max-w-xl">
-          <DialogHeader>
-            <DialogTitle>Course Schedule</DialogTitle>
-            <DialogDescription>
-              {scheduleCourse?.name}
-              {scheduleCourse?.availability?.summary && ` - ${scheduleCourse.availability.summary}`}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="p-6">
-            <DialogPanel className="space-y-4 p-6">
-              <h4 className="text-sm font-semibold text-gray-900">Weekly Classes</h4>
-              {scheduleCourse?.availability?.slots &&
-              scheduleCourse.availability.slots.length > 0 ? (
-                <div className="space-y-2">
-                  {scheduleCourse.availability.slots.map((slot, idx) => (
-                    <div
-                      key={idx}
-                      className="flex items-center justify-between rounded-lg border bg-gray-50 p-3 text-sm"
-                    >
-                      <span className="font-medium text-gray-900">{slot.dayOfWeek}</span>
-                      <span className="text-gray-600">
-                        {slot.startTime} ({slot.durationMinutes} mins)
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="rounded-lg bg-gray-50 p-4 text-center">
-                  <p className="text-sm text-gray-600">Flexible schedule (TBD with tutor)</p>
-                </div>
-              )}
-            </DialogPanel>
-          </div>
-          <DialogFooter align="end" className="gap-3">
-            <Button
-              variant="modal-secondary-dark"
-              className="h-10"
-              onClick={() => setScheduleCourse(null)}
-            >
-              Close Schedule
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {/* Schedule Modal — shared named-schedule view (side by side) */}
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
 
       {/* Tabs */}
       <SessionCalendarPanel

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/MyCoursesCard.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/MyCoursesCard.tsx
@@ -15,8 +15,10 @@ import {
   FileText,
   School,
   Trophy,
+  CalendarClock,
 } from 'lucide-react'
 import { toast } from 'sonner'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 
 export interface EnrolledCourse {
   id: string
@@ -41,6 +43,7 @@ interface MyCoursesCardProps {
 export function MyCoursesCard({ courses, onCourseRemoved }: MyCoursesCardProps) {
   const [showAll, setShowAll] = useState(false)
   const [removingSubject, setRemovingSubject] = useState<string | null>(null)
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
 
   const visibleCourses =
     showAll || courses.length <= VISIBLE_COURSES ? courses : courses.slice(0, VISIBLE_COURSES)
@@ -173,6 +176,18 @@ export function MyCoursesCard({ courses, onCourseRemoved }: MyCoursesCardProps) 
                       My scores
                     </Link>
                   </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 text-xs"
+                    onClick={e => {
+                      e.stopPropagation()
+                      setScheduleCourse({ id: course.id, name: course.name })
+                    }}
+                  >
+                    <CalendarClock className="mr-1 h-3 w-3" />
+                    Schedule
+                  </Button>
                   <Button variant="outline" size="sm" className="h-8 text-xs" asChild>
                     <Link
                       href={`/student/subjects/${encodeURIComponent(course.subject)}/courses/${encodeURIComponent(course.id)}/details`}
@@ -201,6 +216,11 @@ export function MyCoursesCard({ courses, onCourseRemoved }: MyCoursesCardProps) 
           </div>
         )}
       </CardContent>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </Card>
   )
 }

--- a/tutorme-app/src/app/[locale]/student/favorites/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/favorites/page.tsx
@@ -10,8 +10,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useNavigationOverlay } from '@/components/navigation/NavigationOverlay'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { toast } from 'sonner'
-import { Heart, BookOpen, Users, Star, Trash2, ExternalLink } from 'lucide-react'
+import { Heart, BookOpen, Users, Star, Trash2, ExternalLink, CalendarClock } from 'lucide-react'
 import { resolvePublicUrl } from '@/lib/utils'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 
 interface FavoriteTutor {
   id: string
@@ -51,6 +52,7 @@ export default function StudentFavoritesPage() {
   const [favoriteTutors, setFavoriteTutors] = useState<FavoriteTutor[]>([])
   const [favoriteCourses, setFavoriteCourses] = useState<FavoriteCourse[]>([])
   const [loading, setLoading] = useState(true)
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
 
   useEffect(() => {
     loadFavorites()
@@ -319,12 +321,25 @@ export default function StudentFavoritesPage() {
                           {course.price}
                         </span>
                       )}
-                      <Button asChild size="sm">
-                        <Link href={`/${locale}/course/${course.id}`} onClick={() => showOverlay()}>
-                          View Course
-                          <ExternalLink className="ml-1 h-3 w-3" />
-                        </Link>
-                      </Button>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setScheduleCourse({ id: course.id, name: course.name })}
+                        >
+                          <CalendarClock className="mr-1 h-3 w-3" />
+                          Schedule
+                        </Button>
+                        <Button asChild size="sm">
+                          <Link
+                            href={`/${locale}/course/${course.id}`}
+                            onClick={() => showOverlay()}
+                          >
+                            View Course
+                            <ExternalLink className="ml-1 h-3 w-3" />
+                          </Link>
+                        </Button>
+                      </div>
                     </div>
                   </CardContent>
                 </Card>
@@ -333,6 +348,11 @@ export default function StudentFavoritesPage() {
           )}
         </TabsContent>
       </Tabs>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </div>
   )
 }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -36,9 +36,11 @@ import {
   AlertCircle,
   Ban,
   Eye,
+  CalendarClock,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 
 import {
   CreateClassDialog,
@@ -146,6 +148,7 @@ function TutorDashboardContent() {
   const locale = typeof params?.locale === 'string' ? params.locale : 'en'
   const hasLocalePrefix = pathname.startsWith(`/${locale}/`)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   const [scheduleDate, setScheduleDate] = useState<Date | null>(null)
   const [timezone, setTimezone] = useState(DEFAULT_TIMEZONE)
   const [calendarView, setCalendarView] = useState<CalendarView>('day')
@@ -777,6 +780,17 @@ function TutorDashboardContent() {
                                 Edit
                               </Link>
                             </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="hover:bg-muted/80 transition-all duration-200"
+                              onClick={() =>
+                                setScheduleCourse({ id: course.id, name: course.name })
+                              }
+                            >
+                              <CalendarClock className="mr-1 h-3 w-3" />
+                              Schedule
+                            </Button>
                           </div>
                         </div>
                       )
@@ -1124,6 +1138,11 @@ function TutorDashboardContent() {
           </DialogContent>
         </Dialog>
       </div>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </div>
   )
 }

--- a/tutorme-app/src/app/[locale]/tutor/revenue/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/revenue/page.tsx
@@ -43,7 +43,9 @@ import {
   CheckCircle2,
   XCircle,
   Hourglass,
+  CalendarClock,
 } from 'lucide-react'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 
 interface Transaction {
   id: string
@@ -118,6 +120,7 @@ interface RevenueData {
 export default function RevenuePage() {
   const router = useRouter()
   const [activeTab, setActiveTab] = useState('overview')
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   const [showEmailDialog, setShowEmailDialog] = useState(false)
   const [emailAddress, setEmailAddress] = useState('')
   const [sendingEmail, setSendingEmail] = useState(false)
@@ -669,15 +672,27 @@ export default function RevenuePage() {
                               )}
                             </div>
                           </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() =>
-                              router.push(`/tutor/insights?tab=builder&courseId=${course.id}`)
-                            }
-                          >
-                            <ChevronRight className="h-4 w-4" />
-                          </Button>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                setScheduleCourse({ id: course.id, name: course.name })
+                              }
+                            >
+                              <CalendarClock className="mr-1 h-4 w-4" />
+                              Schedule
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                router.push(`/tutor/insights?tab=builder&courseId=${course.id}`)
+                              }
+                            >
+                              <ChevronRight className="h-4 w-4" />
+                            </Button>
+                          </div>
                         </div>
                         <div className="grid grid-cols-3 gap-4">
                           <div className="rounded-lg bg-blue-50 p-3 text-center">
@@ -1044,6 +1059,11 @@ export default function RevenuePage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </div>
   )
 }

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
   DialogPanel,
 } from '@/components/ui/dialog'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { DEFAULT_LOCALE } from '@/lib/i18n/config'
 import {
@@ -2078,45 +2079,11 @@ export default function PublicTutorPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={!!scheduleCourse} onOpenChange={open => !open && setScheduleCourse(null)}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{scheduleCourse?.name}</DialogTitle>
-            <DialogDescription>{scheduleCourse?.description}</DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4 p-6 pt-0">
-            <DialogPanel>
-              <h4 className="mb-2 text-sm font-semibold text-gray-900">Weekly Schedule</h4>
-              {scheduleCourse?.schedule && scheduleCourse.schedule.length > 0 ? (
-                <div className="space-y-2">
-                  {scheduleCourse.schedule.map((slot: any, idx: number) => (
-                    <div
-                      key={idx}
-                      className="flex items-center justify-between rounded-lg border border-gray-200 p-2 text-sm"
-                    >
-                      <span className="font-medium text-gray-900">{slot.dayOfWeek}</span>
-                      <span className="text-gray-600">
-                        {slot.startTime} ({slot.durationMinutes} mins)
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-gray-500">No fixed schedule for this course.</p>
-              )}
-            </DialogPanel>
-          </div>
-          <DialogFooter className="gap-3">
-            <Button
-              variant="modal-secondary-dark"
-              onClick={() => setScheduleCourse(null)}
-              className="h-10"
-            >
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
 
       <Dialog
         open={!!classroomPickerCourse}

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -66,7 +66,7 @@ export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleVie
 
   return (
     <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <CalendarClock className="h-5 w-5" /> Class Schedules
@@ -76,7 +76,7 @@ export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleVie
           </DialogDescription>
         </DialogHeader>
 
-        <div className="max-h-[60vh] space-y-4 overflow-y-auto p-1">
+        <div className="max-h-[65vh] overflow-y-auto p-1">
           {loading ? (
             <div className="flex items-center justify-center py-10">
               <Loader2 className="h-6 w-6 animate-spin text-indigo-500" />
@@ -88,8 +88,9 @@ export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleVie
               No fixed schedules yet — class times are arranged with the tutor.
             </p>
           ) : (
-            schedules.map(s => (
-              <div key={s.scheduleId} className="rounded-lg border bg-gray-50 p-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {schedules.map(s => (
+                <div key={s.scheduleId} className="flex flex-col rounded-lg border bg-gray-50 p-4">
                 <div className="mb-2 flex items-center justify-between gap-2">
                   <h4 className="font-semibold text-gray-900">{s.name}</h4>
                   {s.maxStudents != null && (
@@ -122,8 +123,9 @@ export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleVie
                 {s.weeksToSchedule ? (
                   <p className="mt-2 text-xs text-gray-400">Runs for {s.weeksToSchedule} weeks</p>
                 ) : null}
-              </div>
-            ))
+                </div>
+              ))}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## **User description**
Follow-up to the schedule-selection feature: make schedules viewable from **every** course card, shown **side by side**.

## Changes
- **`ScheduleViewModal`** now renders the named schedules in a responsive grid (1 / 2 / 3 columns) and is widened to `max-w-4xl`, so multiple schedules sit side by side and are easy to compare (per request).
- **Added a "Schedule" / "View Schedule" action** to course cards on every remaining surface:
  - Student **favorites** page
  - Student **dashboard** "My Courses" card
  - **Tutor dashboard** course cards
  - **Tutor revenue** per-course rows
  - (already added previously: student subject→courses list, tutor My Page rows)
- **Unified the two bespoke schedule dialogs** — the student "My Courses" page and the public tutor profile (`u/[username]`) each had their own one-off schedule modal (flat single schedule); both now use the shared `ScheduleViewModal`, so every entry point shows the same named, capacity-aware, side-by-side view.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show course schedules from more places and compare them side by side**

### What Changed
- Course cards now include a **Schedule** button on student favorites, student dashboard courses, tutor dashboard courses, and tutor revenue rows
- Public tutor profiles and the student courses page now use the same schedule view as the rest of the app
- The schedule popup is wider and shows multiple named schedules in a side-by-side grid, making them easier to compare

### Impact
`✅ Faster schedule checks from course cards`
`✅ Easier comparison of multiple class options`
`✅ Consistent schedule view across student and tutor pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
