### PR TITLE
chore(video): script to recreate Daily rooms for mock-URL sessions

### DIFF
--- a/tutorme-app/scripts/recreate-mock-daily-rooms.js
+++ b/tutorme-app/scripts/recreate-mock-daily-rooms.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * One-off: recreate Daily.co rooms for live sessions that were created while
+ * DAILY_API_KEY was missing (their roomUrl is a fake https://mock.daily.co/...
+ * that can't be joined).
+ *
+ * For each non-ended LiveSession with a mock room URL, this creates a real Daily
+ * room (mirroring lib/video/daily-provider.ts createRoom config) and updates the
+ * row's roomId + roomUrl. Idempotent: only touches rows whose roomUrl is a mock.
+ *
+ * Usage (from tutorme-app/):
+ *   DATABASE_URL=...  DAILY_API_KEY=...  node scripts/recreate-mock-daily-rooms.js            # dry run (lists, no changes)
+ *   DATABASE_URL=...  DAILY_API_KEY=...  node scripts/recreate-mock-daily-rooms.js --apply    # recreate + update
+ *
+ * (DIRECT_URL is used if set, falling back to DATABASE_URL.)
+ */
+const { Pool } = require('pg')
+
+const DAILY_API_URL = 'https://api.daily.co/v1'
+
+async function createRealRoom(apiKey, sessionId, durationMinutes, maxStudents) {
+  const roomName = `tutorme-${sessionId}-${Date.now()}`
+  // Match daily-provider.ts: 60-min buffer beyond the session duration.
+  const effectiveDuration = (Number(durationMinutes) || 240) + 60
+  const exp = Math.floor((Date.now() + effectiveDuration * 60 * 1000) / 1000)
+
+  const res = await fetch(`${DAILY_API_URL}/rooms`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: roomName,
+      privacy: 'public',
+      properties: {
+        max_participants: Number(maxStudents) || 10,
+        enable_screenshare: true,
+        enable_chat: false,
+        exp,
+        start_audio_off: true,
+        start_video_off: true,
+        enable_recording: 'cloud',
+      },
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error(`Daily API ${res.status}: ${await res.text()}`)
+  }
+  const room = await res.json()
+  return { id: room.name, url: room.url }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply')
+  const dbUrl = process.env.DIRECT_URL || process.env.DATABASE_URL
+  const apiKey = process.env.DAILY_API_KEY
+
+  if (!dbUrl) throw new Error('DATABASE_URL (or DIRECT_URL) is required')
+  if (!apiKey) throw new Error('DAILY_API_KEY is required')
+
+  const pool = new Pool({ connectionString: dbUrl, max: 1 })
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, title, status, "durationMinutes", "maxStudents", "roomUrl"
+         FROM "LiveSession"
+        WHERE "roomUrl" LIKE 'https://mock.daily.co/%'
+          AND status <> 'ended'
+        ORDER BY "scheduledAt" NULLS LAST`
+    )
+
+    console.log(`Found ${rows.length} non-ended session(s) with mock Daily room URLs.`)
+    rows.forEach(r => console.log(`  - ${r.id}  [${r.status}]  ${r.title || '(untitled)'}`))
+
+    if (!apply) {
+      console.log('\nDry run — re-run with --apply to recreate these rooms.')
+      return
+    }
+
+    let ok = 0
+    let fail = 0
+    for (const r of rows) {
+      try {
+        const room = await createRealRoom(apiKey, r.id, r.durationMinutes, r.maxStudents)
+        await pool.query('UPDATE "LiveSession" SET "roomId" = $1, "roomUrl" = $2 WHERE id = $3', [
+          room.id,
+          room.url,
+          r.id,
+        ])
+        console.log(`  ✓ ${r.id} -> ${room.url}`)
+        ok++
+      } catch (e) {
+        console.error(`  ✗ ${r.id}: ${e.message}`)
+        fail++
+      }
+    }
+    console.log(`\nDone: ${ok} recreated, ${fail} failed.`)
+  } finally {
+    await pool.end()
+  }
+}
+
+main().catch(e => {
+  console.error('recreate-mock-daily-rooms failed:', e.message)
+  process.exit(1)
+})


### PR DESCRIPTION
## **User description**
One-off maintenance script (`tutorme-app/scripts/recreate-mock-daily-rooms.js`).

Sessions created while `DAILY_API_KEY` was missing have unjoinable `https://mock.daily.co/...` room URLs. This finds **non-ended** `LiveSession`s with a mock room URL and recreates a real Daily room for each (same config as `daily-provider.createRoom`), updating `roomId` / `roomUrl`.

- **Dry run by default** (lists affected sessions, no changes).
- `--apply` to recreate + update.
- Idempotent (only touches rows whose `roomUrl` is a mock); skips ended sessions (no room needed).

Run with prod creds:
```
DATABASE_URL=… DAILY_API_KEY=… node scripts/recreate-mock-daily-rooms.js          # preview
DATABASE_URL=… DAILY_API_KEY=… node scripts/recreate-mock-daily-rooms.js --apply  # execute
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Recreate unjoinable Daily rooms for live sessions**

### What Changed
- Adds a script to find live sessions that still point to mock Daily room links and recreate real rooms for them
- Updates each affected session with a usable room ID and room URL so the room can be joined again
- Runs as a dry run by default, with a separate apply mode to make changes
- Skips ended sessions and reports which sessions were found, updated, or failed

### Impact
`✅ Restored access to affected live sessions`
`✅ Fewer unjoinable class links`
`✅ Safer room recovery with dry-run preview`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
