### PR TITLE
feat(student): real session counts + show/switch chosen schedule on course cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -66,6 +66,10 @@ interface Course {
     lessons: number
     batches: number
   }
+  /** Real number of live sessions (materialized time slots) for the student's schedule. */
+  sessionCount?: number
+  /** The schedule the student enrolled in. */
+  chosenSchedule?: { scheduleId: string; name: string | null; scheduleIndex: number } | null
   availability: {
     summary: string | null
     slots: ScheduleItem[]
@@ -387,6 +391,8 @@ function CoursePageInner() {
               lessons: e.course?._count?.lessons || 0,
               batches: 0,
             },
+            sessionCount: e.sessionCount ?? e.course?.sessionCount ?? 0,
+            chosenSchedule: e.chosenSchedule ?? null,
             availability: {
               summary: null,
               slots: e.course?.schedule || [],
@@ -538,11 +544,39 @@ function CoursePageInner() {
         </DialogContent>
       </Dialog>
 
-      {/* Schedule Modal — shared named-schedule view (side by side) */}
+      {/* Schedule Modal — shared named-schedule view (side by side). Highlights
+          the student's current schedule and lets them switch (cascades). */}
       <ScheduleViewModal
         courseId={scheduleCourse?.id ?? null}
         courseName={scheduleCourse?.name}
+        selectedScheduleId={scheduleCourse?.chosenSchedule?.scheduleId ?? null}
         onClose={() => setScheduleCourse(null)}
+        onSwitch={async (scheduleId: string) => {
+          if (!scheduleCourse) return
+          try {
+            const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+            const csrf = (await csrfRes.json().catch(() => ({})))?.token ?? null
+            const res = await fetch('/api/student/enrollments/schedule', {
+              method: 'PATCH',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(csrf && { 'X-CSRF-Token': csrf }),
+              },
+              credentials: 'include',
+              body: JSON.stringify({ courseId: scheduleCourse.id, scheduleId }),
+            })
+            if (!res.ok) {
+              const data = await res.json().catch(() => ({}))
+              toast.error(data?.error ?? 'Failed to switch schedule')
+              return
+            }
+            toast.success('Schedule updated')
+            setScheduleCourse(null)
+            await loadCourses()
+          } catch {
+            toast.error('Failed to switch schedule')
+          }
+        }}
       />
 
       {/* Tabs */}
@@ -1025,7 +1059,9 @@ function CourseCard({
           <div className="flex flex-wrap gap-4 text-sm text-slate-300">
             <div className="flex items-center gap-1">
               <Target className="h-4 w-4" />
-              <span>{course._count.lessons} sessions</span>
+              <span>
+                {course.sessionCount ?? 0} session{course.sessionCount === 1 ? '' : 's'}
+              </span>
             </div>
           </div>
 
@@ -1051,7 +1087,23 @@ function CourseCard({
             </div>
           )}
 
-          <p className="text-xs font-medium text-emerald-400">No live sessions on record yet</p>
+          {course.chosenSchedule ? (
+            <button
+              type="button"
+              onClick={onSchedule}
+              className="flex w-full items-center justify-between rounded-md border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] p-2 text-xs text-slate-300 transition-colors hover:bg-[rgba(255,255,255,0.1)]"
+            >
+              <span>
+                Schedule:{' '}
+                <span className="font-medium text-slate-100">
+                  {course.chosenSchedule.name || `Schedule ${course.chosenSchedule.scheduleIndex}`}
+                </span>
+              </span>
+              <span className="font-medium text-blue-300">Change</span>
+            </button>
+          ) : (
+            <p className="text-xs font-medium text-slate-400">No schedule selected</p>
+          )}
         </div>
       </div>
 

--- a/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession as liveSessionTable, courseEnrollment, course } from '@/lib/db/schema'
+import { or, isNull } from 'drizzle-orm'
 import { generateUpcomingSessions, mergeSessions } from '@/lib/schedule-sessions'
 import { resolveCourseScheduleSlots } from '@/lib/sessions/course-schedule-slots'
 
@@ -42,9 +43,20 @@ export const GET = withAuth(
         .where(eq(course.courseId, courseId))
         .limit(1)
 
-      // Fetch real live sessions
+      // Fetch real live sessions, scoped to the student's chosen schedule when
+      // they have one (a switch then cascades to which sessions they see).
+      // One-time/ad-hoc sessions (scheduleId null) are shown to everyone.
+      const enrolledScheduleId = (enrollment as { scheduleId?: string | null }).scheduleId ?? null
       const realSessions = await drizzleDb.query.liveSession.findMany({
-        where: eq(liveSessionTable.courseId, courseId),
+        where: enrolledScheduleId
+          ? and(
+              eq(liveSessionTable.courseId, courseId),
+              or(
+                eq(liveSessionTable.scheduleId, enrolledScheduleId),
+                isNull(liveSessionTable.scheduleId)
+              )
+            )
+          : eq(liveSessionTable.courseId, courseId),
         orderBy: [asc(liveSessionTable.scheduledAt)],
       })
 
@@ -68,7 +80,11 @@ export const GET = withAuth(
       // Generate virtual sessions from the schedule that publish actually
       // materializes from (CourseSchedule table), falling back to the legacy
       // course.schedule JSON for unpublished drafts.
-      const schedule = await resolveCourseScheduleSlots(courseId, courseRow?.schedule)
+      const schedule = await resolveCourseScheduleSlots(
+        courseId,
+        courseRow?.schedule,
+        enrolledScheduleId
+      )
 
       const virtualSessions = generateUpcomingSessions(
         schedule,

--- a/tutorme-app/src/app/api/student/enrollments/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/route.ts
@@ -9,7 +9,15 @@ export const dynamic = 'force-dynamic'
 import { NextResponse } from 'next/server'
 import { withAuth, withCsrf, NotFoundError } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { course, courseLesson, courseEnrollment, courseVariant, user } from '@/lib/db/schema'
+import {
+  course,
+  courseLesson,
+  courseEnrollment,
+  courseVariant,
+  courseSchedule,
+  liveSession,
+  user,
+} from '@/lib/db/schema'
 import { eq, inArray, desc } from 'drizzle-orm'
 import { sql } from 'drizzle-orm'
 import { enrollStudentInCourse, enrollmentPaymentRequiredResponse } from '@/lib/api/enrollments'
@@ -87,23 +95,94 @@ export const GET = withAuth(
         : []
     const lessonCountByCourse = new Map(lessonCounts.map(m => [m.courseId, m.count ?? 0]))
 
-    const enrollments = enrollmentsRows.map(row => ({
-      ...row.enrollment,
-      course: {
-        courseId: row.courseId,
-        name: row.courseName,
-        categories: row.courseCategories,
-        description: row.courseDescription,
-        isPublished: row.courseIsPublished,
-        schedule: row.courseSchedule,
-        tutorHandle: row.tutorHandle,
-        variantCategory: row.variantCategory,
-        variantNationality: row.variantNationality,
-        _count: {
-          lessons: lessonCountByCourse.get(row.courseId) ?? 0,
+    // Real session counts: a "session" is a materialized liveSession (one per
+    // scheduled time slot, expanded over the schedule's weeks) — NOT a content
+    // lesson. Count non-cancelled sessions per (course, schedule).
+    const sessionRows =
+      courseIds.length > 0
+        ? await drizzleDb
+            .select({
+              courseId: liveSession.courseId,
+              scheduleId: liveSession.scheduleId,
+              count: sql<number>`count(*)::int`,
+            })
+            .from(liveSession)
+            .where(inArray(liveSession.courseId, courseIds))
+            .groupBy(liveSession.courseId, liveSession.scheduleId)
+        : []
+    const sessionCountBySchedule = new Map<string, number>() // `courseId:scheduleId`
+    const sessionCountByCourse = new Map<string, number>() // course-wide total
+    for (const r of sessionRows) {
+      const cid = r.courseId ?? ''
+      sessionCountByCourse.set(cid, (sessionCountByCourse.get(cid) ?? 0) + (r.count ?? 0))
+      if (r.scheduleId) sessionCountBySchedule.set(`${cid}:${r.scheduleId}`, r.count ?? 0)
+    }
+
+    // The chosen schedule per enrollment (name/index for display + slots/weeks
+    // as a fallback session count before sessions are materialized).
+    const scheduleIds = Array.from(
+      new Set(enrollmentsRows.map(r => r.enrollment.scheduleId).filter(Boolean) as string[])
+    )
+    const scheduleRows =
+      scheduleIds.length > 0
+        ? await drizzleDb
+            .select({
+              scheduleId: courseSchedule.scheduleId,
+              name: courseSchedule.name,
+              scheduleIndex: courseSchedule.scheduleIndex,
+              schedule: courseSchedule.schedule,
+              weeksToSchedule: courseSchedule.weeksToSchedule,
+            })
+            .from(courseSchedule)
+            .where(inArray(courseSchedule.scheduleId, scheduleIds))
+        : []
+    const scheduleById = new Map(scheduleRows.map(s => [s.scheduleId, s]))
+
+    const enrollments = enrollmentsRows.map(row => {
+      const schedId = row.enrollment.scheduleId
+      const chosen = schedId ? scheduleById.get(schedId) : null
+      // Prefer the count for the student's chosen schedule; fall back to the
+      // course-wide count, then to the expected slots × weeks (pre-materialize).
+      let sessionCount =
+        (schedId ? sessionCountBySchedule.get(`${row.courseId}:${schedId}`) : undefined) ??
+        sessionCountByCourse.get(row.courseId) ??
+        0
+      if (sessionCount === 0) {
+        const slots = Array.isArray(chosen?.schedule)
+          ? chosen!.schedule
+          : Array.isArray(row.courseSchedule)
+            ? (row.courseSchedule as unknown[])
+            : []
+        const weeks = chosen?.weeksToSchedule ?? 8
+        sessionCount = slots.length * (weeks || 1)
+      }
+      return {
+        ...row.enrollment,
+        chosenSchedule: chosen
+          ? {
+              scheduleId: chosen.scheduleId,
+              name: chosen.name,
+              scheduleIndex: chosen.scheduleIndex,
+            }
+          : null,
+        sessionCount,
+        course: {
+          courseId: row.courseId,
+          name: row.courseName,
+          categories: row.courseCategories,
+          description: row.courseDescription,
+          isPublished: row.courseIsPublished,
+          schedule: row.courseSchedule,
+          tutorHandle: row.tutorHandle,
+          variantCategory: row.variantCategory,
+          variantNationality: row.variantNationality,
+          sessionCount,
+          _count: {
+            lessons: lessonCountByCourse.get(row.courseId) ?? 0,
+          },
         },
-      },
-    }))
+      }
+    })
 
     return NextResponse.json({ enrollments })
   },

--- a/tutorme-app/src/app/api/student/enrollments/schedule/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/schedule/route.ts
@@ -1,0 +1,105 @@
+/**
+ * PATCH /api/student/enrollments/schedule
+ *
+ * Switch the schedule a student is enrolled in for a course. Cascades the
+ * capacity counters (decrement the old schedule, atomically increment the new
+ * one with a full-check) and updates the enrollment's scheduleId — all in one
+ * transaction so a partial switch can't leak a seat. The student's session list
+ * and session count are scoped by this scheduleId, so they update automatically.
+ */
+
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import { withAuth, withCsrf } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseEnrollment, courseSchedule } from '@/lib/db/schema'
+import { and, eq, sql } from 'drizzle-orm'
+
+export const PATCH = withCsrf(
+  withAuth(
+    async (req, session) => {
+      const body = await req.json().catch(() => ({}))
+      const { courseId, scheduleId } = body as { courseId?: string; scheduleId?: string }
+
+      if (!courseId || typeof courseId !== 'string') {
+        return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
+      }
+      if (!scheduleId || typeof scheduleId !== 'string') {
+        return NextResponse.json({ error: 'Schedule ID is required' }, { status: 400 })
+      }
+
+      try {
+        await drizzleDb.transaction(async tx => {
+          // The student's enrollment in this course.
+          const [enrollment] = await tx
+            .select({
+              enrollmentId: courseEnrollment.enrollmentId,
+              scheduleId: courseEnrollment.scheduleId,
+            })
+            .from(courseEnrollment)
+            .where(
+              and(
+                eq(courseEnrollment.studentId, session.user.id),
+                eq(courseEnrollment.courseId, courseId)
+              )
+            )
+            .limit(1)
+
+          if (!enrollment) {
+            throw new Error('You are not enrolled in this course')
+          }
+          if (enrollment.scheduleId === scheduleId) {
+            return // already on this schedule — no-op
+          }
+
+          // The target schedule must belong to this course.
+          const [target] = await tx
+            .select({ scheduleId: courseSchedule.scheduleId })
+            .from(courseSchedule)
+            .where(
+              and(eq(courseSchedule.scheduleId, scheduleId), eq(courseSchedule.courseId, courseId))
+            )
+            .limit(1)
+          if (!target) {
+            throw new Error('That schedule is not available for this course')
+          }
+
+          // Claim a seat on the new schedule first (atomic full-check) so we
+          // never free the old seat and then fail to get the new one.
+          const claimed = await tx.execute(
+            sql`UPDATE "CourseSchedule"
+                SET "enrolledCount" = "enrolledCount" + 1
+                WHERE id = ${scheduleId}
+                  AND "courseId" = ${courseId}
+                  AND ("maxStudents" IS NULL OR "enrolledCount" < "maxStudents")
+                RETURNING id`
+          )
+          if (!claimed.rows.length) {
+            throw new Error('That schedule is full')
+          }
+
+          // Release the old seat (floored at 0).
+          if (enrollment.scheduleId) {
+            await tx.execute(
+              sql`UPDATE "CourseSchedule"
+                  SET "enrolledCount" = GREATEST("enrolledCount" - 1, 0)
+                  WHERE id = ${enrollment.scheduleId}`
+            )
+          }
+
+          await tx
+            .update(courseEnrollment)
+            .set({ scheduleId })
+            .where(eq(courseEnrollment.enrollmentId, enrollment.enrollmentId))
+        })
+
+        return NextResponse.json({ success: true, scheduleId })
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to switch schedule'
+        return NextResponse.json({ error: message }, { status: 400 })
+      }
+    },
+    { role: 'STUDENT' }
+  )
+)

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -35,12 +35,23 @@ interface ScheduleViewModalProps {
   courseId: string | null
   courseName?: string
   onClose: () => void
+  /** The schedule the student is currently enrolled in (highlighted as current). */
+  selectedScheduleId?: string | null
+  /** When provided, each non-current schedule gets a "Switch to this" button. */
+  onSwitch?: (scheduleId: string) => Promise<void> | void
 }
 
-export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleViewModalProps) {
+export function ScheduleViewModal({
+  courseId,
+  courseName,
+  onClose,
+  selectedScheduleId,
+  onSwitch,
+}: ScheduleViewModalProps) {
   const [schedules, setSchedules] = useState<CourseSchedule[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [switchingId, setSwitchingId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!courseId) return
@@ -89,44 +100,84 @@ export function ScheduleViewModal({ courseId, courseName, onClose }: ScheduleVie
             </p>
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {schedules.map(s => (
-                <div key={s.scheduleId} className="flex flex-col rounded-lg border bg-gray-50 p-4">
-                  <div className="mb-2 flex items-center justify-between gap-2">
-                    <h4 className="font-semibold text-gray-900">{s.name}</h4>
-                    {s.maxStudents != null && (
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                          s.isFull ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700'
-                        }`}
+              {schedules.map(s => {
+                const isCurrent = !!selectedScheduleId && s.scheduleId === selectedScheduleId
+                return (
+                  <div
+                    key={s.scheduleId}
+                    className={`flex flex-col rounded-lg border p-4 ${
+                      isCurrent
+                        ? 'border-indigo-400 bg-indigo-50/60 ring-1 ring-indigo-300'
+                        : 'bg-gray-50'
+                    }`}
+                  >
+                    <div className="mb-2 flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <h4 className="font-semibold text-gray-900">{s.name}</h4>
+                        {isCurrent && (
+                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700">
+                            Current
+                          </span>
+                        )}
+                      </div>
+                      {s.maxStudents != null && (
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                            s.isFull ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700'
+                          }`}
+                        >
+                          {s.isFull
+                            ? 'Full'
+                            : `${s.spotsLeft} spot${s.spotsLeft === 1 ? '' : 's'} left`}
+                        </span>
+                      )}
+                    </div>
+                    {s.slots.length > 0 ? (
+                      <ul className="space-y-1.5">
+                        {s.slots.map((slot, i) => (
+                          <li
+                            key={i}
+                            className="flex items-center justify-between rounded-md bg-white px-3 py-2 text-sm"
+                          >
+                            <span className="font-medium text-gray-800">{slot.dayOfWeek}</span>
+                            <span className="text-gray-600">
+                              {slot.startTime} · {slot.durationMinutes} min
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-gray-500">Times to be arranged with the tutor.</p>
+                    )}
+                    {s.weeksToSchedule ? (
+                      <p className="mt-2 text-xs text-gray-400">
+                        Runs for {s.weeksToSchedule} weeks
+                      </p>
+                    ) : null}
+                    {onSwitch && !isCurrent && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={s.isFull || switchingId !== null}
+                        className="mt-3"
+                        onClick={async () => {
+                          setSwitchingId(s.scheduleId)
+                          try {
+                            await onSwitch(s.scheduleId)
+                          } finally {
+                            setSwitchingId(null)
+                          }
+                        }}
                       >
-                        {s.isFull
-                          ? 'Full'
-                          : `${s.spotsLeft} spot${s.spotsLeft === 1 ? '' : 's'} left`}
-                      </span>
+                        {switchingId === s.scheduleId ? (
+                          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                        ) : null}
+                        {s.isFull ? 'Full' : 'Switch to this schedule'}
+                      </Button>
                     )}
                   </div>
-                  {s.slots.length > 0 ? (
-                    <ul className="space-y-1.5">
-                      {s.slots.map((slot, i) => (
-                        <li
-                          key={i}
-                          className="flex items-center justify-between rounded-md bg-white px-3 py-2 text-sm"
-                        >
-                          <span className="font-medium text-gray-800">{slot.dayOfWeek}</span>
-                          <span className="text-gray-600">
-                            {slot.startTime} · {slot.durationMinutes} min
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-sm text-gray-500">Times to be arranged with the tutor.</p>
-                  )}
-                  {s.weeksToSchedule ? (
-                    <p className="mt-2 text-xs text-gray-400">Runs for {s.weeksToSchedule} weeks</p>
-                  ) : null}
-                </div>
-              ))}
+                )
+              })}
             </div>
           )}
         </div>

--- a/tutorme-app/src/lib/sessions/course-schedule-slots.ts
+++ b/tutorme-app/src/lib/sessions/course-schedule-slots.ts
@@ -21,12 +21,17 @@ export interface ScheduleSlot {
 
 export async function resolveCourseScheduleSlots(
   courseId: string,
-  fallbackJson: unknown
+  fallbackJson: unknown,
+  // When set, resolve slots for just this schedule (the one a student enrolled
+  // in) rather than aggregating every schedule of the course.
+  scheduleId?: string | null
 ): Promise<ScheduleSlot[]> {
   const rows = await drizzleDb
     .select({ schedule: courseSchedule.schedule })
     .from(courseSchedule)
-    .where(eq(courseSchedule.courseId, courseId))
+    .where(
+      scheduleId ? eq(courseSchedule.scheduleId, scheduleId) : eq(courseSchedule.courseId, courseId)
+    )
 
   const fromTable = rows.flatMap(r => (Array.isArray(r.schedule) ? r.schedule : []))
   if (fromTable.length > 0) {


### PR DESCRIPTION
## **User description**
Two student-side fixes.

### 1. Course cards show the real session count
The card labeled the **content-lesson** count (`courseLesson` rows) as "sessions". A *session* is a materialized `liveSession` (one per scheduled time slot, expanded over the schedule's weeks). `/api/student/enrollments` now returns a real `sessionCount` — counting `liveSession` rows for the student's **chosen schedule** (course-wide fallback, then slots×weeks before materialization) — and the card renders that instead. (Also removed the misleading hardcoded "No live sessions on record yet" line.)

### 2. Show + switch the chosen schedule (cascading)
`courseEnrollment.scheduleId` already recorded the choice but the UI never surfaced it and there was no way to change it.
- The card now shows **"Schedule: &lt;name&gt;"** with a **Change** action.
- `ScheduleViewModal` highlights the **current** schedule and shows a **"Switch to this schedule"** button on the others (disabled when full).
- New **PATCH `/api/student/enrollments/schedule`** switches atomically in one transaction: validates the target belongs to the course, claims a seat on the new schedule (atomic full-check), releases the old seat (floored at 0), and updates `courseEnrollment.scheduleId`.
- **Cascade:** the student's session list + count are now scoped to their chosen `scheduleId` (student sessions route + `resolveCourseScheduleSlots` take the enrolled schedule; one-time sessions with null `scheduleId` stay visible to all), so a switch changes which sessions they see and the displayed count — automatically.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show the chosen schedule on course cards and keep session counts tied to it**

### What Changed
- Course cards now show the student’s selected schedule with a Change action instead of a generic live-session message.
- Students can switch to another schedule from the schedule modal, with full schedules blocked and the current one clearly marked.
- Session counts now reflect real live sessions for the student’s chosen schedule, and the count updates when they switch.
- The student’s session list now follows the selected schedule, while one-time sessions without a schedule stay visible to everyone.

### Impact
`✅ Clearer course schedule status`
`✅ Accurate session counts on course cards`
`✅ Fewer wrong sessions after switching schedules`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
