### PR TITLE
feat(submissions): color-code sessions by status/chronology

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -183,6 +183,31 @@ export function SubmissionsPanel({
     return map
   }, [sessions, lessons])
 
+  // Color-code sessions by lifecycle/chronology so the tutor can see status at a
+  // glance: green = active now, yellow = the session immediately after the active
+  // one, red = ended, black = the rest (upcoming/scheduled). "Next after active"
+  // is computed on the global chronological order, not per-lesson.
+  const sessionColorById = useMemo(() => {
+    const ACTIVE = new Set(['active', 'live', 'paused', 'preparing'])
+    const sorted = [...sessions].sort((a, b) => {
+      const ta = a.scheduledAt ? new Date(a.scheduledAt).getTime() : 0
+      const tb = b.scheduledAt ? new Date(b.scheduledAt).getTime() : 0
+      return ta - tb
+    })
+    const activeIdx = sorted.findIndex(s => ACTIVE.has((s.status || '').toLowerCase()))
+    const nextAfterActiveId =
+      activeIdx >= 0 && activeIdx + 1 < sorted.length ? sorted[activeIdx + 1].id : null
+    const map: Record<string, string> = {}
+    for (const s of sorted) {
+      const st = (s.status || '').toLowerCase()
+      if (ACTIVE.has(st)) map[s.id] = 'text-green-600'
+      else if (st === 'ended') map[s.id] = 'text-red-600'
+      else if (s.id === nextAfterActiveId) map[s.id] = 'text-yellow-600'
+      else map[s.id] = 'text-slate-900'
+    }
+    return map
+  }, [sessions])
+
   const enrolled = useMemo(() => {
     const list =
       (data?.enrolledStudents || [])
@@ -327,6 +352,7 @@ export function SubmissionsPanel({
                                 onToggle={() => toggle(sessionKey)}
                                 icon={<Folder className="h-4 w-4 text-slate-500" />}
                                 title={formatSessionTitle(session)}
+                                titleClassName={sessionColorById[session.id]}
                                 subtitle={session.status || `Session ${idx + 1}`}
                               />
 
@@ -496,12 +522,15 @@ function FolderRow({
   title,
   subtitle,
   icon,
+  titleClassName,
 }: {
   isOpen: boolean
   onToggle: () => void
   title: string
   subtitle?: string
   icon: ReactNode
+  /** Overrides the default title color (used to color-code session status). */
+  titleClassName?: string
 }) {
   return (
     <button
@@ -514,7 +543,9 @@ function FolderRow({
           {icon}
         </span>
         <div className="min-w-0">
-          <div className="truncate text-sm font-semibold text-slate-800">{title}</div>
+          <div className={`truncate text-sm font-semibold ${titleClassName || 'text-slate-800'}`}>
+            {title}
+          </div>
           {subtitle && <div className="truncate text-xs text-slate-500">{subtitle}</div>}
         </div>
       </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -184,9 +184,10 @@ export function SubmissionsPanel({
   }, [sessions, lessons])
 
   // Color-code sessions by lifecycle/chronology so the tutor can see status at a
-  // glance: green = active now, yellow = the session immediately after the active
-  // one, red = ended, black = the rest (upcoming/scheduled). "Next after active"
-  // is computed on the global chronological order, not per-lesson.
+  // glance: green = active now, yellow = the next-upcoming session (the one right
+  // after the active session, or — when nothing is active — the soonest session
+  // that hasn't ended), red = ended, black = the rest. Chronology is the global
+  // scheduledAt order, not per-lesson.
   const sessionColorById = useMemo(() => {
     const ACTIVE = new Set(['active', 'live', 'paused', 'preparing'])
     const sorted = [...sessions].sort((a, b) => {
@@ -195,14 +196,18 @@ export function SubmissionsPanel({
       return ta - tb
     })
     const activeIdx = sorted.findIndex(s => ACTIVE.has((s.status || '').toLowerCase()))
-    const nextAfterActiveId =
-      activeIdx >= 0 && activeIdx + 1 < sorted.length ? sorted[activeIdx + 1].id : null
+    const highlightId =
+      activeIdx >= 0
+        ? // there's an active session — highlight the one right after it
+          (sorted[activeIdx + 1]?.id ?? null)
+        : // nothing active — highlight the soonest session that hasn't ended
+          (sorted.find(s => (s.status || '').toLowerCase() !== 'ended')?.id ?? null)
     const map: Record<string, string> = {}
     for (const s of sorted) {
       const st = (s.status || '').toLowerCase()
       if (ACTIVE.has(st)) map[s.id] = 'text-green-600'
       else if (st === 'ended') map[s.id] = 'text-red-600'
-      else if (s.id === nextAfterActiveId) map[s.id] = 'text-yellow-600'
+      else if (s.id === highlightId) map[s.id] = 'text-yellow-600'
       else map[s.id] = 'text-slate-900'
     }
     return map


### PR DESCRIPTION
## **User description**
## What
In the submissions tree (the **Desk / Submissions panel**, `SubmissionsPanel.tsx`), session titles are now color-coded so the tutor sees status at a glance:

- 🟢 **green** — active now (`active`/`live`/`paused`/`preparing`)
- 🟡 **yellow** — the session immediately following the active one in chronological order
- 🔴 **red** — ended
- ⬛ **black** — the rest (upcoming/scheduled)

## How
- A `sessionColorById` memo maps each session id → a Tailwind text-color class. "Next after active" is computed on the **global `scheduledAt` order**, not per-lesson, so it's correct even though the UI groups sessions under lessons.
- `FolderRow` gains an optional `titleClassName` prop; the session row passes the computed color. Everything else (including the existing `session.status` subtitle) is unchanged.

## Notes
- If no session is currently active, nothing is yellow (faithful to "the session that follows the active one"). Ended is still red, the rest black.
- `typecheck`, `lint` (0 errors), `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Color-code session titles by status and order**

### What Changed
- Session titles in the submissions panel now use color to show status at a glance: green for active sessions, red for ended sessions, yellow for the session right after the active one, and black for the rest.
- The highlighted “next” session is chosen from the full session timeline, so the color reflects the real chronological order even when sessions are grouped under different lessons.
- Session rows can now display a custom title color while keeping the existing status subtitle unchanged.

### Impact
`✅ Faster status scanning in submissions`
`✅ Clearer session order at a glance`
`✅ Less time finding the active and next session`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
