### PR TITLE
feat(calendar): shade tutor availability on the Week/Day calendar grids

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -199,6 +199,20 @@ const generateAvailability = (): AvailabilityBlock[] => {
   return slots
 }
 
+// Whether the tutor is available at a given weekday + hour, per their set
+// availability blocks. Hours with no block default to available (the model is
+// available-by-default / opt-out). Used to shade off-hours on the calendar.
+function isHourAvailable(
+  availability: AvailabilityBlock[],
+  dayOfWeek: number,
+  hour: number
+): boolean {
+  if (!availability || availability.length === 0) return true
+  const startTime = `${String(hour).padStart(2, '0')}:00`
+  const block = availability.find(b => b.dayOfWeek === dayOfWeek && b.startTime === startTime)
+  return block ? block.isAvailable : true
+}
+
 export type CalendarView = 'month' | 'week' | 'day' | 'availability'
 
 // Draggable Event Component
@@ -1024,6 +1038,7 @@ export function InteractiveCalendar({
                       onEventClick={handleEventClick}
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
+                      availability={isStudent ? [] : availability}
                     />
                   )}
 
@@ -1034,6 +1049,7 @@ export function InteractiveCalendar({
                       onEventClick={handleEventClick}
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
+                      availability={isStudent ? [] : availability}
                     />
                   )}
 
@@ -1928,6 +1944,7 @@ function WeekView({
   onEventClick,
   conflicts,
   readOnly = false,
+  availability = [],
 }: any) {
   const weekStart = new Date(currentDate)
   weekStart.setDate(currentDate.getDate() - currentDate.getDay())
@@ -1966,7 +1983,17 @@ function WeekView({
         {weekDays.map((day, index) => (
           <div key={index} className="relative flex flex-col border-r last:border-r-0">
             {hours.map(hour => (
-              <DroppableHour key={hour} date={day} hour={hour} className="h-10 shrink-0 border-b" />
+              <DroppableHour
+                key={hour}
+                date={day}
+                hour={hour}
+                className={cn(
+                  'h-10 shrink-0 border-b',
+                  // Shade hours outside the tutor's set availability.
+                  !isHourAvailable(availability, day.getDay(), hour) &&
+                    'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
+                )}
+              />
             ))}
             <div className="flex-1" />
 
@@ -2001,7 +2028,14 @@ function WeekView({
   )
 }
 
-function DayView({ currentDate, events: _events, onEventClick, conflicts, readOnly = false }: any) {
+function DayView({
+  currentDate,
+  events: _events,
+  onEventClick,
+  conflicts,
+  readOnly = false,
+  availability = [],
+}: any) {
   const hours = Array.from({ length: 24 }, (_, i) => i)
 
   const formatHour = (hour: number) => {
@@ -2035,7 +2069,11 @@ function DayView({ currentDate, events: _events, onEventClick, conflicts, readOn
             key={hour}
             date={currentDate}
             hour={hour}
-            className="h-10 shrink-0 border-b"
+            className={cn(
+              'h-10 shrink-0 border-b',
+              !isHourAvailable(availability, currentDate.getDay(), hour) &&
+                'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
+            )}
           />
         ))}
         <div className="flex-1" />


### PR DESCRIPTION
## **User description**
**Task 2 (part 2 of 2) — show availability on the calendars.**

Availability was loaded but only surfaced in the separate "Availability" tab — the Month/Week/Day views the tutor normally looks at didn't reflect working hours. The **Week and Day grids now shade hours outside the tutor's set availability** (subtle diagonal hatch), so availability is visible on the calendars consistently with the scheduler and 1-on-1 booking (which already respect it).

- Hours default to available (the app's available-by-default model), so a tutor who hasn't blocked any time sees no shading.
- Student calendars pass no availability (unchanged).
- Month view is day-granular, so hourly shading doesn't apply there.

Together with #139 (enforce-at-publish), this completes both Task-2 items you selected: availability is now **enforced** in the scheduler/publish and **visible** on the calendars.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show tutor availability shading on the Week and Day calendars**

### What Changed
- Week and Day calendar grids now visually shade hours that fall outside a tutor’s set availability
- Tutors who have not blocked any time still see empty calendars, since available hours remain unshaded by default
- Student calendars are unchanged and do not show availability shading

### Impact
`✅ Clearer weekly scheduling`
`✅ Easier to spot unavailable hours`
`✅ More consistent calendar views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
