### PR TITLE
fix(live): submissions tab, real analytics, monitor roster, course-name parity

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -67,6 +67,7 @@ type Props = UseCourseBuilderContentArgs & {
   insightsProps: CourseBuilderInsightsProps
   sessionCategory?: string | null
   sessionNationality?: string | null
+  sessionVariantName?: string | null
   onSaveCourse?: (lessons: any[], options?: any) => void
   onSyncToLiveSession?: (silent?: boolean) => void
   onCreateCourse?: () => void
@@ -114,6 +115,7 @@ function CourseBuilderInsightsRouteInner({
   detachedCourseName,
   sessionCategory,
   sessionNationality,
+  sessionVariantName,
   onSaveCourse,
   onSyncToLiveSession,
   onCreateCourse,
@@ -588,13 +590,18 @@ function CourseBuilderInsightsRouteInner({
                       )}
                     </h1>
                   )}
-                  {activeMainTab === 'live' && (sessionCategory || sessionNationality) && (
-                    <span className="bg-muted text-muted-foreground ml-2 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
-                      {sessionCategory && sessionNationality
-                        ? `${sessionCategory} — ${sessionNationality}`
-                        : sessionCategory || sessionNationality}
-                    </span>
-                  )}
+                  {activeMainTab === 'live' &&
+                    (sessionVariantName || sessionCategory || sessionNationality) && (
+                      <span className="bg-muted text-muted-foreground ml-2 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
+                        {/* Prefer the canonical variant label (same helper the
+                            student side uses) so both headers read identically. */}
+                        {sessionVariantName
+                          ? sessionVariantName
+                          : sessionCategory && sessionNationality
+                            ? `${sessionCategory} — ${sessionNationality}`
+                            : sessionCategory || sessionNationality}
+                      </span>
+                    )}
                   {activeMainTab !== 'live' &&
                   currentCourse &&
                   (currentCourse as any).categories?.length > 0 ? (

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AnalyticsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AnalyticsPanel.tsx
@@ -1,38 +1,16 @@
 'use client'
 
 import { useMemo } from 'react'
-import {
-  PieChart,
-  Pie,
-  Cell,
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  CartesianGrid,
-} from 'recharts'
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts'
 import { Badge } from '@/components/ui/badge'
-import { Progress } from '@/components/ui/progress'
-import {
-  Users,
-  Activity,
-  MessageSquare,
-  Clock,
-  Radio,
-  TrendingUp,
-  TrendingDown,
-  Minus,
-  Hand,
-  Smile,
-  CheckCircle2,
-} from 'lucide-react'
+import { Users, MessageSquare, Clock, Radio, Smile, CheckCircle2, ListChecks } from 'lucide-react'
 import type { LiveTask } from '@/lib/socket/socket-types'
 import type { LiveStudent, EngagementMetrics } from '@/types/live-session'
 
 interface AnalyticsPanelProps {
   students?: LiveStudent[]
+  // Kept for API compatibility; engagement/attention have no real signal source
+  // so they are intentionally not rendered (see below).
   metrics?: EngagementMetrics | null
   liveTasks?: LiveTask[]
   classDuration?: number
@@ -41,42 +19,33 @@ interface AnalyticsPanelProps {
   sessionId?: string | null
 }
 
-const ENGAGEMENT_COLORS = {
-  veryEngaged: '#10b981', // emerald-500
-  engaged: '#3b82f6', // blue-500
-  passive: '#f59e0b', // amber-500
-  disengaged: '#ef4444', // red-500
-}
-
+/**
+ * Live-session analytics. Everything shown here is derived from REAL session
+ * data — present students (socket roster), deployed tasks, and their poll/
+ * question responses and completions. Fields that the app has no real signal
+ * for (engagement score, attention level, hands raised, participation rate)
+ * were previously fabricated and have been removed rather than faked.
+ */
 export function AnalyticsPanel({
   students,
-  metrics,
   liveTasks,
   classDuration,
   isRecording,
   recordingDuration,
   sessionId,
 }: AnalyticsPanelProps) {
-  const engagementData = useMemo(() => {
-    if (!metrics) return []
-    return [
-      { name: 'Very Engaged', value: metrics.veryEngaged, color: ENGAGEMENT_COLORS.veryEngaged },
-      { name: 'Engaged', value: metrics.engaged, color: ENGAGEMENT_COLORS.engaged },
-      { name: 'Passive', value: metrics.passive, color: ENGAGEMENT_COLORS.passive },
-      { name: 'Disengaged', value: metrics.disengaged, color: ENGAGEMENT_COLORS.disengaged },
-    ].filter(d => d.value > 0)
-  }, [metrics])
+  const totalStudents = students?.length ?? 0
+  const activeStudents = useMemo(
+    () => (students || []).filter(s => s.status !== 'offline').length,
+    [students]
+  )
 
   const studentStatusData = useMemo(() => {
     if (!students) return []
-    const online = students.filter(s => s.status === 'online').length
-    const idle = students.filter(s => s.status === 'idle').length
-    const away = students.filter(s => s.status === 'away').length
+    const online = students.filter(s => s.status !== 'offline').length
     const offline = students.filter(s => s.status === 'offline').length
     return [
       { name: 'Online', value: online, color: '#10b981' },
-      { name: 'Idle', value: idle, color: '#f59e0b' },
-      { name: 'Away', value: away, color: '#8b5cf6' },
       { name: 'Offline', value: offline, color: '#9ca3af' },
     ].filter(d => d.value > 0)
   }, [students])
@@ -109,29 +78,15 @@ export function AnalyticsPanel({
     )
   }, [liveTasks])
 
-  const handsRaised = useMemo(() => {
-    return (students || []).filter(s => s.handRaised).length
-  }, [students])
-
+  // Completion across all deployed tasks: unique students who completed at least
+  // one deployed task, over the number present.
   const taskCompletions = useMemo(() => {
-    const activeTask = liveTasks?.find(t => t.completedBy && t.completedBy.length > 0)
-    if (!activeTask?.completedBy)
-      return { completed: 0, total: students?.length ?? 0, taskName: '' }
-    return {
-      completed: activeTask.completedBy.length,
-      total: students?.length ?? 0,
-      taskName: activeTask.title,
+    const completers = new Set<string>()
+    for (const task of liveTasks || []) {
+      for (const id of task.completedBy || []) completers.add(id)
     }
-  }, [liveTasks, students])
-
-  const trendIcon =
-    metrics?.engagementTrend === 'up' ? (
-      <TrendingUp className="h-4 w-4 text-emerald-500" />
-    ) : metrics?.engagementTrend === 'down' ? (
-      <TrendingDown className="h-4 w-4 text-red-500" />
-    ) : (
-      <Minus className="h-4 w-4 text-amber-500" />
-    )
+    return { completed: completers.size, total: totalStudents }
+  }, [liveTasks, totalStudents])
 
   return (
     <div className="flex flex-col space-y-4 px-1 pb-4">
@@ -152,144 +107,78 @@ export function AnalyticsPanel({
             REC {formattedRecording}
           </Badge>
         )}
-        {metrics && (
-          <Badge variant="outline" className="flex items-center gap-1 text-xs">
-            {trendIcon}
-            Engagement {metrics.engagementTrend}
-          </Badge>
-        )}
       </div>
 
-      {/* Stat cards */}
+      {/* Stat cards — all derived from real session data */}
       <div className="grid grid-cols-2 gap-3">
         <StatCard
           icon={<Users className="h-4 w-4 text-blue-500" />}
           label="Students"
-          value={`${metrics?.activeStudents ?? 0} / ${metrics?.totalStudents ?? 0}`}
-          sub="active"
-        />
-        <StatCard
-          icon={<Activity className="h-4 w-4 text-emerald-500" />}
-          label="Avg Engagement"
-          value={`${Math.round((metrics?.averageEngagement ?? 0) * 100)}%`}
-          sub={metrics?.engagementTrend}
-        />
-        <StatCard
-          icon={<MessageSquare className="h-4 w-4 text-blue-500" />}
-          label="Chat Messages"
-          value={String(metrics?.totalChatMessages ?? 0)}
-          sub="total"
-        />
-        <StatCard
-          icon={<Hand className="h-4 w-4 text-violet-500" />}
-          label="Hands Raised"
-          value={String(handsRaised)}
-          sub="now"
+          value={`${activeStudents} / ${totalStudents}`}
+          sub="present"
         />
         <StatCard
           icon={<CheckCircle2 className="h-4 w-4 text-emerald-500" />}
           label="Task Done"
           value={`${taskCompletions.completed} / ${taskCompletions.total}`}
-          sub={taskCompletions.taskName || 'No active task'}
+          sub="completed"
+        />
+        <StatCard
+          icon={<Smile className="h-4 w-4 text-violet-500" />}
+          label="Poll Responses"
+          value={String(totalPollResponses)}
+          sub="total"
+        />
+        <StatCard
+          icon={<MessageSquare className="h-4 w-4 text-blue-500" />}
+          label="Question Responses"
+          value={String(totalQuestionResponses)}
+          sub="total"
         />
       </div>
 
-      {/* Participation */}
-      {metrics && (
-        <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
-          <div className="mb-2 flex items-center justify-between">
-            <span className="text-xs font-semibold uppercase text-gray-500">
-              Participation Rate
-            </span>
-            <span className="text-sm font-bold text-gray-900">
-              {Math.round(metrics.participationRate * 100)}%
-            </span>
+      {/* Student presence */}
+      <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
+        <p className="mb-2 text-xs font-semibold uppercase text-gray-500">Student Presence</p>
+        {studentStatusData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={160}>
+            <PieChart>
+              <Pie
+                data={studentStatusData}
+                cx="50%"
+                cy="50%"
+                innerRadius={40}
+                outerRadius={60}
+                paddingAngle={3}
+                dataKey="value"
+              >
+                {studentStatusData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[160px] items-center justify-center text-xs text-gray-400">
+            No students have joined yet
           </div>
-          <Progress value={metrics.participationRate * 100} className="h-2" />
-        </div>
-      )}
-
-      {/* Charts row */}
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        {/* Engagement Pie */}
-        <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
-          <p className="mb-2 text-xs font-semibold uppercase text-gray-500">Engagement Breakdown</p>
-          {engagementData.length > 0 ? (
-            <ResponsiveContainer width="100%" height={160}>
-              <PieChart>
-                <Pie
-                  data={engagementData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={40}
-                  outerRadius={60}
-                  paddingAngle={3}
-                  dataKey="value"
-                >
-                  {engagementData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={entry.color} />
-                  ))}
-                </Pie>
-                <Tooltip />
-              </PieChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex h-[160px] items-center justify-center text-xs text-gray-400">
-              No engagement data yet
+        )}
+        <div className="mt-1 flex flex-wrap gap-2">
+          {studentStatusData.map(d => (
+            <div key={d.name} className="flex items-center gap-1 text-[10px] text-gray-600">
+              <span className="h-2 w-2 rounded-full" style={{ background: d.color }} />
+              {d.name}: {d.value}
             </div>
-          )}
-          <div className="mt-1 flex flex-wrap gap-2">
-            {engagementData.map(d => (
-              <div key={d.name} className="flex items-center gap-1 text-[10px] text-gray-600">
-                <span className="h-2 w-2 rounded-full" style={{ background: d.color }} />
-                {d.name}: {d.value}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Student Status Pie */}
-        <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
-          <p className="mb-2 text-xs font-semibold uppercase text-gray-500">Student Status</p>
-          {studentStatusData.length > 0 ? (
-            <ResponsiveContainer width="100%" height={160}>
-              <PieChart>
-                <Pie
-                  data={studentStatusData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={40}
-                  outerRadius={60}
-                  paddingAngle={3}
-                  dataKey="value"
-                >
-                  {studentStatusData.map((entry, index) => (
-                    <Cell key={`cell-${index}`} fill={entry.color} />
-                  ))}
-                </Pie>
-                <Tooltip />
-              </PieChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="flex h-[160px] items-center justify-center text-xs text-gray-400">
-              No student data yet
-            </div>
-          )}
-          <div className="mt-1 flex flex-wrap gap-2">
-            {studentStatusData.map(d => (
-              <div key={d.name} className="flex items-center gap-1 text-[10px] text-gray-600">
-                <span className="h-2 w-2 rounded-full" style={{ background: d.color }} />
-                {d.name}: {d.value}
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
       </div>
 
       {/* Task Activity */}
       {liveTasks && liveTasks.length > 0 && (
         <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
-          <p className="mb-2 text-xs font-semibold uppercase text-gray-500">
+          <p className="mb-2 flex items-center gap-1 text-xs font-semibold uppercase text-gray-500">
+            <ListChecks className="h-3 w-3" />
             Deployed Task Activity
           </p>
           <div className="space-y-2">
@@ -336,7 +225,7 @@ export function AnalyticsPanel({
         </div>
       )}
 
-      {/* Student List */}
+      {/* Student List — name, real presence, and real task-completion badge */}
       {students && students.length > 0 && (
         <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
           <p className="mb-2 text-xs font-semibold uppercase text-gray-500">
@@ -351,13 +240,7 @@ export function AnalyticsPanel({
                 <div className="flex items-center gap-2">
                   <span
                     className={`h-2 w-2 rounded-full ${
-                      s.status === 'online'
-                        ? 'bg-emerald-500'
-                        : s.status === 'idle'
-                          ? 'bg-amber-500'
-                          : s.status === 'away'
-                            ? 'bg-violet-500'
-                            : 'bg-gray-400'
+                      s.status === 'offline' ? 'bg-gray-400' : 'bg-emerald-500'
                     }`}
                   />
                   <span className="text-xs font-medium text-gray-900">{s.name}</span>
@@ -367,26 +250,6 @@ export function AnalyticsPanel({
                       Done
                     </Badge>
                   )}
-                  {s.handRaised && (
-                    <Badge variant="outline" className="h-4 px-1 text-[9px] text-violet-600">
-                      <Hand className="mr-0.5 h-2.5 w-2.5" />
-                      Raised
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex items-center gap-3 text-[10px] text-gray-500">
-                  <span>{Math.round(s.engagementScore * 100)}% eng</span>
-                  <span
-                    className={`capitalize ${
-                      s.attentionLevel === 'high'
-                        ? 'text-emerald-600'
-                        : s.attentionLevel === 'medium'
-                          ? 'text-amber-600'
-                          : 'text-red-600'
-                    }`}
-                  >
-                    {s.attentionLevel}
-                  </span>
                 </div>
               </div>
             ))}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7695,6 +7695,7 @@ FEEDBACK: [your explanation]`
                       width={rightPanelWidth}
                       hidden={rightPanelHidden}
                       onToggleHidden={setRightPanelHidden}
+                      liveSubmissions={insightsProps?.liveSubmissions}
                       headerExtra={
                         <Tabs
                           value={liveRightPanelTab}
@@ -7964,6 +7965,7 @@ FEEDBACK: [your explanation]`
                     width={rightPanelWidth}
                     hidden={rightPanelHidden}
                     onToggleHidden={setRightPanelHidden}
+                    liveSubmissions={insightsProps?.liveSubmissions}
                   />
                 )}
               </>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
@@ -218,7 +218,10 @@ export function MonitoringPanel({
           const activeTab = stateUpdate?.payload?.activeTab
           const activeTaskId = stateUpdate?.payload?.activeTaskId
           const isWhiteboard = activeTab === 'my-board' || activeTab === 'tutor-board'
-          const isOnline = !!stateUpdate || student.status === 'online'
+          // The roster only contains currently-present students (departed ones
+          // are removed), so anyone here is online unless explicitly 'offline' —
+          // don't gate on having received a state-sync event yet.
+          const isOnline = student.status !== 'offline'
 
           return (
             <Card

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -41,6 +41,7 @@ type SubmissionsTreeResponse = {
     score: number | null
     maxScore: number
     submittedAt: string | Date
+    answers?: Record<string, string> | null
   }[]
   reports: {
     id: string
@@ -73,18 +74,30 @@ type SelectedLeaf = {
   report?: SubmissionsTreeResponse['reports'][number] | null
 }
 
+export interface LiveSubmission {
+  taskId: string
+  studentId: string
+  studentName?: string
+  submittedAt: string | number
+  answers?: Record<string, string>
+}
+
 export function SubmissionsPanel({
   courseId,
   width,
   hidden,
   onToggleHidden,
   headerExtra,
+  liveSubmissions,
 }: {
   courseId: string
   width: number
   hidden: boolean
   onToggleHidden: (value: boolean) => void
   headerExtra?: ReactNode
+  /** In-session completions received over the socket — overlaid on the DB rows
+   *  so a student's "Task Complete" shows immediately without a DB write. */
+  liveSubmissions?: LiveSubmission[]
 }) {
   const [data, setData] = useState<SubmissionsTreeResponse | null>(null)
   const [loading, setLoading] = useState(false)
@@ -187,8 +200,24 @@ export function SubmissionsPanel({
     ;(data?.submissions || []).forEach(s => {
       map.set(`${s.studentId}:${s.taskId}`, s)
     })
+    // Overlay live (in-session) completions so a student's "Task Complete" shows
+    // up immediately. DB rows (graded, persisted) take precedence when present.
+    ;(liveSubmissions || []).forEach(ls => {
+      const key = `${ls.studentId}:${ls.taskId}`
+      if (map.has(key)) return
+      map.set(key, {
+        submissionId: `live-${key}`,
+        taskId: ls.taskId,
+        studentId: ls.studentId,
+        status: 'submitted',
+        score: null,
+        maxScore: 100,
+        submittedAt: new Date(ls.submittedAt).toISOString(),
+        answers: ls.answers ?? null,
+      })
+    })
     return map
-  }, [data])
+  }, [data, liveSubmissions])
 
   const reportMap = useMemo(() => {
     const map = new Map<string, SubmissionsTreeResponse['reports'][number]>()
@@ -366,6 +395,22 @@ export function SubmissionsPanel({
                           : '—'}
                       </div>
                     </div>
+                    {selected.submission?.answers &&
+                      Object.keys(selected.submission.answers).length > 0 && (
+                        <div className="mt-3 border-t border-slate-200 pt-3">
+                          <div className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+                            Answers
+                          </div>
+                          <div className="mt-2 space-y-2">
+                            {Object.entries(selected.submission.answers).map(([qid, ans]) => (
+                              <div key={qid} className="text-sm">
+                                <span className="font-semibold text-slate-600">{qid}:</span>{' '}
+                                <span className="whitespace-pre-wrap text-slate-800">{ans}</span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                   </div>
 
                   <div className="rounded-xl border border-slate-200 bg-white p-4">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -302,6 +302,14 @@ export interface CourseBuilderInsightsProps {
   onSessionChange: (sessionId: string) => void
   onStartSession?: () => void
   liveTasks: LiveTask[]
+  /** In-session task/assessment completions (with answers) for the Submissions tab. */
+  liveSubmissions?: {
+    taskId: string
+    studentId: string
+    studentName?: string
+    submittedAt: string | number
+    answers?: Record<string, string>
+  }[]
   /** Present only inside a live session; deploy buttons hide when undefined. */
   onDeployTask?: (task: LiveTask) => void
   onSendPoll: (payload: { taskId: string; question: string }) => void

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -77,7 +77,20 @@ function TutorInsightsPageInner() {
   const [linkedCourseId, setLinkedCourseId] = useState<string | null>(null)
   const [sessionCategory, setSessionCategory] = useState<string | null>(null)
   const [sessionNationality, setSessionNationality] = useState<string | null>(null)
+  // Canonical "Category — Nationality" label from the API (formatCourseVariantName),
+  // so the tutor header matches exactly what the student side shows.
+  const [sessionVariantName, setSessionVariantName] = useState<string | null>(null)
   const [liveTasks, setLiveTasks] = useState<LiveTask[]>([])
+  // In-session task/assessment completions (with answers) for the Submissions tab.
+  const [liveSubmissions, setLiveSubmissions] = useState<
+    {
+      taskId: string
+      studentId: string
+      studentName?: string
+      submittedAt: string | number
+      answers?: Record<string, string>
+    }[]
+  >([])
   const [studentBoards, setStudentBoards] = useState<
     Record<string, { pages: unknown[]; pageIndex: number; updatedAt?: number }>
   >({})
@@ -677,6 +690,7 @@ function TutorInsightsPageInner() {
         setLinkedCourseId(data?.session?.linkedCourseId || null)
         setSessionCategory(data?.session?.category || null)
         setSessionNationality(data?.session?.nationality || null)
+        setSessionVariantName(data?.session?.variantName || null)
       } catch {
         // Ignore; keep existing selection
       }
@@ -766,11 +780,11 @@ function TutorInsightsPageInner() {
         })
       },
       onStudentLeft: (userId: string) => {
-        setStudents(prev =>
-          prev.map(s =>
-            ((s as any)?.userId ?? s?.id) === userId ? { ...s, status: 'offline' } : s
-          )
-        )
+        // Remove the student so the client roster mirrors the server's
+        // room.students (which deletes on disconnect). Previously this only
+        // flipped status to 'offline', so departed students accumulated forever
+        // and the Monitor tab showed people who had already left.
+        setStudents(prev => prev.filter(s => ((s as any)?.userId ?? s?.id) !== userId))
       },
       onStudentStateUpdate: (data: { userId: string; state: any }) => {
         setStudents(prev =>
@@ -839,6 +853,7 @@ function TutorInsightsPageInner() {
       studentName: string
       completedAt: number
       totalCompleted: number
+      answers?: Record<string, string>
     }) => {
       toast.success(`${data.studentName} completed a task`, {
         description: `${data.totalCompleted} student${data.totalCompleted === 1 ? '' : 's'} completed this task`,
@@ -851,6 +866,18 @@ function TutorInsightsPageInner() {
             : item
         )
       )
+      // Record the submission (with any typed answers) so the Submissions tab
+      // shows it live. Replace any prior entry for the same student+task.
+      setLiveSubmissions(prev => [
+        ...prev.filter(s => !(s.taskId === data.taskId && s.studentId === data.studentId)),
+        {
+          taskId: data.taskId,
+          studentId: data.studentId,
+          studentName: data.studentName,
+          submittedAt: data.completedAt,
+          answers: data.answers,
+        },
+      ])
     }
 
     const handleSessionEndingSoon = (data: { sessionId: string; minutesRemaining: number }) => {
@@ -1232,6 +1259,7 @@ function TutorInsightsPageInner() {
           sessions,
           onSessionChange: setSessionId,
           liveTasks,
+          liveSubmissions,
           // Only expose deploy inside a live session — the deploy buttons gate
           // on this callback, so hiding it prevents "deploying" from the plain
           // builder (where the emit would be silently dropped, no session/room).
@@ -1251,6 +1279,7 @@ function TutorInsightsPageInner() {
         }}
         sessionCategory={sessionCategory}
         sessionNationality={sessionNationality}
+        sessionVariantName={sessionVariantName}
         onSaveCourse={handleSave}
         onSyncToLiveSession={handleSyncToLiveSession}
         onCreateCourse={() => setIsCreateDialogOpen(true)}


### PR DESCRIPTION
## **User description**
Four live-session fixes.

### 1. Submissions tab shows student submissions
The socket `task:complete` only updated in-memory/Redis state, never a `taskSubmission` DB row — but the Submissions panel reads only `taskSubmission`, so live completions never appeared. (A DB write from the socket is unsafe: `taskSubmission.taskId` has a strict FK to `builderTask` + several NOT NULL columns, and live task ids aren't guaranteed builderTask rows.) Instead, the tutor host accumulates completions (with answers) from `task:completed` into `liveSubmissions` and passes them to `SubmissionsPanel`, which **overlays** them on the DB rows (keyed `studentId:taskId`) so items flip to *submitted* in real time. The detail dialog now shows the typed answers.

### 2. Analytics tab — real data only
`metrics` was always `null` and per-student engagement/attention/hands-raised were fabricated upstream (e.g. `engagementScore = 40 + chatCount*12`). Removed the fabricated UI (engagement breakdown, avg engagement, hands raised, participation rate, per-student eng%/attention) and derive everything from real session data: present students, task completions, poll/question responses, deployed-task activity.

### 3. Monitor tab roster
`onStudentLeft` only flipped status to 'offline', so departed students accumulated forever and the Monitor showed people who'd left. Now removes them (mirroring the server's `room.students`, which deletes on disconnect); the online dot reflects real presence.

### 4. Course-name parity (tutor ↔ student)
The tutor live header used raw `liveSession.category` + a never-supplied nationality; the student side used `formatCourseVariantName`. The tutor's own `/api/tutor/classes/[id]` already returns the canonical `variantName` — the header now reads it, so both sides show the identical "Course — Category — Nationality".

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show live submissions, real analytics, current roster, and matching course names in live sessions**

### What Changed
- Live task completions now appear in the Submissions tab right away, including typed answers in the submission details.
- The Analytics tab now shows only real session data and removes fabricated engagement, attention, hands-raised, and participation figures.
- The Monitor tab no longer keeps departed students in the roster; online status now matches who is actually present.
- The tutor live header now uses the same course variant label as the student view, so both sides show the same course name.

### Impact
`✅ Faster live submission visibility`
`✅ Clearer session analytics`
`✅ Fewer stale students in Monitor`
`✅ Matching course names for tutors and students`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
