### PR TITLE
fix(tutor): persist schedule names + real session count on course cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -213,89 +213,89 @@ export default function StudentTutorDirectoryPage() {
 
       {/* Filters */}
       <div className="grid grid-cols-1 gap-3 py-4 sm:py-6 md:grid-cols-4">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-slate-400" />
-              <Input
-                value={searchQuery}
-                onChange={event => setSearchQuery(event.target.value)}
-                placeholder="Search tutor, subject, specialty..."
-                className="border-slate-200 bg-white pl-9 text-slate-900 placeholder:text-slate-400"
-              />
-            </div>
-            <Select
-              value={selectedRegion}
-              onValueChange={value => {
-                setSelectedRegion(value)
-                setSelectedCountryCode('')
-              }}
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-slate-400" />
+          <Input
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+            placeholder="Search tutor, subject, specialty..."
+            className="border-slate-200 bg-white pl-9 text-slate-900 placeholder:text-slate-400"
+          />
+        </div>
+        <Select
+          value={selectedRegion}
+          onValueChange={value => {
+            setSelectedRegion(value)
+            setSelectedCountryCode('')
+          }}
+        >
+          <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:backdrop-blur-none">
+            <SelectValue placeholder="Region" />
+          </SelectTrigger>
+          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
+            {REGIONS.map(region => (
+              <SelectItem
+                key={region.id}
+                value={region.id}
+                className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+              >
+                {region.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={selectedCountryCode}
+          onValueChange={setSelectedCountryCode}
+          disabled={!selectedRegion || selectedRegion === 'global'}
+        >
+          <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:backdrop-blur-none disabled:hover:translate-y-0 disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
+            <SelectValue placeholder="Country" />
+          </SelectTrigger>
+          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
+            {availableCountries.map(country => (
+              <SelectItem
+                key={country.code}
+                value={country.code}
+                className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+              >
+                {country.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={sortBy} onValueChange={value => setSortBy(value as typeof sortBy)}>
+          <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
+            <SelectValue placeholder="Sort by" />
+          </SelectTrigger>
+          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
+            <SelectItem
+              value="popular"
+              className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
             >
-              <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:backdrop-blur-none">
-                <SelectValue placeholder="Region" />
-              </SelectTrigger>
-              <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
-                {REGIONS.map(region => (
-                  <SelectItem
-                    key={region.id}
-                    value={region.id}
-                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                  >
-                    {region.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select
-              value={selectedCountryCode}
-              onValueChange={setSelectedCountryCode}
-              disabled={!selectedRegion || selectedRegion === 'global'}
+              Most Popular
+            </SelectItem>
+            <SelectItem
+              value="newest"
+              className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
             >
-              <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:backdrop-blur-none disabled:hover:translate-y-0 disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-[0_4px_12px_rgba(0,0,0,0.15)]">
-                <SelectValue placeholder="Country" />
-              </SelectTrigger>
-              <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
-                {availableCountries.map(country => (
-                  <SelectItem
-                    key={country.code}
-                    value={country.code}
-                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                  >
-                    {country.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={sortBy} onValueChange={value => setSortBy(value as typeof sortBy)}>
-              <SelectTrigger className="h-10 w-full rounded-lg border border-slate-700/25 bg-white/30 text-slate-700 shadow-[0_4px_12px_rgba(0,0,0,0.15)] backdrop-blur-sm transition-all duration-200 hover:-translate-y-[1px] hover:border-slate-700/50 hover:bg-white/60 hover:shadow-[0_6px_16px_rgba(0,0,0,0.20)] focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
-                <SelectValue placeholder="Sort by" />
-              </SelectTrigger>
-              <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
-                <SelectItem
-                  value="popular"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                >
-                  Most Popular
-                </SelectItem>
-                <SelectItem
-                  value="newest"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                >
-                  Recently Updated
-                </SelectItem>
-                <SelectItem
-                  value="courses"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                >
-                  Most Courses
-                </SelectItem>
-                <SelectItem
-                  value="rate"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
-                >
-                  Highest Rated
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+              Recently Updated
+            </SelectItem>
+            <SelectItem
+              value="courses"
+              className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+            >
+              Most Courses
+            </SelectItem>
+            <SelectItem
+              value="rate"
+              className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+            >
+              Highest Rated
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* Tutor grid */}
       <div className="h-[calc(100vh-380px)] min-h-[400px] flex-1 overflow-y-auto">

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -607,97 +607,97 @@ function CourseBuilderInsightsRouteInner({
             </div>
 
             <div className="flex items-center gap-2">
-                {(activeMainTab === 'builder' || activeMainTab === 'live') &&
-                  onSaveModeChange &&
-                  !modeLocked && (
-                    <Select
-                      value={saveMode}
-                      onValueChange={(val: 'live' | 'draft') => onSaveModeChange(val)}
-                    >
-                      <SelectTrigger className="h-9 w-[190px] border-slate-200 bg-white text-sm font-medium">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="live">
-                          <div className="flex items-center gap-2">
-                            <div className="h-2 w-2 rounded-full bg-green-500" />
-                            Live
-                          </div>
-                        </SelectItem>
-                        <SelectItem value="draft">
-                          <div className="flex items-center gap-2">
-                            <div className="h-2 w-2 rounded-full bg-amber-500" />
-                            Editing
-                          </div>
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  )}
-                {(activeMainTab === 'builder' || activeMainTab === 'live') && modeLocked && (
-                  <div className="flex h-9 w-[190px] items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 text-sm font-medium text-slate-600">
-                    <div className="h-2 w-2 rounded-full bg-amber-500" />
-                    Editing
-                  </div>
-                )}
-                {activeMainTab === 'builder' && onSaveCourse && (
-                  <Button
-                    variant="outline"
-                    className="gap-2 font-medium text-slate-700 hover:text-slate-900"
-                    onClick={async () => {
-                      const cb = (model.courseBuilderRef.current as any)?.saveAll
-                      if (typeof cb === 'function') {
-                        await cb()
-                      } else {
-                        toast.error('Builder not ready to save')
-                      }
-                    }}
+              {(activeMainTab === 'builder' || activeMainTab === 'live') &&
+                onSaveModeChange &&
+                !modeLocked && (
+                  <Select
+                    value={saveMode}
+                    onValueChange={(val: 'live' | 'draft') => onSaveModeChange(val)}
                   >
-                    <Save className="h-4 w-4" />
-                    Save
+                    <SelectTrigger className="h-9 w-[190px] border-slate-200 bg-white text-sm font-medium">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="live">
+                        <div className="flex items-center gap-2">
+                          <div className="h-2 w-2 rounded-full bg-green-500" />
+                          Live
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="draft">
+                        <div className="flex items-center gap-2">
+                          <div className="h-2 w-2 rounded-full bg-amber-500" />
+                          Editing
+                        </div>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                )}
+              {(activeMainTab === 'builder' || activeMainTab === 'live') && modeLocked && (
+                <div className="flex h-9 w-[190px] items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 text-sm font-medium text-slate-600">
+                  <div className="h-2 w-2 rounded-full bg-amber-500" />
+                  Editing
+                </div>
+              )}
+              {activeMainTab === 'builder' && onSaveCourse && (
+                <Button
+                  variant="outline"
+                  className="gap-2 font-medium text-slate-700 hover:text-slate-900"
+                  onClick={async () => {
+                    const cb = (model.courseBuilderRef.current as any)?.saveAll
+                    if (typeof cb === 'function') {
+                      await cb()
+                    } else {
+                      toast.error('Builder not ready to save')
+                    }
+                  }}
+                >
+                  <Save className="h-4 w-4" />
+                  Save
+                </Button>
+              )}
+              {activeMainTab === 'builder' &&
+                courseId &&
+                courseId !== 'insights-draft' &&
+                (saveMode === 'draft' || (saveMode === 'live' && isCourseVariant)) && (
+                  <Button
+                    variant="default"
+                    className="gap-2 bg-blue-600 font-medium text-white hover:bg-blue-700"
+                    onClick={saveMode === 'draft' ? handlePublishDraft : openRescheduleDialog}
+                  >
+                    <Calendar className="h-4 w-4" />
+                    {saveMode === 'draft' ? 'Schedule' : 'Reschedule'}
                   </Button>
                 )}
-                {activeMainTab === 'builder' &&
-                  courseId &&
-                  courseId !== 'insights-draft' &&
-                  (saveMode === 'draft' || (saveMode === 'live' && isCourseVariant)) && (
-                    <Button
-                      variant="default"
-                      className="gap-2 bg-blue-600 font-medium text-white hover:bg-blue-700"
-                      onClick={saveMode === 'draft' ? handlePublishDraft : openRescheduleDialog}
-                    >
-                      <Calendar className="h-4 w-4" />
-                      {saveMode === 'draft' ? 'Schedule' : 'Reschedule'}
+              {/* Kebab menu — visible for all real courses on the builder tab */}
+              {activeMainTab === 'builder' && courseId && courseId !== 'insights-draft' && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="icon" className="shrink-0">
+                      <MoreVertical className="h-5 w-5" />
                     </Button>
-                  )}
-                {/* Kebab menu — visible for all real courses on the builder tab */}
-                {activeMainTab === 'builder' && courseId && courseId !== 'insights-draft' && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="icon" className="shrink-0">
-                        <MoreVertical className="h-5 w-5" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {/* Go Live only when in draft mode and no active session */}
-                      {saveMode === 'draft' && !insightsProps.sessionId && (
-                        <DropdownMenuItem onClick={handleStartSessionClick}>
-                          <VideoIcon className="mr-2 h-4 w-4 text-green-600" />
-                          Go Live
-                        </DropdownMenuItem>
-                      )}
-                      {onDeleteCourse && (
-                        <DropdownMenuItem
-                          onClick={onDeleteCourse}
-                          disabled={!!insightsProps.sessionId}
-                          className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                        >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          Delete Course
-                        </DropdownMenuItem>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {/* Go Live only when in draft mode and no active session */}
+                    {saveMode === 'draft' && !insightsProps.sessionId && (
+                      <DropdownMenuItem onClick={handleStartSessionClick}>
+                        <VideoIcon className="mr-2 h-4 w-4 text-green-600" />
+                        Go Live
+                      </DropdownMenuItem>
+                    )}
+                    {onDeleteCourse && (
+                      <DropdownMenuItem
+                        onClick={onDeleteCourse}
+                        disabled={!!insightsProps.sessionId}
+                        className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete Course
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           </div>
 

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7644,13 +7644,13 @@ FEEDBACK: [your explanation]`
                           <TabsList className="flex w-auto items-center gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
                             <TabsTrigger
                               value="submissions"
-                              className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                              className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
                             >
                               Submissions
                             </TabsTrigger>
                             <TabsTrigger
                               value="insights"
-                              className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                              className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
                             >
                               Insights
                             </TabsTrigger>
@@ -7688,13 +7688,13 @@ FEEDBACK: [your explanation]`
                               <TabsList className="flex w-auto items-center gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
                                 <TabsTrigger
                                   value="submissions"
-                                  className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                                  className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
                                 >
                                   Submissions
                                 </TabsTrigger>
                                 <TabsTrigger
                                   value="insights"
-                                  className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=inactive]:bg-white data-[state=inactive]:text-gray-700 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                                  className="h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
                                 >
                                   Insights
                                 </TabsTrigger>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -678,8 +678,8 @@ function TutorDashboardContent() {
                                 )}
                                 onClick={() => handleOpenSessionsModal(course)}
                               >
-                                {course.upcomingSessionsCount
-                                  ? `${course.upcomingSessionsCount} session${course.upcomingSessionsCount === 1 ? '' : 's'}`
+                                {course.sessionCount
+                                  ? `${course.sessionCount} session${course.sessionCount === 1 ? '' : 's'}`
                                   : course.schedule && course.schedule.length > 0
                                     ? `${course.schedule.length} slot${course.schedule.length === 1 ? '' : 's'}`
                                     : '0 sessions'}

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -60,6 +60,7 @@ export const GET = withAuth(
                 scheduleId: courseSchedule.scheduleId,
                 courseId: courseSchedule.courseId,
                 scheduleIndex: courseSchedule.scheduleIndex,
+                name: courseSchedule.name,
                 schedule: courseSchedule.schedule,
                 weeksToSchedule: courseSchedule.weeksToSchedule,
                 maxStudents: courseSchedule.maxStudents,
@@ -82,6 +83,7 @@ export const GET = withAuth(
         schedules: (schedulesByCourse.get(r.publishedCourseId) || []).map(s => ({
           scheduleId: s.scheduleId,
           scheduleIndex: s.scheduleIndex,
+          name: s.name,
           schedule: s.schedule,
           weeksToSchedule: s.weeksToSchedule,
           maxStudents: s.maxStudents,
@@ -460,6 +462,7 @@ export const POST = withCsrf(
                 await tx
                   .update(courseSchedule)
                   .set({
+                    name: s.name ?? null,
                     schedule: s.schedule || [],
                     weeksToSchedule: s.weeksToSchedule || 8,
                     maxStudents: s.maxStudents ?? null,
@@ -473,6 +476,7 @@ export const POST = withCsrf(
                   scheduleId: newScheduleId,
                   courseId: publishedCourseId,
                   scheduleIndex: s.scheduleIndex || i + 1,
+                  name: s.name ?? null,
                   schedule: s.schedule || [],
                   weeksToSchedule: s.weeksToSchedule || 8,
                   maxStudents: s.maxStudents ?? null,

--- a/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
@@ -45,28 +45,27 @@ export const GET = withAuth(
       )
       .orderBy(desc(enrollmentCount))
 
-    // Get session counts for each course
+    // Get session counts for each course. `total` counts every non-cancelled
+    // session (so a course whose sessions are all past/ended still shows a real
+    // number rather than 0); `upcoming` counts only the actionable ones.
     const courseIds = courses.map(c => c.courseId)
-    let sessionCounts: { courseId: string; count: number }[] = []
+    let sessionCounts: { courseId: string; total: number; upcoming: number }[] = []
 
     if (courseIds.length > 0) {
       const sessions = await drizzleDb
         .select({
           courseId: liveSession.courseId,
-          count: sql<number>`count(${liveSession.sessionId})::int`,
+          total: sql<number>`count(*) filter (where ${liveSession.status} <> 'cancelled')::int`,
+          upcoming: sql<number>`count(*) filter (where ${liveSession.status} in ('scheduled', 'active', 'live', 'paused'))::int`,
         })
         .from(liveSession)
-        .where(
-          and(
-            eq(liveSession.tutorId, tutorId),
-            inArray(liveSession.status, ['scheduled', 'active', 'live', 'paused'])
-          )
-        )
+        .where(eq(liveSession.tutorId, tutorId))
         .groupBy(liveSession.courseId)
 
       sessionCounts = sessions.map(s => ({
         courseId: s.courseId ?? '',
-        count: s.count,
+        total: s.total,
+        upcoming: s.upcoming,
       }))
     }
 
@@ -91,6 +90,7 @@ export const GET = withAuth(
 
     const coursesWithSessionCount = courses.map(c => {
       const variant = variantMap.get(c.courseId)
+      const counts = sessionCounts.find(s => s.courseId === c.courseId)
       return {
         id: c.courseId,
         name: c.name,
@@ -101,7 +101,8 @@ export const GET = withAuth(
         schedule: c.schedule,
         enrollmentCount: c.enrollmentCount,
         subject: c.categories?.[0] ?? null,
-        upcomingSessionsCount: sessionCounts.find(s => s.courseId === c.courseId)?.count ?? 0,
+        sessionCount: counts?.total ?? 0,
+        upcomingSessionsCount: counts?.upcoming ?? 0,
         nationality: variant?.nationality ?? undefined,
         variantCategory: variant?.category ?? undefined,
       }


### PR DESCRIPTION
## **User description**
## Summary
Fixes two tutor-side issues:

1. **All schedules now stay visible/editable on the course scheduler.** Schedule names (Schedule 1, Schedule 2, …) were never persisted — the publish `POST` omitted `name` on insert/update and the `GET` never selected it, so custom names reset to the index placeholder on reload. The multi-schedule UI (render all, edit name, remove, "Add another schedule" → next index) already existed in `VariantManager`; it just had no name to load. `name` now round-trips end to end, so arriving via **Add to schedule** shows every schedule, each editable, with the ability to add another.

2. **Course cards show the real session count.** The dashboard "Sessions" tab card showed `0 sessions` once a course's sessions were all past/ended, because `/api/tutor/courses/enrolled` counted only `scheduled/active/live/paused`. Now returns a total `sessionCount` (all non-cancelled sessions) via conditional aggregation; the card uses the total. `upcomingSessionsCount` is retained.

## Changes
- `api/tutor/courses/[id]/publish/route.ts` — persist `name` on schedule insert + update; return `name` in GET.
- `api/tutor/courses/enrolled/route.ts` — add total `sessionCount` (filtered aggregation), keep `upcomingSessionsCount`.
- `tutor/dashboard/page.tsx` — course-card badge uses `sessionCount`.

## Verification
- `tsc --noEmit` clean; Prettier applied.
- Round-trip traced: VariantManager state → POST persists → GET returns → UI renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep schedule names visible and show the full session count on tutor course cards**

### What Changed
- Schedule names now stay saved when tutors publish or edit a course, so custom names no longer reset after reloading the scheduler.
- All schedules keep showing with their saved names, making it possible to review, rename, remove, or add another schedule without losing labels.
- Tutor course cards now show the total number of sessions for a course, even when all sessions are in the past, instead of dropping to `0 sessions`.
- The sessions badge still shows the number of upcoming sessions when that is the most relevant count.

### Impact
`✅ Saved schedule names`
`✅ Accurate course session counts`
`✅ Fewer confusing 0-session cards`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
