### PR TITLE
fix: view-all-schedules, publish→dashboard, student exit, deployed doc display

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -91,6 +91,7 @@ import {
   type ExamCategory,
 } from '@/lib/data/tutor-categories'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { ScheduleViewModal } from '@/components/course/ScheduleViewModal'
 import { cn } from '@/lib/utils'
 
 // --- Types ---
@@ -1758,6 +1759,8 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
   const [coursesPage, setCoursesPage] = useState(0)
   const [tutorsPage, setTutorsPage] = useState(0)
   const [selectedCourse, setSelectedCourse] = useState<any | null>(null)
+  // Course whose full schedule list is open in the ScheduleViewModal.
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   const [rotation, setRotation] = useState(0)
   const router = useRouter()
 
@@ -2329,9 +2332,21 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
               </div>
               <div className="space-y-0.5">
                 <div className="text-xs font-medium text-[#1F2933]/70">Schedule</div>
-                <div className="text-sm font-semibold text-[#1F2933]">
-                  {selectedCourse?.scheduleSummary?.trim() || 'Schedule to be announced'}
-                </div>
+                {selectedCourse?.id ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setScheduleCourse({ id: selectedCourse.id, name: selectedCourse.name })
+                    }
+                    className="text-sm font-semibold text-blue-600 hover:underline"
+                  >
+                    View schedules
+                  </button>
+                ) : (
+                  <div className="text-sm font-semibold text-[#1F2933]">
+                    Schedule to be announced
+                  </div>
+                )}
               </div>
             </DialogPanel>
             <DialogPanel variant="default" className="border-slate-200 bg-white p-3 text-[#1F2933]">
@@ -2454,6 +2469,12 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ScheduleViewModal
+        courseId={scheduleCourse?.id ?? null}
+        courseName={scheduleCourse?.name}
+        onClose={() => setScheduleCourse(null)}
+      />
     </section>
   )
 }

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -35,6 +35,7 @@ import {
   Loader2,
   Layout,
   ArrowLeft,
+  LogOut,
   FileText,
   ChevronRight,
   ChevronLeft,
@@ -1191,8 +1192,17 @@ function StudentFeedbackContent() {
               )}
             </div>
 
-            <div className="flex flex-1 items-center justify-end">
+            <div className="flex flex-1 items-center justify-end gap-3">
               <WifiSignal connected={isConnected} error={!!error} />
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                onClick={() => router.push('/student/dashboard')}
+              >
+                <LogOut className="h-4 w-4" />
+                Leave session
+              </Button>
             </div>
           </div>
 
@@ -1396,43 +1406,63 @@ function StudentFeedbackContent() {
                           </div>
                         )}
 
