### PR TITLE
feat(course): Save persists schedule edits on published courses without going live

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -75,6 +75,8 @@ interface VariantManagerProps {
 
 export type VariantManagerHandle = {
   publish: () => Promise<void>
+  /** Persist schedule edits to already-published variants without publishing. */
+  saveSchedules: () => Promise<void>
   setPanelsOpen: (open: boolean) => void
 }
 
@@ -407,6 +409,31 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
       }
     }, [variants, templateCourseId, onSaved])
 
+    // Persist schedule edits to already-published variants WITHOUT publishing
+    // anything new (schedulesOnly). Used by the page's Save button so a tutor can
+    // save schedule changes on a live course without putting more of it live.
+    const handleSaveSchedules = useCallback(async () => {
+      if (variants.length === 0) return
+      try {
+        const payload = variants.map(v => ({
+          ...v,
+          price: v.isFree ? 0 : typeof v.price === 'number' ? v.price : null,
+        }))
+        const res = await fetchWithCsrf(`/api/tutor/courses/${templateCourseId}/publish`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ variants: payload, schedulesOnly: true }),
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          toast.error(data?.error || 'Failed to save schedules')
+        }
+      } catch (err) {
+        console.error(err)
+        toast.error('Failed to save schedules')
+      }
+    }, [variants, templateCourseId])
+
     const publishedCount = variants.filter(v => v.isPublished).length
 
     useEffect(() => {
@@ -424,9 +451,10 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
         publish: async () => {
           await handleSave()
         },
+        saveSchedules: handleSaveSchedules,
         setPanelsOpen,
       }),
