### PR TITLE
feat(courses): show course variant name on course cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -18,6 +18,7 @@ import {
   type ScheduleItem,
 } from '@/components/course/PreferenceEnrollmentDialog'
 import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
+import { formatCourseVariantName } from '@/lib/courses/variant-name'
 import {
   Clock,
   Calendar,
@@ -53,6 +54,7 @@ import { toast } from 'sonner'
 interface Course {
   id: string
   name: string
+  variantName?: string
   description: string | null
   subject: string
   difficulty: string
@@ -366,6 +368,10 @@ function CoursePageInner() {
           return {
             id: e.courseId,
             name: e.course?.name || 'Unknown Course',
+            variantName: formatCourseVariantName(
+              e.course?.variantCategory,
+              e.course?.variantNationality
+            ),
             description: e.course?.description || null,
             subject: e.course?.categories?.[0] || 'general',
             tutorHandle: e.course?.tutorHandle || null,
@@ -971,6 +977,9 @@ function CourseCard({
           </div>
         </div>
         <h3 className="mt-4 text-xl font-semibold text-slate-100">{course.name}</h3>
+        {course.variantName && (
+          <p className="mt-0.5 text-sm font-medium text-blue-300">{course.variantName}</p>
+        )}
         {course.tutorHandle && (
           <p className="mt-1 text-sm font-medium text-slate-300">@{course.tutorHandle}</p>
         )}

--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/page.tsx
@@ -32,6 +32,7 @@ import { cn } from '@/lib/utils'
 interface CourseListItem {
   id: string
   name: string
+  variantName?: string
   subject: string
   description: string | null
   difficulty: string
@@ -197,6 +198,11 @@ export default function SubjectCoursesPage() {
                     >
                       <div className="flex flex-col p-5">
                         <h3 className="text-xl font-semibold text-slate-100">{c.name}</h3>
+                        {c.variantName && (
+                          <p className="mt-0.5 text-sm font-medium text-blue-300">
+                            {c.variantName}
+                          </p>
+                        )}
                         {c.difficulty && (
                           <div className="mt-2 flex flex-wrap gap-2">
                             <span className="rounded-full border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.08)] px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wider text-slate-200">

--- a/tutorme-app/src/app/api/courses/list/route.ts
+++ b/tutorme-app/src/app/api/courses/list/route.ts
@@ -6,8 +6,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { course, courseLesson, courseEnrollment } from '@/lib/db/schema'
+import { course, courseLesson, courseEnrollment, courseVariant } from '@/lib/db/schema'
 import { eq, inArray, sql } from 'drizzle-orm'
+import { formatCourseVariantName } from '@/lib/courses/variant-name'
 
 export const GET = withAuth(
   async (req: NextRequest) => {
@@ -31,8 +32,11 @@ export const GET = withAuth(
         currency: course.currency,
         isFree: course.isFree,
         createdAt: course.createdAt,
+        variantCategory: courseVariant.category,
+        variantNationality: courseVariant.nationality,
       })
       .from(course)
+      .leftJoin(courseVariant, eq(courseVariant.publishedCourseId, course.courseId))
       .where(whereClause)
 
     const courseIds = coursesRows.map(c => c.courseId)
@@ -66,6 +70,7 @@ export const GET = withAuth(
     const courses = coursesRows.map(c => ({
       id: c.courseId,
       name: c.name,
+      variantName: formatCourseVariantName(c.variantCategory, c.variantNationality),
       subject: c.categories?.[0] || 'general',
       description: c.description,
       difficulty: 'intermediate',

--- a/tutorme-app/src/app/api/student/enrollments/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/route.ts
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic'
 import { NextResponse } from 'next/server'
 import { withAuth, withCsrf, NotFoundError } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { course, courseLesson, courseEnrollment, user } from '@/lib/db/schema'
+import { course, courseLesson, courseEnrollment, courseVariant, user } from '@/lib/db/schema'
 import { eq, inArray, desc } from 'drizzle-orm'
 import { sql } from 'drizzle-orm'
 import { enrollStudentInCourse, enrollmentPaymentRequiredResponse } from '@/lib/api/enrollments'
@@ -62,10 +62,13 @@ export const GET = withAuth(
         courseIsPublished: course.isPublished,
         courseSchedule: course.schedule,
         tutorHandle: user.handle,
+        variantCategory: courseVariant.category,
+        variantNationality: courseVariant.nationality,
       })
       .from(courseEnrollment)
       .innerJoin(course, eq(courseEnrollment.courseId, course.courseId))
       .leftJoin(user, eq(course.creatorId, user.userId))
+      .leftJoin(courseVariant, eq(courseVariant.publishedCourseId, course.courseId))
       .where(eq(courseEnrollment.studentId, session.user.id))
       .orderBy(desc(courseEnrollment.enrolledAt))
 
@@ -94,6 +97,8 @@ export const GET = withAuth(
         isPublished: row.courseIsPublished,
         schedule: row.courseSchedule,
         tutorHandle: row.tutorHandle,
+        variantCategory: row.variantCategory,
+        variantNationality: row.variantNationality,
         _count: {
           lessons: lessonCountByCourse.get(row.courseId) ?? 0,
         },

--- a/tutorme-app/src/lib/courses/variant-name.ts
+++ b/tutorme-app/src/lib/courses/variant-name.ts
@@ -1,0 +1,21 @@
+/**
+ * Human-readable name for a course variant.
+ *
+ * A published course is a variant of its template, identified by a
+ * (category × nationality) pair. The tutor-typed course name is shared across
+ * variants, so cards should also show the variant so students/tutors can tell
+ * them apart. Returns e.g. "Mathematics — Hong Kong", or just "Mathematics"
+ * when the variant is Global / has no nationality. Returns '' when there is no
+ * variant info to show.
+ */
+export function formatCourseVariantName(
+  category?: string | null,
+  nationality?: string | null
+): string {
+  const cat = (category ?? '').trim()
+  const nat = (nationality ?? '').trim()
+  if (!cat && !nat) return ''
+  if (!nat || nat.toLowerCase() === 'global') return cat
+  if (!cat) return nat
+  return `${cat} — ${nat}`
+}


### PR DESCRIPTION
## **User description**
Course cards showed only the tutor-typed course **name**, which is shared across a course's published variants (each variant = a category × nationality). This adds the **variant name** (e.g. "Mathematics — Hong Kong") next to the course name so students/tutors can tell variants apart — consistently across cards.

## Changes
- New shared `formatCourseVariantName(category, nationality)` helper (`Category — Nationality`, or just the category when Global).
- `/api/student/enrollments` and `/api/courses/list` now `leftJoin` `CourseVariant` on `publishedCourseId` and return the variant `category` + `nationality`.
- **My Courses** page cards and the **subject course-list** (browse/enroll) cards now render the variant name under the course name.

Tutor My Page, tutor dashboard, and the public tutor profile **already** display the variant (`Category — Nationality` / `— country`), so this brings the student-facing cards in line.

## Notes
- `student/favorites` (localStorage source) and the student dashboard "My Courses" summary card (its `/api/student/subjects` GET route doesn't exist, so it renders empty) don't carry variant data; left as-is.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show course variant names on student course cards**

### What Changed
- Student course cards now show the course variant name under the main course title, so courses with the same name can be told apart.
- The variant name is now included in student enrollment data and published course listings, allowing both the “My Courses” page and subject course lists to display it.
- Variant names are shown in a simple format like “Mathematics — Hong Kong,” or just the category when the course is global.

### Impact
`✅ Easier to tell similar courses apart`
`✅ Clearer course cards in My Courses`
`✅ Clearer browsing and enrollment pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
