### PR TITLE
test(integration): regression test for live-submission persistence + tutor reads

### DIFF
--- a/tutorme-app/src/__tests__/integration/live-submission-persistence.test.ts
+++ b/tutorme-app/src/__tests__/integration/live-submission-persistence.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Integration regression test: live-session submission persistence + tutor reads.
+ *
+ * Guards the bug chain that repeatedly broke grading:
+ *  1. Schema-drift class — columns declared notNull().defaultNow()/.default(...)
+ *     must have real DB DEFAULTs, or inserts that omit them fail with a not-null
+ *     violation. This is exactly what silently dropped every live submission
+ *     (BuilderTask.updatedAt). The test inserts the live-flow rows WITHOUT the
+ *     defaulted timestamps; if a default is missing again, these throw and fail.
+ *  2. Reader visibility — a completed task/assessment must show on BOTH tutor
+ *     views: the Grading page (/api/tutor/submissions, real handler) and the
+ *     in-session panel (/submissions-tree query shape: deployedMaterial.itemId
+ *     + sessionParticipant/enrollee).
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { and, eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  user,
+  course,
+  courseLesson,
+  builderTask,
+  liveSession,
+  deployedMaterial,
+  sessionParticipant,
+  taskSubmission,
+} from '@/lib/db/schema'
+import { GET as getSubmissions } from '@/app/api/tutor/submissions/route'
+
+const stamp = Date.now()
+const tutorEmail = `claude-subm-tutor-${stamp}@example.com`
+const studentEmail = `claude-subm-student-${stamp}@example.com`
+
+const tutorId = crypto.randomUUID()
+const studentId = crypto.randomUUID()
+const courseId = `c_${stamp}`
+const lessonId = `l_${stamp}`
+const sessionId = `sess_${stamp}`
+const taskItemId = `task_${stamp}`
+const assessmentItemId = `asmt_${stamp}`
+
+// Mock next-auth so the real /api/tutor/submissions handler runs as our tutor.
+// @/lib/auth.getServerSession delegates to next-auth's getServerSession.
+const mockSession = {
+  user: { id: tutorId, email: tutorEmail, role: 'TUTOR' as const },
+  expires: new Date(Date.now() + 86400 * 1000).toISOString(),
+}
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(() => Promise.resolve(mockSession)),
+}))
+
+function request(url: string): Request {
+  return new Request(url, { headers: { 'Content-Type': 'application/json' } })
+}
+
+/**
+ * Replicates the durable writes the live `task:complete` socket handler performs
+ * for one deployed item. Deliberately OMITS the defaulted timestamp columns
+ * (createdAt/updatedAt/deployedAt/joinedAt/submittedAt) so the test fails loudly
+ * if the DB defaults ever drift away again.
+ */
+async function persistCompletion(itemId: string, source: 'task' | 'assessment') {
+  await drizzleDb
+    .insert(courseLesson)
+    .values({ lessonId, courseId, title: 'Live Session', order: 0 })
+    .onConflictDoNothing({ target: courseLesson.lessonId })
+  await drizzleDb.insert(builderTask).values({
+    taskId: itemId,
+    courseId,
+    lessonId,
+    tutorId,
+    title: `Item ${itemId}`,
+    content: 'content',
+    pci: '',
+    type: source,
+    status: 'published',
+  })
+  await drizzleDb.insert(deployedMaterial).values({
+    sessionId,
+    courseId,
+    type: source,
+    itemId,
+    title: `Item ${itemId}`,
+    sessionSequence: 1,
+  })
+  await drizzleDb
+    .insert(sessionParticipant)
+    .values({ participantId: `p_${itemId}`, sessionId, studentId })
+    .onConflictDoNothing({ target: [sessionParticipant.sessionId, sessionParticipant.studentId] })
+  await drizzleDb.insert(taskSubmission).values({
+    submissionId: `s_${itemId}`,
+    taskId: itemId,
+    studentId,
+    answers: {},
+    timeSpent: 0,
+    attempts: 1,
+    maxScore: 100,
+    status: 'submitted',
+    tutorApproved: false,
+  })
+}
+
+describe('Live-session submission persistence + tutor visibility', () => {
+  beforeAll(async () => {
+    const now = new Date()
+    await drizzleDb.insert(user).values([
+      { userId: tutorId, email: tutorEmail, role: 'TUTOR', createdAt: now, updatedAt: now },
+      { userId: studentId, email: studentEmail, role: 'STUDENT', createdAt: now, updatedAt: now },
+    ])
+    await drizzleDb
+      .insert(course)
+      .values({ courseId, name: 'Claude E2E Course', creatorId: tutorId })
+    await drizzleDb.insert(liveSession).values({
+      sessionId,
+      tutorId,
+      courseId,
+      title: 'Claude E2E Session',
+      category: 'general',
+      status: 'active',
+      scheduledAt: now,
+    })
+  })
+
+  afterAll(async () => {
+    // FK-safe teardown (children first).
+    try {
+      await drizzleDb
+        .delete(taskSubmission)
+        .where(inArray(taskSubmission.taskId, [taskItemId, assessmentItemId]))
+    } catch {}
+    try {
+      await drizzleDb.delete(sessionParticipant).where(eq(sessionParticipant.sessionId, sessionId))
+    } catch {}
+    try {
+      await drizzleDb.delete(deployedMaterial).where(eq(deployedMaterial.sessionId, sessionId))
+    } catch {}
+    try {
+      await drizzleDb
+        .delete(builderTask)
+        .where(inArray(builderTask.taskId, [taskItemId, assessmentItemId]))
+    } catch {}
+    try {
+      await drizzleDb.delete(courseLesson).where(eq(courseLesson.courseId, courseId))
+    } catch {}
+    try {
+      await drizzleDb.delete(liveSession).where(eq(liveSession.sessionId, sessionId))
+    } catch {}
+    try {
+      await drizzleDb.delete(course).where(eq(course.courseId, courseId))
+    } catch {}
+    try {
+      await drizzleDb.delete(user).where(inArray(user.userId, [tutorId, studentId]))
+    } catch {}
+  })
+
+  it('persists a task and an assessment completion without relying on missing defaults', async () => {
+    // Throws if any defaulted timestamp column lacks its DB DEFAULT (the drift bug).
+    await expect(persistCompletion(taskItemId, 'task')).resolves.not.toThrow()
+    await expect(persistCompletion(assessmentItemId, 'assessment')).resolves.not.toThrow()
+
+    const rows = await drizzleDb
+      .select({
+        taskId: builderTask.taskId,
+        createdAt: builderTask.createdAt,
+        updatedAt: builderTask.updatedAt,
+        submittedAt: taskSubmission.submittedAt,
+      })
+      .from(taskSubmission)
+      .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+      .where(inArray(builderTask.taskId, [taskItemId, assessmentItemId]))
+    expect(rows).toHaveLength(2)
+    // Defaults filled the omitted timestamps.
+    for (const r of rows) {
+      expect(r.createdAt).toBeTruthy()
+      expect(r.updatedAt).toBeTruthy()
+      expect(r.submittedAt).toBeTruthy()
+    }
+  })
+
+  it('shows both submissions on the tutor Grading page (real /api/tutor/submissions handler)', async () => {
+    const res = await getSubmissions(
+      request('http://localhost/api/tutor/submissions?status=submitted') as never
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    const ids = (data.submissions || []).map((s: { taskId: string }) => s.taskId)
+    expect(ids).toContain(taskItemId)
+    expect(ids).toContain(assessmentItemId)
+  })
+
+  it('shows both submissions to the in-session panel query (deployedMaterial + participant)', async () => {
+    const sessions = await drizzleDb
+      .select({ id: liveSession.sessionId })
+      .from(liveSession)
+      .where(and(eq(liveSession.courseId, courseId), eq(liveSession.tutorId, tutorId)))
+    const sessionIds = sessions.map(s => s.id)
+
+    const deployed = await drizzleDb
+      .select({ itemId: deployedMaterial.itemId })
+      .from(deployedMaterial)
+      .where(
+        and(
+          eq(deployedMaterial.courseId, courseId),
+          inArray(deployedMaterial.sessionId, sessionIds)
+        )
+      )
+    const itemIds = Array.from(new Set(deployed.map(d => d.itemId)))
+
+    const participants = await drizzleDb
+      .select({ studentId: sessionParticipant.studentId })
+      .from(sessionParticipant)
+      .where(inArray(sessionParticipant.sessionId, sessionIds))
+    const studentIds = Array.from(new Set(participants.map(p => p.studentId)))
+
+    const visible = await drizzleDb
+      .select({ taskId: taskSubmission.taskId })
+      .from(taskSubmission)
+      .where(
+        and(inArray(taskSubmission.taskId, itemIds), inArray(taskSubmission.studentId, studentIds))
+      )
+    const ids = visible.map(v => v.taskId)
+    expect(ids).toContain(taskItemId)
+    expect(ids).toContain(assessmentItemId)
+  })
+})

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -534,7 +534,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
               <div className="grid gap-6 sm:grid-cols-5">
                 <div className="form-group space-y-2 sm:col-span-2">
                   <Label className="form-label font-semibold text-slate-700">Free course</Label>
-                  <div className="flex h-10 items-center justify-between rounded-xl border border-input bg-white px-4">
+                  <div className="border-input flex h-10 items-center justify-between rounded-xl border bg-white px-4">
                     <span className="text-sm font-medium text-slate-600">
                       {globalIsFree ? 'Enabled' : 'Disabled'}
                     </span>
@@ -697,7 +697,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
                       <div className="grid gap-6 sm:grid-cols-4">
                         <div className="form-group space-y-2">
                           <Label className="form-label font-semibold text-slate-700">Free</Label>
-                          <div className="flex h-10 items-center justify-between rounded-xl border border-input bg-white px-4">
+                          <div className="border-input flex h-10 items-center justify-between rounded-xl border bg-white px-4">
                             <span className="text-sm font-medium text-slate-600">
                               {variant.isFree ? 'Yes' : 'No'}
                             </span>

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
@@ -466,7 +466,7 @@ export function VariantScheduleEditor({
                   const v = Math.max(1, Math.min(52, Number.isNaN(val) ? 1 : val))
                   setNumberOfWeeks(v)
                 }}
-                className="h-9 w-12 rounded-lg border border-input bg-white px-1 text-center text-sm text-[#1F2933] [appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                className="border-input h-9 w-12 rounded-lg border bg-white px-1 text-center text-sm text-[#1F2933] [appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               />
               <span className="text-sm font-semibold">weeks.</span>
             </div>

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -845,7 +845,7 @@ export default function TutorCoursePage() {
                           setSelectedCountryCode('')
                         }}
                       >
-                        <SelectTrigger className="h-10 w-full rounded-lg border border-input bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-input/60 hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
+                        <SelectTrigger className="border-input hover:border-input/60 h-10 w-full rounded-lg border bg-white text-slate-700 shadow-sm transition-all duration-200 hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
                           <SelectValue placeholder="Select Regions..." />
                         </SelectTrigger>
                         <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-white/20 bg-[#1E2832]/50 p-1.5 shadow-lg">
@@ -873,7 +873,7 @@ export default function TutorCoursePage() {
                         onValueChange={setSelectedCountryCode}
                         disabled={!selectedRegion}
                       >
-                        <SelectTrigger className="h-10 w-full rounded-lg border border-input bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-input/60 hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/50 disabled:text-slate-400 disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/50 disabled:hover:shadow-none">
+                        <SelectTrigger className="border-input hover:border-input/60 h-10 w-full rounded-lg border bg-white text-slate-700 shadow-sm transition-all duration-200 hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none disabled:border-slate-400/20 disabled:bg-slate-100/50 disabled:text-slate-400 disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/50 disabled:hover:shadow-none">
                           <SelectValue
                             placeholder={
                               selectedRegion ? 'Select Countries...' : 'Select Region First'
@@ -1030,7 +1030,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1073,7 +1073,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1116,7 +1116,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1159,7 +1159,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1202,7 +1202,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1257,7 +1257,7 @@ export default function TutorCoursePage() {
                                               type="checkbox"
                                               checked={selectedCategories.includes(exam)}
                                               onChange={() => selectCategory(exam)}
-                                              className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                              className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                             />
                                             <span className="text-sm text-slate-700">{exam}</span>
                                           </label>
@@ -1311,7 +1311,7 @@ export default function TutorCoursePage() {
                                               name="category"
                                               checked={selectedCategories[0] === exam}
                                               onChange={() => selectCategory(exam)}
-                                              className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                              className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                             />
                                             <span className="text-sm text-slate-700">{exam}</span>
                                           </label>
@@ -1355,7 +1355,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1398,7 +1398,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="text-sm text-slate-700">{exam}</span>
                                       </label>
@@ -1473,7 +1473,7 @@ export default function TutorCoursePage() {
                                           name="category"
                                           checked={selectedCategories[0] === exam}
                                           onChange={() => selectCategory(exam)}
-                                          className="rounded border-input text-indigo-600 focus:ring-indigo-500"
+                                          className="border-input rounded text-indigo-600 focus:ring-indigo-500"
                                         />
                                         <span className="flex-1 text-sm text-slate-700">
                                           {exam}


### PR DESCRIPTION
## **User description**
## What
Adds a permanent integration regression test (`src/__tests__/integration/live-submission-persistence.test.ts`) for the live-session submission flow that broke repeatedly.

It guards two things:
1. **Schema-drift class** — it runs the live `task:complete` persistence sequence (`courseLesson → builderTask → deployedMaterial → sessionParticipant → taskSubmission`) **omitting the defaulted timestamp columns**. If any `notNull().defaultNow()`/`.default(...)` column ever loses its DB DEFAULT again, the insert throws and the test fails — catching the exact `BuilderTask.updatedAt` not-null violation that silently dropped every submission.
2. **Reader visibility** — asserts a completed **task** *and* **assessment** appear on **both** tutor views:
   - the real `/api/tutor/submissions` handler (Grading page), driven with a mocked tutor session;
   - the in-session panel query shape (`deployedMaterial.itemId` + `sessionParticipant`/enrollee).

## Safety / CI
- Runs via `npm run test:integration` (needs Postgres). The default unit config excludes `src/__tests__/integration/**`, so the no-DB unit CI job is unaffected.
- Seeds and tears down its own rows (FK-safe), uses `claude-*@example.com` test accounts.
- Verified green against an ephemeral migrated Postgres (3/3 passing); `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add regression coverage for live submission saving and tutor visibility**

### What Changed
- Adds an integration test that fails if live-session submissions stop saving when default timestamps are missing from the database
- Verifies both a task and an assessment appear on the tutor Grading page
- Verifies both submissions are visible in the in-session tutor view for the same live session

### Impact
`✅ Fewer silent lost submissions`
`✅ Clearer grading visibility`
`✅ Earlier detection of database default drift`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
