### PR TITLE
fix(live): keep builder content visible when switching to the Live tab

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5603,6 +5603,11 @@ FEEDBACK: [your explanation]`
         <Tabs
           value={mainTab}
           onValueChange={v => {
+            // Switching to Live shows liveNodes, a snapshot separate from the
+            // builderNodes the Build tab edits. Sync the latest builder content
+            // into it first so edits made in Build don't vanish on the Live tab.
+            // This is a local view sync only — it does not deploy to students.
+            if (v === 'live') handleSyncToLive()
             setMainTab(v as 'live' | 'builder' | 'test-pci')
             // Add callback to notify parent route
             if (onMainTabChange) {


### PR DESCRIPTION
## **User description**
The Build tab edits `builderNodes` while the Live tab renders a separate `liveNodes` snapshot (`nodes = mainTab === 'live' ? liveNodes : builderNodes`, CourseBuilder.tsx:445). Content added in Build wasn't copied into `liveNodes`, so switching to Live showed the old/empty snapshot and the new content appeared to vanish.

Fix: switching to the Live tab now syncs the latest builder content into `liveNodes` first (via the existing `handleSyncToLive`). This is a **local view sync only** — it does not emit `course:sync` / deploy to students, so it doesn't conflict with the explicit-deploy model.

tsc clean; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Keep builder edits visible when switching to the Live tab

### What Changed
- Switching from Build to Live now copies the latest builder content into the Live view first, so edits do not disappear
- This only updates what you see in the Live tab and does not publish changes to students

### Impact
`✅ Fewer disappearing content issues in the Live tab`
`✅ Clearer Build-to-Live workflow`
`✅ Less confusion before publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
