### PR TITLE
fix(migration): TutorFollow 0057 — delete orphan rows before adding FKs

### DIFF
--- a/tutorme-app/drizzle/0057_create_tutor_follow.sql
+++ b/tutorme-app/drizzle/0057_create_tutor_follow.sql
@@ -1,14 +1,21 @@
--- Create the TutorFollow table. The original 0010_tutor_follow migration is an
--- empty placeholder (the real DDL was archived), and 0032 only ALTERs the table,
--- so on the active migration chain "TutorFollow" was never created — every
--- follow/unfollow INSERT 500s with relation "TutorFollow" does not exist.
--- Idempotent so it's safe on databases where the table somehow already exists.
+-- Ensure the TutorFollow table exists with the correct FKs/indexes.
+-- The original 0010_tutor_follow migration is an empty placeholder (real DDL was
+-- archived) and 0032 only ALTERs the table, so the active chain never reliably
+-- created/constrained it — follow/unfollow could 500. Idempotent and safe to run
+-- whether the table is missing or already present (possibly with legacy rows).
 CREATE TABLE IF NOT EXISTS "TutorFollow" (
   "followId" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "followerId" text NOT NULL,
   "tutorId" text NOT NULL,
   "createdAt" timestamptz DEFAULT now() NOT NULL
 );
+
+-- Remove orphaned rows (follows referencing a since-deleted user) so the FK
+-- constraints below can be added and validated. Without this, ADD CONSTRAINT
+-- fails on a pre-existing table that accumulated rows while no FK was enforced.
+DELETE FROM "TutorFollow"
+WHERE "followerId" NOT IN (SELECT "id" FROM "User")
+   OR "tutorId" NOT IN (SELECT "id" FROM "User");
 
 DO $$ BEGIN
   ALTER TABLE "TutorFollow"


### PR DESCRIPTION
## **User description**
**The previous deploy failed at the migration step** (so #133 didn't ship; traffic never switched — prod is still on the prior good revision, no outage).

Cause: prod's `TutorFollow` table **already exists** and accumulated rows while no FK was enforced. My `0057` migration's `ADD CONSTRAINT ... FOREIGN KEY (tutorId) REFERENCES User(id)` validated existing data and threw *"insert or update on table TutorFollow violates foreign key constraint"* on an orphaned row (a follow pointing to a since-deleted user). The migration ran in a transaction and rolled back (not recorded), so re-running is clean.

Fix: **delete orphaned rows** (followerId/tutorId not in `User`) before adding the FK constraints. Still idempotent and safe whether the table is missing or already present. The re-deploy retries 0057 with the corrected SQL, which then unblocks the rest of #133 (X handle, follow code, 1-on-1 pay flow) to ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix TutorFollow migration so follow actions can ship on existing databases**

### What Changed
- Deletes old follow records that point to users who no longer exist before adding the TutorFollow links
- Keeps the TutorFollow table creation and constraint setup safe to run again on databases that already have the table
- Prevents the migration from failing on existing data, which was blocking follow/unfollow changes from deploying

### Impact
`✅ Fewer deploy failures from follow data`
`✅ Follow/unfollow features can ship on existing databases`
`✅ Cleaner recovery after a failed migration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
