### PR TITLE
feat(sessions): schedule name + course/variant on sessions modal & details

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -120,6 +120,8 @@ type CourseSession = {
   isVirtual?: boolean
   /** null/absent = a one-time session; set = materialized from the course schedule */
   scheduleId?: string | null
+  /** Display name of the linked schedule, e.g. "Schedule 1" (null for one-time). */
+  scheduleName?: string | null
   durationMinutes?: number
 }
 
@@ -153,6 +155,11 @@ function TutorDashboardContent() {
   const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   // Course context for creating a one-time (non-schedule) session from the sessions modal.
   const [oneTimeCourse, setOneTimeCourse] = useState<{ id: string; name: string } | null>(null)
+  // Course name + variant for the sessions modal (from the sessions API).
+  const [sessionsCourseMeta, setSessionsCourseMeta] = useState<{
+    name: string | null
+    variantName: string
+  } | null>(null)
   const [scheduleDate, setScheduleDate] = useState<Date | null>(null)
   const [timezone, setTimezone] = useState(DEFAULT_TIMEZONE)
   const [calendarView, setCalendarView] = useState<CalendarView>('day')
@@ -399,6 +406,7 @@ function TutorDashboardContent() {
       if (res.ok) {
         const data = await res.json()
         setCourseSessions(data.sessions || [])
+        setSessionsCourseMeta(data.course || { name: course.name, variantName: '' })
       } else {
         const errData = await res.json().catch(() => ({}))
         console.error('Tutor session load failed:', errData, res.status)
@@ -451,7 +459,6 @@ function TutorDashboardContent() {
     },
     [launchingCourseId, router]
   )
-
 
   const handleCancelSession = useCallback(async (sessionId: string, reason?: string) => {
     setCancellingSessionId(sessionId)
@@ -956,7 +963,11 @@ function TutorDashboardContent() {
                         >
                           <div className="min-w-0 flex-1 space-y-1">
                             <div className="flex flex-wrap items-center gap-2">
-                              <p className="truncate font-medium">{session.title}</p>
+                              <p className="truncate font-medium">
+                                {sessionsCourseMeta?.name
+                                  ? `${sessionsCourseMeta.name}${sessionsCourseMeta.variantName ? ` — ${sessionsCourseMeta.variantName}` : ''}`
+                                  : session.title}
+                              </p>
                               <Badge
                                 variant="outline"
                                 className={cn('text-[10px] uppercase tracking-wide', badgeClass)}
@@ -974,6 +985,14 @@ function TutorDashboardContent() {
                               >
                                 {isVirtual || session.scheduleId ? 'From schedule' : 'One-time'}
                               </Badge>
+                              {session.scheduleName && (
+                                <Badge
+                                  variant="outline"
+                                  className="border-primary/25 bg-primary/10 text-primary text-[10px] uppercase tracking-wide"
+                                >
+                                  {session.scheduleName}
+                                </Badge>
+                              )}
                             </div>
                             <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
                               {session.scheduledAt && (

--- a/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
@@ -17,6 +17,9 @@ interface SessionData {
     status: string
     scheduledAt: string | null
     startedAt: string | null
+    scheduleName?: string | null
+    courseName?: string | null
+    variantName?: string | null
     summary?: string
     summaryJson?: {
       sessionMeta?: {
@@ -137,14 +140,18 @@ export default function TutorSessionInsightsPage() {
               </button>
               <div>
                 <h1 className="text-2xl font-bold tracking-tight text-[#344054]">
-                  {session.title || 'Untitled Session'}
+                  {session.courseName
+                    ? `${session.courseName}${session.variantName ? ` — ${session.variantName}` : ''}`
+                    : session.title || 'Untitled Session'}
                 </h1>
-                {session.subject && (
-                  <p className="mt-1 text-sm text-[#7F7C77]">
-                    {session.subject} • {scheduledDate}
-                  </p>
-                )}
-                {!session.subject && <p className="mt-1 text-sm text-[#7F7C77]">{scheduledDate}</p>}
+                <p className="mt-1 text-sm text-[#7F7C77]">
+                  {[
+                    session.scheduleName || (session.courseName ? 'One-time session' : null),
+                    scheduledDate,
+                  ]
+                    .filter(Boolean)
+                    .join(' • ')}
+                </p>
               </div>
             </div>
             <Badge

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -15,12 +15,16 @@ import {
   user,
   profile,
   course,
+  courseSchedule,
+  courseVariant,
   sessionReplayArtifact,
   calendarEvent,
 } from '@/lib/db/schema'
 import { eq, and, asc, desc, sql } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { generateSessionSummary } from '@/lib/chat/summary'
+import { formatScheduleName } from '@/lib/sessions/schedule-name'
+import { formatCourseVariantName } from '@/lib/courses/variant-name'
 import { dailyProvider } from '@/lib/video/daily-provider'
 import { getIO } from '@/lib/socket-server-enhanced'
 
@@ -206,6 +210,35 @@ export const GET = withAuth(
       }
     }
 
+    // Schedule name (if this session came from a schedule) + course name/variant,
+    // so the details page can show "Schedule 1" and the course instead of a
+    // generic "Live Session" title.
+    let scheduleName: string | null = null
+    if (liveSessionRow.scheduleId) {
+      const [sch] = await drizzleDb
+        .select({ name: courseSchedule.name, scheduleIndex: courseSchedule.scheduleIndex })
+        .from(courseSchedule)
+        .where(eq(courseSchedule.scheduleId, liveSessionRow.scheduleId))
+        .limit(1)
+      if (sch) scheduleName = formatScheduleName(sch.name, sch.scheduleIndex)
+    }
+    let courseName: string | null = null
+    let variantName = ''
+    if (liveSessionRow.courseId) {
+      const [courseRow2] = await drizzleDb
+        .select({ name: course.name })
+        .from(course)
+        .where(eq(course.courseId, liveSessionRow.courseId))
+        .limit(1)
+      courseName = courseRow2?.name ?? null
+      const [variantRow] = await drizzleDb
+        .select({ category: courseVariant.category, nationality: courseVariant.nationality })
+        .from(courseVariant)
+        .where(eq(courseVariant.publishedCourseId, liveSessionRow.courseId))
+        .limit(1)
+      variantName = formatCourseVariantName(variantRow?.category, variantRow?.nationality)
+    }
+
     return NextResponse.json({
       session: {
         id: liveSessionRow.sessionId,
@@ -220,6 +253,10 @@ export const GET = withAuth(
         maxStudents: liveSessionRow.maxStudents,
         linkedCourseId: deterministicLinkedCourseId,
         category: liveSessionRow.category,
+        scheduleId: liveSessionRow.scheduleId ?? null,
+        scheduleName,
+        courseName,
+        variantName,
       },
       students,
       messages: messages.map(m => ({

--- a/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
@@ -9,9 +9,16 @@ import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { eq, and, asc, inArray } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession as liveSessionTable, course } from '@/lib/db/schema'
+import {
+  liveSession as liveSessionTable,
+  course,
+  courseSchedule,
+  courseVariant,
+} from '@/lib/db/schema'
 import { generateUpcomingSessions, mergeSessions } from '@/lib/schedule-sessions'
 import { resolveCourseScheduleSlots } from '@/lib/sessions/course-schedule-slots'
+import { formatScheduleName } from '@/lib/sessions/schedule-name'
+import { formatCourseVariantName } from '@/lib/courses/variant-name'
 
 export const GET = withAuth(
   async (req, session, context) => {
@@ -40,6 +47,28 @@ export const GET = withAuth(
         .from(course)
         .where(eq(course.courseId, courseId))
         .limit(1)
+
+      // Map each schedule id -> its display name ("Schedule 1" or the tutor's name),
+      // and resolve this course's variant (category × nationality) for labelling.
+      const [scheduleRows, [variantRow]] = await Promise.all([
+        drizzleDb
+          .select({
+            scheduleId: courseSchedule.scheduleId,
+            name: courseSchedule.name,
+            scheduleIndex: courseSchedule.scheduleIndex,
+          })
+          .from(courseSchedule)
+          .where(eq(courseSchedule.courseId, courseId)),
+        drizzleDb
+          .select({ category: courseVariant.category, nationality: courseVariant.nationality })
+          .from(courseVariant)
+          .where(eq(courseVariant.publishedCourseId, courseId))
+          .limit(1),
+      ])
+      const scheduleNameById = new Map(
+        scheduleRows.map(r => [r.scheduleId, formatScheduleName(r.name, r.scheduleIndex)])
+      )
+      const variantName = formatCourseVariantName(variantRow?.category, variantRow?.nationality)
 
       const conditions = [
         eq(liveSessionTable.tutorId, tutorId),
@@ -77,6 +106,7 @@ export const GET = withAuth(
         isVirtual: false,
         // null scheduleId = a one-time/ad-hoc session (not tied to the recurring schedule)
         scheduleId: s.scheduleId ?? null,
+        scheduleName: s.scheduleId ? (scheduleNameById.get(s.scheduleId) ?? null) : null,
         durationMinutes: s.durationMinutes ?? 120,
       }))
 
@@ -94,7 +124,10 @@ export const GET = withAuth(
 
       const merged = mergeSessions(formattedReal, virtualSessions)
 
-      return NextResponse.json({ sessions: merged })
+      return NextResponse.json({
+        sessions: merged,
+        course: { name: courseRow?.name ?? null, variantName },
+      })
     } catch (err) {
       // Log full error details for debugging
       const errObj = err as any

--- a/tutorme-app/src/lib/sessions/schedule-name.ts
+++ b/tutorme-app/src/lib/sessions/schedule-name.ts
@@ -1,0 +1,10 @@
+/**
+ * Display name for a course schedule. Uses the tutor-given name when set,
+ * otherwise falls back to "Schedule {index}" (e.g. "Schedule 1"). Matches the
+ * label shown in the schedule view modal.
+ */
+export function formatScheduleName(name?: string | null, scheduleIndex?: number | null): string {
+  if (name && name.trim()) return name.trim()
+  if (typeof scheduleIndex === 'number') return `Schedule ${scheduleIndex}`
+  return 'Schedule'
+}


### PR DESCRIPTION
## **User description**
## What
- **Schedule name** is now shown for sessions linked to a schedule — "Schedule 1" (or the tutor's custom name), via a shared `formatScheduleName` helper.
  - **Course sessions modal**: a badge per row (e.g. **Schedule 1**); one-time sessions stay tagged **One-time**.
  - **Session details page**: shown in the subtitle ("Schedule 1 • <date>", or "One-time session • <date>").
- **Course name + variant instead of "Live Session"**: the sessions-modal row title now shows the **course name + variant** (e.g. "Algebra I — Mathematics — Hong Kong") rather than the redundant auto-generated "Live Session — <date>". The date/time stays in the sub-row. The session details header does the same.

## How
- `/api/tutor/courses/[id]/sessions` joins `CourseSchedule` (id → name/index) and `CourseVariant`, returning per-session `scheduleName` and a top-level `course: { name, variantName }`.
- `GET /api/tutor/classes/[id]` returns `scheduleName`, `courseName`, `variantName` for the details page.

## Verification
`npm run typecheck` → 0 · `npm run build` → 0 · `npm run lint` → 0 errors (changed files Prettier-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show schedule names and course labels on sessions pages**

### What Changed
- Sessions tied to a schedule now show the schedule’s display name, or a fallback like “Schedule 1”; one-time sessions keep a one-time label.
- The sessions list and session details page now show the course name with its variant instead of a generic live session title.
- The sessions list now includes a separate badge for the schedule name when a session comes from a schedule.

### Impact
`✅ Clearer session labels`
`✅ Easier to tell scheduled and one-time sessions apart`
`✅ Less confusion on session details pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