-                        {activeTask.sourceDocument && (
-                          <div className="mb-4 h-[55vh] w-full">
-                            {activeTask.sourceDocument.mimeType === 'application/pdf' ||
-                            !activeTask.sourceDocument.mimeType ? (
-                              <iframe
-                                src={
-                                  activeTask.sourceDocument.fileUrl.includes('#')
-                                    ? `${activeTask.sourceDocument.fileUrl}&toolbar=0&navpanes=0`
-                                    : `${activeTask.sourceDocument.fileUrl}#toolbar=0&navpanes=0`
-                                }
-                                title={activeTask.sourceDocument.fileName}
-                                className="h-full w-full rounded-lg border"
-                              />
-                            ) : activeTask.sourceDocument.mimeType.startsWith('image/') ? (
-                              <div className="flex h-full items-center justify-center">
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img
-                                  src={activeTask.sourceDocument.fileUrl}
-                                  alt={activeTask.sourceDocument.fileName}
-                                  className="max-h-full max-w-full object-contain"
-                                />
+                        {activeTask.sourceDocument &&
+                          (() => {
+                            const doc = activeTask.sourceDocument
+                            const url = doc.fileUrl || ''
+                            // A blob: URL only resolves in the tutor's browser, and
+                            // an empty URL means the document never reached storage —
+                            // either way the student can't load it. Show a clear
+                            // message instead of a silently blank frame.
+                            const loadable = !!url && !url.startsWith('blob:')
+                            const isPdf =
+                              doc.mimeType === 'application/pdf' ||
+                              (!doc.mimeType && /\.pdf($|\?|#)/i.test(url))
+                            const isImage = doc.mimeType?.startsWith('image/')
+                            const pdfSrc = url.includes('#')
+                              ? `${url}&toolbar=0&navpanes=0`
+                              : `${url}#toolbar=0&navpanes=0`
+                            return (
+                              <div className="mb-4 h-[55vh] w-full">
+                                {!loadable ? (
+                                  <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border bg-slate-50 text-center">
+                                    <FileText className="h-8 w-8 text-slate-400" />
+                                    <p className="text-sm text-slate-500">
+                                      {doc.fileName || 'Document'} is unavailable. Ask your tutor to
+                                      re-deploy it.
+                                    </p>
+                                  </div>
+                                ) : isPdf ? (
+                                  <iframe
+                                    src={pdfSrc}
+                                    title={doc.fileName}
+                                    className="h-full w-full rounded-lg border"
+                                  />
+                                ) : isImage ? (
+                                  <div className="flex h-full items-center justify-center">
+                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                    <img
+                                      src={url}
+                                      alt={doc.fileName}
+                                      className="max-h-full max-w-full object-contain"
+                                    />
+                                  </div>
+                                ) : (
+                                  <div className="flex h-full flex-col items-center justify-center gap-2">
+                                    <FileText className="h-8 w-8 text-blue-600" />
+                                    <a
+                                      href={url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="text-sm text-blue-600 underline"
+                                    >
+                                      Open {doc.fileName}
+                                    </a>
+                                  </div>
+                                )}
                               </div>
-                            ) : (
-                              <div className="flex h-full flex-col items-center justify-center gap-2">
-                                <FileText className="h-8 w-8 text-blue-600" />
-                                <a
-                                  href={activeTask.sourceDocument.fileUrl}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-sm text-blue-600 underline"
-                                >
-                                  Open {activeTask.sourceDocument.fileName}
-                                </a>
-                              </div>
-                            )}
-                          </div>
-                        )}
+                            )
+                          })()}
 
                         {Array.isArray(activeTask.dmiItems) && activeTask.dmiItems.length > 0 && (
                           <div className="space-y-3">

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -1231,24 +1231,17 @@ export default function PublicTutorPage() {
                             </div>
                             <div className="h-3.5 w-px self-center bg-[rgba(255,255,255,0.12)]" />
                             <div className="min-w-0">
-                              {course.scheduleSummary ? (
-                                <button
-                                  type="button"
-                                  onClick={e => {
-                                    e.preventDefault()
-                                    setScheduleCourse(course)
-                                  }}
-                                  className="inline-flex items-center gap-1 font-medium text-blue-400 transition-colors hover:text-blue-300 hover:underline"
-                                >
-                                  <CalendarDays className="h-3.5 w-3.5" />
-                                  Schedule <ExternalLink className="h-3 w-3" />
-                                </button>
-                              ) : (
-                                <span className="inline-flex items-center gap-1 font-medium text-slate-300">
-                                  <CalendarDays className="h-3.5 w-3.5 text-slate-400" />
-                                  Schedule TBA
-                                </span>
-                              )}
+                              <button
+                                type="button"
+                                onClick={e => {
+                                  e.preventDefault()
+                                  setScheduleCourse(course)
+                                }}
+                                className="inline-flex items-center gap-1 font-medium text-blue-400 transition-colors hover:text-blue-300 hover:underline"
+                              >
+                                <CalendarDays className="h-3.5 w-3.5" />
+                                View schedules <ExternalLink className="h-3 w-3" />
+                              </button>
                             </div>
                           </div>
                         </div>
@@ -1263,22 +1256,16 @@ export default function PublicTutorPage() {
                           </div>
                           <div className="flex items-center gap-2 text-sm text-slate-200">
                             <CalendarDays className="h-4 w-4 text-slate-400" />
-                            {course.scheduleSummary ? (
-                              <button
-                                type="button"
-                                onClick={e => {
-                                  e.preventDefault()
-                                  setScheduleCourse(course)
-                                }}
-                                className="inline-flex items-center gap-1 font-medium text-blue-400 transition-colors hover:text-blue-300 hover:underline"
-                              >
-                                Schedule <ExternalLink className="h-3 w-3" />
-                              </button>
-                            ) : (
-                              <span className="font-medium text-slate-300">
-                                Schedule to be announced
-                              </span>
-                            )}
+                            <button
+                              type="button"
+                              onClick={e => {
+                                e.preventDefault()
+                                setScheduleCourse(course)
+                              }}
+                              className="inline-flex items-center gap-1 font-medium text-blue-400 transition-colors hover:text-blue-300 hover:underline"
+                            >
+                              View schedules <ExternalLink className="h-3 w-3" />
+                            </button>
                           </div>
                           <div className="pt-0.5">
                             <Badge
@@ -2042,9 +2029,19 @@ export default function PublicTutorPage() {
             <DialogPanel className="p-3">
               <div className="space-y-0.5">
                 <div className="text-muted-foreground text-xs font-medium">Schedule</div>
-                <div className="text-foreground text-sm font-semibold">
-                  {detailsCourse?.scheduleSummary?.trim() || 'Schedule to be announced'}
-                </div>
+                {detailsCourse?.id ? (
+                  <button
+                    type="button"
+                    onClick={() => setScheduleCourse(detailsCourse)}
+                    className="text-sm font-semibold text-blue-600 hover:underline"
+                  >
+                    View schedules
+                  </button>
+                ) : (
+                  <div className="text-foreground text-sm font-semibold">
+                    Schedule to be announced
+                  </div>
+                )}
               </div>
             </DialogPanel>
             <DialogPanel className="p-3">

--- a/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
@@ -32,7 +32,10 @@ export const GET = withAuth(
         enrollmentCount,
       })
       .from(course)
-      .innerJoin(courseEnrollment, eq(courseEnrollment.courseId, course.courseId))
+      // leftJoin (not inner) so a published course with zero enrollments still
+      // appears on the tutor dashboard — enrollment is not a precondition for a
+      // published course to show as active.
+      .leftJoin(courseEnrollment, eq(courseEnrollment.courseId, course.courseId))
       .where(and(eq(course.creatorId, tutorId), eq(course.isPublished, true)))
       .groupBy(
         course.courseId,

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -957,10 +957,17 @@ export async function initEnhancedSocketServer(server: NetServer) {
         return
       }
 
-      // Refresh any GCS document URLs before deploying to students
-      const refreshedSourceDocument = task.sourceDocument
-        ? await refreshDocumentUrls(task.sourceDocument)
-        : undefined
+      // Refresh any GCS document URLs (re-sign from fileKey) before deploying so
+      // students get a live URL rather than a possibly-expired one. Never let a
+      // refresh failure block the deploy — fall back to the original document.
+      let refreshedSourceDocument = task.sourceDocument
+      if (task.sourceDocument) {
+        try {
+          refreshedSourceDocument = await refreshDocumentUrls(task.sourceDocument)
+        } catch (err) {
+          console.warn('[task:deploy] document URL refresh failed:', err)
+        }
+      }
 
       const normalizedTask: LiveTask = {
         id: task.id,
@@ -1104,6 +1111,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
               ? await refreshDocumentUrls({
                   fileName: (rawSourceDoc.fileName as string) || '',
                   fileUrl: (rawSourceDoc.fileUrl as string) || '',
+                  // Preserve fileKey so the URL is re-signed from the object key
+                  // (reliable) rather than regex-parsing a possibly-expired URL.
+                  fileKey: (rawSourceDoc.fileKey as string) || undefined,
                   mimeType: (rawSourceDoc.mimeType as string) || '',
                 })
               : undefined

--- a/tutorme-app/src/lib/storage/gcs.ts
+++ b/tutorme-app/src/lib/storage/gcs.ts
@@ -156,7 +156,14 @@ export async function refreshDocumentUrls<T>(obj: T): Promise<T> {
     isGcsConfigured()
   ) {
     const refreshed = { ...record }
-    refreshed.fileUrl = await createPresignedDownloadUrl(fileKey, 3600)
+    try {
+      refreshed.fileUrl = await createPresignedDownloadUrl(fileKey, 3600)
+    } catch (err: any) {
+      // A signing failure (e.g. missing iam.serviceAccounts.signBlob) must not
+      // reject the whole deploy/sync — keep the existing fileUrl so the rest of
+      // the task still reaches students.
+      console.warn('[GCS] fileKey presign failed, keeping existing URL:', err?.message || err)
+    }
     // Recursively refresh nested objects
     for (const [key, value] of Object.entries(refreshed)) {
       if (key !== 'fileUrl' && typeof value === 'object' && value !== null) {


### PR DESCRIPTION
## **User description**
Four fixes.

**1. View all schedules from course cards** — replaced the static "Schedule TBA" / "Schedule to be announced" placeholders with a **View schedules** button opening the existing `ScheduleViewModal` (fetches all CourseSchedule rows; graceful empty state). Wired on the public tutor profile grid + list cards and details dialog, and the homepage course details dialog (added import/state/modal there).

**2. Published course appears on dashboard without enrollment** — `/api/tutor/courses/enrolled` used an `innerJoin` on `courseEnrollment`, so a course with zero enrollments never showed. Switched to `leftJoin` so a published course shows as active regardless of enrollment.

**3. Student exit button** — added a clear, labelled red **Leave session** button to the student live classroom header (alongside the existing back arrow).

**4. Deployed task document won't display on student side** — hardened the path: try/catch around the fileKey presign in `refreshDocumentUrls` (a signing failure no longer rejects the whole deploy), try/catch around the `task:deploy` refresh, preserved `fileKey` on the `course:sync` path so URLs re-sign reliably (not regex-parsed/expired), and made the student viewer robust — empty/blob URLs now show a clear "unavailable, ask tutor to re-deploy" message instead of a blank frame, plus PDF detection by file extension.

> Note: if documents still don't display after this, the remaining cause is the **socket-server runtime missing GCS env / signBlob permission** (it then serves the original, eventually-expired URL). That's a Cloud Run env check, not code.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix course visibility, schedule access, classroom exit, and document display**

### What Changed
- Published tutor courses now stay visible on the dashboard even when no one is enrolled yet.
- Course cards and course details now show a **View schedules** button that opens the full schedule list instead of static "Schedule TBA" text.
- Students now have a clear **Leave session** button in the live classroom header.
- Deployed documents now keep loading even if URL refresh fails, and students see a clear unavailable message instead of a blank document area.

### Impact
`✅ Published courses show up sooner on tutor dashboards`
`✅ Fewer blank schedule placeholders`
`✅ Clearer exit from live sessions`
`✅ Fewer blank document previews for students`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
