### PR TITLE
feat: X social handle, fix follow-tutor 500, complete 1-on-1 pay flow

### DIFF
--- a/tutorme-app/drizzle/0057_create_tutor_follow.sql
+++ b/tutorme-app/drizzle/0057_create_tutor_follow.sql
@@ -1,0 +1,27 @@
+-- Create the TutorFollow table. The original 0010_tutor_follow migration is an
+-- empty placeholder (the real DDL was archived), and 0032 only ALTERs the table,
+-- so on the active migration chain "TutorFollow" was never created — every
+-- follow/unfollow INSERT 500s with relation "TutorFollow" does not exist.
+-- Idempotent so it's safe on databases where the table somehow already exists.
+CREATE TABLE IF NOT EXISTS "TutorFollow" (
+  "followId" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "followerId" text NOT NULL,
+  "tutorId" text NOT NULL,
+  "createdAt" timestamptz DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+  ALTER TABLE "TutorFollow"
+    ADD CONSTRAINT "TutorFollow_followerId_User_id_fk"
+    FOREIGN KEY ("followerId") REFERENCES "User"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "TutorFollow"
+    ADD CONSTRAINT "TutorFollow_tutorId_User_id_fk"
+    FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS "TutorFollow_followerId_idx" ON "TutorFollow" ("followerId");
+CREATE INDEX IF NOT EXISTS "TutorFollow_tutorId_idx" ON "TutorFollow" ("tutorId");
+CREATE UNIQUE INDEX IF NOT EXISTS "TutorFollow_follower_tutor_key" ON "TutorFollow" ("followerId", "tutorId");

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1781100000000,
       "tag": "0056_drop_courseenrollment_lessonscompleted",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1781200000000,
+      "tag": "0057_create_tutor_follow",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -100,6 +100,13 @@ const TikTokIcon = (props: SVGProps<SVGSVGElement>) => (
   </svg>
 )
 
+// X (formerly Twitter) brand glyph.
+const XBrandIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+)
+
 const KakaoTalkIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 512 512" aria-hidden="true" {...props}>
     <rect width="512" height="512" rx="115" fill="currentColor" />
@@ -634,6 +641,7 @@ export default function TutorMyPage() {
     instagram: '',
     tiktok: '',
     facebook: '',
+    x: '',
     kakaoTalk: '',
   })
   const [profileSettingsOpen, setProfileSettingsOpen] = useState(true)
@@ -745,6 +753,7 @@ export default function TutorMyPage() {
           instagram: typeof links.instagram === 'string' ? stripAt(links.instagram) : '',
           tiktok: typeof links.tiktok === 'string' ? stripAt(links.tiktok) : '',
           facebook: typeof links.facebook === 'string' ? stripAt(links.facebook) : '',
+          x: typeof links.x === 'string' ? stripAt(links.x) : '',
           kakaoTalk: typeof links.kakaoTalk === 'string' ? stripAt(links.kakaoTalk) : '',
         })
         // Derive categories from published courses
@@ -1046,6 +1055,7 @@ export default function TutorMyPage() {
             tiktok: socialAccounts.tiktok.trim().replace(/^@+/, ''),
             youtube: socialAccounts.youtube.trim().replace(/^@+/, ''),
             facebook: socialAccounts.facebook.trim().replace(/^@+/, ''),
+            x: socialAccounts.x.trim().replace(/^@+/, ''),
             kakaoTalk: socialAccounts.kakaoTalk.trim().replace(/^@+/, ''),
           },
         }),
@@ -1635,6 +1645,14 @@ export default function TutorMyPage() {
                     bgClass: 'bg-blue-600',
                     muted: !socialAccounts.facebook,
                   },
