### PR TITLE
fix(1-on-1): let students propose a time so the Book modal is always actionable

### DIFF
--- a/tutorme-app/src/app/[locale]/student/account/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/account/page.tsx
@@ -445,7 +445,8 @@ export default function StudentAccount() {
                 title="Billing & Payment Methods"
                 description="Manage your payment methods and billing preferences"
                 defaultOpen
-               className={sectionCardClass}>
+                className={sectionCardClass}
+              >
                 <CardContent className="space-y-6">
                   {paymentMethods.map(method => (
                     <div
@@ -511,7 +512,8 @@ export default function StudentAccount() {
                 title="Billing History"
                 description="View and download your invoices and receipts"
                 defaultOpen
-               className={sectionCardClass}>
+                className={sectionCardClass}
+              >
                 <CardContent>
                   <div className="space-y-4">
                     {billingHistory.map(invoice => (
@@ -567,7 +569,8 @@ export default function StudentAccount() {
                 title="Notification Preferences"
                 description="Control how and when we contact you"
                 defaultOpen
-               className={sectionCardClass}>
+                className={sectionCardClass}
+              >
                 <CardContent className="space-y-6">
                   <div className="space-y-4">
                     <div className="flex items-center justify-between">
@@ -678,7 +681,8 @@ export default function StudentAccount() {
                 title="Privacy & Security"
                 description="Manage your password and account security"
                 defaultOpen
-               className={sectionCardClass}>
+                className={sectionCardClass}
+              >
                 <CardContent className="space-y-6">
                   {/* Password Change */}
                   <div className="space-y-4">
@@ -785,7 +789,8 @@ export default function StudentAccount() {
                 title="Account Controls"
                 description="Temporarily deactivate or permanently delete your account"
                 defaultOpen
-               className={sectionCardClass}>
+                className={sectionCardClass}
+              >
                 <CardContent className="space-y-6">
                   {/* Deactivate Account */}
                   <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7342,7 +7342,8 @@ FEEDBACK: [your explanation]`
                                                 {!isSectionCollapsed(node.id, 'homework') && (
                                                   <div
                                                     ref={el => {
-                                                      sectionRefs.current[`${node.id}:homework`] = el
+                                                      sectionRefs.current[`${node.id}:homework`] =
+                                                        el
                                                     }}
                                                     className="mt-1.5 space-y-1"
                                                   >

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -211,6 +211,10 @@ function Book1on1Dialog({
   const [availability, setAvailability] = useState<AvailabilityData | null>(null)
   const [availabilityError, setAvailabilityError] = useState<string | null>(null)
   const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null)
+  // Custom (student-proposed) time — the tutor accepts/declines any proposed
+  // time, so booking shouldn't require the tutor to have preset availability.
+  const [customDate, setCustomDate] = useState('')
+  const [customStartTime, setCustomStartTime] = useState('')
   const [hasPendingRequest, setHasPendingRequest] = useState(false)
   const [activeRequest, setActiveRequest] = useState<{ id: string; status: string } | null>(null)
 
@@ -269,6 +273,26 @@ function Book1on1Dialog({
     } catch {
       // ignore
     }
+  }
+
+  // Turn a custom date + start time into a 1-hour selectedSlot.
+  const applyCustomSlot = (date: string, time: string) => {
+    setCustomDate(date)
+    setCustomStartTime(time)
+    if (!date || !time) {
+      setSelectedSlot(null)
+      return
+    }
+    const [h, m] = time.split(':').map(Number)
+    const end = new Date(2000, 0, 1, h, m + 60)
+    const endTime = `${String(end.getHours()).padStart(2, '0')}:${String(end.getMinutes()).padStart(2, '0')}`
+    setSelectedSlot({
+      date,
+      startTime: time,
+      endTime,
+      dayOfWeek: parseISO(date).getDay(),
+      timezone: availability?.timezone ?? 'UTC',
+    })
   }
 
   const handleSubmit = async () => {
@@ -494,7 +518,11 @@ function Book1on1Dialog({
                                       : 'outline'
                                   }
                                   size="sm"
-                                  onClick={() => setSelectedSlot(slot)}
+                                  onClick={() => {
+                                    setCustomDate('')
+                                    setCustomStartTime('')
+                                    setSelectedSlot(slot)
+                                  }}
                                 >
                                   {slot.startTime} - {slot.endTime}
                                 </Button>
@@ -506,6 +534,30 @@ function Book1on1Dialog({
                     )}
                   </div>
                 </ScrollArea>
+              </DialogPanel>
+
+              {/* Propose a custom time — the tutor reviews and confirms any
+                  proposed time, so this works even with no preset slots. */}
+              <DialogPanel className="space-y-2">
+                <p className="text-sm font-medium text-gray-900">
+                  {dates.length === 0 ? 'Propose a time' : 'Or propose your own time'}
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <input
+                    type="date"
+                    value={customDate}
+                    min={new Date().toISOString().split('T')[0]}
+                    onChange={e => applyCustomSlot(e.target.value, customStartTime)}
+                    className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+                  />
+                  <input
+                    type="time"
+                    value={customStartTime}
+                    onChange={e => applyCustomSlot(customDate, e.target.value)}
+                    className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+                  />
+                  <span className="text-xs text-gray-500">(1-hour session)</span>
+                </div>
               </DialogPanel>
 
               {selectedSlot && (

--- a/tutorme-app/src/components/support/support-page.tsx
+++ b/tutorme-app/src/components/support/support-page.tsx
@@ -86,7 +86,10 @@ export function SupportPage({ subtitle, heroGradient, topics }: SupportPageProps
               <h2 className="text-lg font-semibold text-slate-900">{activeTopicData.title}</h2>
               <p className="text-sm text-slate-500">{activeTopicData.description}</p>
             </div>
-            <div ref={contentRef} className="scrollbar-hide flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+            <div
+              ref={contentRef}
+              className="scrollbar-hide flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
+            >
               {activeTopicData.items.map((item, idx) => (
                 <div key={idx} className="rounded-xl border border-slate-100 bg-slate-50/50 p-4">
                   <h4 className="font-medium text-gray-900">{item.title}</h4>

--- a/tutorme-app/src/hooks/use-auto-scroll-on-expand.ts
+++ b/tutorme-app/src/hooks/use-auto-scroll-on-expand.ts
@@ -10,10 +10,7 @@ export interface UseAutoScrollOnExpandOptions {
   block?: 'start' | 'end' | 'nearest'
 }
 
-export function useAutoScrollOnExpand(
-  open: boolean,
-  options: UseAutoScrollOnExpandOptions = {}
-) {
+export function useAutoScrollOnExpand(open: boolean, options: UseAutoScrollOnExpandOptions = {}) {
   const { disabled = false, delay = 150, margin, block = 'end' } = options
   const ref = useRef<HTMLDivElement>(null)
   const wasOpenRef = useRef(open)

--- a/tutorme-app/src/lib/scroll-into-view.ts
+++ b/tutorme-app/src/lib/scroll-into-view.ts
@@ -105,10 +105,7 @@ function smoothScrollBy(scroller: HTMLElement | Window, top: number) {
   }
 }
 
-export function scrollElementIntoView(
-  el: Element,
-  options: ScrollIntoViewOptions = {}
-): void {
+export function scrollElementIntoView(el: Element, options: ScrollIntoViewOptions = {}): void {
   if (typeof window === 'undefined') return
 
   const { margin = 16, block = 'end' } = options


### PR DESCRIPTION
## **User description**
**Symptom:** clicking *Book 1-on-1* opens a modal that's inactive except Cancel.

**Cause:** the modal only rendered preset slots from the tutor's `calendarAvailability`. When a tutor hasn't configured availability (common), it showed *"No available slots"* with nothing clickable but Cancel. But the request endpoint **accepts any proposed time** — it doesn't validate against availability; the tutor reviews and confirms — so forcing students to pick a preset slot was an unnecessary dead-end.

**Fix:** added a **"Propose a time"** date + start-time picker (1-hour session) that builds the `selectedSlot`, so a student can always submit a request. Preset slots still work (and clear the custom inputs when chosen). The picker shows whenever booking is possible (tutor enables one-on-one + has a rate); the *pricing-not-set* / *not-offering* states are unchanged.

Frontend-only; no API change needed. tsc clean; 270 unit tests pass; prettier applied.

> If "inactive" instead meant a hard error (the availability endpoint 500ing) rather than "no slots," let me know — that'd be a separate fix — but the no-availability dead-end is the most likely cause and this makes the modal usable regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let students propose a time when booking a 1-on-1**

### What Changed
- The booking modal now lets students pick a custom date and start time, so they can request a 1-on-1 even when the tutor has no preset availability.
- Custom selections create a 1-hour session and still show the chosen time before submission.
- Choosing a preset slot clears any custom date or time, so students can switch between suggested slots and their own proposal.
- The custom time option appears whenever booking is available; the no-rate and not-offering states stay unchanged.

### Impact
`✅ Fewer booking dead-ends`
`✅ More 1-on-1 requests sent without preset availability`
`✅ Clearer booking options for students`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
