### PR TITLE
feat(live): persist live task completions to TaskSubmission for grading

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
@@ -138,6 +138,7 @@ export const GET = withAuth(async (request, session, context) => {
             score: taskSubmission.score,
             maxScore: taskSubmission.maxScore,
             submittedAt: taskSubmission.submittedAt,
+            answers: taskSubmission.answers,
           })
           .from(taskSubmission)
           .where(

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -19,6 +19,8 @@ import {
   sessionParticipant,
   courseLesson,
   message,
+  builderTask,
+  taskSubmission,
 } from '@/lib/db/schema'
 import { initFeedbackHandlers, initPollHandlers } from './socket-server'
 import { activePolls, sessionPolls, cleanupStaleSocketState } from '@/lib/socket'
@@ -1214,6 +1216,42 @@ export async function initEnhancedSocketServer(server: NetServer) {
           answers: answers ?? {},
         })
         io.to(roomId).emit('task:updated', { task })
+
+        // Persist to TaskSubmission for durable grading. Best-effort and
+        // FK-safe: taskSubmission.taskId references builderTask, so we only
+        // insert when the deployed task corresponds to a real builderTask row
+        // (it won't for an unsaved/ephemeral task). onConflictDoNothing keeps
+        // the one-submission-per-(task,student) rule and never overwrites a row
+        // a tutor may already have graded. Failures here never affect the live
+        // session — the in-memory/Redis state and the socket overlay still work.
+        void (async () => {
+          try {
+            const [bt] = await drizzleDb
+              .select({ taskId: builderTask.taskId })
+              .from(builderTask)
+              .where(eq(builderTask.taskId, taskId))
+              .limit(1)
+            if (!bt) return // ephemeral/unsaved task — nothing to reference
+            await drizzleDb
+              .insert(taskSubmission)
+              .values({
+                submissionId: crypto.randomUUID(),
+                taskId,
+                studentId,
+                answers: answers ?? {},
+                timeSpent: 0,
+                attempts: 1,
+                questionResults: null,
+                score: null,
+                maxScore: 100,
+                status: 'submitted',
+                tutorApproved: false,
+              })
+              .onConflictDoNothing({ target: [taskSubmission.taskId, taskSubmission.studentId] })
+          } catch (err) {
+            console.warn('[task:complete] TaskSubmission persist failed (non-critical):', err)
+          }
+        })()
       }
     )
 


### PR DESCRIPTION
## **User description**
Follow-up to PR #126: live submissions are now durable and gradable, not just shown in-session.

When a student clicks **Task Complete** in the live classroom, the server now writes a `TaskSubmission` row (in addition to the in-memory/Redis state + socket overlay).

**FK-safe & non-disruptive:**
- `taskSubmission.taskId` references `builderTask`, so the insert only runs when the deployed task maps to a real `builderTask` row (skipped for unsaved/ephemeral tasks — no FK violation).
- `onConflictDoNothing` on the `(taskId, studentId)` unique index → re-completion never errors and never overwrites a row the tutor may have already graded.
- Mirrors the existing REST submit writer (`answers`, `status: 'submitted'`, `maxScore: 100`, `tutorApproved: false`).
- Entirely best-effort: any failure is logged and never affects the live session (the overlay still shows the submission live).

Also: the `submissions-tree` API now returns each submission's `answers`, so the tutor's Submissions detail dialog shows responses for persisted submissions too (not just the live overlay).

Result: submissions persist across reloads/after the session and are available to the grading flow.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Persist live task completions for grading and show saved answers in tutor submissions

### What Changed
- Live task completions are now saved as submissions, so they can be graded after the session ends or after a reload
- If a task is only temporary or has already been recorded for that student, the save is skipped without interrupting the live class
- Tutor submission details now include saved answers, so persisted responses appear in the grading view as well

### Impact
`✅ Fewer lost live submissions`
`✅ Grading stays available after session reloads`
`✅ Clearer tutor review of student answers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
