### PR TITLE
fix(live): persist live-session submissions to all tutor reader paths

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1436,14 +1436,13 @@ function StudentFeedbackContent() {
                                   <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border bg-slate-50 text-center">
                                     <FileText className="h-8 w-8 text-slate-400" />
                                     <p className="text-sm text-slate-500">
-                                      {doc.fileName || 'Document'} is unavailable. Ask your tutor to
-                                      re-deploy it.
+                                      This document is unavailable. Ask your tutor to re-deploy it.
                                     </p>
                                   </div>
                                 ) : isPdf ? (
                                   <iframe
                                     src={pdfSrc}
-                                    title={doc.fileName}
+                                    title="Document"
                                     className="h-full w-full rounded-lg border"
                                   />
                                 ) : isImage ? (
@@ -1451,7 +1450,7 @@ function StudentFeedbackContent() {
                                     {/* eslint-disable-next-line @next/next/no-img-element */}
                                     <img
                                       src={url}
-                                      alt={doc.fileName}
+                                      alt="Document"
                                       className="max-h-full max-w-full object-contain"
                                     />
                                   </div>
@@ -1464,7 +1463,7 @@ function StudentFeedbackContent() {
                                       rel="noreferrer"
                                       className="text-sm text-blue-600 underline"
                                     >
-                                      Open {doc.fileName}
+                                      Open document
                                     </a>
                                   </div>
                                 )}
@@ -1485,12 +1484,17 @@ function StudentFeedbackContent() {
                                 </p>
                                 <textarea
                                   value={taskAnswers[item.id] ?? ''}
-                                  onChange={e =>
+                                  // Once the student starts working on a task/assessment,
+                                  // stop auto-following the tutor so their navigation can't
+                                  // yank the student away from what they're answering.
+                                  onFocus={() => setFollowTutor(false)}
+                                  onChange={e => {
+                                    setFollowTutor(false)
                                     setTaskAnswers(prev => ({
                                       ...prev,
                                       [item.id]: e.target.value,
                                     }))
-                                  }
+                                  }}
                                   placeholder="Type your answer…"
                                   className="min-h-[64px] w-full resize-y rounded-md border border-gray-200 p-2 text-sm focus:border-[#F17623] focus:outline-none"
                                 />
@@ -1657,7 +1661,7 @@ function StudentFeedbackContent() {
                   size="sm"
                   onClick={() => setRightPanelTab('interactions')}
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'interactions'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'
@@ -1672,7 +1676,7 @@ function StudentFeedbackContent() {
                     setRightPanelTab(prev => (prev === 'dmi' ? 'interactions' : 'dmi'))
                   }
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'dmi'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'
@@ -1687,7 +1691,7 @@ function StudentFeedbackContent() {
                     setRightPanelTab(prev => (prev === 'my-board' ? 'interactions' : 'my-board'))
                   }
                   className={cn(
-                    'h-8 flex-1 rounded-md px-3 text-xs font-medium transition-all',
+                    'h-8 min-w-0 flex-1 rounded-md px-3 text-xs font-medium transition-all',
                     rightPanelTab === 'my-board'
                       ? 'bg-gray-800 text-white'
                       : 'text-gray-500 hover:bg-white hover:text-gray-900'

--- a/tutorme-app/src/components/class/enhanced-whiteboard.tsx
+++ b/tutorme-app/src/components/class/enhanced-whiteboard.tsx
@@ -23,8 +23,8 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { TeachingAssistant } from './teaching-assistant'
 import { FloatingToolMenu } from './floating-tool-menu'
+import { FloatingMathTool } from './floating-math-tool'
 import { GraphDialog } from './graph-dialog'
-import { LatexFormulaDialog } from './latex-formula-dialog'
 import { sampleGraph, drawGraphOnCanvas, svgToDataUrl } from '@/lib/whiteboard/math-render'
 import {
   Plus,
@@ -408,7 +408,6 @@ export function EnhancedWhiteboard({
 
   // Math tools state
   const [showGraphDialog, setShowGraphDialog] = useState(false)
-  const [showFormulaDialog, setShowFormulaDialog] = useState(false)
   const [snapToGrid, setSnapToGrid] = useState(false)
   const gridStep = 20
 
@@ -1793,13 +1792,6 @@ export function EnhancedWhiteboard({
 
   // Open math dialogs immediately when tool is selected
   useEffect(() => {
-    if (tool === 'formula') {
-      setShowFormulaDialog(true)
-      setTool('select')
-    }
-  }, [tool])
-
-  useEffect(() => {
     if (tool === 'graph') {
       setShowGraphDialog(true)
       setTool('select')
@@ -2029,6 +2021,9 @@ export function EnhancedWhiteboard({
             currentPointerPos={pointerPos}
           />
         )}
+
+        {/* Dedicated, draggable math tool (separate from the radial menu) */}
+        {!readOnly && <FloatingMathTool onPlace={handlePlaceFormula} defaultColor={color} />}
 
         {/* Floating Background Color Toggle */}
         {!readOnly && (
@@ -2742,11 +2737,6 @@ export function EnhancedWhiteboard({
         onOpenChange={setShowGraphDialog}
         onPlot={handlePlotGraph}
         defaultColor={color}
-      />
-      <LatexFormulaDialog
-        open={showFormulaDialog}
-        onOpenChange={setShowFormulaDialog}
-        onPlace={handlePlaceFormula}
       />
 
       {/* Bottom Page Navigation - only show when using internal state */}

--- a/tutorme-app/src/components/class/floating-math-tool.tsx
+++ b/tutorme-app/src/components/class/floating-math-tool.tsx
@@ -1,0 +1,420 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+import { Sigma, X, Loader2, AlertCircle, CornerDownLeft, Eraser } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface FloatingMathToolProps {
+  /** Places the rendered formula on the board. Reuses the whiteboard's formula handler. */
+  onPlace: (options: { latex: string; scale: number; color: string }) => void | Promise<void>
+  /** Current pen color, used as the default formula color. */
+  defaultColor?: string
+}
+
+/**
+ * A self-contained, draggable floating tool dedicated to math (and science
+ * notation) entry. Unlike the old modal Formula dialog, this stays open so a
+ * tutor/student can drop several expressions in a row, and offers a symbol +
+ * template palette so users don't have to know LaTeX to write math fast.
+ */
+
+// Templates insert a LaTeX skeleton and drop the caret inside the first slot.
+// `caretBack` = how many characters from the end of the snippet the caret sits.
+interface Template {
+  label: string
+  latex: string
+  caretBack: number
+}
+
+const TEMPLATES: Template[] = [
+  { label: 'a/b', latex: '\\frac{}{}', caretBack: 3 },
+  { label: 'xⁿ', latex: '^{}', caretBack: 1 },
+  { label: 'xₙ', latex: '_{}', caretBack: 1 },
+  { label: '√', latex: '\\sqrt{}', caretBack: 1 },
+  { label: 'ⁿ√', latex: '\\sqrt[]{}', caretBack: 3 },
+  { label: '∫', latex: '\\int_{}^{}', caretBack: 4 },
+  { label: '∑', latex: '\\sum_{}^{}', caretBack: 4 },
+  { label: 'lim', latex: '\\lim_{}', caretBack: 1 },
+  { label: '( )', latex: '\\left(\\right)', caretBack: 7 },
+  { label: 'vec', latex: '\\vec{}', caretBack: 1 },
+]
+
+// Symbols insert as-is (caret lands right after them).
+interface SymbolGroup {
+  name: string
+  symbols: { display: string; latex: string }[]
+}
+
+const SYMBOL_GROUPS: SymbolGroup[] = [
+  {
+    name: 'Basic',
+    symbols: [
+      { display: '×', latex: '\\times ' },
+      { display: '÷', latex: '\\div ' },
+      { display: '±', latex: '\\pm ' },
+      { display: '∓', latex: '\\mp ' },
+      { display: '·', latex: '\\cdot ' },
+      { display: '∞', latex: '\\infty ' },
+      { display: '°', latex: '^{\\circ}' },
+      { display: '%', latex: '\\% ' },
+      { display: '∝', latex: '\\propto ' },
+      { display: '∴', latex: '\\therefore ' },
+    ],
+  },
+  {
+    name: 'Relations',
+    symbols: [
+      { display: '=', latex: '= ' },
+      { display: '≠', latex: '\\neq ' },
+      { display: '≤', latex: '\\leq ' },
+      { display: '≥', latex: '\\geq ' },
+      { display: '≈', latex: '\\approx ' },
+      { display: '≡', latex: '\\equiv ' },
+      { display: '→', latex: '\\to ' },
+      { display: '⇌', latex: '\\rightleftharpoons ' },
+      { display: '∈', latex: '\\in ' },
+      { display: '⊂', latex: '\\subset ' },
+      { display: '∪', latex: '\\cup ' },
+      { display: '∩', latex: '\\cap ' },
+    ],
+  },
+  {
+    name: 'Greek',
+    symbols: [
+      { display: 'α', latex: '\\alpha ' },
+      { display: 'β', latex: '\\beta ' },
+      { display: 'γ', latex: '\\gamma ' },
+      { display: 'δ', latex: '\\delta ' },
+      { display: 'θ', latex: '\\theta ' },
+      { display: 'λ', latex: '\\lambda ' },
+      { display: 'μ', latex: '\\mu ' },
+      { display: 'π', latex: '\\pi ' },
+      { display: 'ρ', latex: '\\rho ' },
+      { display: 'σ', latex: '\\sigma ' },
+      { display: 'φ', latex: '\\phi ' },
+      { display: 'ω', latex: '\\omega ' },
+      { display: 'Δ', latex: '\\Delta ' },
+      { display: 'Σ', latex: '\\Sigma ' },
+      { display: 'Ω', latex: '\\Omega ' },
+    ],
+  },
+  {
+    name: 'Calculus',
+    symbols: [
+      { display: '∫', latex: '\\int ' },
+      { display: '∮', latex: '\\oint ' },
+      { display: '∑', latex: '\\sum ' },
+      { display: '∏', latex: '\\prod ' },
+      { display: '∂', latex: '\\partial ' },
+      { display: '∇', latex: '\\nabla ' },
+      { display: 'd/dx', latex: '\\frac{d}{dx} ' },
+      { display: '∂/∂x', latex: '\\frac{\\partial}{\\partial x} ' },
+      { display: 'lim', latex: '\\lim_{x \\to } ' },
+    ],
+  },
+  {
+    name: 'Science',
+    symbols: [
+      { display: '×10ⁿ', latex: '\\times 10^{}' },
+      { display: 'Δ', latex: '\\Delta ' },
+      { display: 'λ', latex: '\\lambda ' },
+      { display: 'ℏ', latex: '\\hbar ' },
+      { display: '(aq)', latex: '_{(aq)} ' },
+      { display: '(g)', latex: '_{(g)} ' },
+      { display: '(s)', latex: '_{(s)} ' },
+      { display: '(l)', latex: '_{(l)} ' },
+      { display: '→', latex: '\\rightarrow ' },
+      { display: '⇌', latex: '\\rightleftharpoons ' },
+      { display: '°C', latex: '^{\\circ}\\text{C}' },
+      { display: 'x̂', latex: '\\hat{}' },
+    ],
+  },
+]
+
+const COLORS = ['#000000', '#ef4444', '#22c55e', '#3b82f6', '#a855f7', '#f59e0b']
+const SCALES = [1, 1.5, 2, 2.5]
+
+export function FloatingMathTool({ onPlace, defaultColor }: FloatingMathToolProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [position, setPosition] = useState({ x: 20, y: 90 })
+  const [latex, setLatex] = useState('')
+  const [scale, setScale] = useState(1.5)
+  const [color, setColor] = useState(defaultColor || '#000000')
+  const [activeGroup, setActiveGroup] = useState(SYMBOL_GROUPS[0].name)
+  const [previewSvg, setPreviewSvg] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const caretRef = useRef<number | null>(null)
+
+  // Keep the formula color in sync with the pen color until the user overrides it.
+  useEffect(() => {
+    if (defaultColor) setColor(defaultColor)
+  }, [defaultColor])
+
+  // Restore the caret after a palette insertion re-renders the input.
+  useEffect(() => {
+    if (caretRef.current !== null && inputRef.current) {
+      const pos = caretRef.current
+      inputRef.current.focus()
+      inputRef.current.setSelectionRange(pos, pos)
+      caretRef.current = null
+    }
+  }, [latex])
+
+  const insert = useCallback(
+    (snippet: string, caretBack = 0) => {
+      const el = inputRef.current
+      const start = el?.selectionStart ?? latex.length
+      const end = el?.selectionEnd ?? start
+      const next = latex.slice(0, start) + snippet + latex.slice(end)
+      caretRef.current = start + snippet.length - caretBack
+      setLatex(next)
+      setError('')
+    },
+    [latex]
+  )
+
+  const renderPreview = useCallback(async (expr: string) => {
+    if (!expr.trim()) {
+      setPreviewSvg('')
+      setError('')
+      return
+    }
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setIsLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/whiteboard/render-formula', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex: expr, display: true }),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error || 'Could not render')
+        setPreviewSvg('')
+        return
+      }
+      const data = await res.json()
+      setPreviewSvg(data.svg)
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') setError('Network error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Debounced live preview.
+  useEffect(() => {
+    const timer = setTimeout(() => renderPreview(latex), 350)
+    return () => clearTimeout(timer)
+  }, [latex, renderPreview])
+
+  const handlePlace = useCallback(() => {
+    if (!latex.trim()) {
+      setError('Type a math expression first')
+      return
+    }
+    if (!previewSvg) {
+      setError('Wait for the preview to render')
+      return
+    }
+    onPlace({ latex: latex.trim(), scale, color })
+    // Keep the panel open but clear the input so the next formula is fast.
+    setLatex('')
+    setPreviewSvg('')
+  }, [latex, previewSvg, scale, color, onPlace])
+
+  return (
+    <motion.div
+      className="pointer-events-auto absolute z-50"
+      animate={{ x: position.x, y: position.y }}
+      transition={{ type: 'spring', stiffness: 200, damping: 22 }}
+      drag
+      dragMomentum={false}
+      onDragEnd={(_e, info) =>
+        setPosition({ x: position.x + info.offset.x, y: position.y + info.offset.y })
+      }
+      style={{ touchAction: 'none' }}
+    >
+      {isOpen ? (
+        <div className="w-[300px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl">
+          {/* Header (drag handle) */}
+          <div className="flex cursor-grab items-center justify-between border-b border-slate-100 bg-slate-50 px-3 py-2 active:cursor-grabbing">
+            <span className="flex items-center gap-1.5 text-sm font-semibold text-slate-700">
+              <Sigma className="h-4 w-4 text-blue-500" /> Math
+            </span>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700"
+              title="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="space-y-2.5 p-3" onPointerDownCapture={e => e.stopPropagation()}>
+            {/* Input */}
+            <div className="relative">
+              <input
+                ref={inputRef}
+                value={latex}
+                onChange={e => {
+                  setLatex(e.target.value)
+                  setError('')
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handlePlace()
+                  }
+                }}
+                placeholder="Type or tap symbols below…"
+                spellCheck={false}
+                autoComplete="off"
+                className="w-full rounded-lg border border-slate-200 py-2 pl-2.5 pr-8 font-mono text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-200"
+              />
+              {latex && (
+                <button
+                  onClick={() => {
+                    setLatex('')
+                    setPreviewSvg('')
+                    setError('')
+                    inputRef.current?.focus()
+                  }}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-slate-400 hover:text-slate-700"
+                  title="Clear"
+                >
+                  <Eraser className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+
+            {/* Templates */}
+            <div className="flex flex-wrap gap-1">
+              {TEMPLATES.map(t => (
+                <button
+                  key={t.label}
+                  onClick={() => insert(t.latex, t.caretBack)}
+                  className="min-w-[34px] rounded-md border border-slate-200 bg-white px-1.5 py-1 text-xs font-medium text-slate-700 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
+                  title={t.latex}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Symbol category tabs */}
+            <div className="flex gap-1 overflow-x-auto">
+              {SYMBOL_GROUPS.map(g => (
+                <button
+                  key={g.name}
+                  onClick={() => setActiveGroup(g.name)}
+                  className={cn(
+                    'shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors',
+                    activeGroup === g.name
+                      ? 'bg-slate-800 text-white'
+                      : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                  )}
+                >
+                  {g.name}
+                </button>
+              ))}
+            </div>
+
+            {/* Symbol palette */}
+            <div className="grid grid-cols-6 gap-1">
+              {SYMBOL_GROUPS.find(g => g.name === activeGroup)?.symbols.map(s => (
+                <button
+                  key={s.latex}
+                  onClick={() => insert(s.latex)}
+                  className="flex h-8 items-center justify-center rounded-md border border-slate-200 bg-white text-sm text-slate-700 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
+                  title={s.latex.trim()}
+                >
+                  {s.display}
+                </button>
+              ))}
+            </div>
+
+            {/* Preview */}
+            <div className="flex min-h-[56px] items-center justify-center rounded-lg border border-slate-100 bg-slate-50 p-2">
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+              ) : error ? (
+                <span className="flex items-center gap-1.5 text-xs text-red-500">
+                  <AlertCircle className="h-3.5 w-3.5" /> {error}
+                </span>
+              ) : previewSvg ? (
+                <div
+                  dangerouslySetInnerHTML={{ __html: previewSvg }}
+                  style={{ color }}
+                  className="max-h-[80px] max-w-full overflow-auto [&_svg]:max-w-full"
+                />
+              ) : (
+                <span className="text-xs text-slate-400">Preview</span>
+              )}
+            </div>
+
+            {/* Color + scale + place */}
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-1">
+                {COLORS.map(c => (
+                  <button
+                    key={c}
+                    onClick={() => setColor(c)}
+                    className="h-5 w-5 rounded-full border-2 transition-transform hover:scale-110"
+                    style={{
+                      backgroundColor: c,
+                      borderColor: color === c ? '#1f2937' : 'transparent',
+                    }}
+                    title={c}
+                  />
+                ))}
+              </div>
+              <div className="flex items-center gap-1">
+                {SCALES.map(s => (
+                  <button
+                    key={s}
+                    onClick={() => setScale(s)}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors',
+                      scale === s
+                        ? 'bg-slate-800 text-white'
+                        : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                    )}
+                    title={`Scale ${s}x`}
+                  >
+                    {s}x
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handlePlace}
+              disabled={isLoading || !previewSvg}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <CornerDownLeft className="h-4 w-4" /> Place on Board
+            </button>
+          </div>
+        </div>
+      ) : (
+        <motion.button
+          onClick={() => setIsOpen(true)}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          className="flex h-14 w-14 cursor-grab items-center justify-center rounded-full bg-white text-slate-800 shadow-[0_0_15px_rgba(0,0,0,0.15)] transition-colors hover:bg-slate-50 active:cursor-grabbing"
+          title="Math tool"
+        >
+          <Sigma className="h-6 w-6" />
+        </motion.button>
+      )}
+    </motion.div>
+  )
+}

--- a/tutorme-app/src/components/class/floating-tool-menu.tsx
+++ b/tutorme-app/src/components/class/floating-tool-menu.tsx
@@ -328,12 +328,6 @@ export function FloatingToolMenu({
             active: currentTool === 'select',
           },
           {
-            icon: <Sigma className="h-5 w-5" />,
-            label: 'Formula',
-            action: () => onToolChange('formula'),
-            active: currentTool === 'formula',
-          },
-          {
             icon: <TrendingUp className="h-5 w-5" />,
             label: 'Graph',
             action: () => onToolChange('graph'),

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1265,73 +1265,107 @@ export async function initEnhancedSocketServer(server: NetServer) {
         })
         io.to(roomId).emit('task:updated', { task })
 
-        // Persist to TaskSubmission for durable grading. Best-effort and
-        // FK-safe: taskSubmission.taskId references builderTask, so we only
-        // insert when the deployed task corresponds to a real builderTask row
-        // (it won't for an unsaved/ephemeral task). onConflictDoNothing keeps
-        // the one-submission-per-(task,student) rule and never overwrites a row
-        // a tutor may already have graded. Failures here never affect the live
-        // session — the in-memory/Redis state and the socket overlay still work.
+        // Persist the completion durably so it reaches the tutor's grading
+        // views. There are THREE tutor readers with DIFFERENT requirements:
+        //   - Grading page (/api/tutor/submissions): taskSubmission ⋈ builderTask,
+        //     filtered by builderTask.tutorId.
+        //   - In-session SubmissionsPanel (/submissions-tree) and the live panel:
+        //     taskSubmission filtered by deployedMaterial.itemId AND the student
+        //     being a sessionParticipant (or course enrollee).
+        // So a submission only shows everywhere if builderTask, deployedMaterial,
+        // and sessionParticipant all exist. The deploy-time creation of those is
+        // skipped when the live session had no courseId (or failed), which is why
+        // completions went missing. Self-heal all of them here. Everything is
+        // FK-safe and idempotent; failures never affect the live session.
         void (async () => {
           try {
-            const [bt] = await drizzleDb
-              .select({ taskId: builderTask.taskId })
-              .from(builderTask)
-              .where(eq(builderTask.taskId, taskId))
-              .limit(1)
-            if (!bt) {
-              // Self-heal: the deploy-time builderTask auto-create is skipped
-              // when the live session has no courseId yet (ad-hoc room) or its
-              // DB write failed. Without a builderTask row, the FK on
-              // taskSubmission.taskId blocks the insert and the submission never
-              // reaches the tutor's grading page. Recreate it now from the
-              // session so the completion is durably persisted. builderTask's
-              // courseId/lessonId/tutorId are all NOT NULL, so we need a
-              // resolvable course; if there genuinely is none, we can't persist.
-              const sess = await drizzleDb.query.liveSession.findFirst({
-                where: eq(liveSession.sessionId, roomId),
-                columns: { courseId: true, tutorId: true },
-              })
-              const courseId = sess?.courseId
-              const tutorId = sess?.tutorId || room.tutorId
-              if (!courseId || !tutorId) {
-                console.warn(
-                  '[task:complete] cannot persist submission — session has no courseId/tutor',
-                  { roomId, taskId }
-                )
-                return
-              }
-              let [lesson] = await drizzleDb
-                .select({ lessonId: courseLesson.lessonId })
-                .from(courseLesson)
-                .where(eq(courseLesson.courseId, courseId))
-                .limit(1)
-              if (!lesson?.lessonId) {
-                const newLessonId = crypto.randomUUID()
-                await drizzleDb.insert(courseLesson).values({
-                  lessonId: newLessonId,
-                  courseId,
-                  title: 'Live Session',
-                  order: 0,
-                })
-                lesson = { lessonId: newLessonId }
-              }
-              await drizzleDb
-                .insert(builderTask)
-                .values({
-                  taskId,
-                  courseId,
-                  lessonId: lesson.lessonId,
-                  tutorId,
-                  title: task.title || 'Untitled',
-                  content: task.content || '',
-                  pci: '',
-                  type: task.source,
-                  status: 'published',
-                  publishedAt: new Date(),
-                })
-                .onConflictDoNothing({ target: builderTask.taskId })
+            const sess = await drizzleDb.query.liveSession.findFirst({
+              where: eq(liveSession.sessionId, roomId),
+              columns: { courseId: true, tutorId: true },
+            })
+            const courseId = sess?.courseId
+            const tutorId = sess?.tutorId || room.tutorId
+            // builderTask/deployedMaterial both require a NOT NULL courseId, and
+            // the tree readers are course-scoped — so without a course we can't
+            // make the submission visible. Log loudly so this is diagnosable.
+            if (!courseId || !tutorId) {
+              console.warn(
+                '[task:complete] NOT persisting — live session has no courseId/tutor (ad-hoc session). Submissions require a course.',
+                { roomId, taskId, studentId, hasSessionRow: !!sess, courseId, tutorId }
+              )
+              return
             }
+
+            // 1) Lesson (builderTask.lessonId is NOT NULL).
+            let [lesson] = await drizzleDb
+              .select({ lessonId: courseLesson.lessonId })
+              .from(courseLesson)
+              .where(eq(courseLesson.courseId, courseId))
+              .limit(1)
+            if (!lesson?.lessonId) {
+              const newLessonId = crypto.randomUUID()
+              await drizzleDb.insert(courseLesson).values({
+                lessonId: newLessonId,
+                courseId,
+                title: 'Live Session',
+                order: 0,
+              })
+              lesson = { lessonId: newLessonId }
+            }
+
+            // 2) builderTask — FK target for taskSubmission; read by the Grading page.
+            await drizzleDb
+              .insert(builderTask)
+              .values({
+                taskId,
+                courseId,
+                lessonId: lesson.lessonId,
+                tutorId,
+                title: task.title || 'Untitled',
+                content: task.content || '',
+                pci: '',
+                type: task.source,
+                status: 'published',
+                publishedAt: new Date(),
+              })
+              .onConflictDoNothing({ target: builderTask.taskId })
+
+            // 3) deployedMaterial — without it, the in-session SubmissionsPanel
+            //    (/submissions-tree) and live panel filter the submission out.
+            //    No unique constraint on (sessionId, itemId), so check first.
+            const [alreadyDeployed] = await drizzleDb
+              .select({ id: deployedMaterial.id })
+              .from(deployedMaterial)
+              .where(
+                and(eq(deployedMaterial.sessionId, roomId), eq(deployedMaterial.itemId, taskId))
+              )
+              .limit(1)
+            if (!alreadyDeployed) {
+              await drizzleDb.insert(deployedMaterial).values({
+                sessionId: roomId,
+                courseId,
+                type: task.source,
+                itemId: taskId,
+                title: task.title || 'Untitled',
+                sessionSequence: 1,
+              })
+            }
+
+            // 4) sessionParticipant — the tree readers require the student to be
+            //    a participant (or course enrollee). The student is here now.
+            await drizzleDb
+              .insert(sessionParticipant)
+              .values({
+                participantId: crypto.randomUUID(),
+                sessionId: roomId,
+                studentId,
+              })
+              .onConflictDoNothing({
+                target: [sessionParticipant.sessionId, sessionParticipant.studentId],
+              })
+
+            // 5) The submission itself. onConflictDoNothing preserves the
+            //    one-per-(task,student) rule and never overwrites a graded row.
             await drizzleDb
               .insert(taskSubmission)
               .values({
@@ -1348,6 +1382,14 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 tutorApproved: false,
               })
               .onConflictDoNothing({ target: [taskSubmission.taskId, taskSubmission.studentId] })
+
+            console.log('[task:complete] submission persisted', {
+              roomId,
+              taskId,
+              studentId,
+              courseId,
+              source: task.source,
+            })
           } catch (err) {
             console.warn('[task:complete] TaskSubmission persist failed (non-critical):', err)
           }


### PR DESCRIPTION
## **User description**
## Problem
After a student clicks **Task complete** in a live session (tasks and assessments share this exact path — `socket.emit('task:complete')`), the submission stays empty on the tutor side.

## Root cause
There are **three** tutor readers with different requirements:
- **Grading page** (`/api/tutor/submissions`) — `taskSubmission ⋈ builderTask`, filtered by `builderTask.tutorId`.
- **In-session SubmissionsPanel** (`/api/tutor/courses/[id]/submissions-tree`) and the live panel — `taskSubmission` filtered by `deployedMaterial.itemId` **and** the student being a `sessionParticipant` (or course enrollee).

`builderTask` and `deployedMaterial` are created at **deploy** time only when the live session has a `courseId`. When it doesn't (ad-hoc session) — or that write failed — nothing persists, so `task:complete` had nothing to attach the submission to. My previous fix only created `builderTask` (Grading page), not `deployedMaterial`/`sessionParticipant`, so the **in-session panel** stayed empty.

## Fix
`task:complete` now self-heals **all** reader requirements when a course is resolvable from the session: `builderTask` → `deployedMaterial` → `sessionParticipant` → `taskSubmission`. All idempotent and FK-safe; failures never affect the live session.

Adds diagnostic logging — a loud `warn` when the session has no `courseId`/tutor (so the one unfixable case, a truly course-less ad-hoc session, is obvious in logs) and a success log on persist.

## Note / limitation
`builderTask` and `deployedMaterial` both require a non-null `courseId`, and the in-session readers are course-scoped, so a live session with **no course at all** still can't produce gradable submissions — that'd need a schema change. The logging makes that case explicit.

`typecheck`, `lint` (0 errors), `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep live submissions visible to tutors and add a dedicated math tool**

### What Changed
- When a student marks a task complete in a live session, the submission now saves in all tutor views instead of only some of them.
- If a live session is missing the records needed to show the submission, the app now recreates them when a course is available and logs the case when it cannot.
- The whiteboard now uses a separate floating math panel with templates, symbol palettes, live preview, color and size options, and one-click placement on the board.
- The old Formula item was removed from the main tool menu, and students also stop following the tutor automatically as soon as they start typing an answer.
- Student-facing document views now use generic wording instead of showing the deployed file name, and the right-panel tabs stay evenly sized.

### Impact
`✅ Fewer missing live-session submissions`
`✅ Clearer tutor grading views`
`✅ Faster math entry on the whiteboard`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
