### PR TITLE
fix(tutor+student): sessions scroll, rejoin, student classroom info, task deploy

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -332,6 +332,8 @@ function StudentFeedbackContent() {
     courseCategory: string
     courseId: string | null
     courseName: string | null
+    variantName: string | null
+    scheduleName: string | null
     status: string | null
     startedAt: string | null
     scheduledAt: string | null
@@ -708,6 +710,8 @@ function StudentFeedbackContent() {
           courseCategory: data?.session?.category || 'General',
           courseId: data?.session?.courseId ?? null,
           courseName: data?.session?.course?.name ?? null,
+          variantName: data?.session?.variantName ?? null,
+          scheduleName: data?.session?.scheduleName ?? null,
           status: data?.session?.status ?? null,
           startedAt: data?.session?.startedAt ?? null,
           scheduledAt: data?.session?.scheduledAt ?? null,
@@ -1140,30 +1144,44 @@ function StudentFeedbackContent() {
                 <ArrowLeft className="h-5 w-5" />
               </Button>
               {sessionContext && (
-                <div className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium',
-                      sessionContext.status === 'active'
-                        ? 'bg-emerald-100 text-emerald-700'
+                <div className="flex min-w-0 flex-col">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <h1 className="truncate text-sm font-semibold text-[#1F2933]">
+                      {sessionContext.courseName
+                        ? `${sessionContext.courseName}${sessionContext.variantName ? ` — ${sessionContext.variantName}` : ''}`
+                        : sessionContext.courseCategory || 'Live Class'}
+                    </h1>
+                    <span
+                      className={cn(
+                        'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium',
+                        sessionContext.status === 'active'
+                          ? 'bg-emerald-100 text-emerald-700'
+                          : sessionContext.status === 'scheduled'
+                            ? 'bg-amber-100 text-amber-700'
+                            : sessionContext.status === 'ended'
+                              ? 'bg-slate-100 text-slate-600'
+                              : 'bg-gray-100 text-gray-600'
+                      )}
+                    >
+                      {sessionContext.status === 'active'
+                        ? '● Live'
                         : sessionContext.status === 'scheduled'
-                          ? 'bg-amber-100 text-amber-700'
+                          ? '⏳ Scheduled'
                           : sessionContext.status === 'ended'
-                            ? 'bg-slate-100 text-slate-600'
-                            : 'bg-gray-100 text-gray-600'
+                            ? '■ Ended'
+                            : sessionContext.status || 'Unknown'}
+                    </span>
+                    {sessionTimer && (
+                      <span className="shrink-0 font-mono text-xs text-slate-500">
+                        {sessionTimer}
+                      </span>
                     )}
-                  >
-                    {sessionContext.status === 'active'
-                      ? '● Live'
-                      : sessionContext.status === 'scheduled'
-                        ? '⏳ Scheduled'
-                        : sessionContext.status === 'ended'
-                          ? '■ Ended'
-                          : sessionContext.status || 'Unknown'}
-                  </span>
-                  {sessionTimer && (
-                    <span className="font-mono text-xs text-slate-500">{sessionTimer}</span>
-                  )}
+                  </div>
+                  <p className="truncate text-xs text-slate-500">
+                    {[sessionContext.scheduleName, `with ${sessionContext.tutorUsername}`]
+                      .filter(Boolean)
+                      .join(' • ')}
+                  </p>
                 </div>
               )}
             </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1902,7 +1902,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
         // Auto-deploy to student homework folder
         if (insightsProps?.onDeployTask) {
-          insightsProps.onDeployTask({
+          insightsProps.onDeployTask?.({
             id: homeworkItem.id,
             title: homeworkItem.title || 'Homework',
             content: homeworkItem.description || '',
@@ -2527,8 +2527,9 @@ FEEDBACK: [your explanation]`
           : undefined,
       }
 
-      insightsProps.onDeployTask(task)
-      toast.success('DMI deployed to live session')
+      // Success is confirmed by the server's task:deployed broadcast (handled in
+      // insights/page.tsx), not optimistically here.
+      insightsProps.onDeployTask?.(task)
     }, [assessmentBuilder, assessmentDmiItems, insightsProps, loadedAssessmentId])
 
     useEffect(() => {
@@ -6290,7 +6291,7 @@ FEEDBACK: [your explanation]`
                                                                             task.activeDmiVersionId
                                                                         ) ||
                                                                         (task.dmiVersions || [])[0]
-                                                                      insightsProps.onDeployTask({
+                                                                      insightsProps.onDeployTask?.({
                                                                         id: task.id,
                                                                         title: task.title,
                                                                         content:
@@ -6657,7 +6658,7 @@ FEEDBACK: [your explanation]`
                                                                               className="font-medium text-emerald-600 focus:text-emerald-600"
                                                                               onClick={e => {
                                                                                 e.stopPropagation()
-                                                                                insightsProps.onDeployTask(
+                                                                                insightsProps.onDeployTask?.(
                                                                                   {
                                                                                     id: ext.id,
                                                                                     title: ext.name,
@@ -7070,7 +7071,7 @@ FEEDBACK: [your explanation]`
                                                                           v.id ===
                                                                           hw.activeDmiVersionId
                                                                       ) || (hw.dmiVersions || [])[0]
-                                                                    insightsProps.onDeployTask({
+                                                                    insightsProps.onDeployTask?.({
                                                                       id: hw.id,
                                                                       title: hw.title,
                                                                       content:
@@ -7389,7 +7390,7 @@ FEEDBACK: [your explanation]`
                                                                             ) ||
                                                                             (hw.dmiVersions ||
                                                                               [])[0]
-                                                                          insightsProps.onDeployTask(
+                                                                          insightsProps.onDeployTask?.(
                                                                             {
                                                                               id: hw.id,
                                                                               title: hw.title,
@@ -8724,7 +8725,7 @@ FEEDBACK: [your explanation]`
                                                 if (testPciSource === 'task') {
                                                   const task = findTaskById(loadedTaskId || '')
                                                   if (task) {
-                                                    insightsProps.onDeployTask({
+                                                    insightsProps.onDeployTask?.({
                                                       id: task.id,
                                                       title: task.title || 'Task',
                                                       content: task.description || '',

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -302,7 +302,8 @@ export interface CourseBuilderInsightsProps {
   onSessionChange: (sessionId: string) => void
   onStartSession?: () => void
   liveTasks: LiveTask[]
-  onDeployTask: (task: LiveTask) => void
+  /** Present only inside a live session; deploy buttons hide when undefined. */
+  onDeployTask?: (task: LiveTask) => void
   onSendPoll: (payload: { taskId: string; question: string }) => void
   onSendQuestion: (payload: { taskId: string; prompt: string }) => void
   students?: LiveStudent[]

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -16,7 +16,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 
 import {
@@ -297,6 +296,21 @@ function TutorDashboardContent() {
     }
   }, [session?.user?.id])
 
+  // Lightweight refresh of just the live-class list — used to keep the
+  // "Rejoin live" button in sync without re-pulling the whole dashboard.
+  const refreshClasses = useCallback(async () => {
+    if (!session?.user?.id) return
+    try {
+      const res = await fetch('/api/tutor/classes', { credentials: 'include' })
+      if (res.ok) {
+        const d = await res.json()
+        setClasses(d.classes ?? [])
+      }
+    } catch {
+      // best-effort; the next refresh will retry
+    }
+  }, [session?.user?.id])
+
   useEffect(() => {
     if (session?.user?.id) {
       setLoading(true)
@@ -306,22 +320,28 @@ function TutorDashboardContent() {
     }
   }, [session?.user?.id, fetchData])
 
-  // Refresh on return to the dashboard (e.g. backing out of a live classroom,
-  // which is a client-side navigation that doesn't remount this page). Without
-  // this, `classes` stays stale and a now-active session — and its "Rejoin
-  // live" button — never appears.
+  // Keep the active-session state fresh so the "Rejoin live" button reliably
+  // appears after a tutor backs out of the live classroom. A session only
+  // flips to 'active' once the tutor is inside the room, and backing out is a
+  // client-side navigation that doesn't always remount this page or fire
+  // `focus` — so poll on an interval and refresh on focus / tab-visibility /
+  // bfcache restore (`pageshow`).
   useEffect(() => {
     if (!session?.user?.id) return
     const refresh = () => {
-      if (document.visibilityState === 'visible') fetchData()
+      if (document.visibilityState === 'visible') refreshClasses()
     }
+    const interval = setInterval(refresh, 20000)
     window.addEventListener('focus', refresh)
+    window.addEventListener('pageshow', refresh)
     document.addEventListener('visibilitychange', refresh)
     return () => {
+      clearInterval(interval)
       window.removeEventListener('focus', refresh)
+      window.removeEventListener('pageshow', refresh)
       document.removeEventListener('visibilitychange', refresh)
     }
-  }, [session?.user?.id, fetchData])
+  }, [session?.user?.id, refreshClasses])
 
   const handleClassCreated = useCallback(
     (classData?: { id: string; [key: string]: unknown }) => {
@@ -978,8 +998,13 @@ function TutorDashboardContent() {
                   )}
                 </div>
               ) : (
-                <ScrollArea className="max-h-[400px]">
-                  <div className="space-y-3 pr-4">
+                <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-2">
+                  {courseSessions.length > 6 && (
+                    <p className="text-muted-foreground pb-1 text-xs">
+                      {courseSessions.length} sessions — scroll to see all
+                    </p>
+                  )}
+                  <div className="space-y-3">
                     {courseSessions.map(session => {
                       const isVirtual = session.isVirtual === true
                       const _isPassedSession =
@@ -1162,7 +1187,7 @@ function TutorDashboardContent() {
                       )
                     })}
                   </div>
-                </ScrollArea>
+                </div>
               )}
             </div>
 
@@ -1183,7 +1208,7 @@ function TutorDashboardContent() {
                         )}
                       >
                         <CalendarClock className="mr-1 h-4 w-4" />
-                        +Add schedule
+                        +Add/Edit schedule
                       </Link>
                     </Button>
                     <Button

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -823,6 +823,10 @@ function TutorInsightsPageInner() {
         }
         return [...prev, task]
       })
+      // Confirm only once the server has broadcast the deploy — this is the real
+      // "it reached students" signal, vs. an optimistic toast fired on click
+      // before the emit was even acknowledged.
+      toast.success(`Deployed to students${task.title ? `: ${task.title}` : ''}`)
     }
 
     const handleTaskUpdated = (payload: { task: LiveTask }) => {
@@ -1056,14 +1060,24 @@ function TutorInsightsPageInner() {
     if (source !== 'homework' && currentSession.status === 'ended') {
       return { ok: false, error: 'Session has ended' }
     }
-    if (new Date(currentSession.scheduledAt).getTime() > Date.now()) {
+    // A live session is deployable regardless of its scheduled time — the tutor
+    // may have started early. Only block a still-scheduled session that hasn't
+    // begun; otherwise an active-but-early session would wrongly reject deploys.
+    const isLive =
+      currentSession.status === 'active' ||
+      currentSession.status === 'live' ||
+      currentSession.status === 'preparing'
+    if (!isLive && new Date(currentSession.scheduledAt).getTime() > Date.now()) {
       return { ok: false, error: 'Session has not started yet' }
     }
     return { ok: true }
   }
 
   const handleDeployTask = (task: LiveTask) => {
-    if (!socket || !sessionId) return
+    if (!socket || !sessionId) {
+      toast.error('Open a live session before deploying')
+      return
+    }
     const check = checkSessionActive(task.source)
     if (!check.ok) {
       toast.error(check.error || 'Cannot deploy right now')
@@ -1218,7 +1232,10 @@ function TutorInsightsPageInner() {
           sessions,
           onSessionChange: setSessionId,
           liveTasks,
-          onDeployTask: handleDeployTask,
+          // Only expose deploy inside a live session — the deploy buttons gate
+          // on this callback, so hiding it prevents "deploying" from the plain
+          // builder (where the emit would be silently dropped, no session/room).
+          onDeployTask: sessionId ? handleDeployTask : undefined,
           onSendPoll: handleSendPoll,
           onSendQuestion: handleSendQuestion,
           students,

--- a/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
+++ b/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
@@ -13,8 +13,18 @@ import { withAuth, withCsrf, ValidationError, NotFoundError } from '@/lib/api/mi
 import { getParamAsync } from '@/lib/api/params'
 import { dailyProvider } from '@/lib/video/daily-provider'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession, sessionParticipant, user, profile, course } from '@/lib/db/schema'
+import {
+  liveSession,
+  sessionParticipant,
+  user,
+  profile,
+  course,
+  courseSchedule,
+  courseVariant,
+} from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
+import { formatScheduleName } from '@/lib/sessions/schedule-name'
+import { formatCourseVariantName } from '@/lib/courses/variant-name'
 
 const EARLY_ENTRY_MS = 20 * 60 * 1000 // students may enter 20 min before scheduledAt
 
@@ -137,6 +147,7 @@ export const POST = withCsrf(
       : [null]
 
     let courseName = null
+    let variantName: string | null = null
     if (classSessionRow.courseId) {
       const [courseRow] = await drizzleDb
         .select({ name: course.name })
@@ -145,6 +156,28 @@ export const POST = withCsrf(
         .limit(1)
       if (courseRow) {
         courseName = courseRow.name
+      }
+      // The session's courseId is the published variant; resolve its
+      // category × nationality label (e.g. "Mathematics — Hong Kong").
+      const [variantRow] = await drizzleDb
+        .select({ category: courseVariant.category, nationality: courseVariant.nationality })
+        .from(courseVariant)
+        .where(eq(courseVariant.publishedCourseId, classSessionRow.courseId))
+        .limit(1)
+      if (variantRow) {
+        variantName = formatCourseVariantName(variantRow.category, variantRow.nationality)
+      }
+    }
+
+    let scheduleName: string | null = null
+    if (classSessionRow.scheduleId) {
+      const [scheduleRow] = await drizzleDb
+        .select({ name: courseSchedule.name, scheduleIndex: courseSchedule.scheduleIndex })
+        .from(courseSchedule)
+        .where(eq(courseSchedule.scheduleId, classSessionRow.scheduleId))
+        .limit(1)
+      if (scheduleRow) {
+        scheduleName = formatScheduleName(scheduleRow.name, scheduleRow.scheduleIndex)
       }
     }
 
@@ -157,6 +190,8 @@ export const POST = withCsrf(
       ...classSessionRow,
       tutor: tutorRow ? { profile: tutorProfile } : null,
       course: courseName ? { name: courseName } : null,
+      variantName,
+      scheduleName,
       participants,
     }
 


### PR DESCRIPTION
## **User description**
## Summary
Five fixes.

### Task 1 — "Rejoin live" reliability
The button logic was correct, but the dashboard's `classes` data went stale: backing out of the classroom is a client-side nav that doesn't remount the page or fire `focus`, and a session only flips to `active` *inside* the room. Added a lightweight `/api/tutor/classes` refresh on a 20s interval + `focus`/`visibilitychange`/`pageshow`, so the active session and its **Rejoin live** button reliably appear.

### Task 2 — Sessions modal scroll
Replaced the fragile Radix `ScrollArea` (max-h on root + `h-full` viewport inside an unconstrained dialog) with a native `max-h-[60vh] overflow-y-auto` container, plus a "N sessions — scroll to see all" hint. All sessions are now reachable.

### Task 3 — Rename
Sessions-modal button "+Add schedule" → **"+Add/Edit schedule"**.

### Task 4 — Student live classroom shows the course
The join API (`/api/class/rooms/[id]/join`) now also returns `variantName` + `scheduleName`. The student feedback header shows **"Course — Variant"**, the live-status pill + timer, the schedule name, and the tutor — mirroring the tutor side (uses the same `formatCourseVariantName` / `formatScheduleName` helpers).

### Task 5 — Task/assessment Deploy actually deploys
The socket plumbing (`task:deploy` → server → `task:deployed` → student) was correct, but:
- `checkSessionActive` blocked deploys on an **active-but-early** session via a `scheduledAt > now` check — now only blocks not-yet-started *scheduled* sessions.
- Deploy was offered in the plain builder with **no session**, where the emit was silently dropped with a false success toast — `onDeployTask` is now wired only when a session is open, and the no-session path shows an error.
- Replaced the optimistic on-click success toast with one fired on the **server-confirmed** `task:deployed` broadcast (the real "it reached students" signal).

## Verification
- `tsc --noEmit` clean; 270 unit tests pass; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep live session details and deploy actions in sync**

### What Changed
- Tutor dashboard now refreshes the live class list automatically, so a session that turns active shows the **Rejoin live** button without needing a full page reload.
- The sessions modal now scrolls properly and shows a hint when there are many sessions, so every session can be reached.
- The schedule button is renamed to **+Add/Edit schedule**.
- Student live classroom headers now show the course, variant, schedule name, live status, timer, and tutor.
- Deploying tasks and assessments now works only from a live session, shows an error when no session is open, and confirms success only after students are notified.

### Impact
`✅ Fewer missing Rejoin live buttons`
`✅ Easier access to long session lists`
`✅ Clearer live classroom details for students`
`✅ Fewer failed or false-success deployments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
