### PR TITLE
fix(scheduler): enforce tutor availability server-side on publish

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -337,7 +337,12 @@ export const POST = withCsrf(
         const skippedSessions: Array<{
           scheduledAt: Date
           durationMinutes: number
-          reason: 'calendar_event' | 'other_course_live_session' | 'one_on_one'
+          reason:
+            | 'calendar_event'
+            | 'other_course_live_session'
+            | 'one_on_one'
+            | 'outside_availability'
+            | 'exception'
           conflictWith?: { start?: Date | null; end?: Date | null }
           recommendations: Array<{ date: string; startTime: string; endTime: string }>
         }> = []
@@ -597,6 +602,86 @@ export const POST = withCsrf(
                     : Promise.resolve([]),
                 ])
 
+              // Tutor availability (recurring available windows) + date exceptions,
+              // so the server enforces the same availability rules the scheduler UI
+              // shows (out-of-availability / blocked sessions are skipped, not
+              // silently published). Matches VariantScheduleEditor.getSlotStatus.
+              const [availabilityWindows, dateExceptions] = await Promise.all([
+                tx
+                  .select({
+                    dayOfWeek: calendarAvailability.dayOfWeek,
+                    startTime: calendarAvailability.startTime,
+                    endTime: calendarAvailability.endTime,
+                  })
+                  .from(calendarAvailability)
+                  .where(
+                    and(
+                      eq(calendarAvailability.tutorId, userId),
+                      eq(calendarAvailability.isAvailable, true),
+                      or(
+                        isNull(calendarAvailability.validUntil),
+                        gte(calendarAvailability.validUntil, now)
+                      )
+                    )
+                  ),
+                minScheduledAt && maxScheduledAt
+                  ? tx
+                      .select({
+                        date: calendarException.date,
+                        startTime: calendarException.startTime,
+                        endTime: calendarException.endTime,
+                        isAvailable: calendarException.isAvailable,
+                      })
+                      .from(calendarException)
+                      .where(
+                        and(
+                          eq(calendarException.tutorId, userId),
+                          gte(calendarException.date, minScheduledAt),
+                          lte(calendarException.date, sessionEndMax ?? maxScheduledAt)
+                        )
+                      )
+                  : Promise.resolve([]),
+              ])
+
+              // Wall-clock helpers (sessions are built as server-local = UTC, the
+              // same wall clock the scheduler compares against).
+              const hhmm = (d: Date) =>
+                `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+              const dateKeyOf = (d: Date) => d.toISOString().split('T')[0]
+              const timesOverlapStr = (s1: string, e1: string, s2: string, e2: string) =>
+                s1 < e2 && e1 > s2
+
+              // Returns a skip reason if the session falls outside availability or
+              // on a blocked exception, else null.
+              function availabilityBlock(
+                start: Date,
+                end: Date
+              ): 'outside_availability' | 'exception' | null {
+                const dow = start.getUTCDay()
+                const sStr = hhmm(start)
+                const eStr = hhmm(end)
+                const dateKey = dateKeyOf(start)
+                const dayWindows = availabilityWindows.filter(a => a.dayOfWeek === dow)
+                if (
+                  dayWindows.length > 0 &&
+                  !dayWindows.some(a => timesOverlapStr(sStr, eStr, a.startTime, a.endTime))
+                ) {
+                  return 'outside_availability'
+                }
+                for (const ex of dateExceptions) {
+                  if (dateKeyOf(new Date(ex.date)) !== dateKey) continue
+                  if (!ex.isAvailable) return 'exception'
+                  if (
+                    ex.startTime &&
+                    ex.endTime &&
+                    timesOverlapStr(sStr, eStr, ex.startTime, ex.endTime)
+                  ) {
+                    return 'exception'
+                  }
+                }
+                return null
+              }
+
               // Helper: check if a generated session overlaps with an existing event
               function overlaps(
                 start: Date,
@@ -621,6 +706,24 @@ export const POST = withCsrf(
                 const sessionEnd = new Date(
                   sessionStart.getTime() + session.durationMinutes * 60000
                 )
+
+                // Enforce tutor availability server-side (the scheduler UI guard
+                // is not authoritative on its own).
+                const availReason = availabilityBlock(sessionStart, sessionEnd)
+                if (availReason) {
+                  const recs = await findAlternativeSlots(
+                    userId,
+                    session.scheduledAt,
+                    session.durationMinutes
+                  )
+                  skippedSessions.push({
+                    scheduledAt: session.scheduledAt,
+                    durationMinutes: session.durationMinutes,
+                    reason: availReason,
+                    recommendations: recs,
+                  })
+                  continue
+                }
 
                 const conflictingLs = existingLiveSessions.find(ls =>
                   overlaps(sessionStart, sessionEnd, ls)


### PR DESCRIPTION
## **User description**
**Task 2 (part 1 of 2) — enforce availability at publish.**

The scheduler blocks out-of-availability cells in the UI, but the **publish API never re-checked availability**, so a session overlapping the tutor's blocked hours or a blocked date-exception could still be materialized (the UI guard is bypassable via direct API calls, stale availability, or the legacy slot editor).

Publish now fetches the tutor's recurring available windows (`calendarAvailability`, `isAvailable`) + date exceptions (`calendarException`) and **skips** any generated session that falls outside availability or on a blocked exception — pushing it into the existing `skippedSessions` report (new reasons `outside_availability` / `exception`) with alternative-slot recommendations, exactly like the other conflict checks.

The availability evaluation mirrors `VariantScheduleEditor.getSlotStatus` (wall-clock comparison; sessions are built server-local = UTC), so **server enforcement matches what the scheduler UI shows** — no surprising silent drops.

Part 2 (the other selected item) — **overlaying availability on the Month/Week/Day calendar grids** — is an additive UI change across the calendar view components and will follow in its own focused PR.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent publishing sessions that fall outside a tutor’s availability**

### What Changed
- Sessions that overlap blocked tutor hours or blocked date exceptions are now skipped during publish instead of being created.
- Those skipped sessions are added to the existing skipped-sessions report with clear reasons: `outside_availability` or `exception`, along with alternative slot suggestions.
- Publish now uses the same availability rules as the scheduler calendar, so what users see in the UI matches what gets published.

### Impact
`✅ Fewer invalid sessions published`
`✅ Clearer publish conflict reports`
`✅ Consistent scheduler and publish behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
