### PR TITLE
fix(live): stop auto-sync toast loop, fix video modal close, wire Daily key

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -181,7 +181,7 @@ jobs:
             --min-instances=0
             --max-instances=10
           # Cloud Run env vars (comma-separated to avoid gcloud multiline parsing issues)
-          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},AI_PROVIDER=${{ secrets.AI_PROVIDER }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,ADK_BASE_URL=${{ steps.deploy-adk.outputs.url }},ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }}
+          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},AI_PROVIDER=${{ secrets.AI_PROVIDER }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},DAILY_API_KEY=${{ secrets.DAILY_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,ADK_BASE_URL=${{ steps.deploy-adk.outputs.url }},ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }}
 
       - name: Route 100% traffic to latest
         run: |

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -68,7 +68,7 @@ type Props = UseCourseBuilderContentArgs & {
   sessionCategory?: string | null
   sessionNationality?: string | null
   onSaveCourse?: (lessons: any[], options?: any) => void
-  onSyncToLiveSession?: () => void
+  onSyncToLiveSession?: (silent?: boolean) => void
   onCreateCourse?: () => void
   onDeleteCourse?: () => void
   isCreateDialogOpen?: boolean

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1569,7 +1569,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }))
     }, [courseName, courseDescription])
 
-    const doSave = useCallback(() => {
+    const doSave = useCallback((isAutoSave = false) => {
       // If courseName is missing (e.g. builder-draft), prompt for properties
       if (!courseName?.trim() && !coursePropsModal.name?.trim()) {
         setCoursePropsModal(prev => ({ ...prev, isOpen: true }))
@@ -1585,6 +1585,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             courseName: coursePropsModal.name || courseName,
             courseDescription: coursePropsModal.description,
             isLive: coursePropsModal.isLive,
+            isAutoSave,
           }
         )
       }
@@ -1598,21 +1599,34 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       onSave,
     ])
 
+    // Declared above triggerSync so the sync can record the node ref it produces,
+    // preventing the sync's own liveNodes clone from being re-detected as a fresh
+    // unsynced edit (which previously caused an infinite save/sync toast loop).
+    const prevNodesRef = useRef(nodes)
+
     const handleSyncToLive = useCallback(() => {
-      setLiveNodes(cloneNodes(builderNodes))
+      const cloned = cloneNodes(builderNodes)
+      setLiveNodes(cloned)
+      return cloned
     }, [builderNodes, cloneNodes, setLiveNodes])
 
-    // Trigger full sync: save → sync to live → emit to session
-    const triggerSync = useCallback(() => {
-      doSave()
-      handleSyncToLive()
-      onSyncToLiveSession?.()
-      setHasUnsyncedChanges(false)
-      setAskToastShown(false)
-    }, [doSave, handleSyncToLive, onSyncToLiveSession])
+    // Trigger full sync: save → sync to live → emit to session.
+    // isAuto suppresses the save/sync toasts so background auto-sync is silent.
+    const triggerSync = useCallback(
+      (isAuto = false) => {
+        doSave(isAuto)
+        const cloned = handleSyncToLive()
+        // In live mode `nodes` becomes this clone; record it so the effect below
+        // doesn't treat the sync as a new edit and re-arm another auto-sync.
+        prevNodesRef.current = cloned
+        onSyncToLiveSession?.(isAuto)
+        setHasUnsyncedChanges(false)
+        setAskToastShown(false)
+      },
+      [doSave, handleSyncToLive, onSyncToLiveSession]
+    )
 
     // Track when nodes change during an active session to mark unsynced changes
