### PR TITLE
fix(scheduler): keep the real variant so added schedules persist; simpler schedule view

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -57,6 +57,10 @@ interface VariantConfig {
   currency: string
   languageOfInstruction: string
   schedules: CourseScheduleConfig[]
+  /** Loaded from the DB (an existing published/draft variant) — never churned
+   *  out by the desired-keys sync, so a tutor editing a live course keeps and
+   *  schedules the REAL variant instead of a regenerated Global stand-in. */
+  persisted?: boolean
 }
 
 interface VariantManagerProps {
@@ -192,6 +196,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
               languageOfInstruction:
                 typeof v.languageOfInstruction === 'string' ? v.languageOfInstruction : '',
               schedules,
+              persisted: true,
             }
           })
           setVariants(loaded)
@@ -252,6 +257,14 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
           const existing = map.get(key)
           if (!existing) {
             const [category, nationality] = key.split('|')
+            // Don't conjure a stand-in (e.g. "<cat>|Global") when the course
+            // already has a persisted variant for this category — on load the
+            // pickers don't reproduce the stored country, and adding a duplicate
+            // would make the tutor schedule the wrong (unsaved) variant.
+            const hasPersistedSameCategory = Array.from(map.values()).some(
+              v => v.persisted && v.category === category
+            )
+            if (hasPersistedSameCategory) continue
             map.set(key, {
               category,
               nationality,
@@ -278,6 +291,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
         // scheduler, leaving only the "Add another schedule" button.
         for (const [key, variant] of map.entries()) {
           if (desiredKeys.has(key)) continue
+          if (variant.persisted) continue // keep real DB variants (the live course)
           if (variantHasSchedules(variant)) continue
           map.delete(key)
           changed = true

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -249,8 +249,18 @@ export const POST = withCsrf(
   withAuth(
     async (req: NextRequest, session, context) => {
       const params = await context.params
-      const templateCourseId = params.id as string
+      let templateCourseId = params.id as string
       const userId = session.user.id
+      // Safety net (mirrors the GET): if a *published variant* id was passed,
+      // resolve it back to its template so variant lookups aren't empty.
+      const asVariantRow = await drizzleDb
+        .select({ templateCourseId: courseVariant.templateCourseId })
+        .from(courseVariant)
+        .where(eq(courseVariant.publishedCourseId, templateCourseId))
+        .limit(1)
+      if (asVariantRow.length > 0) {
+        templateCourseId = asVariantRow[0].templateCourseId
+      }
       const body = await req.json().catch(() => ({}))
       // schedulesOnly: persist schedule edits to ALREADY-published variants
       // without publishing unpublished ones or changing any publish state — lets

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -18,6 +18,19 @@ interface ScheduleSlot {
   durationMinutes: number
 }
 
+// Concise weekly-pattern summary instead of listing every slot.
+function summarizeSlots(slots: ScheduleSlot[]): { line: string; perWeek: number } {
+  if (slots.length === 0) return { line: 'Times arranged with the tutor', perWeek: 0 }
+  const days = Array.from(new Set(slots.map(s => s.dayOfWeek.slice(0, 3)))).join(', ')
+  const times = Array.from(new Set(slots.map(s => s.startTime)))
+  const timePart = times.length === 1 ? times[0] : `${times.length} times/wk`
+  const dur = slots[0]?.durationMinutes
+  return {
+    line: [days, timePart, dur ? `${dur} min` : null].filter(Boolean).join(' · '),
+    perWeek: slots.length,
+  }
+}
+
 interface CourseSchedule {
   scheduleId: string
   scheduleIndex: number
@@ -132,28 +145,22 @@ export function ScheduleViewModal({
                         </span>
                       )}
                     </div>
-                    {s.slots.length > 0 ? (
-                      <ul className="space-y-1.5">
-                        {s.slots.map((slot, i) => (
-                          <li
-                            key={i}
-                            className="flex items-center justify-between rounded-md bg-white px-3 py-2 text-sm"
-                          >
-                            <span className="font-medium text-gray-800">{slot.dayOfWeek}</span>
-                            <span className="text-gray-600">
-                              {slot.startTime} · {slot.durationMinutes} min
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-sm text-gray-500">Times to be arranged with the tutor.</p>
-                    )}
-                    {s.weeksToSchedule ? (
-                      <p className="mt-2 text-xs text-gray-400">
-                        Runs for {s.weeksToSchedule} weeks
-                      </p>
-                    ) : null}
+                    {(() => {
+                      const { line, perWeek } = summarizeSlots(s.slots)
+                      const weeks = s.weeksToSchedule || 0
+                      return (
+                        <div className="space-y-1">
+                          <p className="text-sm text-gray-700">{line}</p>
+                          {perWeek > 0 && (
+                            <p className="text-xs text-gray-400">
+                              {weeks > 0
+                                ? `${perWeek * weeks} sessions over ${weeks} weeks`
+                                : `${perWeek} session${perWeek === 1 ? '' : 's'}/week`}
+                            </p>
+                          )}
+                        </div>
+                      )
+                    })()}
                     {onSwitch && !isCurrent && (
                       <Button
                         variant="outline"


### PR DESCRIPTION
## **User description**
Two fixes.

### 1. Added schedules don't reflect (no sessions / no schedules)
**Root cause:** on opening a course in the scheduler, the editor's desired-keys sync **dropped the loaded published variant** (it had no schedules and a key like `<cat>|Hong Kong`) and **conjured a `<cat>|Global` stand-in** (the page doesn't reproduce the course's stored country on load). The tutor then added schedules to that stand-in, and `schedulesOnly` Save **silently skipped** it because its key didn't match the published DB variant — so nothing persisted, and the dashboard stayed at "no sessions".

**Fixes:**
- Mark DB-loaded variants `persisted` and never churn them out of the editor; and don't add a Global stand-in when a persisted same-category variant exists. The tutor now edits the **real published variant**, so Save persists its schedule rows and materializes sessions.
- The publish **POST** now resolves a published-variant id back to its template (mirroring GET), so variant lookups can't come up empty from any entry point.

### 2. "Schedule" view modal was overwhelming/redundant
It listed **every** weekly slot per schedule. Each schedule now shows one concise line — **days · time · duration** — plus a **"{N} sessions over {weeks} weeks"** subtitle, keeping the Current / Full / spots badges and the switch action.

tsc clean; 270 unit tests pass; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep scheduled course variants intact and simplify the schedule summary**

### What Changed
- Saving schedules now updates the real published course variant, so added sessions persist instead of disappearing on refresh.
- The editor no longer creates a duplicate placeholder variant when a live course already has a saved version for the same category.
- Publishing now works when opened from a published-variant link by resolving it back to the original course before saving.
- The schedule modal now shows one short summary line per schedule, with a clear sessions-over-weeks note instead of listing every weekly slot.

### Impact
`✅ Fewer missing sessions after saving`
`✅ Reliable schedule edits on live courses`
`✅ Clearer schedule summaries for tutors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
