### PR TITLE
feat(student): My Availability tab (editable weekly slots + upcoming sessions)

### DIFF
--- a/tutorme-app/drizzle/0060_student_availability.sql
+++ b/tutorme-app/drizzle/0060_student_availability.sql
@@ -1,0 +1,38 @@
+-- 0060_student_availability.sql
+-- Student-owned weekly availability + date exceptions (mirror of the tutor
+-- CalendarAvailability / CalendarException tables, keyed by studentId). Powers
+-- the student dashboard "My Availability" tab. Idempotent; defaults set
+-- explicitly (the prod DB has historically dropped column defaults).
+
+CREATE TABLE IF NOT EXISTS "StudentAvailability" (
+  "id" text PRIMARY KEY NOT NULL,
+  "studentId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "dayOfWeek" integer NOT NULL,
+  "startTime" text NOT NULL,
+  "endTime" text NOT NULL,
+  "timezone" text NOT NULL,
+  "isAvailable" boolean NOT NULL,
+  "validFrom" timestamptz,
+  "validUntil" timestamptz,
+  "createdAt" timestamptz NOT NULL DEFAULT now(),
+  "updatedAt" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "StudentAvailability_studentId_idx" ON "StudentAvailability" ("studentId");
+CREATE UNIQUE INDEX IF NOT EXISTS "StudentAvailability_studentId_dayOfWeek_startTime_endTime_key"
+  ON "StudentAvailability" ("studentId", "dayOfWeek", "startTime", "endTime");
+
+CREATE TABLE IF NOT EXISTS "StudentAvailabilityException" (
+  "id" text PRIMARY KEY NOT NULL,
+  "studentId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "date" timestamptz NOT NULL,
+  "isAvailable" boolean NOT NULL,
+  "startTime" text,
+  "endTime" text,
+  "reason" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "StudentAvailabilityException_studentId_idx" ON "StudentAvailabilityException" ("studentId");
+CREATE UNIQUE INDEX IF NOT EXISTS "StudentAvailabilityException_studentId_date_startTime_key"
+  ON "StudentAvailabilityException" ("studentId", "date", "startTime");

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1781400000000,
       "tag": "0059_restore_column_defaults",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1781500000000,
+      "tag": "0060_student_availability",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -11,6 +11,7 @@ import {
   type CalendarView,
 } from '@/app/[locale]/tutor/dashboard/components/InteractiveCalendar'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
+import { StudentAvailabilityTab } from './StudentAvailabilityTab'
 import { Badge } from '@/components/ui/badge'
 import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -206,6 +207,7 @@ export function DashboardCalendar({
       tabs={[
         { value: 'classes', label: 'Sessions' },
         { value: 'calendar', label: 'Calendar' },
+        { value: 'availability', label: 'My Availability' },
         { value: 'bookings', label: 'Bookings' },
       ]}
       showCalendarControls={activeTab === 'calendar'}
@@ -228,6 +230,14 @@ export function DashboardCalendar({
           view={calendarView}
           onViewChange={setCalendarView}
         />
+      </TabsContent>
+
+      {/* My Availability Tab */}
+      <TabsContent
+        value="availability"
+        className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <StudentAvailabilityTab />
       </TabsContent>
 
       {/* Bookings Tab */}

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/StudentAvailabilityTab.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/StudentAvailabilityTab.tsx
@@ -1,0 +1,277 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, Check, CalendarClock, Info } from 'lucide-react'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+
+const DAYS = [
+  { idx: 1, short: 'Mon', long: 'Monday' },
+  { idx: 2, short: 'Tue', long: 'Tuesday' },
+  { idx: 3, short: 'Wed', long: 'Wednesday' },
+  { idx: 4, short: 'Thu', long: 'Thursday' },
+  { idx: 5, short: 'Fri', long: 'Friday' },
+  { idx: 6, short: 'Sat', long: 'Saturday' },
+  { idx: 0, short: 'Sun', long: 'Sunday' },
+]
+
+// Waking hours shown as togglable slots (24h grid would be unwieldy).
+const HOURS = Array.from({ length: 17 }, (_, i) => i + 6) // 6:00 .. 22:00
+
+const pad = (n: number) => String(n).padStart(2, '0')
+const slotKey = (day: number, hour: number) => `${day}-${pad(hour)}:00`
+const hourLabel = (h: number) => {
+  const period = h < 12 ? 'AM' : 'PM'
+  const display = h % 12 === 0 ? 12 : h % 12
+  return `${display} ${period}`
+}
+
+interface SessionItem {
+  id: string
+  title: string
+  startTime: string
+  courseName?: string | null
+}
+
+/**
+ * Student "My Availability" — an editable weekly grid of free slots, plus the
+ * student's upcoming course sessions for context (so availability is set around
+ * existing commitments). Persists to /api/student/calendar/availability.
+ */
+export function StudentAvailabilityTab() {
+  const [loading, setLoading] = useState(true)
+  const [savingKey, setSavingKey] = useState<string | null>(null)
+  const [available, setAvailable] = useState<Set<string>>(new Set())
+  const [selectedDay, setSelectedDay] = useState<number>(() => {
+    const d = new Date().getDay()
+    return d
+  })
+  const [sessions, setSessions] = useState<SessionItem[]>([])
+
+  const timezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC', [])
+
+  // Load saved availability
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetch('/api/student/calendar/availability', { credentials: 'include' })
+      .then(r => r.json())
+      .then(data => {
+        if (cancelled) return
+        const set = new Set<string>()
+        for (const a of data?.availability ?? []) {
+          if (a.isAvailable) set.add(`${a.dayOfWeek}-${a.startTime}`)
+        }
+        setAvailable(set)
+      })
+      .catch(() => {
+        if (!cancelled) toast.error('Could not load your availability')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Load upcoming sessions (commitments) for context
+  useEffect(() => {
+    let cancelled = false
+    const start = new Date()
+    const end = new Date()
+    end.setDate(end.getDate() + 30)
+    fetch(
+      `/api/student/calendar/events?start=${encodeURIComponent(
+        start.toISOString()
+      )}&end=${encodeURIComponent(end.toISOString())}`,
+      { credentials: 'include' }
+    )
+      .then(r => r.json())
+      .then(data => {
+        if (cancelled) return
+        const evs = Array.isArray(data?.events) ? data.events : []
+        setSessions(
+          evs
+            .map((e: Record<string, unknown>) => ({
+              id: String(e.id ?? e.eventId ?? Math.random()),
+              title: String(e.title ?? 'Session'),
+              startTime: String(e.startTime ?? e.scheduledAt ?? ''),
+              courseName: (e.courseName as string) ?? null,
+            }))
+            .filter((e: SessionItem) => e.startTime)
+            .sort(
+              (a: SessionItem, b: SessionItem) =>
+                new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+            )
+            .slice(0, 8)
+        )
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const toggleSlot = useCallback(
+    async (day: number, hour: number) => {
+      const key = slotKey(day, hour)
+      const startTime = `${pad(hour)}:00`
+      const endTime = `${pad(hour + 1)}:00`
+      const currentlyAvailable = available.has(key)
+      const next = !currentlyAvailable
+
+      // Optimistic
+      setAvailable(prev => {
+        const s = new Set(prev)
+        if (next) s.add(key)
+        else s.delete(key)
+        return s
+      })
+      setSavingKey(key)
+      try {
+        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrfData = await csrfRes.json().catch(() => ({}))
+        const csrfToken = csrfData?.token ?? null
+        const res = await fetch('/api/student/calendar/availability', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+          },
+          credentials: 'include',
+          body: JSON.stringify({
+            dayOfWeek: day,
+            startTime,
+            endTime,
+            timezone,
+            isAvailable: next,
+          }),
+        })
+        if (!res.ok) throw new Error('save failed')
+      } catch {
+        // Revert
+        setAvailable(prev => {
+          const s = new Set(prev)
+          if (currentlyAvailable) s.add(key)
+          else s.delete(key)
+          return s
+        })
+        toast.error('Could not save that change')
+      } finally {
+        setSavingKey(null)
+      }
+    },
+    [available, timezone]
+  )
+
+  const dayLong = DAYS.find(d => d.idx === selectedDay)?.long ?? ''
+  const availableCount = available.size
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-1">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-[#1F2933]">My Availability</h3>
+          <p className="text-xs text-gray-500">
+            Tap the hours you’re free. Tutors use this when scheduling 1-on-1s.
+          </p>
+        </div>
+        <span className="rounded-full bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-700">
+          {availableCount} slot{availableCount === 1 ? '' : 's'} marked free
+        </span>
+      </div>
+
+      {/* Day selector */}
+      <div className="flex flex-wrap gap-1">
+        {DAYS.map(d => (
+          <button
+            key={d.idx}
+            type="button"
+            onClick={() => setSelectedDay(d.idx)}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-xs font-medium transition-colors',
+              selectedDay === d.idx
+                ? 'bg-orange-500 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            )}
+          >
+            {d.short}
+          </button>
+        ))}
+      </div>
+
+      {/* Hour grid for the selected day */}
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
+        </div>
+      ) : (
+        <div>
+          <p className="mb-2 text-xs font-medium text-gray-500">{dayLong}</p>
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+            {HOURS.map(h => {
+              const key = slotKey(selectedDay, h)
+              const isFree = available.has(key)
+              const isSaving = savingKey === key
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  disabled={isSaving}
+                  onClick={() => void toggleSlot(selectedDay, h)}
+                  className={cn(
+                    'flex items-center justify-center gap-1 rounded-lg border px-2 py-2 text-xs font-medium transition-colors disabled:opacity-60',
+                    isFree
+                      ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
+                      : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50'
+                  )}
+                >
+                  {isSaving ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : isFree ? (
+                    <Check className="h-3 w-3" />
+                  ) : null}
+                  {hourLabel(h)}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Upcoming commitments (course sessions) */}
+      <div className="rounded-xl border border-gray-100 bg-gray-50/60 p-3">
+        <div className="mb-2 flex items-center gap-2 text-xs font-semibold text-gray-700">
+          <CalendarClock className="h-4 w-4 text-orange-500" />
+          Your upcoming sessions
+        </div>
+        {sessions.length === 0 ? (
+          <p className="flex items-center gap-1.5 text-xs text-gray-400">
+            <Info className="h-3.5 w-3.5" />
+            No upcoming sessions from your enrolled courses.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {sessions.map(s => (
+              <li key={s.id} className="flex items-center justify-between gap-2 text-xs">
+                <span className="truncate font-medium text-gray-700">
+                  {s.title}
+                  {s.courseName ? <span className="text-gray-400"> · {s.courseName}</span> : null}
+                </span>
+                <span className="shrink-0 text-gray-500">
+                  {new Date(s.startTime).toLocaleString([], {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/app/api/student/calendar/availability/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/availability/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Student weekly availability.
+ *  GET    -> { availability: [...], exceptions: [...] }
+ *  POST   -> upsert one weekly slot { dayOfWeek, startTime, endTime, timezone, isAvailable }
+ *  DELETE -> remove one slot { id }
+ *
+ * Mirrors /api/tutor/calendar/availability but keyed to the student.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import crypto from 'crypto'
+import { withAuth, withCsrf } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { studentAvailability, studentAvailabilityException } from '@/lib/db/schema'
+
+export const dynamic = 'force-dynamic'
+
+export const GET = withAuth(
+  async (_req: NextRequest, session) => {
+    const studentId = session.user.id
+    const [availability, exceptions] = await Promise.all([
+      drizzleDb
+        .select()
+        .from(studentAvailability)
+        .where(eq(studentAvailability.studentId, studentId)),
+      drizzleDb
+        .select()
+        .from(studentAvailabilityException)
+        .where(eq(studentAvailabilityException.studentId, studentId)),
+    ])
+    return NextResponse.json({ availability, exceptions })
+  },
+  { role: 'STUDENT' }
+)
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session) => {
+      const studentId = session.user.id
+      const body = await req.json().catch(() => null)
+      const dayOfWeek = Number(body?.dayOfWeek)
+      const startTime = typeof body?.startTime === 'string' ? body.startTime : ''
+      const endTime = typeof body?.endTime === 'string' ? body.endTime : ''
+      const timezone = typeof body?.timezone === 'string' && body.timezone ? body.timezone : 'UTC'
+      const isAvailable = body?.isAvailable !== false
+
+      if (
+        !Number.isInteger(dayOfWeek) ||
+        dayOfWeek < 0 ||
+        dayOfWeek > 6 ||
+        !startTime ||
+        !endTime
+      ) {
+        return NextResponse.json({ error: 'Invalid availability slot' }, { status: 400 })
+      }
+
+      const now = new Date()
+      await drizzleDb
+        .insert(studentAvailability)
+        .values({
+          availabilityId: crypto.randomUUID(),
+          studentId,
+          dayOfWeek,
+          startTime,
+          endTime,
+          timezone,
+          isAvailable,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            studentAvailability.studentId,
+            studentAvailability.dayOfWeek,
+            studentAvailability.startTime,
+            studentAvailability.endTime,
+          ],
+          set: { isAvailable, timezone, updatedAt: now },
+        })
+
+      return NextResponse.json({ success: true })
+    },
+    { role: 'STUDENT' }
+  )
+)
+
+export const DELETE = withCsrf(
+  withAuth(
+    async (req: NextRequest, session) => {
+      const studentId = session.user.id
+      const body = await req.json().catch(() => null)
+      const id = typeof body?.id === 'string' ? body.id : ''
+      if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 })
+      await drizzleDb
+        .delete(studentAvailability)
+        .where(
+          and(
+            eq(studentAvailability.availabilityId, id),
+            eq(studentAvailability.studentId, studentId)
+          )
+        )
+      return NextResponse.json({ success: true })
+    },
+    { role: 'STUDENT' }
+  )
+)

--- a/tutorme-app/src/app/api/student/calendar/exceptions/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/exceptions/route.ts
@@ -1,0 +1,91 @@
+/**
+ * Student date-specific availability exceptions.
+ *  GET    -> { exceptions: [...] }
+ *  POST   -> upsert one exception { date, isAvailable, startTime?, endTime?, reason? }
+ *  DELETE -> remove one exception { id }
+ *
+ * Mirrors /api/tutor/calendar/exceptions but keyed to the student.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import crypto from 'crypto'
+import { withAuth, withCsrf } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { studentAvailabilityException } from '@/lib/db/schema'
+
+export const dynamic = 'force-dynamic'
+
+export const GET = withAuth(
+  async (_req: NextRequest, session) => {
+    const exceptions = await drizzleDb
+      .select()
+      .from(studentAvailabilityException)
+      .where(eq(studentAvailabilityException.studentId, session.user.id))
+    return NextResponse.json({ exceptions })
+  },
+  { role: 'STUDENT' }
+)
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session) => {
+      const studentId = session.user.id
+      const body = await req.json().catch(() => null)
+      const dateRaw = body?.date
+      const date = dateRaw ? new Date(dateRaw) : null
+      if (!date || Number.isNaN(date.getTime())) {
+        return NextResponse.json({ error: 'A valid date is required' }, { status: 400 })
+      }
+      const isAvailable = body?.isAvailable === true
+      const startTime = typeof body?.startTime === 'string' ? body.startTime : null
+      const endTime = typeof body?.endTime === 'string' ? body.endTime : null
+      const reason = typeof body?.reason === 'string' ? body.reason : null
+
+      await drizzleDb
+        .insert(studentAvailabilityException)
+        .values({
+          exceptionId: crypto.randomUUID(),
+          studentId,
+          date,
+          isAvailable,
+          startTime,
+          endTime,
+          reason,
+          createdAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [
+            studentAvailabilityException.studentId,
+            studentAvailabilityException.date,
+            studentAvailabilityException.startTime,
+          ],
+          set: { isAvailable, endTime, reason },
+        })
+
+      return NextResponse.json({ success: true })
+    },
+    { role: 'STUDENT' }
+  )
+)
+
+export const DELETE = withCsrf(
+  withAuth(
+    async (req: NextRequest, session) => {
+      const studentId = session.user.id
+      const body = await req.json().catch(() => null)
+      const id = typeof body?.id === 'string' ? body.id : ''
+      if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 })
+      await drizzleDb
+        .delete(studentAvailabilityException)
+        .where(
+          and(
+            eq(studentAvailabilityException.exceptionId, id),
+            eq(studentAvailabilityException.studentId, studentId)
+          )
+        )
+      return NextResponse.json({ success: true })
+    },
+    { role: 'STUDENT' }
+  )
+)

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -156,6 +156,62 @@ export const calendarException = pgTable(
   })
 )
 
+// Student weekly availability (mirror of CalendarAvailability, keyed by student)
+export const studentAvailability = pgTable(
+  'StudentAvailability',
+  {
+    availabilityId: text('id').primaryKey().notNull(),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    dayOfWeek: integer('dayOfWeek').notNull(),
+    startTime: text('startTime').notNull(),
+    endTime: text('endTime').notNull(),
+    timezone: text('timezone').notNull(),
+    isAvailable: boolean('isAvailable').notNull(),
+    validFrom: timestamp('validFrom', { withTimezone: true }),
+    validUntil: timestamp('validUntil', { withTimezone: true }),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  table => ({
+    StudentAvailability_studentId_idx: index('StudentAvailability_studentId_idx').on(
+      table.studentId
+    ),
+    StudentAvailability_studentId_dayOfWeek_startTime_endTime_key: uniqueIndex(
+      'StudentAvailability_studentId_dayOfWeek_startTime_endTime_key'
+    ).on(table.studentId, table.dayOfWeek, table.startTime, table.endTime),
+  })
+)
+
+// Student date-specific availability exceptions (mirror of CalendarException)
+export const studentAvailabilityException = pgTable(
+  'StudentAvailabilityException',
+  {
+    exceptionId: text('id').primaryKey().notNull(),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    date: timestamp('date', { withTimezone: true }).notNull(),
+    isAvailable: boolean('isAvailable').notNull(),
+    startTime: text('startTime'),
+    endTime: text('endTime'),
+    reason: text('reason'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => ({
+    StudentAvailabilityException_studentId_idx: index(
+      'StudentAvailabilityException_studentId_idx'
+    ).on(table.studentId),
+    StudentAvailabilityException_studentId_date_startTime_key: uniqueIndex(
+      'StudentAvailabilityException_studentId_date_startTime_key'
+    ).on(table.studentId, table.date, table.startTime),
+  })
+)
+
 // One-on-one booking requests
 export const oneOnOneBookingRequest = pgTable(
   'OneOnOneBookingRequest',


### PR DESCRIPTION
## **User description**
Adds a "My Availability" tab to the student dashboard (item 2), editable + wired to the calendar/sessions.

## What
- **Schema + migration 0060**: new `StudentAvailability` and `StudentAvailabilityException` tables — mirror of the tutor `CalendarAvailability`/`CalendarException`, keyed by `studentId`. Explicit column defaults; validated against Postgres.
- **APIs** (STUDENT auth + CSRF): `/api/student/calendar/availability` (GET / POST upsert / DELETE) and `/api/student/calendar/exceptions` (GET / POST / DELETE).
- **UI**: `StudentAvailabilityTab` — an editable weekly grid where the student taps the hours they're free (per-day hourly toggles, optimistic save), plus a "Your upcoming sessions" list pulled from `/api/student/calendar/events` so availability is set around existing course commitments. Mounted as a new **My Availability** tab in `DashboardCalendar`.

## Design note
Built as a **self-contained component** rather than rewiring the shared `InteractiveCalendar` (whose `isStudent` guards intentionally make it read-only across all student tabs). This keeps the tutor and existing student calendar tabs completely untouched — zero regression risk — while delivering an editable student availability surface.

`typecheck`, `lint` (0 errors), `build` pass; migration validated on an ephemeral Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Students can now set weekly free slots and see upcoming sessions in a new “My Availability” tab**

### What Changed
- Added a new “My Availability” tab in the student dashboard
- Students can mark and unmark hourly free slots for each day of the week, with changes saved right away
- The tab shows upcoming course sessions so students can plan availability around existing commitments
- Added support for saving and loading student-specific weekly availability and date exceptions

### Impact
`✅ Faster scheduling from the student dashboard`
`✅ Fewer double-booked tutoring times`
`✅ Clearer view of upcoming course commitments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
