### PR TITLE
fix(tutor): saved schedules visible, live-session re-entry, builder→live sync

### DIFF
--- a/tutorme-app/src/app/[locale]/student/layout.tsx
+++ b/tutorme-app/src/app/[locale]/student/layout.tsx
@@ -391,7 +391,7 @@ export default function StudentLayout({ children }: { children: React.ReactNode 
         className={cn(
           'relative z-0 h-screen flex-1 overflow-hidden',
           !isFeedbackRoute && [
-            'pt-16 lg:mt-4 lg:mb-0 lg:h-[calc(100vh-1rem)] lg:w-[calc(100%-17rem)] transition-[margin] duration-500 ease-in-out',
+            'pt-16 transition-[margin] duration-500 ease-in-out lg:mb-0 lg:mt-4 lg:h-[calc(100vh-1rem)] lg:w-[calc(100%-17rem)]',
             desktopNavOpen ? 'lg:ml-64 lg:mr-4' : 'lg:ml-[8.5rem] lg:mr-[8.5rem]',
             isFloatingPage && 'lg:pt-0',
             !isFloatingPage &&

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -226,9 +226,28 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
       setVariants(prev => {
         const map = new Map(prev.map(v => [`${v.category}|${v.nationality}`, v]))
         let changed = false
+        // The template course schedule (course.schedule) shown as "Schedule 1"
+        // for variants that have no saved CourseSchedule rows of their own.
+        const baselineSchedules =
+          Array.isArray(defaultSchedule) && defaultSchedule.length > 0
+            ? [
+                {
+                  scheduleIndex: 1,
+                  name: null,
+                  schedule: [...defaultSchedule],
+                  weeksToSchedule: 8,
+                  maxStudents: null,
+                },
+              ]
+            : []
+        const variantHasSchedules = (v: VariantConfig): boolean =>
+          v.schedules.some(
+            s => s.scheduleId || (Array.isArray(s.schedule) && s.schedule.length > 0)
+          )
         // Add missing
         for (const key of desiredKeys) {
-          if (!map.has(key)) {
+          const existing = map.get(key)
+          if (!existing) {
             const [category, nationality] = key.split('|')
             map.set(key, {
               category,
@@ -238,19 +257,14 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
               price: globalIsFree ? 0 : globalPrice ? parseFloat(globalPrice) : null,
               currency: globalCurrency,
               languageOfInstruction: globalLanguage,
-              schedules:
-                Array.isArray(defaultSchedule) && defaultSchedule.length > 0
-                  ? [
-                      {
-                        scheduleIndex: 1,
-                        name: null,
-                        schedule: [...defaultSchedule],
-                        weeksToSchedule: 8,
-                        maxStudents: null,
-                      },
-                    ]
-                  : [],
+              schedules: baselineSchedules,
             })
+            changed = true
+          } else if (!variantHasSchedules(existing) && baselineSchedules.length > 0) {
+            // Backfill: the variant was created before the course schedule had
+            // loaded (course fetch is async), so adopt the template schedule now
+            // instead of leaving the scheduler showing only the "Add" button.
+            map.set(key, { ...existing, schedules: baselineSchedules })
             changed = true
           }
         }
@@ -261,10 +275,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
         // scheduler, leaving only the "Add another schedule" button.
         for (const [key, variant] of map.entries()) {
           if (desiredKeys.has(key)) continue
-          const hasSavedSchedules = variant.schedules.some(
-            s => s.scheduleId || (Array.isArray(s.schedule) && s.schedule.length > 0)
-          )
-          if (hasSavedSchedules) continue
+          if (variantHasSchedules(variant)) continue
           map.delete(key)
           changed = true
         }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1615,8 +1615,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Trigger full sync: save → sync to live → emit to session.
     // isAuto suppresses the save/sync toasts so background auto-sync is silent.
     const triggerSync = useCallback(
-      (isAuto = false) => {
-        doSave(isAuto)
+      async (isAuto = false) => {
+        // Wait for the builder save (PUT of builderData) to commit BEFORE
+        // emitting course:sync. The server's course:sync handler re-reads
+        // builderData from the DB, so emitting before the save resolves would
+        // sync the previous content — making edits appear one save behind.
+        await doSave(isAuto)
         const cloned = handleSyncToLive()
         // In live mode `nodes` becomes this clone; record it so the effect below
         // doesn't treat the sync as a new edit and re-arm another auto-sync.
@@ -1693,11 +1697,18 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       ref,
       () => ({
         save: doSave,
-        saveAll: doSave,
+        // When a session is open, the manual Save button must also push the
+        // edits into the live session. Otherwise Save persists to the DB but
+        // the live view keeps showing stale content (it only refreshes on a
+        // course:sync emit). triggerSync saves AND emits course:sync. Gate on
+        // sessionId (not status === 'active'), since a stale session list could
+        // otherwise silently suppress the sync on an explicit save.
+        saveAll: (isAuto = false) =>
+          insightsProps?.sessionId && onSyncToLiveSession ? triggerSync(isAuto) : doSave(isAuto),
         syncToLive: handleSyncToLive,
         getLessons: () => nodes.map(n => n.lessons[0]),
       }),
-      [doSave, handleSyncToLive, nodes]
+      [doSave, handleSyncToLive, nodes, insightsProps?.sessionId, onSyncToLiveSession, triggerSync]
     )
 
     const trackObjectUrl = useCallback((url: string) => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -695,6 +695,35 @@ function TutorDashboardContent() {
                                 </Badge>
                               </Link>
                             </div>
+                            {hasActive &&
+                              (() => {
+                                // A session is live right now — give a one-click
+                                // way back into the classroom. Leaving the live
+                                // room (back arrow) doesn't end the session, so a
+                                // tutor must be able to rejoin without hunting
+                                // through the sessions modal.
+                                const live = courseClasses.find(
+                                  c =>
+                                    c.status === 'active' ||
+                                    c.status === 'live' ||
+                                    c.status === 'preparing'
+                                )
+                                return live ? (
+                                  <Button
+                                    variant="default"
+                                    size="sm"
+                                    onClick={() =>
+                                      router.push(
+                                        withLocalePath(`/tutor/classroom?sessionId=${live.id}`)
+                                      )
+                                    }
+                                    className="bg-success text-success-foreground transition-all duration-200 hover:brightness-110"
+                                  >
+                                    <Video className="mr-1 h-3 w-3" />
+                                    Rejoin live
+                                  </Button>
+                                ) : null
+                              })()}
                             {courseClasses.length > 0 ? (
                               <Button
                                 variant="default"

--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -95,7 +95,8 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   const isDashboardPage = pathname?.includes('/tutor/dashboard')
   const isCommunicationsPage = pathname?.includes('/tutor/communications')
   const isSubmissionsPage = pathname?.includes('/tutor/submissions')
-  const isFloatingPage = isDashboardPage || isReportsPage || isCommunicationsPage || isSubmissionsPage
+  const isFloatingPage =
+    isDashboardPage || isReportsPage || isCommunicationsPage || isSubmissionsPage
   const isAccountPage = pathname?.includes('/tutor/settings')
   const isSupportPage = pathname?.includes('/tutor/support') || pathname?.includes('/tutor/help')
   const [desktopNavOpen, setDesktopNavOpen] = useState(
@@ -322,7 +323,7 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
       <main
         className={cn(
           'relative z-0 h-screen flex-1 overflow-hidden pt-16',
-          'lg:mt-4 lg:mb-0 lg:h-[calc(100vh-1rem)] lg:w-[calc(100%-17rem)] transition-[margin] duration-500 ease-in-out',
+          'transition-[margin] duration-500 ease-in-out lg:mb-0 lg:mt-4 lg:h-[calc(100vh-1rem)] lg:w-[calc(100%-17rem)]',
           desktopNavOpen ? 'lg:ml-64 lg:mr-4' : 'lg:ml-[8.5rem] lg:mr-[8.5rem]',
           isFloatingPage && 'lg:pt-0',
           !isFloatingPage &&


### PR DESCRIPTION
## **User description**
## Summary
Three tutor-side fixes.

### 1. Saved schedules now appear on the course scheduler
Opening the scheduler showed only the "Add another schedule" button. Two causes: (a) the schedule a tutor saves on the course page is stored in `course.schedule` (template), while `VariantManager` reads `CourseSchedule` rows; (b) the variant is created before the async course fetch populates the schedule, and was never backfilled afterward. Fix: backfill any variant that has no saved schedules with the template schedule as "Schedule 1", so existing schedules show up and can be edited. (Builds on the earlier name-persistence + preserve-loaded-schedules fixes.)

### 2. Tutors can re-enter a live session
Leaving the live classroom via the back arrow does **not** end the session (status stays `active`), but the dashboard offered no obvious way back in. Added a green **"Rejoin live"** button on the course card whenever a session is active, linking straight to `/tutor/classroom?sessionId=…`.

### 3. Builder edits now reflect in the live session
- `triggerSync` emitted `course:sync` **before** the `builderData` PUT committed; the server's `course:sync` handler re-reads `builderData` from the DB, so it synced stale content (edits appeared one save behind). Now it **awaits the save** before emitting.
- The manual **Save** button only persisted, never synced. Now `saveAll` also emits `course:sync` when a session is open (gated on `sessionId`, not a possibly-stale `status === 'active'`).

## Changes
- `tutor/courses/[id]/components/VariantManager.tsx` — backfill template schedule into empty variants.
- `tutor/dashboard/page.tsx` — "Rejoin live" button.
- `tutor/dashboard/components/CourseBuilder.tsx` — await save before sync; manual Save syncs.

## Verification
- `tsc --noEmit` clean; 270 unit tests pass; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep saved schedules visible, let tutors rejoin live sessions, and sync builder changes to the live classroom**

### What Changed
- Saved course schedules now appear in the scheduler instead of showing only the “Add another schedule” option
- Tutors can re-enter an active live session from the dashboard with a one-click “Rejoin live” button
- Saving course builder changes now updates the live classroom too, so the live view no longer falls behind after edits
- Manual Save now pushes changes into an open live session instead of only storing them

### Impact
`✅ Saved schedules stay visible on revisit`
`✅ Faster re-entry to active live sessions`
`✅ Fewer stale lesson changes in live classes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