-    const prevNodesRef = useRef(nodes)
     useEffect(() => {
       if (!isSessionActive) return
       if (!onSyncToLiveSession) return
@@ -1634,9 +1648,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
 
       if (syncMode === 'auto') {
-        // Debounced auto-sync: 3 seconds after last change
+        // Debounced auto-sync: 3 seconds after last change (silent — no toasts)
         syncDebounceRef.current = setTimeout(() => {
-          triggerSync()
+          triggerSync(true)
         }, 3000)
       } else if (syncMode === 'ask' && !askToastShown) {
         // Show confirmation toast once per editing burst

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -349,7 +349,7 @@ export interface CourseBuilderProps {
   saveMode?: 'live' | 'draft'
   onSaveModeChange?: (mode: 'live' | 'draft') => void
   isStudentView?: boolean
-  onSyncToLiveSession?: () => void
+  onSyncToLiveSession?: (silent?: boolean) => void
 }
 
 export interface CourseBuilderRef {

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -784,12 +784,16 @@ function TutorInsightsPageInner() {
 
   const { socket } = useSocket(socketOptions)
 
-  const handleSyncToLiveSession = useCallback(() => {
-    if (sessionId && socket) {
-      socket.emit('course:sync', { roomId: sessionId, courseId })
-    }
-    toast.success('Course synced to live session')
-  }, [sessionId, socket, courseId])
+  const handleSyncToLiveSession = useCallback(
+    (silent = false) => {
+      if (sessionId && socket) {
+        socket.emit('course:sync', { roomId: sessionId, courseId })
+      }
+      // Background auto-sync passes silent=true; only manual syncs toast.
+      if (!silent) toast.success('Course synced to live session')
+    },
+    [sessionId, socket, courseId]
+  )
 
   // Track whether the current session has received the ending-soon alert
   const [endingAlertShown, setEndingAlertShown] = useState(false)

--- a/tutorme-app/src/components/class/floating-video-overlay.tsx
+++ b/tutorme-app/src/components/class/floating-video-overlay.tsx
@@ -119,6 +119,9 @@ export function FloatingVideoOverlay() {
           <div className="truncate pl-2">Video</div>
           <button
             type="button"
+            // Stop the drag handle's pointer capture from stealing the pointerup
+            // (which would suppress this button's click and prevent closing).
+            onPointerDown={e => e.stopPropagation()}
             onClick={() => {
               window.dispatchEvent(new Event('tutorme:daily-video-leave'))
               closeOverlay()

--- a/tutorme-app/src/lib/env.ts
+++ b/tutorme-app/src/lib/env.ts
@@ -9,6 +9,9 @@ const WARN_IF_MISSING_IN_PROD = [
   // AI: either GEMINI_API_KEY or KIMI_API_KEY must be present (see lib/ai/provider.ts)
   'GEMINI_API_KEY',
   'KIMI_API_KEY',
+  // Video: without this, lib/video/daily-provider mints unjoinable mock room URLs
+  // (https://mock.daily.co/...) and every "join video call" fails.
+  'DAILY_API_KEY',
   'SENTRY_DSN',
   'NEXT_PUBLIC_SENTRY_DSN',
 ] as const


### PR DESCRIPTION
## **User description**
Addresses the reported live-session issues.

## 1. Repeated "Course saved successfully" / "Course synced to live session" toasts
The auto-sync cloned `builderNodes` into a **new** `liveNodes` array each cycle; in live mode `nodes === liveNodes`, so the "mark unsynced" effect saw the new reference as a fresh edit → re-armed auto-sync → looped every 3s, firing both toasts forever.
- `triggerSync` now records the node ref it produces (`prevNodesRef.current = cloned`) so the sync isn't re-detected as an edit — **loop broken**.
- Background auto-sync is now **silent** (`isAuto` flag suppresses the save + sync toasts); only **manual** sync toasts.

## 2. Video modal "X" doesn't close (student + tutor)
The close button lived inside the drag-handle div, whose `onPointerDown` calls `setPointerCapture`, which retargets the `pointerup` away from the button so its `click` never fires. Added `onPointerDown={e => e.stopPropagation()}` to the X.

## 3. "Failed to join video call"
Root cause: **`DAILY_API_KEY` is never passed to Cloud Run** (not in the deploy `env_vars`, not a GH secret), so `daily-provider` mints **mock** `https://mock.daily.co/...` room URLs that can't be joined.
- Added `DAILY_API_KEY` to the deploy `env_vars` and to the prod env-validation warn list.
- ⚠️ **Action required (you):** set `DAILY_API_KEY` in GitHub Actions secrets (I can't set secrets). Also, sessions created while the key was missing have mock room URLs baked in and must be recreated.

## 4. Other session wirings (noted, not changed here)
- The join route swallows Daily token-creation failures and returns `token: null` (200), so a private-room join still fails with only a client-side error — worth surfacing.
- Cloud recording only starts after a successful join, so it's dead until #3 is fixed.
- Two "start class" paths (implicit-on-join vs explicit start endpoint) can diverge.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix live session sync noise, video modal closing, and video call setup**

### What Changed
- Background course auto-sync no longer shows repeated save/sync toasts, and manual sync still shows a confirmation message
- Live course syncing now avoids retriggering itself, which stops the repeated sync loop during editing
- The floating video modal close button now closes reliably when tapped or clicked
- Production deploys now include the Daily video key, and production warns when it is missing so video calls can join correctly

### Impact
`✅ Fewer repeated live-session notifications`
`✅ Stable auto-sync during course edits`
`✅ Reliable video modal closing`
`✅ Fewer failed video call joins`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
