### PR TITLE
feat(calendar): availability + blocked times across Month/Week/Day, with legend

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -199,9 +199,22 @@ const generateAvailability = (): AvailabilityBlock[] => {
   return slots
 }
 
-// Whether the tutor is available at a given weekday + hour, per their set
+interface CalendarExceptionItem {
+  date: string
+  isAvailable: boolean
+  startTime?: string | null
+  endTime?: string | null
+  reason?: string | null
+}
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate()
+
+// Whether the tutor is available at a given weekday + hour, per their recurring
 // availability blocks. Hours with no block default to available (the model is
-// available-by-default / opt-out). Used to shade off-hours on the calendar.
+// available-by-default / opt-out).
 function isHourAvailable(
   availability: AvailabilityBlock[],
   dayOfWeek: number,
@@ -212,6 +225,58 @@ function isHourAvailable(
   const block = availability.find(b => b.dayOfWeek === dayOfWeek && b.startTime === startTime)
   return block ? block.isAvailable : true
 }
+
+// Exceptions that apply to a specific calendar date.
+function exceptionsForDate(
+  exceptions: CalendarExceptionItem[],
+  date: Date
+): CalendarExceptionItem[] {
+  return (exceptions || []).filter(e => {
+    const d = new Date(e.date)
+    return !Number.isNaN(d.getTime()) && sameDay(d, date)
+  })
+}
+
+// A whole day is blocked when an exception marks it unavailable with no time range.
+function isDateFullyBlocked(exceptions: CalendarExceptionItem[], date: Date): boolean {
+  return exceptionsForDate(exceptions, date).some(e => !e.isAvailable && !e.startTime)
+}
+
+// Combined off-hours check for a concrete date+hour: outside recurring
+// availability OR covered by a blocking exception (whole-day or time-range).
+function isHourOff(
+  availability: AvailabilityBlock[],
+  exceptions: CalendarExceptionItem[],
+  date: Date,
+  hour: number
+): boolean {
+  if (!isHourAvailable(availability, date.getDay(), hour)) return true
+  for (const e of exceptionsForDate(exceptions, date)) {
+    if (e.isAvailable) continue
+    if (!e.startTime || !e.endTime) return true // whole-day block
+    const startH = parseInt(e.startTime.split(':')[0], 10)
+    const endH = parseInt(e.endTime.split(':')[0], 10)
+    if (!Number.isNaN(startH) && !Number.isNaN(endH) && hour >= startH && hour < endH) return true
+  }
+  return false
+}
+
+// A day is "fully off" when every hour is off (no working hours that day) or a
+// whole-day exception blocks it — used to shade Month cells.
+function isDayFullyOff(
+  availability: AvailabilityBlock[],
+  exceptions: CalendarExceptionItem[],
+  date: Date
+): boolean {
+  if (isDateFullyBlocked(exceptions, date)) return true
+  if (!availability || availability.length === 0) return false
+  const dayBlocks = availability.filter(b => b.dayOfWeek === date.getDay())
+  if (dayBlocks.length === 0) return false
+  return dayBlocks.every(b => !b.isAvailable)
+}
+
+const OFF_HOURS_HATCH =
+  'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
 
 export type CalendarView = 'month' | 'week' | 'day' | 'availability'
 
@@ -322,6 +387,9 @@ export function InteractiveCalendar({
   const [availability, setAvailability] = useState<AvailabilityBlock[]>(
     isStudent ? [] : generateAvailability()
   )
+  // One-off date exceptions (vacation/blocked days or time ranges) so the
+  // calendars reflect blocked TIMES, not just recurring working hours.
+  const [calendarExceptions, setCalendarExceptions] = useState<CalendarExceptionItem[]>([])
   const [currentDate, setCurrentDate] = useState(new Date())
   const [view, setView] = useState<CalendarView>(initialView)
   // Sync controlled view prop
@@ -459,6 +527,29 @@ export function InteractiveCalendar({
       }
     }
     loadAvailability()
+
+    // Load date exceptions (blocked/unblocked specific dates) so the grids can
+    // shade blocked times, not just recurring off-hours. Best-effort.
+    const loadExceptions = async () => {
+      try {
+        const res = await fetch('/api/tutor/calendar/exceptions', { credentials: 'include' })
+        if (!res.ok) return
+        const data = await res.json().catch(() => ({}))
+        const list = Array.isArray(data?.exceptions) ? data.exceptions : []
+        setCalendarExceptions(
+          list.map((e: any) => ({
+            date: typeof e.date === 'string' ? e.date : new Date(e.date).toISOString(),
+            isAvailable: !!e.isAvailable,
+            startTime: e.startTime ?? null,
+            endTime: e.endTime ?? null,
+            reason: e.reason ?? null,
+          }))
+        )
+      } catch {
+        // ignore
+      }
+    }
+    loadExceptions()
   }, [mode, timezoneProp])
 
   // Load calendar events for the visible month (tutor mode)
@@ -1006,6 +1097,12 @@ export function InteractiveCalendar({
               !availabilityOnly && 'overflow-hidden rounded-lg border border-[#374151]'
             )}
           >
+            {!isStudent && !availabilityOnly && view !== 'availability' && (
+              <div className="flex items-center gap-1.5 px-2 pb-1 text-[10px] text-gray-500">
+                <span className={cn('inline-block h-3 w-4 rounded-sm border', OFF_HOURS_HATCH)} />
+                <span>Outside your availability — set it in the Availability tab</span>
+              </div>
+            )}
             {view === 'week' && <WeekViewHeader currentDate={currentDate} />}
             <div
               ref={cardContentRef}
@@ -1028,6 +1125,8 @@ export function InteractiveCalendar({
                       isToday={isToday}
                       getEventsForDate={getEventsForDate}
                       conflicts={showConflictWarning}
+                      availability={isStudent ? [] : availability}
+                      exceptions={isStudent ? [] : calendarExceptions}
                     />
                   )}
 
@@ -1039,6 +1138,7 @@ export function InteractiveCalendar({
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
                       availability={isStudent ? [] : availability}
+                      exceptions={isStudent ? [] : calendarExceptions}
                     />
                   )}
 
@@ -1050,6 +1150,7 @@ export function InteractiveCalendar({
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
                       availability={isStudent ? [] : availability}
+                      exceptions={isStudent ? [] : calendarExceptions}
                     />
                   )}
 
@@ -1829,6 +1930,8 @@ function MonthView({
   isToday,
   getEventsForDate,
   conflicts,
+  availability = [],
+  exceptions = [],
 }: any) {
   return (
     <div className="min-h-full overflow-hidden rounded-lg">
@@ -1844,64 +1947,84 @@ function MonthView({
       </div>
 
       <div className="grid grid-cols-7">
-        {days.map((date: Date | null, index: number) => (
-          <DroppableDay
-            key={index}
-            date={date || new Date()}
-            className={cn(
-              'min-h-[60px] border-b border-r p-1 last:border-r-0',
-              !date && 'bg-gray-50/50',
-              date && 'cursor-pointer hover:bg-gray-50'
-            )}
-          >
-            {date && (
-              <div onClick={() => onDateClick(date)}>
-                <div
-                  className={cn(
-                    'mb-0.5 flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium',
-                    isToday(date) && 'bg-blue-600 text-white'
-                  )}
-                >
-                  {date.getDate()}
+        {days.map((date: Date | null, index: number) => {
+          const dayOff = date ? isDayFullyOff(availability, exceptions, date) : false
+          const blockedException = date ? isDateFullyBlocked(exceptions, date) : false
+          const exReason = date
+            ? (exceptionsForDate(exceptions, date).find(e => !e.isAvailable)?.reason ?? null)
+            : null
+          return (
+            <DroppableDay
+              key={index}
+              date={date || new Date()}
+              className={cn(
+                'min-h-[60px] border-b border-r p-1 last:border-r-0',
+                !date && 'bg-gray-50/50',
+                date && 'cursor-pointer hover:bg-gray-50',
+                dayOff && OFF_HOURS_HATCH
+              )}
+            >
+              {date && (
+                <div onClick={() => onDateClick(date)}>
+                  <div className="mb-0.5 flex items-center justify-between">
+                    <div
+                      className={cn(
+                        'flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium',
+                        isToday(date) && 'bg-blue-600 text-white'
+                      )}
+                    >
+                      {date.getDate()}
+                    </div>
+                    {blockedException && (
+                      <span
+                        title={exReason || 'Unavailable'}
+                        className="rounded-full bg-slate-200 px-1.5 py-px text-[9px] font-medium text-slate-600"
+                      >
+                        Off
+                      </span>
+                    )}
+                  </div>
+                  <div className="space-y-0.5">
+                    {getEventsForDate(date)
+                      .slice(0, 2)
+                      .map((event: CalendarEvent) => {
+                        const hasConflict = !!conflicts.find(
+                          (e: CalendarEvent) => e.id === event.id
+                        )
+                        return (
+                          <div
+                            key={event.id}
+                            className={cn(
+                              'cursor-pointer truncate rounded px-1 py-0.5 text-[10px] leading-tight',
+                              event.color || 'bg-blue-100',
+                              event.status === 'cancelled' && 'line-through opacity-50',
+                              hasConflict && 'ring-1 ring-red-400'
+                            )}
+                            onClick={(e: any) => {
+                              e.stopPropagation()
+                              onEventClick(event)
+                            }}
+                          >
+                            <span className="truncate font-medium">
+                              {event.date.getHours() > 12
+                                ? event.date.getHours() - 12
+                                : event.date.getHours()}
+                              :{event.date.getMinutes().toString().padStart(2, '0')} {event.title}
+                            </span>
+                          </div>
+                        )
+                      })}
+                    {getEventsForDate(date).length > 2 && (
+                      <p className="pl-0.5 text-[10px] text-gray-500">
+                        +{getEventsForDate(date).length - 2} more
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <div className="space-y-0.5">
-                  {getEventsForDate(date)
-                    .slice(0, 2)
-                    .map((event: CalendarEvent) => {
-                      const hasConflict = !!conflicts.find((e: CalendarEvent) => e.id === event.id)
-                      return (
-                        <div
-                          key={event.id}
-                          className={cn(
-                            'cursor-pointer truncate rounded px-1 py-0.5 text-[10px] leading-tight',
-                            event.color || 'bg-blue-100',
-                            event.status === 'cancelled' && 'line-through opacity-50',
-                            hasConflict && 'ring-1 ring-red-400'
-                          )}
-                          onClick={(e: any) => {
-                            e.stopPropagation()
-                            onEventClick(event)
-                          }}
-                        >
-                          <span className="truncate font-medium">
-                            {event.date.getHours() > 12
-                              ? event.date.getHours() - 12
-                              : event.date.getHours()}
-                            :{event.date.getMinutes().toString().padStart(2, '0')} {event.title}
-                          </span>
-                        </div>
-                      )
-                    })}
-                  {getEventsForDate(date).length > 2 && (
-                    <p className="pl-0.5 text-[10px] text-gray-500">
-                      +{getEventsForDate(date).length - 2} more
-                    </p>
-                  )}
-                </div>
-              </div>
-            )}
-          </DroppableDay>
-        ))}
+              )}
+            </DroppableDay>
+          )
+        })}
       </div>
     </div>
   )
@@ -1945,6 +2068,7 @@ function WeekView({
   conflicts,
   readOnly = false,
   availability = [],
+  exceptions = [],
 }: any) {
   const weekStart = new Date(currentDate)
   weekStart.setDate(currentDate.getDate() - currentDate.getDay())
@@ -1989,9 +2113,8 @@ function WeekView({
                 hour={hour}
                 className={cn(
                   'h-10 shrink-0 border-b',
-                  // Shade hours outside the tutor's set availability.
-                  !isHourAvailable(availability, day.getDay(), hour) &&
-                    'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
+                  // Shade hours outside availability or blocked by an exception.
+                  isHourOff(availability, exceptions, day, hour) && OFF_HOURS_HATCH
                 )}
               />
             ))}
@@ -2035,6 +2158,7 @@ function DayView({
   conflicts,
   readOnly = false,
   availability = [],
+  exceptions = [],
 }: any) {
   const hours = Array.from({ length: 24 }, (_, i) => i)
 
@@ -2071,8 +2195,7 @@ function DayView({
             hour={hour}
             className={cn(
               'h-10 shrink-0 border-b',
-              !isHourAvailable(availability, currentDate.getDay(), hour) &&
-                'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
+              isHourOff(availability, exceptions, currentDate, hour) && OFF_HOURS_HATCH
             )}
           />
         ))}

--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -1527,9 +1527,7 @@ export default function TutorMyPage() {
         </section>
 
         <div className="grid gap-5 lg:grid-cols-2 lg:grid-rows-[auto_auto]">
-          <div
-            className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:row-start-1')}
-          >
+          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:row-start-1')}>
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <User className="h-5 w-5" />
               <span className="text-base font-semibold">Bio</span>
@@ -1545,12 +1543,7 @@ export default function TutorMyPage() {
             </div>
           </div>
 
-          <div
-            className={cn(
-              panelCardClass,
-              'flex flex-col lg:col-start-2 lg:row-start-1'
-            )}
-          >
+          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-2 lg:row-start-1')}>
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center justify-between rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <div className="flex items-center gap-3">
                 <Link2 className="h-5 w-5" />

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -1726,9 +1726,7 @@ export default function PublicTutorPage() {
         </section>
 
         <div className="mt-7 grid gap-5 lg:grid-cols-2 lg:grid-rows-[auto_auto]">
-          <div
-            className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:row-start-1')}
-          >
+          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-1 lg:row-start-1')}>
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center gap-3 rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <User className="h-5 w-5" />
               <span className="text-base font-semibold">Bio</span>
@@ -1766,12 +1764,7 @@ export default function PublicTutorPage() {
             </div>
           </div>
 
-          <div
-            className={cn(
-              panelCardClass,
-              'flex flex-col lg:col-start-2 lg:row-start-1'
-            )}
-          >
+          <div className={cn(panelCardClass, 'flex flex-col lg:col-start-2 lg:row-start-1')}>
             <div className="-mx-5 -mt-5 mb-4 flex h-14 items-center justify-between rounded-t-[18px] bg-[linear-gradient(135deg,#0B3A9B_0%,#1D4ED8_35%,#0A2F78_100%)] px-5 text-white">
               <div className="flex items-center gap-3">
                 <Link2 className="h-5 w-5" />


### PR DESCRIPTION
## **User description**
Makes the calendar a robust, consistent view of tutor availability (your two asks: Month/Week/Day shading + good UX).

- **Loads date exceptions** (`calendarException`) alongside recurring availability, so the grids reflect blocked **times** (vacation days / one-off blocks), not just weekly working hours.
- **Month view:** shades days that are fully off (no working hours, or a whole-day block) and badges exception days **"Off"** with the reason as a tooltip.
- **Week/Day views:** shade hours outside availability **or** covered by a blocking exception (whole-day or time-range) via a single `isHourOff()` check.
- **Legend:** a compact key so the hatch pattern is understood, pointing tutors to the Availability tab.

Robustness/UX details:
- Available-by-default preserved — a tutor who's set nothing sees no shading (no false 'all blocked').
- Subtle diagonal hatch so it never obscures events.
- Student calendars pass no availability/exceptions (unchanged).
- Best-effort loads (a failed availability/exception fetch just shows no shading, never breaks the calendar).

This complements the server-side enforcement (#139) so availability is now enforced **and** clearly visible everywhere.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show blocked dates and time ranges in calendar views**

### What Changed
- Calendar month, week, and day views now show one-off blocked dates and blocked time ranges, not just recurring weekly availability.
- Fully unavailable days are shaded in month view and marked with an “Off” badge that can show the reason.
- Week and day views now shade hours that are outside availability or covered by a blocked exception.
- A small legend explains the shaded pattern and points tutors to the Availability tab.
- If no availability is set, the calendar still stays unshaded instead of treating everything as blocked.

### Impact
`✅ Clearer tutor availability`
`✅ Fewer double-booking mistakes`
`✅ Easier vacation and blocked-time planning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
