### PR TITLE
fix(scheduler): Save persists schedule changes on a published course

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -1524,7 +1524,16 @@ export default function TutorCoursePage() {
             <Button
               size="lg"
               variant="default"
-              onClick={handleSaveAll}
+              onClick={async () => {
+                const saved = await handleSaveAll()
+                // For an already-published course, persist schedule/variant edits
+                // (e.g. a newly added Schedule 3) on Save too — these live in
+                // CourseSchedule rows that only the publish path writes, so
+                // without this Save would silently drop the schedule change.
+                if (saved && variantStats.published > 0) {
+                  await variantManagerRef.current?.publish()
+                }
+              }}
               disabled={saving}
               className="h-11 w-full rounded-full border-2 border-transparent bg-gradient-to-r from-[#2563eb] to-[#1d4ed8] px-8 text-white shadow-[0_6px_16px_rgba(37,99,235,0.16),0_2px_4px_rgba(0,0,0,0.08)] transition-all duration-200 ease-in-out hover:translate-y-0 hover:border-[#2563eb] hover:bg-white hover:text-[#2563eb] hover:shadow-[0_8px_18px_rgba(37,99,235,0.18)] hover:[background-image:none] active:bg-gradient-to-r active:from-[#1d4ed8] active:to-[#1e40af] active:shadow-[0_4px_10px_rgba(37,99,235,0.16)] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none sm:w-[220px]"
             >


### PR DESCRIPTION
## **User description**
Task 5 of 5.

Adding a schedule (e.g. Schedule 3) and clicking **Save** didn't appear on course cards. Root cause: Save (`handleSaveAll`) only PATCHes the template course's `schedule` field, but every card reads `CourseSchedule` rows — which are written solely by the publish path. So a schedule added then Saved was never persisted as a `CourseSchedule` row, and `/api/courses/[id]/schedules` (which correctly returns all rows) had nothing new to show.

Fix: when the course is already published, Save now also runs the variant/schedule publish. It's idempotent — re-publishing skips existing same-course sessions (publish/route.ts:678-719) and only inserts the new schedule + its sessions — so the schedule shows up without a separate Publish/Update click, matching the expectation that Save just saves.

tsc clean; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Save now keeps newly added schedules on published courses

### What Changed
- Saving a published course now also preserves schedule changes, so newly added schedules appear after clicking Save
- Users no longer need a separate publish or update action just to make schedule edits show up

### Impact
`✅ Fewer missing schedule updates`
`✅ Less need to republish published courses`
`✅ Clearer save results for course edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
