### PR TITLE
feat(live): sync student whiteboard pages to tutor (view new pages, follow, pick)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -350,6 +350,7 @@ function StudentFeedbackContent() {
   )
   const [tutorBoardPageIndex, setTutorBoardPageIndex] = useState(0)
   const saveBoardsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const boardSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Left Panel state
   const [leftPanelHidden, setLeftPanelHidden] = useState(false)
@@ -796,6 +797,28 @@ function StudentFeedbackContent() {
       if (saveBoardsTimeoutRef.current) clearTimeout(saveBoardsTimeoutRef.current)
     }
   }, [selectedSessionId, myBoardPages, myBoardPageIndex, tutorBoardPages, tutorBoardPageIndex])
+
+  // Push a full snapshot of the student's own board (all pages + the active page)
+  // to the tutor whenever it changes. Per-stroke deltas only reach the tutor when
+  // the student draws, so without this the tutor never sees newly added blank pages
+  // or page switches. Debounced so rapid drawing coalesces into one update.
+  useEffect(() => {
+    if (!socket || !selectedSessionId) return
+    if (boardSyncTimeoutRef.current) clearTimeout(boardSyncTimeoutRef.current)
+    boardSyncTimeoutRef.current = setTimeout(() => {
+      socket.emit('student:whiteboard:update', {
+        roomId: selectedSessionId,
+        board: {
+          pages: myBoardPages,
+          pageIndex: myBoardPageIndex,
+          updatedAt: Date.now(),
+        },
+      })
+    }, 300)
+    return () => {
+      if (boardSyncTimeoutRef.current) clearTimeout(boardSyncTimeoutRef.current)
+    }
+  }, [socket, selectedSessionId, myBoardPages, myBoardPageIndex])
 
   const [followTutor, setFollowTutor] = useState<boolean>(true)
   const openVideoOverlay = useVideoOverlayStore(s => s.openOverlay)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -901,6 +901,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       id: string
       name: string
     } | null>(null)
+    // When viewing a student's board, follow their active page by default; the tutor
+    // can turn this off and page through the board manually to inspect any page.
+    const [followStudentPage, setFollowStudentPage] = useState(true)
+    const [viewedStudentPageIndex, setViewedStudentPageIndex] = useState(0)
+    // Re-enable follow whenever the tutor opens a (different) student's board.
+    useEffect(() => {
+      setFollowStudentPage(true)
+      setViewedStudentPageIndex(0)
+    }, [monitorSelectedStudent?.id])
     const [liveRightPanelTab, setLiveRightPanelTab] = useState<'submissions' | 'insights'>(
       'submissions'
     )
@@ -8509,6 +8518,18 @@ FEEDBACK: [your explanation]`
                                                 typeof studentBoard?.pageIndex === 'number'
                                                   ? studentBoard.pageIndex
                                                   : 0
+                                              const pageCount = Math.max(studentPages.length, 1)
+                                              const clamp = (i: number) =>
+                                                Math.min(Math.max(i, 0), pageCount - 1)
+                                              // Follow → mirror the student's active page; otherwise
+                                              // show whatever page the tutor picked.
+                                              const viewedPageIndex = followStudentPage
+                                                ? clamp(studentPageIndex)
+                                                : clamp(viewedStudentPageIndex)
+                                              const gotoPage = (i: number) => {
+                                                setFollowStudentPage(false)
+                                                setViewedStudentPageIndex(clamp(i))
+                                              }
                                               return (
                                                 <Dialog
                                                   open
@@ -8525,22 +8546,79 @@ FEEDBACK: [your explanation]`
                                                         <div className="font-semibold text-slate-800">
                                                           Viewing: {monitorSelectedStudent.name}
                                                         </div>
