### PR TITLE
chore(tutor): retire "Open in Live Class" + dead Go Live/Create Class stubs

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -178,7 +178,6 @@ export default function TutorCoursePage() {
   const [isFree, setIsFree] = useState(false)
   const [currency, setCurrency] = useState<string>('SGD')
   const [schedule, setSchedule] = useState<ScheduleItem[]>([])
-  const [launchingLiveClass, setLaunchingLiveClass] = useState(false)
   const [tutorProfile, setTutorProfile] = useState<{
     userId?: string
     id?: string
@@ -441,49 +440,8 @@ export default function TutorCoursePage() {
   }, [schedule, scheduleRepeatWeekly, numberOfWeeks, totalSessionsDesired])
 
   // Materials upload removed - using simplified course model
-
-  const handleOpenInLiveClass = async () => {
-    if (!course) return
-    setLaunchingLiveClass(true)
-    try {
-      const durationFromSchedule =
-        Array.isArray(schedule) && schedule.length > 0
-          ? Number(schedule[0]?.durationMinutes) || 60
-          : 60
-
-      const normalizedDescription = (description?.trim() || course.description || '').trim()
-      const payload: Record<string, unknown> = {
-        title: (courseName || course.name || '').trim(),
-        category: (course.categories || [])[0] || 'general',
-        courseId: course.id,
-        maxStudents: 50,
-        durationMinutes: Math.max(15, Math.min(480, durationFromSchedule)),
-      }
-      if (normalizedDescription) payload.description = normalizedDescription
-
-      const res = await fetchWithCsrf('/api/class/rooms', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}))
-        throw new Error(errorData?.error || 'Failed to create live session')
-      }
-
-      const data = await res.json()
-      const sessionId = data?.session?.sessionId
-      if (!sessionId) throw new Error('Live session created but session ID is missing')
-
-      toast.success('Live session created. Redirecting…')
-      router.push(`/tutor/classroom?sessionId=${sessionId}`)
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to open live session')
-    } finally {
-      setLaunchingLiveClass(false)
-    }
-  }
+  // (Ad-hoc "Open in Live Class" retired — sessions come from the schedule, and
+  // one-off sessions are created via the sessions modal's "Create one-time session".)
 
   const handleSaveAll = async (): Promise<boolean> => {
     if (!id) {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -821,7 +821,6 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     )
 
     const [testPciSource, setTestPciSource] = useState<'task' | 'assessment'>('task')
-    const [comingSoonDialog, setComingSoonDialog] = useState(false)
     const [alertDialog, setAlertDialog] = useState<{
       open: boolean
       title: string
@@ -10478,23 +10477,6 @@ FEEDBACK: [your explanation]`
             </DialogFooter>
           </DialogContent>
         </Dialog>
-        {/* Coming Soon Dialog */}
-        <Dialog open={comingSoonDialog} onOpenChange={setComingSoonDialog}>
-          <DialogContent className="rounded-2xl sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Coming Soon!</DialogTitle>
-              <DialogDescription>
-                The Go Live feature is currently under development. Stay tuned!
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button variant="modal-secondary-dark" onClick={() => setComingSoonDialog(false)}>
-                Close
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
         {/* Global Info/Alert Dialog */}
         <Dialog
           open={alertDialog.open}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/ModernHeroSection.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/ModernHeroSection.tsx
@@ -16,7 +16,6 @@ async function fetchTutorUsername(): Promise<string | null> {
     return null
   }
 }
-import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import {
@@ -29,12 +28,9 @@ import {
   ArrowRight,
   BookOpen,
   Award,
-  Video,
-  Plus,
   MessageSquare,
   User,
 } from 'lucide-react'
-import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -323,24 +319,7 @@ export function ModernHeroSection({
 
         {/* Action Bar */}
         <div className="flex flex-wrap items-center gap-2">
-          <div className="flex flex-1 items-center justify-start gap-2">
-            <Button
-              size="sm"
-              className="h-[34px] border border-white bg-[#2563EB] px-3 text-[13px] text-white shadow-none hover:translate-y-0 hover:border-white hover:bg-white hover:text-[#2563EB] hover:shadow-none"
-              onClick={() => toast.info('Coming soon...')}
-            >
-              <Plus className="mr-1 h-4 w-4" />
-              Create Class
-            </Button>
-            <Button
-              size="sm"
-              className="h-[34px] border border-white bg-[#65A30D] px-3 text-[13px] text-white shadow-none hover:translate-y-0 hover:bg-white hover:text-[#65A30D] hover:shadow-none"
-              onClick={() => toast.info('Coming soon...')}
-            >
-              <Video className="mr-1.5 h-4 w-4" />
-              Go Live
-            </Button>
-          </div>
+          <div className="flex flex-1 items-center justify-start gap-2" />
           <div className="flex-none text-center">
             <span className="text-base text-white">
               {formatDate(currentTime)} • {formatTime(currentTime)} {timeZoneAbbr}


### PR DESCRIPTION
## **User description**
Retires the leftover ad-hoc session creators and dead stubs, so the only ways to make a session are: the **course scheduler** (recurring) or the sessions modal's **"Create one-time session"**.

- **`courses/[id]`** — removed the unused `handleOpenInLiveClass` ad-hoc creator (defined but no longer wired to any button) and its `launchingLiveClass` state.
- **`ModernHeroSection`** — removed the **"Create Class"** and **"Go Live"** action-bar buttons (both were `toast.info('Coming soon...')` no-ops) and the now-unused imports.
- **`CourseBuilder`** — removed the dead **"Coming Soon — Go Live under development"** dialog (`comingSoonDialog` was never opened anywhere).

No functional path was removed — the hidden `value="live"` tab (the real live classroom) and the functional GoLive flow are untouched.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove dead “Go Live” and “Create Class” placeholders**

### What Changed
- Removed the “Create Class” and “Go Live” buttons from the tutor dashboard header, so users no longer see actions that only showed a coming-soon message
- Removed the unused “Open in Live Class” path from the course page; live sessions now rely on the scheduled session flow and the one-time session modal
- Removed the unused “Coming Soon” dialog from the course builder

### Impact
`✅ Fewer dead-end buttons`
`✅ Clearer tutor dashboard actions`
`✅ Less confusion about how to start sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
