### PR TITLE
fix(grading): ensure deployed-task submissions reliably reach the Grading page

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1059,35 +1059,46 @@ export async function initEnhancedSocketServer(server: NetServer) {
           // Auto-create a BuilderTask row for this deployed task (if one doesn't
           // already exist) so student completions can be persisted to
           // TaskSubmission — whose taskId FK requires a builderTask. This makes
-          // EVERY deployed task gradable, even ad-hoc/unsaved ones. Idempotent
-          // on the PK so a real saved task is never overwritten. Needs a lesson
-          // of the course to satisfy builderTask.lessonId (FK); published
-          // courses always have lessons, so this is virtually always available.
+          // EVERY deployed task gradable (even ad-hoc/unsaved ones) and ensures
+          // submissions reach the Grading page. Idempotent on the PK so a real
+          // saved task is never overwritten.
           try {
             const tutorId = socket.data.userId
             if (tutorId) {
-              const [lesson] = await drizzleDb
+              // builderTask.lessonId is a NOT NULL FK. Most courses have a
+              // lesson, but one published with only a schedule (no built
+              // content) has none — create a placeholder so the deployed task
+              // can still be persisted and graded.
+              let [lesson] = await drizzleDb
                 .select({ lessonId: courseLesson.lessonId })
                 .from(courseLesson)
                 .where(eq(courseLesson.courseId, sessionRec.courseId))
                 .limit(1)
-              if (lesson?.lessonId) {
-                await drizzleDb
-                  .insert(builderTask)
-                  .values({
-                    taskId: normalizedTask.id,
-                    courseId: sessionRec.courseId,
-                    lessonId: lesson.lessonId,
-                    tutorId,
-                    title: normalizedTask.title || 'Untitled',
-                    content: normalizedTask.content || '',
-                    pci: '',
-                    type: normalizedTask.source,
-                    status: 'published',
-                    publishedAt: new Date(),
-                  })
-                  .onConflictDoNothing({ target: builderTask.taskId })
+              if (!lesson?.lessonId) {
+                const newLessonId = crypto.randomUUID()
+                await drizzleDb.insert(courseLesson).values({
+                  lessonId: newLessonId,
+                  courseId: sessionRec.courseId,
+                  title: 'Live Session',
+                  order: 0,
+                })
+                lesson = { lessonId: newLessonId }
               }
+              await drizzleDb
+                .insert(builderTask)
+                .values({
+                  taskId: normalizedTask.id,
+                  courseId: sessionRec.courseId,
+                  lessonId: lesson.lessonId,
+                  tutorId,
+                  title: normalizedTask.title || 'Untitled',
+                  content: normalizedTask.content || '',
+                  pci: '',
+                  type: normalizedTask.source,
+                  status: 'published',
+                  publishedAt: new Date(),
+                })
+                .onConflictDoNothing({ target: builderTask.taskId })
             }
           } catch (btErr) {
             console.warn('[task:deploy] BuilderTask auto-create failed (non-critical):', btErr)


### PR DESCRIPTION
## **User description**
The **Grading** page (left-nav → `/tutor/submissions`) is already wired to real data — it queries real `taskSubmission` rows (joined to `builderTask`, filtered by the tutor), shows the student's answers, and the grade action persists `score`/`feedback`/`status`/`gradedAt`. There's no mock there.

The reason it appeared **empty / 'not real'** is upstream: persisting a live completion needs a `builderTask` row (FK), and the deploy-time auto-create needs a `courseLesson` (NOT NULL FK on `builderTask.lessonId`). A course published with **only a schedule** (no built lesson content) has no lesson — so the `builderTask`, and therefore the `TaskSubmission`, was silently skipped, and nothing reached the Grading page.

Fix: the deploy auto-create now creates a placeholder **'Live Session'** lesson when the course has none, so **every** deployed task gets a `builderTask` → every completion persists to `TaskSubmission` → it shows on the Grading page.

Also verified the identity chain end-to-end so the tutor filter matches: socket-token JWT `id` = `session.user.id` = `builderTask.tutorId` = the Grading page's session.

**End to end:** deploy task → lesson+builderTask ensured → student **Task Complete** → TaskSubmission persisted → appears under **Needs grading**, tutor scores + leaves feedback → saved to `taskSubmission`.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make deployed task submissions appear on the Grading page

### What Changed
- Deployed tasks now always get a matching lesson and saved task record, even when a course only has a schedule and no built lesson content
- If no lesson exists, the system creates a placeholder “Live Session” lesson so student completions can still be recorded and graded
- This keeps grading available for deployed tasks that were previously skipped and never showed up under Needs grading

### Impact
`✅ Fewer missing grading items`
`✅ Grading works for schedule-only courses`
`✅ More deployed-task submissions reach tutors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