-                                                        <Button
-                                                          variant="ghost"
-                                                          size="sm"
-                                                          className="h-8 text-xs text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-                                                          onClick={() =>
-                                                            setMonitorSelectedStudent(null)
-                                                          }
-                                                        >
-                                                          Clear
-                                                        </Button>
+                                                        <div className="flex items-center gap-2">
+                                                          {/* Page navigation: prev / indicator / next */}
+                                                          <div className="flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-1 py-0.5">
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6 text-slate-600 hover:bg-white disabled:opacity-30"
+                                                              disabled={viewedPageIndex <= 0}
+                                                              onClick={() =>
+                                                                gotoPage(viewedPageIndex - 1)
+                                                              }
+                                                              title="Previous page"
+                                                            >
+                                                              <ChevronLeft className="h-4 w-4" />
+                                                            </Button>
+                                                            <span className="min-w-[64px] text-center text-xs font-medium text-slate-600">
+                                                              Page {viewedPageIndex + 1} /{' '}
+                                                              {pageCount}
+                                                            </span>
+                                                            <Button
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="h-6 w-6 text-slate-600 hover:bg-white disabled:opacity-30"
+                                                              disabled={
+                                                                viewedPageIndex >= pageCount - 1
+                                                              }
+                                                              onClick={() =>
+                                                                gotoPage(viewedPageIndex + 1)
+                                                              }
+                                                              title="Next page"
+                                                            >
+                                                              <ChevronRight className="h-4 w-4" />
+                                                            </Button>
+                                                          </div>
+                                                          {/* Follow toggle */}
+                                                          <Button
+                                                            variant={
+                                                              followStudentPage
+                                                                ? 'default'
+                                                                : 'outline'
+                                                            }
+                                                            size="sm"
+                                                            className="h-8 text-xs"
+                                                            onClick={() =>
+                                                              setFollowStudentPage(f => !f)
+                                                            }
+                                                            title={
+                                                              followStudentPage
+                                                                ? "Following the student's page — click to browse freely"
+                                                                : "Jump to and follow the student's current page"
+                                                            }
+                                                          >
+                                                            {followStudentPage
+                                                              ? 'Following'
+                                                              : 'Follow student'}
+                                                          </Button>
+                                                          <Button
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            className="h-8 text-xs text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                                                            onClick={() =>
+                                                              setMonitorSelectedStudent(null)
+                                                            }
+                                                          >
+                                                            Clear
+                                                          </Button>
+                                                        </div>
                                                       </div>
                                                       <div className="min-h-0 flex-1">
                                                         <EnhancedWhiteboard
                                                           videoOverlay={false}
                                                           pages={studentPages}
-                                                          currentPageIndex={studentPageIndex}
+                                                          currentPageIndex={viewedPageIndex}
                                                           readOnly
                                                         />
                                                       </div>

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1594,7 +1594,16 @@ export async function initEnhancedSocketServer(server: NetServer) {
             [studentId]: board,
           },
         }
-        // Do NOT broadcast — tutor requests on-demand via whiteboard:state:request
+        // Push the full board (pages + active page) to the rest of the room so the
+        // tutor sees newly added pages and can follow the student's page switches in
+        // realtime — not just on-demand. Per-stroke deltas only grow pages when the
+        // student actually draws, so blank pages and page switches need this snapshot.
+        socket.to(roomId).emit('student:whiteboard:update', {
+          studentId,
+          pages: board.pages,
+          pageIndex: board.pageIndex,
+          updatedAt: board.updatedAt ?? Date.now(),
+        })
       }
     )
 


### PR DESCRIPTION
## **User description**
## Problem

During a live session the tutor sees a student's drawing in realtime, but only the **first page**. When the student adds a new page, the tutor still sees the old page — new/blank pages and page switches were never propagated.

Root cause: the student board only reached the tutor via per-stroke socket deltas (which lazily grow pages *only when the student draws*). The student never sent a full board snapshot, and the server's `student:whiteboard:update` was stored for on-demand pull but never broadcast. So blank new pages, page switches, formulas, and graphs were invisible to the tutor.

## Changes

1. **Student → server snapshot** (`student/feedback/page.tsx`): a debounced effect now emits `student:whiteboard:update` with the full board (`pages` + active `pageIndex`) whenever the student's My Board changes. This carries page adds, page switches, formulas, and graphs — not just strokes.
2. **Server broadcast** (`socket-server-enhanced.ts`): the `student:whiteboard:update` handler now broadcasts to the rest of the room (`socket.to(roomId)`), in addition to persisting it, so tutors get realtime updates. The tutor insights page already had a `student:whiteboard:update` listener that rebuilds `studentBoards[id]` with full pages + pageIndex — it was previously dead because nothing emitted the event.
3. **Tutor viewer follow + pick** (`CourseBuilder.tsx`): the student-board dialog now:
   - **follows** the student's active page by default (mirrors `studentBoard.pageIndex`);
   - adds a page navigator — prev / **Page X / N** / next — and a **Follow** toggle so the tutor can break off to inspect any page, then click *Follow student* to snap back and resume following.

Realtime strokes still flow via the existing per-delta handlers (low latency); the debounced snapshot is authoritative and self-correcting for pages/formulas/graphs.

## Testing
- `npm run typecheck` ✅
- `npm run lint` (changed files) ✅ — 0 errors
- `npm run build` ✅ (exit 0)

Runtime/live-session behavior not yet exercised end-to-end (requires two authenticated roles in an active socket session; environment lacks DB/Redis/seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Tutor can see student whiteboard page changes in real time and browse pages manually**

### What Changed
- Student board changes now send the full set of pages and the active page to the tutor, so new blank pages and page switches appear without waiting for a stroke.
- Tutors viewing a student’s board now follow that student’s current page by default, with controls to move to the previous or next page and pause following when they want to inspect another page.
- Opening a different student board resets the view to follow that student again.

### Impact
`✅ Fewer missing whiteboard pages`
`✅ Clearer live tutoring review`
`✅ Easier inspection of multi-page student work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
