### PR TITLE
fix(tutor): open scheduler on template course so saved schedules load

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -92,6 +92,8 @@ type ScheduleSlot = {
 
 type EnrolledCourse = {
   id: string
+  /** The template course id to open in the scheduler/builder (id is the published variant). */
+  templateCourseId?: string
   name: string
   categories?: string[] | null
   isPublished?: boolean | null
@@ -301,6 +303,23 @@ function TutorDashboardContent() {
       fetchData()
     } else {
       setLoading(false)
+    }
+  }, [session?.user?.id, fetchData])
+
+  // Refresh on return to the dashboard (e.g. backing out of a live classroom,
+  // which is a client-side navigation that doesn't remount this page). Without
+  // this, `classes` stays stale and a now-active session — and its "Rejoin
+  // live" button — never appears.
+  useEffect(() => {
+    if (!session?.user?.id) return
+    const refresh = () => {
+      if (document.visibilityState === 'visible') fetchData()
+    }
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', refresh)
+    return () => {
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', refresh)
     }
   }, [session?.user?.id, fetchData])
 
@@ -744,7 +763,11 @@ function TutorDashboardContent() {
                                 size="sm"
                                 className="transition-all duration-200"
                               >
-                                <Link href={withLocalePath(`/tutor/courses/${course.id}`)}>
+                                <Link
+                                  href={withLocalePath(
+                                    `/tutor/courses/${course.templateCourseId ?? course.id}`
+                                  )}
+                                >
                                   <CalendarClock className="mr-1 h-3 w-3" />
                                   Schedule sessions
                                 </Link>
@@ -943,7 +966,11 @@ function TutorDashboardContent() {
                   </p>
                   {selectedCourseForCancel && (
                     <Button asChild size="sm" className="mt-3 transition-all duration-200">
-                      <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
+                      <Link
+                        href={withLocalePath(
+                          `/tutor/courses/${selectedCourseForCancel.templateCourseId ?? selectedCourseForCancel.id}`
+                        )}
+                      >
                         <CalendarClock className="mr-1 h-3 w-3" />
                         Set up the schedule
                       </Link>
@@ -1150,7 +1177,11 @@ function TutorDashboardContent() {
                 {selectedCourseForCancel && (
                   <>
                     <Button asChild variant="outline">
-                      <Link href={withLocalePath(`/tutor/courses/${selectedCourseForCancel.id}`)}>
+                      <Link
+                        href={withLocalePath(
+                          `/tutor/courses/${selectedCourseForCancel.templateCourseId ?? selectedCourseForCancel.id}`
+                        )}
+                      >
                         <CalendarClock className="mr-1 h-4 w-4" />
                         +Add schedule
                       </Link>

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -34,6 +34,20 @@ export const GET = withAuth(
         return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
       }
 
+      // Safety net: if the caller passed a *published variant* id (e.g. a link
+      // built from /api/tutor/courses/enrolled, which returns published ids),
+      // resolve it back to its template so the scheduler still loads the full
+      // variant set and its CourseSchedule rows instead of coming up empty.
+      let effectiveTemplateId = templateCourseId
+      const asVariant = await drizzleDb
+        .select({ templateCourseId: courseVariant.templateCourseId })
+        .from(courseVariant)
+        .where(eq(courseVariant.publishedCourseId, templateCourseId))
+        .limit(1)
+      if (asVariant.length > 0) {
+        effectiveTemplateId = asVariant[0].templateCourseId
+      }
+
       const rows = await drizzleDb
         .select({
           variantId: courseVariant.variantId,
@@ -49,7 +63,7 @@ export const GET = withAuth(
         })
         .from(courseVariant)
         .innerJoin(course, eq(course.courseId, courseVariant.publishedCourseId))
-        .where(eq(courseVariant.templateCourseId, templateCourseId))
+        .where(eq(courseVariant.templateCourseId, effectiveTemplateId))
 
       // Load schedules for each variant
       const variantIds = rows.map(r => r.publishedCourseId)

--- a/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
@@ -75,6 +75,7 @@ export const GET = withAuth(
         ? await drizzleDb
             .select({
               publishedCourseId: courseVariant.publishedCourseId,
+              templateCourseId: courseVariant.templateCourseId,
               nationality: courseVariant.nationality,
               category: courseVariant.category,
             })
@@ -84,7 +85,11 @@ export const GET = withAuth(
     const variantMap = new Map(
       variantRows.map(v => [
         v.publishedCourseId,
-        { nationality: v.nationality, category: v.category },
+        {
+          templateCourseId: v.templateCourseId,
+          nationality: v.nationality,
+          category: v.category,
+        },
       ])
     )
 
@@ -93,6 +98,10 @@ export const GET = withAuth(
       const counts = sessionCounts.find(s => s.courseId === c.courseId)
       return {
         id: c.courseId,
+        // The scheduler/course builder operates on the TEMPLATE course; this id
+        // is the published variant, so expose its template for "Add schedule"
+        // style links (falls back to the published id for legacy/direct courses).
+        templateCourseId: variant?.templateCourseId ?? c.courseId,
         name: c.name,
         categories: c.categories,
         isPublished: c.isPublished,


### PR DESCRIPTION
## **User description**
## Summary
**Real root cause of the empty course scheduler.** `/api/tutor/courses/enrolled` returns **published variant** course ids (`isPublished = true`), and the dashboard built its "Add schedule" / "Schedule sessions" links from those ids. But the scheduler (`VariantManager`) loads variants with `WHERE courseVariant.templateCourseId = [id]` — which matches nothing when `[id]` is a published variant (that id lives in the `publishedCourseId` column). So no variants and no `CourseSchedule` rows ever loaded, and the tutor saw only the "Add another schedule" button. The earlier fixes (name persistence, preserve-loaded, backfill) all operated *inside* VariantManager assuming variants loaded — they never did.

### Fixes
- `enrolled` route returns each course's `templateCourseId`.
- Dashboard scheduler links use `templateCourseId` (falls back to the id).
- `publish` GET resolves a published-variant id back to its template as a server-side safety net for any other entry point.
- Dashboard refetches on window focus / tab visibility, so returning from the live classroom (a client-side nav) surfaces the now-active session and its **"Rejoin live"** button instead of stale data — addresses the "I don't see the Rejoin button" report.

## Changes
- `api/tutor/courses/enrolled/route.ts`
- `api/tutor/courses/[id]/publish/route.ts`
- `[locale]/tutor/dashboard/page.tsx`

## Verification
- `tsc --noEmit` clean; 270 unit tests pass; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix scheduler links so saved course schedules and live session updates load correctly

### What Changed
- Tutor dashboard links now open the template course when a course was published, so the scheduler shows the saved variants and schedule rows instead of an empty state.
- Course listings now carry the template course id, with a fallback to the current course id for direct or legacy courses.
- The publish page now also handles published-course links by resolving them back to the template course before loading schedules.
- The dashboard refreshes when the tab regains focus or becomes visible again, so returning from a live classroom shows current session state and the “Rejoin live” button.

### Impact
`✅ Fewer empty scheduler pages`
`✅ Saved course schedules open from the dashboard`
`✅ Clearer return-from-classroom status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