-      [handleSave, setPanelsOpen]
+      [handleSave, handleSaveSchedules, setPanelsOpen]
     )
 
     if (loading) {

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -1525,10 +1525,14 @@ export default function TutorCoursePage() {
               size="lg"
               variant="default"
               onClick={async () => {
-                // Save persists course details only — it must NOT publish.
-                // Publishing (and persisting schedule rows) is the explicit
-                // Publish/Update action, so Save can never put a course live.
-                await handleSaveAll()
+                // Save persists course details, and schedule edits for variants
+                // that are ALREADY published — without publishing anything new
+                // (saveSchedules runs in schedulesOnly mode, a no-op for an
+                // unpublished course). Save never puts a course live.
+                const saved = await handleSaveAll()
+                if (saved) {
+                  await variantManagerRef.current?.saveSchedules()
+                }
               }}
               disabled={saving}
               className="h-11 w-full rounded-full border-2 border-transparent bg-gradient-to-r from-[#2563eb] to-[#1d4ed8] px-8 text-white shadow-[0_6px_16px_rgba(37,99,235,0.16),0_2px_4px_rgba(0,0,0,0.08)] transition-all duration-200 ease-in-out hover:translate-y-0 hover:border-[#2563eb] hover:bg-white hover:text-[#2563eb] hover:shadow-[0_8px_18px_rgba(37,99,235,0.18)] hover:[background-image:none] active:bg-gradient-to-r active:from-[#1d4ed8] active:to-[#1e40af] active:shadow-[0_4px_10px_rgba(37,99,235,0.16)] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none sm:w-[220px]"

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -252,6 +252,10 @@ export const POST = withCsrf(
       const templateCourseId = params.id as string
       const userId = session.user.id
       const body = await req.json().catch(() => ({}))
+      // schedulesOnly: persist schedule edits to ALREADY-published variants
+      // without publishing unpublished ones or changing any publish state — lets
+      // "Save" save schedules on a live course without putting more of it live.
+      const schedulesOnly = body.schedulesOnly === true
       const variants: VariantConfig[] = Array.isArray(body.variants)
         ? body.variants.filter(
             (v: unknown): v is VariantConfig =>
@@ -331,7 +335,7 @@ export const POST = withCsrf(
           nationality: string
           category: string
           isPublished: boolean
-          action: 'created' | 'updated'
+          action: 'created' | 'updated' | 'schedules_saved'
         }> = []
 
         const skippedSessions: Array<{
@@ -355,8 +359,10 @@ export const POST = withCsrf(
               category: courseVariant.category,
               nationality: courseVariant.nationality,
               publishedCourseId: courseVariant.publishedCourseId,
+              isPublished: course.isPublished,
             })
             .from(courseVariant)
+            .innerJoin(course, eq(course.courseId, courseVariant.publishedCourseId))
             .where(eq(courseVariant.templateCourseId, templateCourseId))
 
           const existingMap = new Map(existingRows.map(r => [`${r.category}|${r.nationality}`, r]))
@@ -367,6 +373,9 @@ export const POST = withCsrf(
             const key = `${v.category}|${v.nationality}`
             requestedKeys.add(key)
             const existing = existingMap.get(key)
+            // In schedules-only mode, only touch variants that are already
+            // published; never create/publish anything new.
+            if (schedulesOnly && (!existing || !existing.isPublished)) continue
             const courseName =
               v.nationality === 'Global'
                 ? templateCourse.name
@@ -380,29 +389,34 @@ export const POST = withCsrf(
             if (existing) {
               // Update existing course row
               publishedCourseId = existing.publishedCourseId
-              await tx
-                .update(course)
-                .set({
-                  name: courseName,
-                  description: templateCourse.description,
-                  categories: [v.category],
-                  isPublished: v.isPublished,
-                  updatedAt: now,
-                  isLiveOnline: templateCourse.isLiveOnline ?? false,
-                  languageOfInstruction: v.languageOfInstruction || null,
-                  price,
-                  currency: v.currency || templateCourse.currency || 'USD',
-                  isFree,
-                })
-                .where(eq(course.courseId, publishedCourseId))
+              // Skip the course-row update in schedules-only mode so publish
+              // state and details are left exactly as they are (we only sync the
+              // schedule rows below).
+              if (!schedulesOnly) {
+                await tx
+                  .update(course)
+                  .set({
+                    name: courseName,
+                    description: templateCourse.description,
+                    categories: [v.category],
+                    isPublished: v.isPublished,
+                    updatedAt: now,
+                    isLiveOnline: templateCourse.isLiveOnline ?? false,
+                    languageOfInstruction: v.languageOfInstruction || null,
+                    price,
+                    currency: v.currency || templateCourse.currency || 'USD',
+                    isFree,
+                  })
+                  .where(eq(course.courseId, publishedCourseId))
+              }
 
               result.push({
                 courseId: publishedCourseId,
                 name: courseName,
                 nationality: v.nationality,
                 category: v.category,
-                isPublished: v.isPublished,
-                action: 'updated',
+                isPublished: existing.isPublished,
+                action: schedulesOnly ? 'schedules_saved' : 'updated',
               })
             } else {
               // Create new course + variant
@@ -894,14 +908,18 @@ export const POST = withCsrf(
             }
           }
 
-          // Unpublish variants that exist in DB but were not sent in the request
-          for (const existing of existingRows) {
-            const key = `${existing.category}|${existing.nationality}`
-            if (!requestedKeys.has(key)) {
-              await tx
-                .update(course)
-                .set({ isPublished: false, updatedAt: now })
-                .where(eq(course.courseId, existing.publishedCourseId))
+          // Unpublish variants that exist in DB but were not sent in the request.
+          // Never do this in schedules-only mode — Save must not change publish
+          // state for anything.
+          if (!schedulesOnly) {
+            for (const existing of existingRows) {
+              const key = `${existing.category}|${existing.nationality}`
+              if (!requestedKeys.has(key)) {
+                await tx
+                  .update(course)
+                  .set({ isPublished: false, updatedAt: now })
+                  .where(eq(course.courseId, existing.publishedCourseId))
+              }
             }
           }
         })


### PR DESCRIPTION
## **User description**
Per your preference — **Save** now also persists schedule changes for **already-published** variants, without publishing anything new.

How it stays safe:
- The publish POST gains a **`schedulesOnly`** mode. For each variant it acts **only** when that variant's course already exists *and* is published — it then syncs the `CourseSchedule` rows and re-materializes sessions, but **skips** the course-row update (no `isPublished` / detail changes) and the "unpublish missing variants" cleanup. For an unpublished course, every variant is skipped → pure no-op.
- `VariantManager` exposes `saveSchedules()` (POSTs `schedulesOnly: true`); the page's **Save** button calls it after `handleSaveAll`.

Net behavior:
- **Save** on a live course → adds e.g. Schedule 3 and its sessions immediately, with no publish-state change anywhere.
- **Save** on an unpublished course → saves details only, publishes nothing (the earlier fix preserved).
- **Publish/Update** remains the explicit way to put variants live.

Session materialization in this path reuses the existing idempotent + availability-aware logic, so re-saving doesn't duplicate sessions.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Save now keeps schedule edits for already-published course variants without putting anything new live**

### What Changed
- Save now persists schedule changes on variants that are already published, while leaving publish status and course details unchanged
- Save skips unpublished variants, so it does not create or publish new course variants
- Variants that were removed from the request are no longer unpublished when using Save
- After saving course details, the page also saves schedule edits for the live variants

### Impact
`✅ Save schedule edits on live courses`
`✅ Fewer accidental publishes`
`✅ Safer updates for unpublished variants`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
