### PR TITLE
fix(submissions): set timestamps explicitly to survive prod schema drift

### DIFF
--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -109,6 +109,9 @@ export async function POST(
       maxScore: MAX_SCORE,
       status: 'submitted',
       tutorApproved: false,
+      // Explicit: prod's submittedAt column has drifted and lacks its DEFAULT,
+      // so relying on defaultNow() would insert NULL and violate not-null.
+      submittedAt: new Date(),
     })
 
     // Best-effort: generate AI feedback into the tutor's review queue. Submission

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1074,6 +1074,13 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 .from(courseLesson)
                 .where(eq(courseLesson.courseId, sessionRec.courseId))
                 .limit(1)
+              // NOTE: set createdAt/updatedAt explicitly. These columns are
+              // declared notNull().defaultNow() in the schema, but the prod DB
+              // has drifted and lacks the column DEFAULT, so relying on the
+              // default inserts NULL and violates the not-null constraint
+              // (this is exactly what was silently breaking grading). $onUpdate
+              // does not apply to inserts, so it can't cover this either.
+              const now = new Date()
               if (!lesson?.lessonId) {
                 const newLessonId = crypto.randomUUID()
                 await drizzleDb.insert(courseLesson).values({
@@ -1081,6 +1088,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   courseId: sessionRec.courseId,
                   title: 'Live Session',
                   order: 0,
+                  createdAt: now,
+                  updatedAt: now,
                 })
                 lesson = { lessonId: newLessonId }
               }
@@ -1096,7 +1105,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   pci: '',
                   type: normalizedTask.source,
                   status: 'published',
-                  publishedAt: new Date(),
+                  publishedAt: now,
+                  createdAt: now,
+                  updatedAt: now,
                 })
                 .onConflictDoNothing({ target: builderTask.taskId })
             }
@@ -1296,6 +1307,13 @@ export async function initEnhancedSocketServer(server: NetServer) {
               return
             }
 
+            // Set createdAt/updatedAt/etc. explicitly throughout. These columns
+            // are notNull().defaultNow() in the schema, but the prod DB has
+            // drifted and lacks the column DEFAULT — relying on it inserts NULL
+            // and violates the not-null constraint, which is what silently broke
+            // every persist in this chain. Explicit values are drift-proof.
+            const now = new Date()
+
             // 1) Lesson (builderTask.lessonId is NOT NULL).
             let [lesson] = await drizzleDb
               .select({ lessonId: courseLesson.lessonId })
@@ -1309,6 +1327,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 courseId,
                 title: 'Live Session',
                 order: 0,
+                createdAt: now,
+                updatedAt: now,
               })
               lesson = { lessonId: newLessonId }
             }
@@ -1326,7 +1346,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 pci: '',
                 type: task.source,
                 status: 'published',
-                publishedAt: new Date(),
+                publishedAt: now,
+                createdAt: now,
+                updatedAt: now,
               })
               .onConflictDoNothing({ target: builderTask.taskId })
 
@@ -1348,6 +1370,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 itemId: taskId,
                 title: task.title || 'Untitled',
                 sessionSequence: 1,
+                deployedAt: now,
               })
             }
 
@@ -1359,6 +1382,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 participantId: crypto.randomUUID(),
                 sessionId: roomId,
                 studentId,
+                joinedAt: now,
               })
               .onConflictDoNothing({
                 target: [sessionParticipant.sessionId, sessionParticipant.studentId],
@@ -1380,6 +1404,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 maxScore: 100,
                 status: 'submitted',
                 tutorApproved: false,
+                submittedAt: now,
               })
               .onConflictDoNothing({ target: [taskSubmission.taskId, taskSubmission.studentId] })
 


### PR DESCRIPTION
## **User description**
## Real root cause (from production logs)
Every submission persist was failing with:
```
null value in column "updatedAt" of relation "BuilderTask" violates not-null constraint
```
`createdAt`/`updatedAt` (and `submittedAt`/`joinedAt`) are declared `notNull().defaultNow()` in the Drizzle schema, but the **prod DB has drifted and the columns lack their DEFAULT**. Drizzle omits defaulted columns from inserts and lets the DB fill them — but with no default, that inserts `NULL` and violates the not-null constraint. `$onUpdate` doesn't apply to inserts.

This silently broke **both** the deploy-time `BuilderTask` auto-create and the `task:complete` self-heal (the whole persist is wrapped in a `try/catch` that only `console.warn`s), so no live-session submission ever reached `taskSubmission` — which is why the tutor side was always empty, regardless of my earlier fixes.

## Fix (surgical, drift-proof)
Set the timestamps explicitly in every insert in the submission chain instead of relying on the missing DB defaults:
- `courseLesson`, `builderTask`, `deployedMaterial`, `sessionParticipant`, `taskSubmission` in the live **deploy** + **complete** handlers (`socket-server-enhanced.ts`)
- the non-live REST path `/api/student/assignments/[taskId]/submit`

Explicit values override the column default when present, so this is safe whether or not the DB default exists.

`typecheck`, `lint` (0 errors), `build` all pass.

## Note (systemic)
The underlying issue is prod schema drift (missing column defaults). A follow-up migration to `ALTER COLUMN … SET DEFAULT now()` across affected tables would fix this class of bug app-wide, but that's broader/riskier than this targeted fix — flagging for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Submission saving no longer fails when database timestamp defaults are missing**

### What Changed
- Submission-related records now save their timestamps explicitly, so live task completion and the student assignment submit flow no longer fail when the database is missing default values.
- Live task deployment now creates the lesson, task, participant, and submission records with timestamps already filled in, so the submission can reach grading and the student’s work appears in the review flow.
- The student assignment submit endpoint now stores `submittedAt` directly, keeping non-live submissions from being rejected by the database.

### Impact
`✅ Fewer submission save failures`
`✅ More live tasks reach grading`
`✅ Fewer empty submission lists for tutors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
