### PR TITLE
test(courses/list): mock leftJoin after adding CourseVariant join

### DIFF
--- a/tutorme-app/src/app/api/courses/list/route.test.ts
+++ b/tutorme-app/src/app/api/courses/list/route.test.ts
@@ -60,6 +60,7 @@ describe('GET /api/courses/list', () => {
     // Build chainable mock for Drizzle queries
     const chainable = {
       from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       groupBy: vi.fn().mockReturnThis(),
       then: vi.fn((cb: any) => Promise.resolve(cb(mockCourses))),


### PR DESCRIPTION
## **User description**
Fixes the unit test broken by #105: the courses/list route now `leftJoin`s `CourseVariant`, but the test's chainable Drizzle mock didn't expose `.leftJoin()` (→ 500 in the test). Adds `leftJoin` to the mock.

Note: the separate CI **Format** failure is pre-existing repo-wide Prettier debt (~31 files from other work) — none of them are from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep the courses list test aligned with the updated query shape**

### What Changed
- The courses list unit test now supports a query that includes a left join for course variants
- This prevents the test from failing with a server error when the route returns course data with variant names

### Impact
`✅ Stable courses list tests`
`✅ Fewer false test failures`
`✅ Safer coverage for course variant names`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
