### PR TITLE
fix(avatars): serve avatar list under /api/public (reachable before login)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/account/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/account/page.tsx
@@ -332,7 +332,7 @@ export default function StudentAccount() {
                       avatarUrl={formData.avatarUrl}
                       uploadUrl="/api/user/avatar"
                       deleteUrl="/api/user/avatar"
-                      presetListUrl="/api/avatars"
+                      presetListUrl="/api/public/avatars"
                       presetSelectUrl="/api/user/avatar/preset"
                       size={80}
                       fallbackText={formData.name.charAt(0).toUpperCase() || '?'}

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -342,7 +342,7 @@ export function DashboardCalendar({
                     </div>
                   </div>
 
-                  <div className="hidden w-1/3 shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs text-gray-600 line-clamp-3 sm:block">
+                  <div className="line-clamp-3 hidden w-1/3 shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs text-gray-600 sm:block">
                     {cls.courseDescription || 'No description available.'}
                   </div>
 

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -203,11 +203,7 @@ function ClassroomControlsPanel({
             }}
           >
             <span className="w-4 shrink-0" aria-hidden="true" />
-            <span
-              className="mx-auto text-xs font-semibold text-white"
-            >
-              Controls
-            </span>
+            <span className="mx-auto text-xs font-semibold text-white">Controls</span>
             <WifiSignal connected={isConnected} error={!!error} />
           </button>
 

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -188,11 +188,7 @@ function TutorControlsPanel({
             }}
           >
             <span className="w-4 shrink-0" aria-hidden="true" />
-            <span
-              className="mx-auto text-xs font-semibold text-white"
-            >
-              Controls
-            </span>
+            <span className="mx-auto text-xs font-semibold text-white">Controls</span>
             <span className="w-4 shrink-0" aria-hidden="true" />
           </button>
 
@@ -256,7 +252,10 @@ function TutorControlsPanel({
                       type="button"
                       disabled={panelDisabled}
                       onClick={onSave}
-                      className={cn(actionButtonBase, 'bg-white text-gray-900 hover:bg-gray-100 active:bg-gray-200')}
+                      className={cn(
+                        actionButtonBase,
+                        'bg-white text-gray-900 hover:bg-gray-100 active:bg-gray-200'
+                      )}
                     >
                       <Save className="h-4 w-4" />
                       Save
@@ -266,7 +265,10 @@ function TutorControlsPanel({
                       type="button"
                       disabled={panelDisabled || mode !== 'build' || !canSchedule}
                       onClick={onSchedule}
-                      className={cn(actionButtonBase, 'bg-white text-[#2563EB] hover:bg-blue-50 active:bg-blue-100')}
+                      className={cn(
+                        actionButtonBase,
+                        'bg-white text-[#2563EB] hover:bg-blue-50 active:bg-blue-100'
+                      )}
                     >
                       <Calendar className="h-4 w-4" />
                       Schedule
@@ -276,7 +278,10 @@ function TutorControlsPanel({
                       type="button"
                       disabled={panelDisabled || mode !== 'build' || !canDelete}
                       onClick={onDelete}
-                      className={cn(actionButtonBase, 'bg-white text-red-600 hover:bg-red-50 active:bg-red-100')}
+                      className={cn(
+                        actionButtonBase,
+                        'bg-white text-red-600 hover:bg-red-50 active:bg-red-100'
+                      )}
                     >
                       <Trash2 className="h-4 w-4" />
                       Delete
@@ -384,7 +389,9 @@ function CourseBuilderInsightsRouteInner({
   const initialMainTab = isClassroomMode
     ? 'live'
     : (tabFromUrl ?? (insightsProps.sessionId ? 'live' : 'builder'))
-  const [activeMainTab, setActiveMainTab] = useState<'live' | 'builder' | 'test-pci'>(initialMainTab)
+  const [activeMainTab, setActiveMainTab] = useState<'live' | 'builder' | 'test-pci'>(
+    initialMainTab
+  )
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false)
   const [goLiveDialogOpen, setGoLiveDialogOpen] = useState(false)
   const [renameValue, setRenameValue] = useState('')
@@ -925,7 +932,6 @@ function CourseBuilderInsightsRouteInner({
                   Editing
                 </div>
               )}
-
             </div>
           </div>
 
@@ -936,7 +942,6 @@ function CourseBuilderInsightsRouteInner({
               Live Classroom — Students can see your screen
             </div>
           )}
-
         </div>
       </div>
 
@@ -1041,17 +1046,21 @@ function CourseBuilderInsightsRouteInner({
               ref?.triggerSync?.()
             }}
             canDelete={!!(courseId && courseId !== 'insights-draft' && onDeleteCourse)}
-            canSchedule={!!(
-              courseId &&
-              courseId !== 'insights-draft' &&
-              (saveMode === 'draft' || (saveMode === 'live' && isCourseVariant))
-            )}
-            canGoLive={!!(
-              courseId &&
-              courseId !== 'insights-draft' &&
-              saveMode === 'draft' &&
-              !insightsProps.sessionId
-            )}
+            canSchedule={
+              !!(
+                courseId &&
+                courseId !== 'insights-draft' &&
+                (saveMode === 'draft' || (saveMode === 'live' && isCourseVariant))
+              )
+            }
+            canGoLive={
+              !!(
+                courseId &&
+                courseId !== 'insights-draft' &&
+                saveMode === 'draft' &&
+                !insightsProps.sessionId
+              )
+            }
             hasSession={!!insightsProps.sessionId}
             hasUnsyncedChanges={hasUnsyncedChanges}
           />

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5780,11 +5780,10 @@ FEEDBACK: [your explanation]`
               >
                 <div className="flex h-full min-h-0 flex-col">
                   <Card className="-ml-3 flex h-full min-h-0 flex-1 flex-col rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)] sm:-ml-4">
-                    <div className="flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white sticky top-0 z-10">
+                    <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
                       Curriculum
                     </div>
                     <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden p-0.5 pt-0">
-
                       {mainTab !== 'live' && mainTab !== 'test-pci' && canEdit && (
                         <Button
                           size="sm"
@@ -7689,7 +7688,7 @@ FEEDBACK: [your explanation]`
                           className="absolute bottom-4 right-0 top-0 z-40 flex flex-col overflow-hidden rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]"
                           style={{ width: rightPanelWidth }}
                         >
-                          <div className="flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white sticky top-0 z-10">
+                          <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
                             Desk
                           </div>
                           <div className="px-2 pt-2">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -301,7 +301,7 @@ export function SubmissionsPanel({
           className="absolute bottom-4 right-0 top-0 z-40 flex flex-col overflow-hidden rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]"
           style={{ width }}
         >
-          <div className="flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white sticky top-0 z-10">
+          <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
             Desk
           </div>
           {headerExtra && <div className="px-2 pt-2">{headerExtra}</div>}

--- a/tutorme-app/src/app/api/public/avatars/route.ts
+++ b/tutorme-app/src/app/api/public/avatars/route.ts
@@ -1,9 +1,10 @@
 /**
- * GET /api/avatars
+ * GET /api/public/avatars
  *
- * Lists the preset avatars students can choose from. Reads `public/avatars/`
- * at request time, so dropping a new image into that folder (and deploying)
- * makes it available immediately — no code change required.
+ * Lists the preset avatars students can choose from. Public (under /api/public,
+ * so reachable before login — e.g. during registration/onboarding). Reads
+ * `public/avatars/` at request time, so dropping a new image into that folder
+ * (and deploying) makes it available immediately — no code change required.
  */
 
 import { NextResponse } from 'next/server'

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -178,7 +178,11 @@ export const GET = withAuth(
     const courseRows =
       eventCourseIds.length > 0
         ? await drizzleDb
-            .select({ courseId: course.courseId, name: course.name, description: course.description })
+            .select({
+              courseId: course.courseId,
+              name: course.name,
+              description: course.description,
+            })
             .from(course)
             .where(inArray(course.courseId, eventCourseIds))
         : []
@@ -206,7 +210,9 @@ export const GET = withAuth(
       tutorAvatarUrl: e.tutorId ? (tutorAvatarMap.get(e.tutorId) ?? null) : null,
       courseName: e.courseId ? (courseMap.get(e.courseId) ?? undefined) : undefined,
       category: e.courseId ? (courseMap.get(e.courseId) ?? undefined) : undefined,
-      courseDescription: e.courseId ? (courseDescriptionMap.get(e.courseId) ?? undefined) : undefined,
+      courseDescription: e.courseId
+        ? (courseDescriptionMap.get(e.courseId) ?? undefined)
+        : undefined,
       enrolledCount: e.sessionId ? (participantMap.get(e.sessionId) ?? 0) : 0,
     }))
 


### PR DESCRIPTION
## **User description**
Moves `GET /api/avatars` → **`/api/public/avatars`** so the preset gallery can be listed **before login** (e.g. during registration/onboarding). The `/api/public` prefix is allowlisted by the auth middleware (`public-paths.ts`), so no session is required.

- The **select** endpoint `/api/user/avatar/preset` stays authenticated (it mutates the user's profile).
- Student Account page updated to fetch `/api/public/avatars`.
- Behaviour is otherwise unchanged: still reads `public/avatars/` at request time, so new images dropped in remain auto-available.

Also formats 6 files that drifted unformatted on `main` from concurrent work, to keep CI Format green (whitespace only; no logic changes).

`typecheck`, `lint`, `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make preset avatars available before login**

### What Changed
- The preset avatar gallery now loads from a public address, so students can browse avatars during registration and onboarding without signing in.
- The student account page now uses the new public avatar gallery address.
- Avatar selection still stays behind login.

### Impact
`✅ Avatar browsing during signup`
`✅ Fewer login-blocked onboarding flows`
`✅ Clearer access to preset avatars`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
