### PR TITLE
fix(live): resilient End-session + serve deployed docs via same-origin proxy

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1409,15 +1409,23 @@ function StudentFeedbackContent() {
                         {activeTask.sourceDocument &&
                           (() => {
                             const doc = activeTask.sourceDocument
-                            const url = doc.fileUrl || ''
-                            // A blob: URL only resolves in the tutor's browser, and
-                            // an empty URL means the document never reached storage —
-                            // either way the student can't load it. Show a clear
-                            // message instead of a silently blank frame.
-                            const loadable = !!url && !url.startsWith('blob:')
+                            const rawUrl = doc.fileUrl || ''
+                            // Prefer streaming by object key through our same-origin
+                            // proxy: it reads from storage server-side (no signed/
+                            // public URL needed), so it works even when GCS URL
+                            // signing is misconfigured or a stored URL has expired.
+                            // Fall back to the direct URL only when there's no key.
+                            const url = doc.fileKey
+                              ? `/api/proxy-file?key=${encodeURIComponent(doc.fileKey)}`
+                              : rawUrl
+                            // Without a key, a blob: URL only resolves in the tutor's
+                            // browser and an empty URL never reached storage — show a
+                            // clear message instead of a silently blank frame.
+                            const loadable =
+                              !!doc.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
                             const isPdf =
                               doc.mimeType === 'application/pdf' ||
-                              (!doc.mimeType && /\.pdf($|\?|#)/i.test(url))
+                              (!doc.mimeType && /\.pdf($|\?|#)/i.test(doc.fileName || rawUrl))
                             const isImage = doc.mimeType?.startsWith('image/')
                             const pdfSrc = url.includes('#')
                               ? `${url}&toolbar=0&navpanes=0`

--- a/tutorme-app/src/app/api/proxy-file/route.ts
+++ b/tutorme-app/src/app/api/proxy-file/route.ts
@@ -8,7 +8,32 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth } from '@/lib/api/middleware'
 import { assertSafeProxyUrl } from '@/lib/security/proxy-url'
-import { isGcsConfigured, refreshGcsUrl } from '@/lib/storage/gcs'
+import { isGcsConfigured, refreshGcsUrl, downloadBuffer } from '@/lib/storage/gcs'
+
+/**
+ * Infer an inline-renderable content type from an object key's extension.
+ * Used by the by-key streaming path so PDFs/images display in an <iframe>/<img>.
+ */
+function contentTypeForKey(key: string): string {
+  const ext = key.split('.').pop()?.toLowerCase() ?? ''
+  switch (ext) {
+    case 'pdf':
+      return 'application/pdf'
+    case 'png':
+      return 'image/png'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'gif':
+      return 'image/gif'
+    case 'webp':
+      return 'image/webp'
+    case 'svg':
+      return 'image/svg+xml'
+    default:
+      return 'application/octet-stream'
+  }
+}
 
 const MAX_SIZE_BYTES = 50 * 1024 * 1024 // 50MB
 const MAX_REDIRECTS = 5
@@ -78,9 +103,44 @@ async function readLimitedResponse(response: Response): Promise<Buffer> {
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url)
   const targetUrl = searchParams.get('url')
+  const objectKey = searchParams.get('key')
+
+  // By-key streaming: download the object server-side using the service
+  // account's READ access (storage.objects.get) and stream it back same-origin.
+  // This is resilient to signing problems — it needs no signed/public URL, so a
+  // missing iam.serviceAccounts.signBlob permission (which makes "signed" URLs
+  // fall back to public URLs that 403 under uniform bucket-level access) no
+  // longer breaks document display for students.
+  if (objectKey) {
+    // Restrict to known upload prefixes and block path traversal so this can't
+    // be used to read arbitrary objects.
+    if (!/^(documents|assets|resources)\//.test(objectKey) || objectKey.includes('..')) {
+      return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
+    }
+    if (!isGcsConfigured()) {
+      return NextResponse.json({ error: 'Storage not configured' }, { status: 503 })
+    }
+    try {
+      const buf = await downloadBuffer(objectKey)
+      if (!buf) {
+        return NextResponse.json({ error: 'File not found' }, { status: 404 })
+      }
+      return new NextResponse(new Uint8Array(buf), {
+        status: 200,
+        headers: {
+          'Content-Type': contentTypeForKey(objectKey),
+          'Content-Disposition': 'inline',
+          'Cache-Control': 'private, max-age=3600',
+        },
+      })
+    } catch (error) {
+      console.error('[proxy-file] by-key download failed:', objectKey, error)
+      return NextResponse.json({ error: 'Failed to load file' }, { status: 502 })
+    }
+  }
 
   if (!targetUrl) {
-    return NextResponse.json({ error: 'Missing url parameter' }, { status: 400 })
+    return NextResponse.json({ error: 'Missing url or key parameter' }, { status: 400 })
   }
 
   let urlToFetch = targetUrl

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -398,117 +398,128 @@ export const PATCH = withCsrf(
         }
       }
 
-      const [partCount, messagesCountResult] = await Promise.all([
-        drizzleDb
-          .select({ count: sql<number>`count(*)::int` })
-          .from(sessionParticipant)
-          .where(eq(sessionParticipant.sessionId, classId)),
-        drizzleDb
-          .select({ count: sql<number>`count(*)::int` })
-          .from(message)
-          .where(eq(message.sessionId, classId)),
-      ])
-
-      const _count = {
-        participants: partCount[0]?.count ?? 0,
-        messages: messagesCountResult[0]?.count ?? 0,
-      }
-
-      const existingArtifact = await drizzleDb
-        .select()
-        .from(sessionReplayArtifact)
-        .where(eq(sessionReplayArtifact.sessionId, classId))
-        .limit(1)
-
-      if (existingArtifact[0]) {
-        await drizzleDb
-          .update(sessionReplayArtifact)
-          .set({
-            recordingUrl: liveSessionRow.recordingUrl,
-            status: 'processing',
-            endedAt,
-          })
-          .where(eq(sessionReplayArtifact.sessionId, classId))
-      } else {
-        await drizzleDb.insert(sessionReplayArtifact).values({
-          artifactId: randomUUID(),
-          sessionId: classId,
-          tutorId,
-          recordingUrl: liveSessionRow.recordingUrl,
-          status: 'processing',
-          startedAt: liveSessionRow.startedAt ?? endedAt,
-          endedAt,
-        })
-      }
-
+      // The session is now ended (status, room teardown and the session:ended
+      // event are done). Everything below is post-processing — replay artifact,
+      // transcript and AI summary. None of it must fail the End request, so it's
+      // all wrapped: a failure here is logged but the tutor still ends cleanly.
       try {
-        const messageRows = await drizzleDb
-          .select({
-            timestamp: message.timestamp,
-            content: message.content,
-            userName: profile.name,
-            userEmail: user.email,
-          })
-          .from(message)
-          .innerJoin(user, eq(message.userId, user.userId))
-          .leftJoin(profile, eq(profile.userId, user.userId))
-          .where(eq(message.sessionId, classId))
-          .orderBy(asc(message.timestamp))
+        const [partCount, messagesCountResult] = await Promise.all([
+          drizzleDb
+            .select({ count: sql<number>`count(*)::int` })
+            .from(sessionParticipant)
+            .where(eq(sessionParticipant.sessionId, classId)),
+          drizzleDb
+            .select({ count: sql<number>`count(*)::int` })
+            .from(message)
+            .where(eq(message.sessionId, classId)),
+        ])
 
-        const transcript =
-          messageRows.length > 0
-            ? buildTranscript(messageRows)
-            : liveSessionRow.recordingUrl
-              ? 'Transcript unavailable from chat history. Recording exists and is pending audio transcription ingestion.'
-              : 'No transcript available for this session.'
-
-        const summaryResult = await generateSessionSummary(classId, {
-          type: 'session',
-          maxLength: 'detailed',
-          includeActionItems: true,
-          language: 'en',
-        })
-
-        const summaryText =
-          summaryResult.success && summaryResult.summary
-            ? summaryResult.summary.overview
-            : 'Summary generation is unavailable for this session.'
-
-        const summaryPayload = {
-          ...(summaryResult.success && summaryResult.summary ? summaryResult.summary : {}),
-          sessionMeta: {
-            title: liveSessionRow.title,
-            subject: liveSessionRow.category,
-            participants: _count.participants,
-            messages: _count.messages,
-            generatedAt: new Date().toISOString(),
-          },
-          transcriptMeta: {
-            source: messageRows.length > 0 ? 'chat_messages' : 'recording_placeholder',
-            hasTranscriptText: Boolean(transcript?.trim()),
-          },
+        const _count = {
+          participants: partCount[0]?.count ?? 0,
+          messages: messagesCountResult[0]?.count ?? 0,
         }
 
-        await drizzleDb
-          .update(sessionReplayArtifact)
-          .set({
-            transcript,
-            summary: summaryText,
-            summaryJson: summaryPayload,
+        const existingArtifact = await drizzleDb
+          .select()
+          .from(sessionReplayArtifact)
+          .where(eq(sessionReplayArtifact.sessionId, classId))
+          .limit(1)
+
+        if (existingArtifact[0]) {
+          await drizzleDb
+            .update(sessionReplayArtifact)
+            .set({
+              recordingUrl: liveSessionRow.recordingUrl,
+              status: 'processing',
+              endedAt,
+            })
+            .where(eq(sessionReplayArtifact.sessionId, classId))
+        } else {
+          await drizzleDb.insert(sessionReplayArtifact).values({
+            artifactId: randomUUID(),
+            sessionId: classId,
+            tutorId,
             recordingUrl: liveSessionRow.recordingUrl,
-            status: summaryResult.success ? 'ready' : 'failed',
-            generatedAt: new Date(),
+            status: 'processing',
+            startedAt: liveSessionRow.startedAt ?? endedAt,
+            endedAt,
           })
-          .where(eq(sessionReplayArtifact.sessionId, classId))
-      } catch (error) {
-        await drizzleDb
-          .update(sessionReplayArtifact)
-          .set({
-            status: 'failed',
-            generatedAt: new Date(),
+        }
+
+        try {
+          const messageRows = await drizzleDb
+            .select({
+              timestamp: message.timestamp,
+              content: message.content,
+              userName: profile.name,
+              userEmail: user.email,
+            })
+            .from(message)
+            .innerJoin(user, eq(message.userId, user.userId))
+            .leftJoin(profile, eq(profile.userId, user.userId))
+            .where(eq(message.sessionId, classId))
+            .orderBy(asc(message.timestamp))
+
+          const transcript =
+            messageRows.length > 0
+              ? buildTranscript(messageRows)
+              : liveSessionRow.recordingUrl
+                ? 'Transcript unavailable from chat history. Recording exists and is pending audio transcription ingestion.'
+                : 'No transcript available for this session.'
+
+          const summaryResult = await generateSessionSummary(classId, {
+            type: 'session',
+            maxLength: 'detailed',
+            includeActionItems: true,
+            language: 'en',
           })
-          .where(eq(sessionReplayArtifact.sessionId, classId))
-        console.error('Failed to generate replay artifact:', error)
+
+          const summaryText =
+            summaryResult.success && summaryResult.summary
+              ? summaryResult.summary.overview
+              : 'Summary generation is unavailable for this session.'
+
+          const summaryPayload = {
+            ...(summaryResult.success && summaryResult.summary ? summaryResult.summary : {}),
+            sessionMeta: {
+              title: liveSessionRow.title,
+              subject: liveSessionRow.category,
+              participants: _count.participants,
+              messages: _count.messages,
+              generatedAt: new Date().toISOString(),
+            },
+            transcriptMeta: {
+              source: messageRows.length > 0 ? 'chat_messages' : 'recording_placeholder',
+              hasTranscriptText: Boolean(transcript?.trim()),
+            },
+          }
+
+          await drizzleDb
+            .update(sessionReplayArtifact)
+            .set({
+              transcript,
+              summary: summaryText,
+              summaryJson: summaryPayload,
+              recordingUrl: liveSessionRow.recordingUrl,
+              status: summaryResult.success ? 'ready' : 'failed',
+              generatedAt: new Date(),
+            })
+            .where(eq(sessionReplayArtifact.sessionId, classId))
+        } catch (error) {
+          await drizzleDb
+            .update(sessionReplayArtifact)
+            .set({
+              status: 'failed',
+              generatedAt: new Date(),
+            })
+            .where(eq(sessionReplayArtifact.sessionId, classId))
+            .catch(() => {})
+          console.error('Failed to generate replay artifact:', error)
+        }
+      } catch (postErr) {
+        // Post-processing (counts / replay artifact / summary) failed — the
+        // session is already ended, so log and still return success.
+        console.error('[end-class] post-processing failed (session still ended):', postErr)
       }
 
       return NextResponse.json({ success: true, status: 'ended' })


### PR DESCRIPTION
## **User description**
Two fixes.

### End button → Internal Server Error
The PATCH end handler ran counts + replay-artifact upsert + AI summary generation with **no outer guard**. The session was already marked `ended`, but any failure in that post-processing bubbled up as a 500. Now all post-end work is wrapped: the session ends, the Daily room is torn down, `session:ended` is emitted, and post-processing failures are logged but never fail the request. (Also made the inner replay-artifact 'failed' update non-throwing.)

### Deployed-task documents not displaying for students — resilient fix
Root cause: GCS URL **signing**. If the service account lacks `iam.serviceAccounts.signBlob`, `refreshGcsUrl` falls back to a *public* URL — but `makePublic` is skipped under uniform bucket-level access, so that URL **403s**. The student iframe then loads nothing, and re-signing on deploy fails the same way. Signed/public URLs are the fragile part.

Fix: stream documents through the existing same-origin **`/api/proxy-file`** endpoint **by object key** — it downloads from storage server-side using read access (`storage.objects.get`, no `signBlob` needed), so display no longer depends on URL signing at all.
- Added a `?key=` branch to `/api/proxy-file` (prefix-allowlisted to `documents/assets/resources`, no path traversal) that streams the object inline with an inferred content-type.
- The student viewer uses `?key=<fileKey>` when a `fileKey` exists, falling back to the direct URL otherwise; PDF detection also considers the file name.
- `fileKey` already flows through `task:deploy` and `course:sync` (preserved in the prior PR).

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make ending a live session finish cleanly and keep deployed documents visible for students

### What Changed
- Ending a session now returns success even if follow-up work like replay details or AI summary generation fails after the room has already been closed.
- Deployed documents now load through the app when a file key is available, instead of relying on signed or public storage links that can fail or expire.
- The student view falls back to the direct document URL only when no file key exists, and PDF detection now also uses the file name.
- File access through the proxy is limited to allowed document folders, with invalid keys rejected.

### Impact
`✅ Fewer end-session server errors`
`✅ Fewer blank student document previews`
`✅ Clearer access to deployed PDFs and images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
