### PR TITLE
fix(builder): task extension no longer inherits the parent task's content

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2119,11 +2119,18 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
 
       try {
-        const slideContent = isTask ? taskBuilder.taskContent : assessmentBuilder.taskContent
+        // When an extension is active, generate from the EXTENSION's own content
+        // and PCI (empty for a fresh extension), not the parent task's — an
+        // extension is a separate item and must not inherit the task's content.
+        const slideContent = isTask
+          ? taskBuilder.activeExtensionId
+            ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.content ||
+              ''
+            : taskBuilder.taskContent
+          : assessmentBuilder.taskContent
         const pci = isTask
           ? taskBuilder.activeExtensionId
-            ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.pci ||
-              taskBuilder.taskPci
+            ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.pci || ''
             : taskBuilder.taskPci
           : assessmentBuilder.taskPci
         const sessionId = isTask
@@ -2270,12 +2277,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setTestPciInputs(prev => ({ ...prev, [testPciActiveTab]: '' }))
       setTestPciLoading(true)
 
-      // Get PCI content from active task/assessment
+      // Get PCI content from the active item — an active extension uses its own
+      // PCI (empty for a fresh extension), never the parent task's.
       const pciContent =
         testPciSource === 'task'
           ? taskBuilder.activeExtensionId
-            ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.pci ||
-              taskBuilder.taskPci
+            ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.pci || ''
             : taskBuilder.taskPci
           : assessmentBuilder.taskPci
 
@@ -5403,9 +5410,12 @@ FEEDBACK: [your explanation]`
       ? taskBuilder.extensions.find(ext => ext.id === taskBuilder.activeExtensionId)
       : null
 
-    // Check if the active extension has a document, otherwise fallback to task document
-    const currentTaskDocument =
-      activeTaskExtension?.sourceDocument || taskSourceDocument || taskBuilder.sourceDocument
+    // An extension is its own item: when one is active, show ONLY its document
+    // (a new extension has none) — do not fall back to the parent task's, which
+    // made extensions look like they inherited the task's content.
+    const currentTaskDocument = activeTaskExtension
+      ? activeTaskExtension.sourceDocument
+      : taskSourceDocument || taskBuilder.sourceDocument
     const hasTaskDocument = !!currentTaskDocument
 
     const currentAssessmentDocument = assessmentSourceDocument || assessmentBuilder.sourceDocument
@@ -8560,7 +8570,7 @@ FEEDBACK: [your explanation]`
                                                 ? liveTask?.sourceDocument
                                                 : liveAssessment?.sourceDocument
                                               : testPciSource === 'task'
-                                                ? currentTaskDocument || taskBuilder.sourceDocument
+                                                ? currentTaskDocument
                                                 : currentAssessmentDocument
                                           const versionId = testPciViewMode.startsWith('dmi_')
                                             ? testPciViewMode.replace('dmi_', '')

--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -1527,7 +1527,9 @@ export default function TutorMyPage() {
         </section>
 
         <div className="grid gap-5 lg:grid-cols-2 lg:grid-rows-[auto_1fr]">
-          <div className={cn(panelCardClass, 'flex h-[280px] flex-col lg:col-start-1 lg:row-start-1')}>
+          <div
+            className={cn(panelCardClass, 'flex h-[280px] flex-col lg:col-start-1 lg:row-start-1')}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <User className="h-5 w-5" />
               <span className="text-base font-semibold">Bio</span>
@@ -1543,187 +1545,197 @@ export default function TutorMyPage() {
             </div>
           </div>
 
-          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-2 lg:row-start-1 lg:row-span-2')}>
+          <div
+            className={cn(
+              panelCardClass,
+              'flex flex-col lg:col-start-2 lg:row-span-2 lg:row-start-1'
+            )}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center justify-between rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <div className="flex items-center gap-3">
                 <Link2 className="h-5 w-5" />
                 <span className="text-base font-semibold">Connect</span>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  onClick={handleCopyProfile}
+                  disabled={!publicUrl}
+                >
+                  <Copy className="mr-1.5 h-3.5 w-3.5" />
+                  Copy Link
+                </Button>
+                {canShare ? (
                   <Button
                     size="sm"
                     variant="outline"
                     className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                    onClick={handleCopyProfile}
-                    disabled={!publicUrl}
+                    onClick={handleShareProfile}
                   >
-                    <Copy className="mr-1.5 h-3.5 w-3.5" />
-                    Copy Link
+                    <Share2 className="mr-1.5 h-3.5 w-3.5" />
+                    Share
                   </Button>
-                  {canShare ? (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                      onClick={handleShareProfile}
-                    >
-                      <Share2 className="mr-1.5 h-3.5 w-3.5" />
-                      Share
-                    </Button>
-                  ) : null}
-                </div>
-              </div>
-
-              {publicUrl ? (
-                <div className="grid grid-cols-1 gap-4 border-b border-slate-100 py-4 sm:grid-cols-2">
-                  <div className="flex items-center gap-3">
-                    <img
-                      src="/solocorn-app-icon.png"
-                      alt="Solocorn"
-                      className="h-12 w-12 shrink-0 rounded-xl object-cover"
-                    />
-                    <div className="text-lg font-semibold text-slate-900">
-                      @{normalizedUsername || 'username'}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <img
-                      src="/solocorn-app-icon.png"
-                      alt="Solocorn"
-                      className="h-12 w-12 shrink-0 rounded-xl object-cover"
-                    />
-                    <div className="min-w-0">
-                      <div className="truncate text-base font-semibold text-slate-900">
-                        Public Page
-                        <span className="ml-2 font-normal text-slate-600">{publicUrl}</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
-                  Add a username in profile settings to generate your public link.
-                </div>
-              )}
-
-              <div className="grid gap-4 pt-4 sm:grid-cols-2">
-                {[
-                  {
-                    key: 'tiktok',
-                    label: 'TikTok',
-                    value: socialAccounts.tiktok ? `@${socialAccounts.tiktok}` : '—',
-                    icon: TikTokIcon,
-                    bgClass: 'bg-black',
-                    muted: !socialAccounts.tiktok,
-                  },
-                  {
-                    key: 'youtube',
-                    label: 'YouTube',
-                    value: socialAccounts.youtube ? `@${socialAccounts.youtube}` : '—',
-                    icon: Youtube,
-                    bgClass: 'bg-red-600',
-                    muted: !socialAccounts.youtube,
-                  },
-                  {
-                    key: 'instagram',
-                    label: 'Instagram',
-                    value: socialAccounts.instagram ? `@${socialAccounts.instagram}` : '—',
-                    icon: Instagram,
-                    bgClass: 'bg-gradient-to-br from-purple-500 via-pink-500 to-orange-400',
-                    muted: !socialAccounts.instagram,
-                  },
-                  {
-                    key: 'kakaoTalk',
-                    label: 'KakaoTalk',
-                    value: socialAccounts.kakaoTalk
-                      ? socialAccounts.kakaoTalk.match(/^https?:\/\//)
-                        ? socialAccounts.kakaoTalk
-                        : `https://${socialAccounts.kakaoTalk}`
-                      : '—',
-                    icon: KakaoTalkBrandIcon,
-                    bgClass: 'bg-[#FEE500]',
-                    muted: !socialAccounts.kakaoTalk,
-                  },
-                  {
-                    key: 'facebook',
-                    label: 'Facebook',
-                    value: socialAccounts.facebook
-                      ? socialAccounts.facebook.match(/^https?:\/\//)
-                        ? socialAccounts.facebook
-                        : `https://${socialAccounts.facebook}`
-                      : '—',
-                    icon: Facebook,
-                    bgClass: 'bg-blue-600',
-                    muted: !socialAccounts.facebook,
-                  },
-                  {
-                    key: 'x',
-                    label: 'X',
-                    value: socialAccounts.x ? `@${socialAccounts.x}` : '—',
-                    icon: XBrandIcon,
-                    bgClass: 'bg-black',
-                    muted: !socialAccounts.x,
-                  },
-                ].map(item => {
-                  const Icon = item.icon
-                  return (
-                    <div key={item.key} className="flex items-center gap-4">
-                      <div
-                        className={cn(
-                          'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl',
-                          item.bgClass,
-                          item.muted && 'opacity-40'
-                        )}
-                      >
-                        <Icon
-                          className={cn(
-                            'text-white',
-                            item.key === 'kakaoTalk' ? 'h-10 w-10' : 'h-6 w-6'
-                          )}
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <div className="truncate text-base font-semibold text-slate-900">
-                          {item.label}
-                          <span
-                            className={cn(
-                              'ml-2 font-normal',
-                              item.muted ? 'text-slate-400' : 'text-slate-600'
-                            )}
-                          >
-                            {item.value}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )
-                })}
+                ) : null}
               </div>
             </div>
 
-          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:col-span-2 lg:row-start-2')}>
+            {publicUrl ? (
+              <div className="grid grid-cols-1 gap-4 border-b border-slate-100 py-4 sm:grid-cols-2">
+                <div className="flex items-center gap-3">
+                  <img
+                    src="/solocorn-app-icon.png"
+                    alt="Solocorn"
+                    className="h-12 w-12 shrink-0 rounded-xl object-cover"
+                  />
+                  <div className="text-lg font-semibold text-slate-900">
+                    @{normalizedUsername || 'username'}
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <img
+                    src="/solocorn-app-icon.png"
+                    alt="Solocorn"
+                    className="h-12 w-12 shrink-0 rounded-xl object-cover"
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-semibold text-slate-900">
+                      Public Page
+                      <span className="ml-2 font-normal text-slate-600">{publicUrl}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+                Add a username in profile settings to generate your public link.
+              </div>
+            )}
+
+            <div className="grid gap-4 pt-4 sm:grid-cols-2">
+              {[
+                {
+                  key: 'tiktok',
+                  label: 'TikTok',
+                  value: socialAccounts.tiktok ? `@${socialAccounts.tiktok}` : '—',
+                  icon: TikTokIcon,
+                  bgClass: 'bg-black',
+                  muted: !socialAccounts.tiktok,
+                },
+                {
+                  key: 'youtube',
+                  label: 'YouTube',
+                  value: socialAccounts.youtube ? `@${socialAccounts.youtube}` : '—',
+                  icon: Youtube,
+                  bgClass: 'bg-red-600',
+                  muted: !socialAccounts.youtube,
+                },
+                {
+                  key: 'instagram',
+                  label: 'Instagram',
+                  value: socialAccounts.instagram ? `@${socialAccounts.instagram}` : '—',
+                  icon: Instagram,
+                  bgClass: 'bg-gradient-to-br from-purple-500 via-pink-500 to-orange-400',
+                  muted: !socialAccounts.instagram,
+                },
+                {
+                  key: 'kakaoTalk',
+                  label: 'KakaoTalk',
+                  value: socialAccounts.kakaoTalk
+                    ? socialAccounts.kakaoTalk.match(/^https?:\/\//)
+                      ? socialAccounts.kakaoTalk
+                      : `https://${socialAccounts.kakaoTalk}`
+                    : '—',
+                  icon: KakaoTalkBrandIcon,
+                  bgClass: 'bg-[#FEE500]',
+                  muted: !socialAccounts.kakaoTalk,
+                },
+                {
+                  key: 'facebook',
+                  label: 'Facebook',
+                  value: socialAccounts.facebook
+                    ? socialAccounts.facebook.match(/^https?:\/\//)
+                      ? socialAccounts.facebook
+                      : `https://${socialAccounts.facebook}`
+                    : '—',
+                  icon: Facebook,
+                  bgClass: 'bg-blue-600',
+                  muted: !socialAccounts.facebook,
+                },
+                {
+                  key: 'x',
+                  label: 'X',
+                  value: socialAccounts.x ? `@${socialAccounts.x}` : '—',
+                  icon: XBrandIcon,
+                  bgClass: 'bg-black',
+                  muted: !socialAccounts.x,
+                },
+              ].map(item => {
+                const Icon = item.icon
+                return (
+                  <div key={item.key} className="flex items-center gap-4">
+                    <div
+                      className={cn(
+                        'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl',
+                        item.bgClass,
+                        item.muted && 'opacity-40'
+                      )}
+                    >
+                      <Icon
+                        className={cn(
+                          'text-white',
+                          item.key === 'kakaoTalk' ? 'h-10 w-10' : 'h-6 w-6'
+                        )}
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-base font-semibold text-slate-900">
+                        {item.label}
+                        <span
+                          className={cn(
+                            'ml-2 font-normal',
+                            item.muted ? 'text-slate-400' : 'text-slate-600'
+                          )}
+                        >
+                          {item.value}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              panelCardClass,
+              'flex flex-col lg:col-span-2 lg:col-start-1 lg:row-start-2'
+            )}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <Tags className="h-5 w-5" />
               <span className="text-base font-semibold">Categories</span>
-                <span className="text-sm text-white/70">({publishedCourseCategories.length})</span>
-              </div>
+              <span className="text-sm text-white/70">({publishedCourseCategories.length})</span>
+            </div>
 
-              <div className="flex flex-wrap gap-2">
-                {publishedCourseCategories.length > 0 ? (
-                  publishedCourseCategories.map((cat, i) => (
-                    <span
-                      key={`${cat}-${i}`}
-                      className="rounded-full border border-slate-100 bg-slate-50 px-4 py-1.5 text-sm font-medium text-slate-700"
-                    >
-                      {cat}
-                    </span>
-                  ))
-                ) : (
-                  <span className="text-sm text-slate-500">
-                    Categories appear here after you publish a course
+            <div className="flex flex-wrap gap-2">
+              {publishedCourseCategories.length > 0 ? (
+                publishedCourseCategories.map((cat, i) => (
+                  <span
+                    key={`${cat}-${i}`}
+                    className="rounded-full border border-slate-100 bg-slate-50 px-4 py-1.5 text-sm font-medium text-slate-700"
+                  >
+                    {cat}
                   </span>
-                )}
-              </div>
+                ))
+              ) : (
+                <span className="text-sm text-slate-500">
+                  Categories appear here after you publish a course
+                </span>
+              )}
+            </div>
           </div>
         </div>
 

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -1726,7 +1726,9 @@ export default function PublicTutorPage() {
         </section>
 
         <div className="mt-7 grid gap-5 lg:grid-cols-2 lg:grid-rows-[auto_1fr]">
-          <div className={cn(panelCardClass, 'flex h-[280px] flex-col lg:col-start-1 lg:row-start-1')}>
+          <div
+            className={cn(panelCardClass, 'flex h-[280px] flex-col lg:col-start-1 lg:row-start-1')}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <User className="h-5 w-5" />
               <span className="text-base font-semibold">Bio</span>
@@ -1764,189 +1766,197 @@ export default function PublicTutorPage() {
             </div>
           </div>
 
-          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-2 lg:row-start-1 lg:row-span-2')}>
+          <div
+            className={cn(
+              panelCardClass,
+              'flex flex-col lg:col-start-2 lg:row-span-2 lg:row-start-1'
+            )}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center justify-between rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <div className="flex items-center gap-3">
                 <Link2 className="h-5 w-5" />
                 <span className="text-base font-semibold">Connect</span>
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  onClick={() => void handleCopyPublicUrl()}
+                  disabled={!publicUrl}
+                >
+                  <Copy className="mr-1.5 h-3.5 w-3.5" />
+                  Copy URL
+                </Button>
+                {canShare ? (
                   <Button
                     size="sm"
                     variant="outline"
                     className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                    onClick={() => void handleCopyPublicUrl()}
-                    disabled={!publicUrl}
+                    onClick={() => void handleSharePublicUrl()}
                   >
-                    <Copy className="mr-1.5 h-3.5 w-3.5" />
-                    Copy URL
+                    <Share2 className="mr-1.5 h-3.5 w-3.5" />
+                    Share
                   </Button>
-                  {canShare ? (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-8 border border-white bg-transparent text-xs text-white hover:border-blue-600 hover:bg-white hover:text-blue-600 hover:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                      onClick={() => void handleSharePublicUrl()}
-                    >
-                      <Share2 className="mr-1.5 h-3.5 w-3.5" />
-                      Share
-                    </Button>
-                  ) : null}
-                </div>
-              </div>
-
-              {publicUrl ? (
-                <div className="grid grid-cols-1 gap-4 border-b border-slate-100 py-4 sm:grid-cols-2">
-                  <div className="flex items-center gap-3">
-                    <img
-                      src="/solocorn-app-icon.png"
-                      alt="Solocorn"
-                      className="h-12 w-12 shrink-0 rounded-xl object-cover"
-                    />
-                    <div className="text-lg font-semibold text-slate-900">@{tutor.username}</div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <img
-                      src="/solocorn-app-icon.png"
-                      alt="Solocorn"
-                      className="h-12 w-12 shrink-0 rounded-xl object-cover"
-                    />
-                    <div className="min-w-0">
-                      <div className="truncate text-base font-semibold text-slate-900">
-                        Public Page
-                        <span className="ml-2 font-normal text-slate-600">{publicUrl}</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
-                  Add a username below to generate your public link.
-                </div>
-              )}
-
-              <div className="grid gap-4 pt-4 sm:grid-cols-2">
-                {[
-                  {
-                    key: 'tiktok',
-                    label: 'TikTok',
-                    value: tutor.socialLinks?.tiktok
-                      ? `@${stripAt(tutor.socialLinks.tiktok)}`
-                      : '—',
-                    icon: TikTokIcon,
-                    bgClass: 'bg-black',
-                    muted: !tutor.socialLinks?.tiktok,
-                  },
-                  {
-                    key: 'youtube',
-                    label: 'YouTube',
-                    value: tutor.socialLinks?.youtube
-                      ? `@${stripAt(tutor.socialLinks.youtube)}`
-                      : '—',
-                    icon: Youtube,
-                    bgClass: 'bg-red-600',
-                    muted: !tutor.socialLinks?.youtube,
-                  },
-                  {
-                    key: 'instagram',
-                    label: 'Instagram',
-                    value: tutor.socialLinks?.instagram
-                      ? `@${stripAt(tutor.socialLinks.instagram)}`
-                      : '—',
-                    icon: Instagram,
-                    bgClass: 'bg-gradient-to-br from-purple-500 via-pink-500 to-orange-400',
-                    muted: !tutor.socialLinks?.instagram,
-                  },
-                  {
-                    key: 'kakaoTalk',
-                    label: 'KakaoTalk',
-                    value: tutor.socialLinks?.kakaoTalk
-                      ? tutor.socialLinks.kakaoTalk.match(/^https?:\/\//)
-                        ? stripAt(tutor.socialLinks.kakaoTalk)
-                        : `https://${stripAt(tutor.socialLinks.kakaoTalk)}`
-                      : '—',
-                    icon: KakaoTalkIcon,
-                    bgClass: 'bg-[#FEE500]',
-                    muted: !tutor.socialLinks?.kakaoTalk,
-                  },
-                  {
-                    key: 'facebook',
-                    label: 'Facebook',
-                    value: tutor.socialLinks?.facebook
-                      ? tutor.socialLinks.facebook.match(/^https?:\/\//)
-                        ? stripAt(tutor.socialLinks.facebook)
-                        : `https://${stripAt(tutor.socialLinks.facebook)}`
-                      : '—',
-                    icon: Facebook,
-                    bgClass: 'bg-blue-600',
-                    muted: !tutor.socialLinks?.facebook,
-                  },
-                  {
-                    key: 'x',
-                    label: 'X',
-                    value: tutor.socialLinks?.x ? `@${stripAt(tutor.socialLinks.x)}` : '—',
-                    icon: XBrandIcon,
-                    bgClass: 'bg-black',
-                    muted: !tutor.socialLinks?.x,
-                  },
-                ].map(item => {
-                  const Icon = item.icon
-                  return (
-                    <div key={item.key} className="flex items-center gap-4">
-                      <div
-                        className={cn(
-                          'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl',
-                          item.bgClass,
-                          item.muted && 'opacity-40'
-                        )}
-                      >
-                        <Icon
-                          className={cn(
-                            'text-white',
-                            item.key === 'kakaoTalk' ? 'h-10 w-10' : 'h-6 w-6'
-                          )}
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <div className="truncate text-base font-semibold text-slate-900">
-                          {item.label}
-                          <span
-                            className={cn(
-                              'ml-2 font-normal',
-                              item.muted ? 'text-slate-400' : 'text-slate-600'
-                            )}
-                          >
-                            {item.value}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )
-                })}
+                ) : null}
               </div>
             </div>
 
-          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:col-span-2 lg:row-start-2')}>
+            {publicUrl ? (
+              <div className="grid grid-cols-1 gap-4 border-b border-slate-100 py-4 sm:grid-cols-2">
+                <div className="flex items-center gap-3">
+                  <img
+                    src="/solocorn-app-icon.png"
+                    alt="Solocorn"
+                    className="h-12 w-12 shrink-0 rounded-xl object-cover"
+                  />
+                  <div className="text-lg font-semibold text-slate-900">@{tutor.username}</div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <img
+                    src="/solocorn-app-icon.png"
+                    alt="Solocorn"
+                    className="h-12 w-12 shrink-0 rounded-xl object-cover"
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-semibold text-slate-900">
+                      Public Page
+                      <span className="ml-2 font-normal text-slate-600">{publicUrl}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+                Add a username below to generate your public link.
+              </div>
+            )}
+
+            <div className="grid gap-4 pt-4 sm:grid-cols-2">
+              {[
+                {
+                  key: 'tiktok',
+                  label: 'TikTok',
+                  value: tutor.socialLinks?.tiktok ? `@${stripAt(tutor.socialLinks.tiktok)}` : '—',
+                  icon: TikTokIcon,
+                  bgClass: 'bg-black',
+                  muted: !tutor.socialLinks?.tiktok,
+                },
+                {
+                  key: 'youtube',
+                  label: 'YouTube',
+                  value: tutor.socialLinks?.youtube
+                    ? `@${stripAt(tutor.socialLinks.youtube)}`
+                    : '—',
+                  icon: Youtube,
+                  bgClass: 'bg-red-600',
+                  muted: !tutor.socialLinks?.youtube,
+                },
+                {
+                  key: 'instagram',
+                  label: 'Instagram',
+                  value: tutor.socialLinks?.instagram
+                    ? `@${stripAt(tutor.socialLinks.instagram)}`
+                    : '—',
+                  icon: Instagram,
+                  bgClass: 'bg-gradient-to-br from-purple-500 via-pink-500 to-orange-400',
+                  muted: !tutor.socialLinks?.instagram,
+                },
+                {
+                  key: 'kakaoTalk',
+                  label: 'KakaoTalk',
+                  value: tutor.socialLinks?.kakaoTalk
+                    ? tutor.socialLinks.kakaoTalk.match(/^https?:\/\//)
+                      ? stripAt(tutor.socialLinks.kakaoTalk)
+                      : `https://${stripAt(tutor.socialLinks.kakaoTalk)}`
+                    : '—',
+                  icon: KakaoTalkIcon,
+                  bgClass: 'bg-[#FEE500]',
+                  muted: !tutor.socialLinks?.kakaoTalk,
+                },
+                {
+                  key: 'facebook',
+                  label: 'Facebook',
+                  value: tutor.socialLinks?.facebook
+                    ? tutor.socialLinks.facebook.match(/^https?:\/\//)
+                      ? stripAt(tutor.socialLinks.facebook)
+                      : `https://${stripAt(tutor.socialLinks.facebook)}`
+                    : '—',
+                  icon: Facebook,
+                  bgClass: 'bg-blue-600',
+                  muted: !tutor.socialLinks?.facebook,
+                },
+                {
+                  key: 'x',
+                  label: 'X',
+                  value: tutor.socialLinks?.x ? `@${stripAt(tutor.socialLinks.x)}` : '—',
+                  icon: XBrandIcon,
+                  bgClass: 'bg-black',
+                  muted: !tutor.socialLinks?.x,
+                },
+              ].map(item => {
+                const Icon = item.icon
+                return (
+                  <div key={item.key} className="flex items-center gap-4">
+                    <div
+                      className={cn(
+                        'flex h-12 w-12 shrink-0 items-center justify-center rounded-xl',
+                        item.bgClass,
+                        item.muted && 'opacity-40'
+                      )}
+                    >
+                      <Icon
+                        className={cn(
+                          'text-white',
+                          item.key === 'kakaoTalk' ? 'h-10 w-10' : 'h-6 w-6'
+                        )}
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-base font-semibold text-slate-900">
+                        {item.label}
+                        <span
+                          className={cn(
+                            'ml-2 font-normal',
+                            item.muted ? 'text-slate-400' : 'text-slate-600'
+                          )}
+                        >
+                          {item.value}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              panelCardClass,
+              'flex flex-col lg:col-span-2 lg:col-start-1 lg:row-start-2'
+            )}
+          >
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <Tags className="h-5 w-5" />
               <span className="text-base font-semibold">Categories</span>
-                <span className="text-sm text-white">({tutor.specialties.length})</span>
-              </div>
+              <span className="text-sm text-white">({tutor.specialties.length})</span>
+            </div>
 
-              <div className="flex flex-wrap gap-2">
-                {tutor.specialties.length > 0 ? (
-                  tutor.specialties.map((s, i) => (
-                    <span
-                      key={`${s}-${i}`}
-                      className="rounded-full border border-slate-100 bg-slate-50 px-4 py-1.5 text-sm font-medium text-slate-700"
-                    >
-                      {s}
-                    </span>
-                  ))
-                ) : (
-                  <span className="text-sm text-slate-500">General tutoring</span>
-                )}
-              </div>
+            <div className="flex flex-wrap gap-2">
+              {tutor.specialties.length > 0 ? (
+                tutor.specialties.map((s, i) => (
+                  <span
+                    key={`${s}-${i}`}
+                    className="rounded-full border border-slate-100 bg-slate-50 px-4 py-1.5 text-sm font-medium text-slate-700"
+                  >
+                    {s}
+                  </span>
+                ))
+              ) : (
+                <span className="text-sm text-slate-500">General tutoring</span>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## **User description**
**Task 1** — creating an Extension for a task showed the task's content instead of an empty item.

The new-extension object already stored empty fields, but the editor's **read/generate fallback paths** borrowed the parent task's values whenever an extension's field was blank:
- `currentTaskDocument` fell back to the task's `sourceDocument`, so a fresh extension showed the **task's attached PDF**. Now an active extension shows ONLY its own document (none for a new one); the test-PCI document preview no longer re-adds the task doc either.
- PCI generation + the PCI preview used the parent task's **content/PCI** when an extension was active. Now they use the extension's own content/PCI (empty for a new extension).

The main content textarea was already correctly empty.

> Scope note: DMI questions are structurally task-level (extensions have no `dmiItems` field) and only surface in the deploy/test-PCI preview, not the main extension editor — left as-is to avoid regressions in this large file. If extensions still show inherited DMI questions where it matters, I'll do a focused follow-up.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stop task extensions from reusing the parent task’s content and document

### What Changed
- When an extension is active, the editor now shows only that extension’s own document and content instead of falling back to the parent task.
- PCI generation and PCI preview now use the active extension’s own PCI data; a new extension stays empty instead of inheriting the task’s PCI.
- Test PCI previews now open with the active extension’s document only, which prevents the task’s PDF from appearing under the extension.

### Impact
`✅ New extensions start empty`
`✅ Fewer cases where extension content looks inherited`
`✅ Clearer document previews for task extensions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
