### PR TITLE
feat(live): follow-tutor auto-off, equal tabs, hide doc name, dedicated math tool

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1436,14 +1436,13 @@ function StudentFeedbackContent() {
                                   <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border bg-slate-50 text-center">
                                     <FileText className="h-8 w-8 text-slate-400" />
                                     <p className="text-sm text-slate-500">
-                                      {doc.fileName || 'Document'} is unavailable. Ask your tutor to
-                                      re-deploy it.
+                                      This document is unavailable. Ask your tutor to re-deploy it.
                                     </p>
                                   </div>
                                 ) : isPdf ? (
                                   <iframe
                                     src={pdfSrc}
-                                    title={doc.fileName}
+                                    title="Document"
                                     className="h-full w-full rounded-lg border"
                                   />
                                 ) : isImage ? (
@@ -1451,7 +1450,7 @@ function StudentFeedbackContent() {
                                     {/* eslint-disable-next-line @next/next/no-img-element */}
                                     <img
                                       src={url}
-                                      alt={doc.fileName}
+                                      alt="Document"
                                       className="max-h-full max-w-full object-contain"
                                     />
                                   </div>
@@ -1464,7 +1463,7 @@ function StudentFeedbackContent() {
                                       rel="noreferrer"
                                       className="text-sm text-blue-600 underline"
                                     >
-                                      Open {doc.fileName}
+                                      Open document
                                     </a>
                                   </div>
                                 )}
@@ -1485,12 +1484,17 @@ function StudentFeedbackContent() {
                                 </p>
                                 <textarea
                                   value={taskAnswers[item.id] ?? ''}
-                                  onChange={e =>
+                                  // Once the student starts working on a task/assessment,
+                                  // stop auto-following the tutor so their navigation can't
+                                  // yank the student away from what they're answering.
+                                  onFocus={() => setFollowTutor(false)}
+                                  onChange={e => {
+                                    setFollowTutor(false)
                                     setTaskAnswers(prev => ({
                                       ...prev,
                                       [item.id]: e.target.value,
                                     }))
-                                  }
+                                  }}
                                   placeholder="Type your answer…"
                                   className="min-h-[64px] w-full resize-y rounded-md border border-gray-200 p-2 text-sm focus:border-[#F17623] focus:outline-none"
                                 />
@@ -1657,7 +1661,7 @@ function StudentFeedbackContent() {
                   size="sm"
                   onClick={() => setRightPanelTab('interactions')}
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'interactions'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'
@@ -1672,7 +1676,7 @@ function StudentFeedbackContent() {
                     setRightPanelTab(prev => (prev === 'dmi' ? 'interactions' : 'dmi'))
                   }
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'dmi'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'
@@ -1687,7 +1691,7 @@ function StudentFeedbackContent() {
                     setRightPanelTab(prev => (prev === 'my-board' ? 'interactions' : 'my-board'))
                   }
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'my-board'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'

--- a/tutorme-app/src/components/class/enhanced-whiteboard.tsx
+++ b/tutorme-app/src/components/class/enhanced-whiteboard.tsx
@@ -23,8 +23,8 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { TeachingAssistant } from './teaching-assistant'
 import { FloatingToolMenu } from './floating-tool-menu'
+import { FloatingMathTool } from './floating-math-tool'
 import { GraphDialog } from './graph-dialog'
-import { LatexFormulaDialog } from './latex-formula-dialog'
 import { sampleGraph, drawGraphOnCanvas, svgToDataUrl } from '@/lib/whiteboard/math-render'
 import {
   Plus,
@@ -408,7 +408,6 @@ export function EnhancedWhiteboard({
 
   // Math tools state
   const [showGraphDialog, setShowGraphDialog] = useState(false)
-  const [showFormulaDialog, setShowFormulaDialog] = useState(false)
   const [snapToGrid, setSnapToGrid] = useState(false)
   const gridStep = 20
 
@@ -1793,13 +1792,6 @@ export function EnhancedWhiteboard({
 
   // Open math dialogs immediately when tool is selected
   useEffect(() => {
-    if (tool === 'formula') {
-      setShowFormulaDialog(true)
-      setTool('select')
-    }
-  }, [tool])
-
-  useEffect(() => {
     if (tool === 'graph') {
       setShowGraphDialog(true)
       setTool('select')
@@ -2029,6 +2021,9 @@ export function EnhancedWhiteboard({
             currentPointerPos={pointerPos}
           />
         )}
+
+        {/* Dedicated, draggable math tool (separate from the radial menu) */}
+        {!readOnly && <FloatingMathTool onPlace={handlePlaceFormula} defaultColor={color} />}
 
         {/* Floating Background Color Toggle */}
         {!readOnly && (
@@ -2742,11 +2737,6 @@ export function EnhancedWhiteboard({
         onOpenChange={setShowGraphDialog}
         onPlot={handlePlotGraph}
         defaultColor={color}
-      />
-      <LatexFormulaDialog
-        open={showFormulaDialog}
-        onOpenChange={setShowFormulaDialog}
-        onPlace={handlePlaceFormula}
       />
 
       {/* Bottom Page Navigation - only show when using internal state */}

--- a/tutorme-app/src/components/class/floating-math-tool.tsx
+++ b/tutorme-app/src/components/class/floating-math-tool.tsx
@@ -1,0 +1,420 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+import { Sigma, X, Loader2, AlertCircle, CornerDownLeft, Eraser } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface FloatingMathToolProps {
+  /** Places the rendered formula on the board. Reuses the whiteboard's formula handler. */
+  onPlace: (options: { latex: string; scale: number; color: string }) => void | Promise<void>
+  /** Current pen color, used as the default formula color. */
+  defaultColor?: string
+}
+
+/**
+ * A self-contained, draggable floating tool dedicated to math (and science
+ * notation) entry. Unlike the old modal Formula dialog, this stays open so a
+ * tutor/student can drop several expressions in a row, and offers a symbol +
+ * template palette so users don't have to know LaTeX to write math fast.
+ */
+
+// Templates insert a LaTeX skeleton and drop the caret inside the first slot.
+// `caretBack` = how many characters from the end of the snippet the caret sits.
+interface Template {
+  label: string
+  latex: string
+  caretBack: number
+}
+
+const TEMPLATES: Template[] = [
+  { label: 'a/b', latex: '\\frac{}{}', caretBack: 3 },
+  { label: 'xⁿ', latex: '^{}', caretBack: 1 },
+  { label: 'xₙ', latex: '_{}', caretBack: 1 },
+  { label: '√', latex: '\\sqrt{}', caretBack: 1 },
+  { label: 'ⁿ√', latex: '\\sqrt[]{}', caretBack: 3 },
+  { label: '∫', latex: '\\int_{}^{}', caretBack: 4 },
+  { label: '∑', latex: '\\sum_{}^{}', caretBack: 4 },
+  { label: 'lim', latex: '\\lim_{}', caretBack: 1 },
+  { label: '( )', latex: '\\left(\\right)', caretBack: 7 },
+  { label: 'vec', latex: '\\vec{}', caretBack: 1 },
+]
+
+// Symbols insert as-is (caret lands right after them).
+interface SymbolGroup {
+  name: string
+  symbols: { display: string; latex: string }[]
+}
+
+const SYMBOL_GROUPS: SymbolGroup[] = [
+  {
+    name: 'Basic',
+    symbols: [
+      { display: '×', latex: '\\times ' },
+      { display: '÷', latex: '\\div ' },
+      { display: '±', latex: '\\pm ' },
+      { display: '∓', latex: '\\mp ' },
+      { display: '·', latex: '\\cdot ' },
+      { display: '∞', latex: '\\infty ' },
+      { display: '°', latex: '^{\\circ}' },
+      { display: '%', latex: '\\% ' },
+      { display: '∝', latex: '\\propto ' },
+      { display: '∴', latex: '\\therefore ' },
+    ],
+  },
+  {
+    name: 'Relations',
+    symbols: [
+      { display: '=', latex: '= ' },
+      { display: '≠', latex: '\\neq ' },
+      { display: '≤', latex: '\\leq ' },
+      { display: '≥', latex: '\\geq ' },
+      { display: '≈', latex: '\\approx ' },
+      { display: '≡', latex: '\\equiv ' },
+      { display: '→', latex: '\\to ' },
+      { display: '⇌', latex: '\\rightleftharpoons ' },
+      { display: '∈', latex: '\\in ' },
+      { display: '⊂', latex: '\\subset ' },
+      { display: '∪', latex: '\\cup ' },
+      { display: '∩', latex: '\\cap ' },
+    ],
+  },
+  {
+    name: 'Greek',
+    symbols: [
+      { display: 'α', latex: '\\alpha ' },
+      { display: 'β', latex: '\\beta ' },
+      { display: 'γ', latex: '\\gamma ' },
+      { display: 'δ', latex: '\\delta ' },
+      { display: 'θ', latex: '\\theta ' },
+      { display: 'λ', latex: '\\lambda ' },
+      { display: 'μ', latex: '\\mu ' },
+      { display: 'π', latex: '\\pi ' },
+      { display: 'ρ', latex: '\\rho ' },
+      { display: 'σ', latex: '\\sigma ' },
+      { display: 'φ', latex: '\\phi ' },
+      { display: 'ω', latex: '\\omega ' },
+      { display: 'Δ', latex: '\\Delta ' },
+      { display: 'Σ', latex: '\\Sigma ' },
+      { display: 'Ω', latex: '\\Omega ' },
+    ],
+  },
+  {
+    name: 'Calculus',
+    symbols: [
+      { display: '∫', latex: '\\int ' },
+      { display: '∮', latex: '\\oint ' },
+      { display: '∑', latex: '\\sum ' },
+      { display: '∏', latex: '\\prod ' },
+      { display: '∂', latex: '\\partial ' },
+      { display: '∇', latex: '\\nabla ' },
+      { display: 'd/dx', latex: '\\frac{d}{dx} ' },
+      { display: '∂/∂x', latex: '\\frac{\\partial}{\\partial x} ' },
+      { display: 'lim', latex: '\\lim_{x \\to } ' },
+    ],
+  },
+  {
+    name: 'Science',
+    symbols: [
+      { display: '×10ⁿ', latex: '\\times 10^{}' },
+      { display: 'Δ', latex: '\\Delta ' },
+      { display: 'λ', latex: '\\lambda ' },
+      { display: 'ℏ', latex: '\\hbar ' },
+      { display: '(aq)', latex: '_{(aq)} ' },
+      { display: '(g)', latex: '_{(g)} ' },
+      { display: '(s)', latex: '_{(s)} ' },
+      { display: '(l)', latex: '_{(l)} ' },
+      { display: '→', latex: '\\rightarrow ' },
+      { display: '⇌', latex: '\\rightleftharpoons ' },
+      { display: '°C', latex: '^{\\circ}\\text{C}' },
+      { display: 'x̂', latex: '\\hat{}' },
+    ],
+  },
+]
+
+const COLORS = ['#000000', '#ef4444', '#22c55e', '#3b82f6', '#a855f7', '#f59e0b']
+const SCALES = [1, 1.5, 2, 2.5]
+
+export function FloatingMathTool({ onPlace, defaultColor }: FloatingMathToolProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [position, setPosition] = useState({ x: 20, y: 90 })
+  const [latex, setLatex] = useState('')
+  const [scale, setScale] = useState(1.5)
+  const [color, setColor] = useState(defaultColor || '#000000')
+  const [activeGroup, setActiveGroup] = useState(SYMBOL_GROUPS[0].name)
+  const [previewSvg, setPreviewSvg] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const caretRef = useRef<number | null>(null)
+
+  // Keep the formula color in sync with the pen color until the user overrides it.
+  useEffect(() => {
+    if (defaultColor) setColor(defaultColor)
+  }, [defaultColor])
+
+  // Restore the caret after a palette insertion re-renders the input.
+  useEffect(() => {
+    if (caretRef.current !== null && inputRef.current) {
+      const pos = caretRef.current
+      inputRef.current.focus()
+      inputRef.current.setSelectionRange(pos, pos)
+      caretRef.current = null
+    }
+  }, [latex])
+
+  const insert = useCallback(
+    (snippet: string, caretBack = 0) => {
+      const el = inputRef.current
+      const start = el?.selectionStart ?? latex.length
+      const end = el?.selectionEnd ?? start
+      const next = latex.slice(0, start) + snippet + latex.slice(end)
+      caretRef.current = start + snippet.length - caretBack
+      setLatex(next)
+      setError('')
+    },
+    [latex]
+  )
+
+  const renderPreview = useCallback(async (expr: string) => {
+    if (!expr.trim()) {
+      setPreviewSvg('')
+      setError('')
+      return
+    }
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setIsLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/whiteboard/render-formula', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex: expr, display: true }),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error || 'Could not render')
+        setPreviewSvg('')
+        return
+      }
+      const data = await res.json()
+      setPreviewSvg(data.svg)
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') setError('Network error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Debounced live preview.
+  useEffect(() => {
+    const timer = setTimeout(() => renderPreview(latex), 350)
+    return () => clearTimeout(timer)
+  }, [latex, renderPreview])
+
+  const handlePlace = useCallback(() => {
+    if (!latex.trim()) {
+      setError('Type a math expression first')
+      return
+    }
+    if (!previewSvg) {
+      setError('Wait for the preview to render')
+      return
+    }
+    onPlace({ latex: latex.trim(), scale, color })
+    // Keep the panel open but clear the input so the next formula is fast.
+    setLatex('')
+    setPreviewSvg('')
+  }, [latex, previewSvg, scale, color, onPlace])
+
+  return (
+    <motion.div
+      className="pointer-events-auto absolute z-50"
+      animate={{ x: position.x, y: position.y }}
+      transition={{ type: 'spring', stiffness: 200, damping: 22 }}
+      drag
+      dragMomentum={false}
+      onDragEnd={(_e, info) =>
+        setPosition({ x: position.x + info.offset.x, y: position.y + info.offset.y })
+      }
+      style={{ touchAction: 'none' }}
+    >
+      {isOpen ? (
+        <div className="w-[300px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl">
+          {/* Header (drag handle) */}
+          <div className="flex cursor-grab items-center justify-between border-b border-slate-100 bg-slate-50 px-3 py-2 active:cursor-grabbing">
+            <span className="flex items-center gap-1.5 text-sm font-semibold text-slate-700">
+              <Sigma className="h-4 w-4 text-blue-500" /> Math
+            </span>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700"
+              title="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="space-y-2.5 p-3" onPointerDownCapture={e => e.stopPropagation()}>
+            {/* Input */}
+            <div className="relative">
+              <input
+                ref={inputRef}
+                value={latex}
+                onChange={e => {
+                  setLatex(e.target.value)
+                  setError('')
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handlePlace()
+                  }
+                }}
+                placeholder="Type or tap symbols below…"
+                spellCheck={false}
+                autoComplete="off"
+                className="w-full rounded-lg border border-slate-200 py-2 pl-2.5 pr-8 font-mono text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+              />
+              {latex && (
+                <button
+                  onClick={() => {
+                    setLatex('')
+                    setPreviewSvg('')
+                    setError('')
+                    inputRef.current?.focus()
+                  }}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-slate-400 hover:text-slate-700"
+                  title="Clear"
+                >
+                  <Eraser className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+
+            {/* Templates */}
+            <div className="flex flex-wrap gap-1">
+              {TEMPLATES.map(t => (
+                <button
+                  key={t.label}
+                  onClick={() => insert(t.latex, t.caretBack)}
+                  className="min-w-[34px] rounded-md border border-slate-200 bg-white px-1.5 py-1 text-xs font-medium text-slate-700 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
+                  title={t.latex}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Symbol category tabs */}
+            <div className="flex gap-1 overflow-x-auto">
+              {SYMBOL_GROUPS.map(g => (
+                <button
+                  key={g.name}
+                  onClick={() => setActiveGroup(g.name)}
+                  className={cn(
+                    'shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors',
+                    activeGroup === g.name
+                      ? 'bg-slate-800 text-white'
+                      : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                  )}
+                >
+                  {g.name}
+                </button>
+              ))}
+            </div>
+
+            {/* Symbol palette */}
+            <div className="grid grid-cols-6 gap-1">
+              {SYMBOL_GROUPS.find(g => g.name === activeGroup)?.symbols.map(s => (
+                <button
+                  key={s.latex}
+                  onClick={() => insert(s.latex)}
+                  className="flex h-8 items-center justify-center rounded-md border border-slate-200 bg-white text-sm text-slate-700 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
+                  title={s.latex.trim()}
+                >
+                  {s.display}
+                </button>
+              ))}
+            </div>
+
+            {/* Preview */}
+            <div className="flex min-h-[56px] items-center justify-center rounded-lg border border-slate-100 bg-slate-50 p-2">
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+              ) : error ? (
+                <span className="flex items-center gap-1.5 text-xs text-red-500">
+                  <AlertCircle className="h-3.5 w-3.5" /> {error}
+                </span>
+              ) : previewSvg ? (
+                <div
+                  dangerouslySetInnerHTML={{ __html: previewSvg }}
+                  style={{ color }}
+                  className="max-h-[80px] max-w-full overflow-auto [&_svg]:max-w-full"
+                />
+              ) : (
+                <span className="text-xs text-slate-400">Preview</span>
+              )}
+            </div>
+
+            {/* Color + scale + place */}
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1">
+                {COLORS.map(c => (
+                  <button
+                    key={c}
+                    onClick={() => setColor(c)}
+                    className="h-5 w-5 rounded-full border-2 transition-transform hover:scale-110"
+                    style={{
+                      backgroundColor: c,
+                      borderColor: color === c ? '#1f2937' : 'transparent',
+                    }}
+                    title={c}
+                  />
+                ))}
+              </div>
+              <div className="flex items-center gap-1">
+                {SCALES.map(s => (
+                  <button
+                    key={s}
+                    onClick={() => setScale(s)}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors',
+                      scale === s
+                        ? 'bg-slate-800 text-white'
+                        : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                    )}
+                    title={`Scale ${s}x`}
+                  >
+                    {s}x
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handlePlace}
+              disabled={isLoading || !previewSvg}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <CornerDownLeft className="h-4 w-4" /> Place on Board
+            </button>
+          </div>
+        </div>
+      ) : (
+        <motion.button
+          onClick={() => setIsOpen(true)}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          className="flex h-14 w-14 cursor-grab items-center justify-center rounded-full bg-white text-slate-800 shadow-[0_0_15px_rgba(0,0,0,0.15)] transition-colors hover:bg-slate-50 active:cursor-grabbing"
+          title="Math tool"
+        >
+          <Sigma className="h-6 w-6" />
+        </motion.button>
+      )}
+    </motion.div>
+  )
+}

--- a/tutorme-app/src/components/class/floating-tool-menu.tsx
+++ b/tutorme-app/src/components/class/floating-tool-menu.tsx
@@ -328,12 +328,6 @@ export function FloatingToolMenu({
             active: currentTool === 'select',
           },
           {
-            icon: <Sigma className="h-5 w-5" />,
-            label: 'Formula',
-            action: () => onToolChange('formula'),
-            active: currentTool === 'formula',
-          },
-          {
             icon: <TrendingUp className="h-5 w-5" />,
             label: 'Graph',
             action: () => onToolChange('graph'),


### PR DESCRIPTION
## **User description**
## Summary

Four live-classroom fixes for the student experience plus a reworked whiteboard math tool.

### 1. Follow Tutor turns off when a student starts working
The task/assessment answer textarea now sets `followTutor = false` on `onFocus`/`onChange`. Once a student begins answering, auto-follow stops so the tutor's navigation can't yank them off what they're working on. (Persists per-session via existing localStorage logic.)

### 2. Interact tab now matches Assessment / My Board width
Added `min-w-0` to the three right-panel tab buttons. They already had `flex-1`, but without `min-w-0` a flex item won't shrink below its label's intrinsic width — so the longer "Assessment"/"My Board" labels claimed extra space and squeezed "Interact". Now all three are exact equal thirds.

### 3. Document name hidden on the student side
In the deployed task/assessment viewer, every visible use of the document's `fileName` ("Open {fileName}", the unavailable message, iframe `title`, image `alt`) is genericized to "Document". The task title still shows; only the underlying filename is hidden. (`fileName` is still used internally for PDF detection.)

### 4. Separate, more functional floating math tool
- New `floating-math-tool.tsx`: a standalone **draggable** floating widget (collapsible FAB → panel) dedicated to math/science entry, replacing the old modal that interrupted after every formula.
  - **Template buttons** (fraction, power, subscript, √, ⁿ√, ∫, ∑, lim, parens, vector) that insert a LaTeX skeleton and drop the caret in the first slot.
  - **Categorized symbol palette** (Basic, Relations, Greek, Calculus, Science) for tap-to-insert — no LaTeX knowledge needed — including science notation like `(aq)/(g)/(s)/(l)`, `×10ⁿ`, `°C`, `⇌`.
  - **Live preview**, color + scale quick-pick, **Enter to place**, and the panel **stays open** (clears input) for fast repeated entry.
- `enhanced-whiteboard.tsx`: renders the new tool (reuses existing `handlePlaceFormula`); removed the redundant modal flow (state/effect/dialog).
- `floating-tool-menu.tsx`: removed the "Formula" radial item (math is now its own floating tool). "Graph" stays in the radial menu.

The old `latex-formula-dialog.tsx` is now unreferenced but left in place to avoid a merge conflict with concurrent work.

## Testing
- `npm run typecheck` ✅
- `npm run lint` (changed files) ✅ — 0 errors
- `npm run build` ✅

UI behaviors not yet exercised in a running session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Improve live classroom controls and make math entry easier**

### What Changed
- Students can start answering without being pulled away by tutor auto-follow.
- The Interact, Assessment, and My Board tabs now share the available space evenly.
- Student document views no longer expose the file name; unavailable files, open links, and previews all use generic "Document" labels.
- Math entry now uses a separate floating tool with quick templates, symbol and science palettes, live preview, and one-tap placement on the board.
- The old formula button and popup flow were removed from the main tool menu.

### Impact
`✅ Fewer students losing their place while answering`
`✅ Equal-width classroom tabs`
`✅ Hidden document names for students`
`✅ Faster repeated math and science entry`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
