### PR TITLE
fix(live): surface video-token errors and unify the start path

### DIFF
--- a/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
+++ b/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
@@ -105,6 +105,9 @@ export const POST = withCsrf(
     })
 
     let token = null
+    // Surfaced to the client so a video-token failure is visible (chat/whiteboard
+    // still work) instead of being silently swallowed into a generic join failure.
+    let videoError: string | null = null
     if (classSessionRow.roomId) {
       const isOwner = userId === classSessionRow.tutorId
       try {
@@ -114,8 +117,10 @@ export const POST = withCsrf(
         })
       } catch (err: any) {
         console.error('[Join] Daily.co token creation failed:', err?.message)
-        // Continue without video token — student can still use directory / chat / whiteboard
+        videoError = 'Video is temporarily unavailable for this session.'
       }
+    } else {
+      videoError = 'No video room is configured for this session.'
     }
 
     const [tutorRow] = await drizzleDb
@@ -159,6 +164,7 @@ export const POST = withCsrf(
       session: classSession,
       token,
       roomUrl: classSessionRow.roomUrl,
+      videoError,
     })
   })
 )

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -70,6 +70,23 @@ export const GET = withAuth(
       )
     }
 
+    // Tutor entering the live classroom starts the session — same guard as the
+    // explicit POST /start (not before scheduledAt, not once ended) — so students
+    // can join regardless of how the tutor opened the room. Unifies the start path
+    // (previously this GET left the session 'scheduled' while POST flipped it).
+    if (
+      liveSessionRow.status === 'scheduled' &&
+      !(liveSessionRow.scheduledAt && new Date(liveSessionRow.scheduledAt).getTime() > Date.now())
+    ) {
+      const startedAt = liveSessionRow.startedAt || new Date()
+      await drizzleDb
+        .update(liveSession)
+        .set({ status: 'active', startedAt })
+        .where(eq(liveSession.sessionId, classId))
+      liveSessionRow.status = 'active'
+      liveSessionRow.startedAt = startedAt
+    }
+
     const participants = await drizzleDb
       .select({
         participant: sessionParticipant,
@@ -175,12 +192,19 @@ export const GET = withAuth(
     const deterministicLinkedCourseId = liveSessionRow.courseId || linkedCourse?.id || null
 
     const sessionDuration = liveSessionRow.durationMinutes ?? 240
-    const token = liveSessionRow.roomId
-      ? await dailyProvider.createMeetingToken(liveSessionRow.roomId, tutorId, {
+    // Resilient: a Daily token hiccup must not 500 the whole classroom (chat /
+    // whiteboard / roster still load; the room is public so video can still join).
+    let token: string | null = null
+    if (liveSessionRow.roomId) {
+      try {
+        token = await dailyProvider.createMeetingToken(liveSessionRow.roomId, tutorId, {
           isOwner: true,
           durationMinutes: sessionDuration,
         })
-      : null
+      } catch (err: any) {
+        console.error('[tutor classes GET] Daily token creation failed:', err?.message)
+      }
+    }
 
     return NextResponse.json({
       session: {


### PR DESCRIPTION
## **User description**
The two remaining session-wiring items from #107.

## Token-swallow
`class/rooms/[id]/join` previously caught a Daily token-creation failure and silently returned `token: null` (200), so the only signal was a generic client-side join error. It now returns a **`videoError`** field (chat/whiteboard still work). The tutor `GET /api/tutor/classes/[id]` that mints the owner token is now wrapped in try/catch too, so a Daily hiccup no longer **500s the entire classroom** (roster/chat/whiteboard load; the room is public so video can still join).

## Start-path divergence
There were two ways a session became `active`: the dashboard's explicit `POST /api/tutor/classes/[id]`, and the join route's tutor-promotion. But entering the classroom via **insights** uses `GET /api/tutor/classes/[id]`, which left the session `scheduled` — so depending on the entry point, students could be blocked from joining.
The GET now promotes `scheduled → active` (+ `startedAt`) when the owning tutor opens the room, using the **same guard** as the POST start (not before `scheduledAt`, not once `ended`). The tutor being in the classroom now reliably means the session is live.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

Paired with the `DAILY_API_KEY` secret now being set, this deploy should make video join real Daily rooms for newly created sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Surface video issues and start sessions when tutors enter the room

### What Changed
- If video token creation fails, the join response now shows a clear video error instead of failing silently; chat and whiteboard still load
- If no video room is set for a session, the join response now tells users video is unavailable
- When a tutor opens a classroom through the tutor view, a scheduled session now starts automatically, so students can join from any entry point
- A video token error in the tutor classroom no longer stops the rest of the classroom from loading

### Impact
`✅ Clearer video join errors`
`✅ Fewer classrooms blocked by video failures`
`✅ Fewer sessions stuck in scheduled state`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