+                  {
+                    key: 'x',
+                    label: 'X',
+                    value: socialAccounts.x ? `@${socialAccounts.x}` : '—',
+                    icon: XBrandIcon,
+                    bgClass: 'bg-black',
+                    muted: !socialAccounts.x,
+                  },
                 ].map(item => {
                   const Icon = item.icon
                   return (
@@ -1918,6 +1936,25 @@ export default function TutorMyPage() {
                             setSocialAccounts(prev => ({
                               ...prev,
                               facebook: e.target.value.replace(/^@+/, ''),
+                            }))
+                          }
+                          disabled={loading || saving}
+                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <XBrandIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
+                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                        <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
+                        <Input
+                          placeholder="username"
+                          value={socialAccounts.x.replace(/^@+/, '')}
+                          onChange={e =>
+                            setSocialAccounts(prev => ({
+                              ...prev,
+                              x: e.target.value.replace(/^@+/, ''),
                             }))
                           }
                           disabled={loading || saving}

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -80,6 +80,7 @@ interface PublicTutorResponse {
       youtube?: string | null
       instagram?: string | null
       facebook?: string | null
+      x?: string | null
       kakaoTalk?: string | null
     } | null
   }
@@ -108,6 +109,13 @@ interface PublicTutorResponse {
 const TikTokIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 256 256" fill="currentColor" aria-hidden="true" {...props}>
     <path d="M208 88.9a71 71 0 0 1-52-22.2v95.5a63.9 63.9 0 1 1-54-63v33.4a30.6 30.6 0 1 0 21 29.1V24h33.1a71 71 0 0 0 52.1 55.3Z" />
+  </svg>
+)
+
+// X (formerly Twitter) brand glyph.
+const XBrandIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
   </svg>
 )
 
@@ -1776,6 +1784,14 @@ export default function PublicTutorPage() {
                     icon: Facebook,
                     bgClass: 'bg-blue-600',
                     muted: !tutor.socialLinks?.facebook,
+                  },
+                  {
+                    key: 'x',
+                    label: 'X',
+                    value: tutor.socialLinks?.x ? `@${stripAt(tutor.socialLinks.x)}` : '—',
+                    icon: XBrandIcon,
+                    bgClass: 'bg-black',
+                    muted: !tutor.socialLinks?.x,
                   },
                 ].map(item => {
                   const Icon = item.icon

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -203,6 +203,7 @@ function Book1on1Dialog({
   locale: string
 }) {
   const { data: session } = useSession()
+  const router = useRouter()
   const [loading, setLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [availability, setAvailability] = useState<AvailabilityData | null>(null)
@@ -256,7 +257,12 @@ function Book1on1Dialog({
       if (res.ok) {
         const data = await res.json()
         setHasPendingRequest(data.hasActiveRequest)
-        setActiveRequest(data.request)
+        // The PK column is `requestId` (Drizzle property), not `id`.
+        setActiveRequest(
+          data.request
+            ? { id: data.request.requestId ?? data.request.id, status: data.request.status }
+            : null
+        )
       }
     } catch {
       // ignore
@@ -300,7 +306,10 @@ function Book1on1Dialog({
       if (res.ok) {
         toast.success('Booking request sent! The tutor will review and confirm.')
         setHasPendingRequest(true)
-        setActiveRequest({ id: data.request.id, status: data.request.status })
+        setActiveRequest({
+          id: data.request.requestId ?? data.request.id,
+          status: data.request.status,
+        })
         onOpenChange(false)
       } else if (res.status === 409) {
         toast.info('You already have a pending request with this tutor')
@@ -352,25 +361,40 @@ function Book1on1Dialog({
   }
 
   if (hasPendingRequest && activeRequest) {
+    const isAccepted = activeRequest.status === 'ACCEPTED'
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Booking Request Pending</DialogTitle>
+            <DialogTitle>
+              {isAccepted ? 'Booking Accepted — Payment Required' : 'Booking Request Pending'}
+            </DialogTitle>
             <DialogDescription>
-              You already have a pending booking request with {tutor.name}.
+              {isAccepted
+                ? `${tutor.name} accepted your booking. Complete payment to confirm your session.`
+                : `You already have a pending booking request with ${tutor.name}.`}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 p-6 pt-0">
             <DialogPanel>
               <p className="font-medium text-gray-900">Status: {activeRequest.status}</p>
               <p className="mt-2 text-sm text-gray-600">
-                Please wait for the tutor to respond. You will receive a notification once they
-                accept or reject your request.
+                {isAccepted
+                  ? 'Your session is reserved pending payment. Complete payment now to secure it.'
+                  : 'Please wait for the tutor to respond. You will receive a notification once they accept or reject your request.'}
               </p>
             </DialogPanel>
           </div>
           <DialogFooter className="gap-3">
+            {isAccepted && activeRequest.id && (
+              <Button
+                variant="modal-primary-dark"
+                className="h-10"
+                onClick={() => router.push(`/${locale}/payment?requestId=${activeRequest.id}`)}
+              >
+                Complete Payment
+              </Button>
+            )}
             <Button
               variant="modal-secondary-dark"
               onClick={() => onOpenChange(false)}

--- a/tutorme-app/src/app/api/public/tutors/[username]/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/[username]/route.ts
@@ -198,6 +198,7 @@ export async function GET(
         youtube: getSocial('youtube'),
         instagram: getSocial('instagram'),
         facebook: getSocial('facebook'),
+        x: getSocial('x'),
         kakaoTalk: getSocial('kakaoTalk'),
       },
     }


### PR DESCRIPTION
## **User description**
Consolidated (supersedes #132 — built on top of it). Three tasks.

### 1 — Add X (formerly Twitter) to tutor social handles
`socialLinks` is JSONB (no schema change). Added an X edit input + display row on the tutor **my-page**, X on the public profile **u/[username]**, and `socialLinks.x` in **/api/public/tutors/[username]**. Added an X brand glyph.

### 2 — "Follow tutor" → Internal Server Error
Schema drift: the **`TutorFollow` table was never created** (migration `0010` is an empty placeholder; `0032` only ALTERs it), so `INSERT INTO "TutorFollow"` 500s. Code + Drizzle schema are correct. Added forward migration **`0057_create_tutor_follow.sql`** (idempotent CREATE TABLE + FKs + indexes, matching the schema), journaled above the watermark so it applies on deploy.

### 3 — 1-on-1 booking: completed the student pay flow
Audited request → accept → pay → join. Two breaks fixed:
- **`activeRequest.id` was always `undefined`** — the PK is `requestId` (Drizzle property), but the client read `data.request.id`. Normalized both setters to `requestId ?? id` so the payment link is valid.
- When a tutor **ACCEPTED**, the student dialog still said "wait for the tutor" with no way to pay (only a notification). It now detects ACCEPTED and shows **Complete Payment** → `/[locale]/payment?requestId=…`.

**Deferred (flagged, need a dedicated tested change — not done to avoid regressing the working flow):** payment isn't enforced before the session/Daily room is created at accept (an unpaid student can currently join); `respond`/`cancel` routes lack CSRF (4 callers); accept-time date parsing ignores the request's `timezone`.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add X profiles, fix follow failures, and complete 1-on-1 payment**

### What Changed
- Tutors can now add and display an X handle on their profile page and public tutor page.
- The public tutor API now includes X so profiles can show it consistently.
- Following a tutor no longer fails because the missing follow data is now created on deploy.
- When a tutor accepts a 1-on-1 request, students now see a clear payment prompt and can go straight to the payment page.
- The booking dialog now uses the correct request ID, so the payment link works.

### Impact
`✅ Fewer failed follow actions`
`✅ Easier tutor profile discovery`
`✅ Fewer blocked 1-on-1 bookings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
