### PR TITLE
feat: schedule-driven sessions + student course-group descriptions

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -424,7 +424,9 @@ function CoursePageInner() {
   )
 
   const upcoming = myCourses.filter(
-    c => !c.enrollment?.startDate || new Date(c.enrollment.startDate) > now
+    c =>
+      !c.progress?.isCompleted &&
+      (!c.enrollment?.startDate || new Date(c.enrollment.startDate) > now)
   )
 
   const completed = myCourses.filter(c => c.progress?.isCompleted)
@@ -568,6 +570,7 @@ function CoursePageInner() {
               {activeTab === 'mine' && (
                 <CourseSection
                   title="Ongoing Courses"
+                  description="Courses you've started — your start date has passed and you haven't finished them yet. Join live sessions and keep learning."
                   courses={ongoing}
                   favoriteIds={favoriteIds}
                   toggleFavorite={toggleFavorite}
@@ -580,6 +583,7 @@ function CoursePageInner() {
               {activeTab === 'pending' && (
                 <CourseSection
                   title="Pending Courses"
+                  description="Courses you're enrolled in that haven't started yet — their start date is still in the future. They'll move to Ongoing once they begin."
                   courses={upcoming}
                   favoriteIds={favoriteIds}
                   toggleFavorite={toggleFavorite}
@@ -592,6 +596,7 @@ function CoursePageInner() {
               {activeTab === 'completed' && (
                 <CourseSection
                   title="Completed Courses"
+                  description="Courses you've finished — you've completed all lessons. Revisit materials and recordings anytime."
                   courses={completed}
                   favoriteIds={favoriteIds}
                   toggleFavorite={toggleFavorite}
@@ -604,6 +609,7 @@ function CoursePageInner() {
               {activeTab === 'favorites' && (
                 <CourseSection
                   title="Favorite Courses"
+                  description="Courses you've saved to revisit later. Favoriting doesn't enrol you — open one to enrol or view details."
                   courses={favorites}
                   favoriteIds={favoriteIds}
                   toggleFavorite={toggleFavorite}
@@ -868,6 +874,7 @@ export default function CoursePage() {
 
 function CourseSection({
   title,
+  description,
   courses,
   favoriteIds,
   toggleFavorite,
@@ -877,6 +884,7 @@ function CourseSection({
   onEnterClass,
 }: {
   title: string
+  description?: string
   courses: Course[]
   favoriteIds: string[]
   toggleFavorite: (id: string) => void
@@ -887,9 +895,14 @@ function CourseSection({
 }) {
   return (
     <section>
-      <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-xl font-bold text-gray-900">{title}</h2>
-        <Badge variant="outline">{courses.length} courses</Badge>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+          {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
+        </div>
+        <Badge variant="outline" className="shrink-0">
+          {courses.length} courses
+        </Badge>
       </div>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {courses.map(course => (

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -448,62 +448,6 @@ function TutorDashboardContent() {
     [launchingCourseId, router]
   )
 
-  const handleEnterCourseClassroom = useCallback(
-    async (course: EnrolledCourse, scheduledAt?: string | null) => {
-      if (launchingCourseId) return
-      setLaunchingCourseId(course.id)
-      try {
-        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
-        const csrfData = await csrfRes.json().catch(() => ({}))
-        const csrfToken = csrfData?.token ?? null
-
-        const res = await fetch('/api/class/rooms', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            courseId: course.id,
-            title: course.name,
-            subject: (course.categories || [])[0] || course.name || 'General',
-            maxStudents: 50,
-            durationMinutes: scheduledAt
-              ? (course.schedule?.find(() => true)?.durationMinutes ?? 60)
-              : 60,
-            scheduledAt,
-          }),
-        })
-
-        const result = await res.json().catch(() => ({}))
-        if (!res.ok) {
-          if (res.status === 409) {
-            toast.info(
-              'You have an active or scheduled session for this slot. Please select it below.'
-            )
-            handleOpenSessionsModal(course)
-            return
-          }
-          toast.error(result?.error || 'Failed to launch classroom')
-          return
-        }
-
-        const sessionId = result?.session?.sessionId
-        if (!sessionId) {
-          toast.error('Classroom created but no session ID returned')
-          return
-        }
-        // Navigate directly to live session page (Live tab)
-        router.push(withLocalePath(`/tutor/classroom?sessionId=${sessionId}`))
-      } catch {
-        toast.error('Failed to launch classroom')
-      } finally {
-        setLaunchingCourseId(null)
-      }
-    },
-    [launchingCourseId, router, handleOpenSessionsModal]
-  )
 
   const handleCancelSession = useCallback(async (sessionId: string, reason?: string) => {
     setCancellingSessionId(sessionId)
@@ -751,19 +695,19 @@ function TutorDashboardContent() {
                                 View Sessions
                               </Button>
                             ) : (
+                              // Sessions come only from the course schedule — send the
+                              // tutor to the scheduler (course details page) to add slots
+                              // and publish, instead of creating an ad-hoc session.
                               <Button
+                                asChild
                                 variant="default"
                                 size="sm"
-                                disabled={launchingCourseId === course.id}
-                                onClick={() => handleEnterCourseClassroom(course)}
                                 className="transition-all duration-200"
                               >
-                                {launchingCourseId === course.id ? (
-                                  <div className="mr-1 h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                                ) : (
-                                  <Video className="mr-1 h-3 w-3" />
-                                )}
-                                Create Session
+                                <Link href={withLocalePath(`/tutor/courses/${course.id}`)}>
+                                  <CalendarClock className="mr-1 h-3 w-3" />
+                                  Schedule sessions
+                                </Link>
                               </Button>
                             )}
                             <Button
@@ -935,19 +879,15 @@ function TutorDashboardContent() {
                 <div className="text-muted-foreground border-border/30 rounded-lg border border-dashed p-6 text-center text-sm">
                   <Calendar className="text-muted-foreground/50 mx-auto mb-2 h-8 w-8" />
                   <p>No sessions found for this course.</p>
+                  <p className="mt-1 text-xs">
+                    Sessions are created from the time slots in the course schedule.
+                  </p>
                   {selectedCourseForCancel && (
-                    <Button
-                      size="sm"
-                      className="mt-3 transition-all duration-200"
-                      disabled={launchingCourseId === selectedCourseForCancel.id}
-                      onClick={() => handleEnterCourseClassroom(selectedCourseForCancel)}
-                    >
-                      {launchingCourseId === selectedCourseForCancel.id ? (
-                        <div className="mr-1 h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                      ) : (
-                        <Video className="mr-1 h-3 w-3" />
-                      )}
-                      Create session
+                    <Button asChild size="sm" className="mt-3 transition-all duration-200">
+                      <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
+                        <CalendarClock className="mr-1 h-3 w-3" />
+                        Set up the schedule
+                      </Link>
                     </Button>
                   )}
                 </div>
@@ -1063,24 +1003,17 @@ function TutorDashboardContent() {
                               </Button>
                             )}
                             {isVirtual ? (
+                              // Upcoming slot from the schedule that isn't materialized yet.
+                              // It becomes startable automatically once published into range;
+                              // tutors add/extend slots via the scheduler (footer button), not
+                              // by creating an ad-hoc session here.
                               <Button
-                                variant="default"
+                                variant="ghost"
                                 size="sm"
-                                disabled={launchingCourseId === selectedCourseForCancel?.id}
-                                onClick={() =>
-                                  handleEnterCourseClassroom(
-                                    selectedCourseForCancel!,
-                                    session.scheduledAt
-                                  )
-                                }
-                                className="transition-all duration-200"
+                                disabled
+                                title="This scheduled slot opens automatically — manage it from the course scheduler."
                               >
-                                {launchingCourseId === selectedCourseForCancel?.id ? (
-                                  <div className="mr-1 h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                                ) : (
-                                  <Video className="mr-1 h-3 w-3" />
-                                )}
-                                Create Session
+                                Upcoming
                               </Button>
                             ) : isScheduled ? (
                               <Button
@@ -1129,11 +1062,21 @@ function TutorDashboardContent() {
             <DialogFooter className="flex items-center justify-between sm:justify-between">
               <div className="text-muted-foreground flex items-center gap-2 text-xs">
                 <AlertCircle className="h-4 w-4" />
-                <span>Cancelling a session will notify enrolled students</span>
+                <span>Sessions come from the course schedule — add one in the scheduler</span>
               </div>
-              <Button variant="modal-secondary-dark" onClick={() => setCancelModalOpen(false)}>
-                Close
-              </Button>
+              <div className="flex items-center gap-2">
+                {selectedCourseForCancel && (
+                  <Button asChild variant="outline">
+                    <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
+                      <CalendarClock className="mr-1 h-4 w-4" />
+                      Add a session
+                    </Link>
+                  </Button>
+                )}
+                <Button variant="modal-secondary-dark" onClick={() => setCancelModalOpen(false)}>
+                  Close
+                </Button>
+              </div>
             </DialogFooter>
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
## **User description**
## 1. Unify tutor session actions — sessions come only from the schedule
**The confusion:** "Create Session" created a brand-new **ad-hoc** session (`POST /api/class/rooms`, *not linked to any schedule*), while "Start Session" started an existing **scheduled** session (`POST /api/tutor/classes/[id]`). Same-looking buttons, different meaning — and the ad-hoc ones produced sessions detached from the course schedule.

**Now:** sessions are strictly schedule-driven (materialized by publish, linked via `scheduleId`). All ad-hoc "Create Session" entry points are replaced with links to the **course scheduler** (the course details page):
- Course row with no sessions → **"Schedule sessions"**
- Sessions-modal empty state → **"Set up the schedule"** (+ "Sessions are created from the time slots in the course schedule.")
- Sessions-modal virtual/unmaterialized rows → a non-creating **"Upcoming"** indicator (no more ad-hoc create on schedule-derived rows)
- Sessions-modal footer → **"Add a session"** → course scheduler

Kept: **"Start Session"** (start a scheduled session) and **"Join Session"** (enter an active one). Removed the now-dead `handleEnterCourseClassroom` ad-hoc creator.

> Per your suggestion — adding a session now routes through the scheduler on the course details page.

## 2. Student "My Courses" group descriptions + wiring fix
Added a one-line description under each group explaining what it contains:
- **Ongoing** — started (start date passed) and not finished.
- **Pending** — enrolled but not started yet (future start date).
- **Completed** — all lessons finished.
- **Favorites** — saved, not enrolled.

Also fixed a categorization overlap: a completed course with no start date previously showed in **both** Pending and Completed — Pending now excludes completed courses.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Sessions now come from the course schedule, and student course groups have clearer labels**

### What Changed
- Tutor pages no longer offer ad-hoc session creation; empty courses and empty session lists now point tutors to the course scheduler instead.
- Scheduled-but-not-yet-started slots are shown as an automatic "Upcoming" item instead of a create-session action.
- Student course groups now show short explanations for Ongoing, Pending, Completed, and Favorites.
- Completed courses no longer appear in Pending when they have no start date.

### Impact
`✅ Fewer accidental unscheduled sessions`
`✅ Clearer path to add class times`
`✅ Easier-to-understand course lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
