### PR TITLE
feat(sessions): tutor one-time sessions, distinguished from schedule

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateClassDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateClassDialog.tsx
@@ -45,6 +45,9 @@ interface CreateClassDialogProps {
   onClassCreated?: (classData?: { id: string; [key: string]: unknown }) => void
   redirectToClass?: boolean
   initialDate?: Date | null
+  /** When set, the one-time session is linked to this course (still scheduleId-null). */
+  courseId?: string
+  courseName?: string
 }
 
 export function CreateClassDialog({
@@ -53,6 +56,8 @@ export function CreateClassDialog({
   onClassCreated,
   redirectToClass = true,
   initialDate,
+  courseId,
+  courseName,
 }: CreateClassDialogProps) {
   const router = useRouter()
   const [creating, setCreating] = useState(false)
@@ -65,6 +70,17 @@ export function CreateClassDialog({
     durationMinutes: 60,
     scheduledAt: '',
   })
+
+  // When launched from a course's sessions modal, prefill subject/title from the
+  // course so the form is valid and the one-time session is clearly associated.
+  useEffect(() => {
+    if (!open || !courseName) return
+    setForm(prev => ({
+      ...prev,
+      subject: prev.subject || courseName,
+      title: prev.title || `${courseName} — one-time session`,
+    }))
+  }, [open, courseName])
 
   useEffect(() => {
     if (!open || !initialDate) return
@@ -116,6 +132,7 @@ export function CreateClassDialog({
           maxStudents: form.maxStudents,
           durationMinutes: form.durationMinutes,
           scheduledAt: scheduledDate.toISOString(),
+          ...(courseId ? { courseId } : {}),
         }),
       })
 

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -118,6 +118,8 @@ type CourseSession = {
   status: string
   roomUrl?: string | null
   isVirtual?: boolean
+  /** null/absent = a one-time session; set = materialized from the course schedule */
+  scheduleId?: string | null
   durationMinutes?: number
 }
 
@@ -149,6 +151,8 @@ function TutorDashboardContent() {
   const hasLocalePrefix = pathname.startsWith(`/${locale}/`)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
+  // Course context for creating a one-time (non-schedule) session from the sessions modal.
+  const [oneTimeCourse, setOneTimeCourse] = useState<{ id: string; name: string } | null>(null)
   const [scheduleDate, setScheduleDate] = useState<Date | null>(null)
   const [timezone, setTimezone] = useState(DEFAULT_TIMEZONE)
   const [calendarView, setCalendarView] = useState<CalendarView>('day')
@@ -831,6 +835,25 @@ function TutorDashboardContent() {
           initialDate={scheduleDate}
         />
 
+        {/* One-time (non-schedule) session for a specific course */}
+        <CreateClassDialog
+          open={!!oneTimeCourse}
+          onOpenChange={open => {
+            if (!open) setOneTimeCourse(null)
+          }}
+          courseId={oneTimeCourse?.id}
+          courseName={oneTimeCourse?.name}
+          redirectToClass={false}
+          onClassCreated={() => {
+            const course = oneTimeCourse
+            setOneTimeCourse(null)
+            if (course) {
+              toast.success('One-time session created')
+              handleOpenSessionsModal({ id: course.id, name: course.name } as EnrolledCourse)
+            }
+          }}
+        />
+
         {/* Course Sessions Modal */}
         <Dialog open={cancelModalOpen} onOpenChange={setCancelModalOpen}>
           <DialogContent className="max-w-2xl">
@@ -932,13 +955,24 @@ function TutorDashboardContent() {
                           className="border-border/30 bg-card/50 hover:border-border/50 hover:bg-card flex items-center justify-between rounded-lg border p-3 transition-all duration-200"
                         >
                           <div className="min-w-0 flex-1 space-y-1">
-                            <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
                               <p className="truncate font-medium">{session.title}</p>
                               <Badge
                                 variant="outline"
                                 className={cn('text-[10px] uppercase tracking-wide', badgeClass)}
                               >
                                 {displayStatus}
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  'text-[10px] uppercase tracking-wide',
+                                  isVirtual || session.scheduleId
+                                    ? 'bg-info/10 text-info border-info/25'
+                                    : 'bg-warning/10 text-warning border-warning/25'
+                                )}
+                              >
+                                {isVirtual || session.scheduleId ? 'From schedule' : 'One-time'}
                               </Badge>
                             </div>
                             <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
@@ -1062,16 +1096,30 @@ function TutorDashboardContent() {
             <DialogFooter className="flex items-center justify-between sm:justify-between">
               <div className="text-muted-foreground flex items-center gap-2 text-xs">
                 <AlertCircle className="h-4 w-4" />
-                <span>Sessions come from the course schedule — add one in the scheduler</span>
+                <span>Add recurring sessions in the scheduler, or create a one-off session</span>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 {selectedCourseForCancel && (
-                  <Button asChild variant="outline">
-                    <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
-                      <CalendarClock className="mr-1 h-4 w-4" />
-                      Add a session
-                    </Link>
-                  </Button>
+                  <>
+                    <Button asChild variant="outline">
+                      <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
+                        <CalendarClock className="mr-1 h-4 w-4" />
+                        Add to schedule
+                      </Link>
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() =>
+                        setOneTimeCourse({
+                          id: selectedCourseForCancel.id,
+                          name: selectedCourseForCancel.name,
+                        })
+                      }
+                    >
+                      <Video className="mr-1 h-4 w-4" />
+                      Create one-time session
+                    </Button>
+                  </>
                 )}
                 <Button variant="modal-secondary-dark" onClick={() => setCancelModalOpen(false)}>
                   Close

--- a/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
@@ -75,6 +75,8 @@ export const GET = withAuth(
         status: s.status,
         roomUrl: s.roomUrl,
         isVirtual: false,
+        // null scheduleId = a one-time/ad-hoc session (not tied to the recurring schedule)
+        scheduleId: s.scheduleId ?? null,
         durationMinutes: s.durationMinutes ?? 120,
       }))
 


### PR DESCRIPTION
## **User description**
Tutors can deliberately create **one-time** (ad-hoc) sessions again — but as a clear, labeled action that's never conflated with schedule-linked sessions.

## Changes
- **Course sessions modal footer** now has two explicit actions:
  - **"Add to schedule"** → the course scheduler (recurring/scheduled sessions)
  - **"Create one-time session"** → a dialog
- **Wired the previously-unused `CreateClassDialog`** as the one-time creator. It now accepts `courseId` / `courseName`, so the one-off session is linked to the course (still `scheduleId`-null) and prefills the title/subject from the course. Creating one refreshes the list.
- **Sessions are tagged** in the modal: **"From schedule"** (has `scheduleId`, or a virtual schedule slot) vs **"One-time"** (`scheduleId` null) — so the two are visually distinct.
- **`/api/tutor/courses/[id]/sessions`** now returns `scheduleId` to drive that distinction.

The generic ad-hoc "Create Session" buttons stay retired (they route to the scheduler); one-time creation is now an intentional, labeled path.

## Notes / remaining (optional)
- `liveSession.scheduleId === null` is the saved indicator for "one-time" (no schema change needed — one-time sessions are `ADHOC`, course-linked, schedule-less).
- Still ad-hoc elsewhere (not touched): the course-builder "Open in Live Class" and the dead "Go Live"/"Create Class" stubs — can retire/relabel if you want full consistency.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Create and clearly label one-time sessions for a course**

### What Changed
- Course sessions now show whether each item comes from the recurring schedule or is a one-time session.
- The course sessions dialog now offers two separate actions: add a session to the schedule or create a one-time session.
- Creating a one-time session now opens a prefilled form tied to the selected course, then returns to the course sessions list after saving.
- The sessions view now includes a clearer note that recurring sessions and one-off sessions are created through different paths.

### Impact
`✅ Easier one-off session creation`
`✅ Clearer session labels in course views`
`✅ Fewer mix-ups between scheduled and ad-hoc sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
