### PR TITLE
feat(live): lock non-active courses in the student Directory during a live session

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -45,6 +45,7 @@ import {
   Minus,
   Presentation,
   Pencil,
+  Lock,
 } from 'lucide-react'
 import {
   Dialog,
@@ -986,6 +987,13 @@ function StudentFeedbackContent() {
     currentSession?.scheduledAt &&
     new Date(currentSession.scheduledAt).getTime() + 2 * 60 * 60 * 1000 < Date.now()
 
+  // While a session is live, the Directory should focus the student on the active
+  // course only — other courses are greyed out and locked so they can't open the
+  // wrong folder/task/assessment. This lifts automatically when the session ends.
+  const activeCourseId = sessionContext?.courseId ?? null
+  const isSessionLive =
+    !!activeCourseId && sessionContext?.status !== 'ended' && !sessionContext?.endedAt
+
   const feedbackPolls = activeTask?.polls ?? []
   const feedbackQuestions = activeTask?.questions ?? []
 
@@ -1832,24 +1840,37 @@ function StudentFeedbackContent() {
                                 {Object.entries(coursesDict).map(([courseName, courseData]) => {
                                   const catKey = `cat_${tutorUsername}_${courseName}`
                                   const isCatOpen = foldersOpen[catKey]
-                                  const isCurrentCategory =
-                                    sessionContext?.courseName === courseName &&
-                                    sessionContext?.tutorUsername &&
-                                    tutorUsername ===
-                                      `Tutor@${sessionContext.tutorUsername.replace(/\s+/g, '')}`
+                                  // Lock every course except the live session's own course
+                                  // while the session is running, so students can't open the
+                                  // wrong folder/task/assessment mid-class.
+                                  const courseLocked =
+                                    isSessionLive &&
+                                    (courseData as { courseId?: string }).courseId !== activeCourseId
 
                                   return (
                                     <div key={courseName}>
                                       <button
-                                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 hover:bg-slate-100"
-                                        onClick={() =>
+                                        disabled={courseLocked}
+                                        title={
+                                          courseLocked
+                                            ? 'Locked during the live session — available when the session ends'
+                                            : undefined
+                                        }
+                                        className={cn(
+                                          'flex w-full items-center gap-2 rounded-md px-2 py-1.5',
+                                          courseLocked
+                                            ? 'cursor-not-allowed opacity-40'
+                                            : 'hover:bg-slate-100'
+                                        )}
+                                        onClick={() => {
+                                          if (courseLocked) return
                                           setFoldersOpen(prev => ({
                                             ...prev,
                                             [catKey]: !prev[catKey],
                                           }))
-                                        }
+                                        }}
                                       >
-                                        {isCatOpen ? (
+                                        {isCatOpen && !courseLocked ? (
                                           <ChevronDown className="h-4 w-4 shrink-0 text-slate-500" />
                                         ) : (
                                           <ChevronRight className="h-4 w-4 shrink-0 text-slate-500" />
@@ -1861,9 +1882,12 @@ function StudentFeedbackContent() {
                                         <span className="truncate text-sm font-medium text-slate-700">
                                           {courseName}
                                         </span>
+                                        {courseLocked && (
+                                          <Lock className="ml-auto h-3.5 w-3.5 shrink-0 text-slate-400" />
+                                        )}
                                       </button>
 
-                                      {isCatOpen && (
+                                      {isCatOpen && !courseLocked && (
                                         <div className="mt-1 flex flex-col gap-1 pl-4">
                                           {/* 1. Tasks */}
                                           <div>


### PR DESCRIPTION
## **User description**
## What
During a live session, the student **Directory** now greys out and **locks every course except the one tied to the active session**, so students can't open the wrong folder / task / assessment mid-class (reduces clutter and mis-clicks).

## Behavior
- Locked course folders are **dimmed (opacity-40)**, show a **lock icon**, are **disabled** (can't expand), and their contents stay hidden.
- The **active session's course stays fully interactive**.
- This **lifts automatically when the session ends** — `handleSessionEnded` flips `sessionContext.status` to `'ended'` (+ `endedAt`), so the lock condition turns off without a reload.
- Only applies when the live session has a known `courseId`; matching is by `courseId` (session `sessionContext.courseId` vs each directory course's `courseId`), not by name.

## Implementation (`student/feedback/page.tsx`)
- Added derived `activeCourseId` + `isSessionLive`.
- In the Directory course map, replaced the unused `isCurrentCategory` with `courseLocked = isSessionLive && courseData.courseId !== activeCourseId`; applied dimmed/disabled styling, a guarded onClick, a `Lock` icon, and gated the children render on `!courseLocked`.

## Checks
`typecheck` ✅ · `lint` ✅ (0 errors) · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Lock other courses during a live session**

### What Changed
- While a live session is running, only the course tied to that session stays open in the student Directory.
- Other courses are dimmed, show a lock icon, and cannot be expanded until the session ends.
- Locked courses also hide their tasks and assessments to reduce wrong clicks during class.

### Impact
`✅ Fewer wrong-folder opens during live classes`
`✅ Less student confusion in the Directory`
`✅ Clearer live-session focus on the active course`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
