### PR TITLE
feat(student): unregister from course — cleanup, token-ledger refund, tutor notify

### DIFF
--- a/tutorme-app/drizzle/0061_llm_token_usage.sql
+++ b/tutorme-app/drizzle/0061_llm_token_usage.sql
@@ -1,0 +1,22 @@
+-- 0061_llm_token_usage.sql
+-- Per-call LLM token usage ledger, optionally attributed to a student + course.
+-- Powers the token-cost deduction in the paid-course unregister refund.
+-- Idempotent; explicit defaults (prod has historically dropped column defaults).
+
+CREATE TABLE IF NOT EXISTS "LlmTokenUsage" (
+  "id" text PRIMARY KEY NOT NULL,
+  "studentId" text REFERENCES "User"("id") ON DELETE SET NULL,
+  "courseId" text REFERENCES "Course"("id") ON DELETE SET NULL,
+  "provider" text NOT NULL,
+  "model" text,
+  "promptTokens" integer NOT NULL DEFAULT 0,
+  "completionTokens" integer NOT NULL DEFAULT 0,
+  "totalTokens" integer NOT NULL DEFAULT 0,
+  "costUsd" double precision NOT NULL DEFAULT 0,
+  "feature" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "LlmTokenUsage_studentId_idx" ON "LlmTokenUsage" ("studentId");
+CREATE INDEX IF NOT EXISTS "LlmTokenUsage_courseId_idx" ON "LlmTokenUsage" ("courseId");
+CREATE INDEX IF NOT EXISTS "LlmTokenUsage_student_course_idx" ON "LlmTokenUsage" ("studentId", "courseId");

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1781500000000,
       "tag": "0060_student_availability",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1781600000000,
+      "tag": "0061_llm_token_usage",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
@@ -44,6 +44,7 @@ function CourseEnrollPageInner() {
   const [course, setCourse] = useState<CourseDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [enrolling, setEnrolling] = useState(false)
+  const [unenrolling, setUnenrolling] = useState(false)
   const [paying, setPaying] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [startDate, setStartDate] = useState<string | null>(null)
@@ -165,6 +166,42 @@ function CourseEnrollPageInner() {
       toast.error('Enrollment failed')
     } finally {
       setEnrolling(false)
+    }
+  }
+
+  const handleUnenroll = async () => {
+    if (!course) return
+    const confirmed = window.confirm(
+      'Unregister from this course? Your progress will be removed. For a paid course, a partial refund (based on sessions taken) will be sent to your tutor for review.'
+    )
+    if (!confirmed) return
+    setUnenrolling(true)
+    try {
+      const csrf = await getCsrf()
+      const res = await fetch(`/api/student/courses/${encodeURIComponent(courseId)}/unenroll`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(csrf && { 'X-CSRF-Token': csrf }) },
+        credentials: 'include',
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(json?.error ?? 'Could not unregister')
+        return
+      }
+      if (json?.refund) {
+        toast.success(
+          `Unregistered. A partial refund of ${json.refund.currency} ${Number(
+            json.refund.amount
+          ).toFixed(2)} is pending review.`
+        )
+      } else {
+        toast.success('Unregistered from the course')
+      }
+      router.push('/student/courses?tab=mine')
+    } catch {
+      toast.error('Could not unregister')
+    } finally {
+      setUnenrolling(false)
     }
   }
 
@@ -292,6 +329,14 @@ function CourseEnrollPageInner() {
                     >
                       View course details
                     </Link>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={handleUnenroll}
+                    disabled={unenrolling}
+                    className="border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700"
+                  >
+                    {unenrolling ? 'Unregistering…' : 'Unregister'}
                   </Button>
                 </div>
               </div>

--- a/tutorme-app/src/app/api/student/courses/[courseId]/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[courseId]/unenroll/route.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /api/student/courses/[courseId]/unenroll
+ *
+ * Lets a student unregister from a course with full cleanup:
+ *  - delete the enrollment + its progress row, release the schedule seat
+ *  - for a paid course, record a PENDING partial-refund request (no automatic
+ *    gateway money movement): refund = paid x (unused session fraction) minus
+ *    the LLM token cost attributed to this student+course
+ *  - notify the tutor (course creator)
+ *
+ * The refund is recorded for tutor/admin approval via the existing refund flow.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq, sql } from 'drizzle-orm'
+import crypto from 'crypto'
+import { withAuth, withCsrf } from '@/lib/api/middleware'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseEnrollment, courseProgress, course, payment, refund } from '@/lib/db/schema'
+import { notify } from '@/lib/notifications/notify'
+import { sumLlmUsageForStudentCourse } from '@/lib/ai/usage'
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session, context) => {
+      const studentId = session.user.id
+      const courseId = await getParamAsync(context.params, 'courseId')
+      if (!courseId) {
+        return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
+      }
+
+      // 1. Verify enrollment + capture progress BEFORE deleting (needed for the refund math).
+      const [enrollment] = await drizzleDb
+        .select({
+          enrollmentId: courseEnrollment.enrollmentId,
+          scheduleId: courseEnrollment.scheduleId,
+        })
+        .from(courseEnrollment)
+        .where(
+          and(eq(courseEnrollment.studentId, studentId), eq(courseEnrollment.courseId, courseId))
+        )
+        .limit(1)
+      if (!enrollment) {
+        return NextResponse.json({ error: 'You are not enrolled in this course' }, { status: 404 })
+      }
+
+      const [courseRow] = await drizzleDb
+        .select({ name: course.name, creatorId: course.creatorId })
+        .from(course)
+        .where(eq(course.courseId, courseId))
+        .limit(1)
+
+      const [progress] = await drizzleDb
+        .select({
+          lessonsCompleted: courseProgress.lessonsCompleted,
+          totalLessons: courseProgress.totalLessons,
+        })
+        .from(courseProgress)
+        .where(and(eq(courseProgress.studentId, studentId), eq(courseProgress.courseId, courseId)))
+        .limit(1)
+
+      // Completed (paid) payment for this enrollment, if any.
+      const [paymentRow] = await drizzleDb
+        .select({
+          paymentId: payment.paymentId,
+          amount: payment.amount,
+          currency: payment.currency,
+        })
+        .from(payment)
+        .where(
+          and(eq(payment.enrollmentId, enrollment.enrollmentId), eq(payment.status, 'COMPLETED'))
+        )
+        .limit(1)
+
+      // 2. Cleanup in a transaction: progress, enrollment, schedule seat.
+      await drizzleDb.transaction(async tx => {
+        await tx
+          .delete(courseProgress)
+          .where(
+            and(eq(courseProgress.studentId, studentId), eq(courseProgress.courseId, courseId))
+          )
+        await tx
+          .delete(courseEnrollment)
+          .where(eq(courseEnrollment.enrollmentId, enrollment.enrollmentId))
+        if (enrollment.scheduleId) {
+          await tx.execute(
+            sql`UPDATE "CourseSchedule"
+                SET "enrolledCount" = GREATEST("enrolledCount" - 1, 0)
+                WHERE id = ${enrollment.scheduleId}`
+          )
+        }
+      })
+
+      // 3. Partial refund request for paid courses.
+      let refundInfo: { amount: number; currency: string; status: string } | null = null
+      if (paymentRow && paymentRow.amount > 0) {
+        const total = progress?.totalLessons ?? 0
+        const done = progress?.lessonsCompleted ?? 0
+        const usedFraction = total > 0 ? Math.min(1, Math.max(0, done / total)) : 0
+        const proRata = paymentRow.amount * (1 - usedFraction)
+
+        // Deduct the LLM token cost this student incurred in this course.
+        const { costUsd: tokenCost } = await sumLlmUsageForStudentCourse(studentId, courseId)
+        const amount = Math.max(0, Math.round((proRata - tokenCost) * 100) / 100)
+
+        await drizzleDb.insert(refund).values({
+          refundId: crypto.randomUUID(),
+          paymentId: paymentRow.paymentId,
+          amount,
+          reason: `Student unregistered from "${courseRow?.name ?? courseId}". Pro-rata on ${done}/${total} sessions taken, minus token cost $${tokenCost.toFixed(2)}.`,
+          status: 'PENDING',
+          createdAt: new Date(),
+        })
+        refundInfo = { amount, currency: paymentRow.currency, status: 'PENDING' }
+      }
+
+      // 4. Notify the tutor.
+      if (courseRow?.creatorId) {
+        await notify({
+          userId: courseRow.creatorId,
+          type: 'enrollment',
+          title: 'A student left your course',
+          message: refundInfo
+            ? `A student unregistered from "${courseRow.name}". A partial refund of ${refundInfo.currency} ${refundInfo.amount.toFixed(2)} is pending your review.`
+            : `A student unregistered from "${courseRow.name}".`,
+          actionUrl: `/tutor/courses/${courseId}/enrollments`,
+        }).catch(err => console.warn('[unenroll] tutor notify failed (non-critical):', err))
+      }
+
+      return NextResponse.json({ success: true, refund: refundInfo })
+    },
+    { role: 'STUDENT' }
+  )
+)

--- a/tutorme-app/src/lib/ai/kimi.ts
+++ b/tutorme-app/src/lib/ai/kimi.ts
@@ -6,6 +6,7 @@
 
 import { fetchWithTimeoutAndRetry } from '@/lib/ai/fetch-utils'
 import { isGeminiActive } from '@/lib/ai/provider'
+import { recordLlmUsage, type UsageContext } from '@/lib/ai/usage'
 import {
   generateWithGemini,
   chatWithGemini,
@@ -53,6 +54,7 @@ export async function generateWithKimi(
     systemPrompt?: string
     timeoutMs?: number
     retries?: number
+    usageContext?: UsageContext
   } = {}
 ): Promise<string> {
   if (isGeminiActive()) {
@@ -98,6 +100,14 @@ export async function generateWithKimi(
     }
 
     const data: KimiResponse = await response.json()
+    void recordLlmUsage({
+      provider: 'kimi',
+      model: options.model || DEFAULT_MODEL,
+      promptTokens: data.usage?.prompt_tokens,
+      completionTokens: data.usage?.completion_tokens,
+      totalTokens: data.usage?.total_tokens,
+      context: options.usageContext,
+    })
     return data.choices[0]?.message?.content || ''
   } catch (error) {
     console.error('Kimi generation error:', error)
@@ -270,6 +280,7 @@ export async function generateWithKimiVision(
     systemPrompt?: string
     timeoutMs?: number
     retries?: number
+    usageContext?: UsageContext
   } = {}
 ): Promise<string> {
   if (isGeminiActive()) {
@@ -320,6 +331,14 @@ export async function generateWithKimiVision(
     }
 
     const data: KimiResponse = await response.json()
+    void recordLlmUsage({
+      provider: 'kimi',
+      model: options.model || DEFAULT_MODEL,
+      promptTokens: data.usage?.prompt_tokens,
+      completionTokens: data.usage?.completion_tokens,
+      totalTokens: data.usage?.total_tokens,
+      context: options.usageContext,
+    })
     return data.choices[0]?.message?.content || ''
   } catch (error) {
     console.error('Kimi vision generation error:', error)

--- a/tutorme-app/src/lib/ai/usage.ts
+++ b/tutorme-app/src/lib/ai/usage.ts
@@ -1,0 +1,72 @@
+/**
+ * LLM token-usage ledger helpers.
+ *
+ * `recordLlmUsage` persists one row of token consumption (best-effort; never
+ * throws into the caller). Pass a `context` with studentId/courseId/feature to
+ * attribute the usage — this is what the paid-course unregister refund reads to
+ * deduct token cost. `sumLlmUsageForStudentCourse` aggregates that attribution.
+ */
+
+import crypto from 'crypto'
+import { and, eq } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { llmTokenUsage } from '@/lib/db/schema'
+
+export interface UsageContext {
+  studentId?: string | null
+  courseId?: string | null
+  feature?: string
+}
+
+// Rough blended USD cost per 1K tokens (override via env). Exact tokens are
+// stored regardless; this only drives the costUsd estimate.
+const USD_PER_1K_TOKENS = Number(process.env.LLM_USD_PER_1K_TOKENS || '0.002')
+
+export async function recordLlmUsage(params: {
+  provider: string
+  model?: string | null
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  context?: UsageContext
+}): Promise<void> {
+  try {
+    const prompt = params.promptTokens ?? 0
+    const completion = params.completionTokens ?? 0
+    const total = params.totalTokens ?? prompt + completion
+    if (total <= 0 && prompt <= 0 && completion <= 0) return // nothing to record
+
+    await drizzleDb.insert(llmTokenUsage).values({
+      usageId: crypto.randomUUID(),
+      studentId: params.context?.studentId ?? null,
+      courseId: params.context?.courseId ?? null,
+      provider: params.provider,
+      model: params.model ?? null,
+      promptTokens: prompt,
+      completionTokens: completion,
+      totalTokens: total,
+      costUsd: (total / 1000) * USD_PER_1K_TOKENS,
+      feature: params.context?.feature ?? null,
+      createdAt: new Date(),
+    })
+  } catch (err) {
+    console.warn('[llm-usage] failed to record token usage (non-critical):', err)
+  }
+}
+
+export async function sumLlmUsageForStudentCourse(
+  studentId: string,
+  courseId: string
+): Promise<{ totalTokens: number; costUsd: number }> {
+  const rows = await drizzleDb
+    .select({ totalTokens: llmTokenUsage.totalTokens, costUsd: llmTokenUsage.costUsd })
+    .from(llmTokenUsage)
+    .where(and(eq(llmTokenUsage.studentId, studentId), eq(llmTokenUsage.courseId, courseId)))
+  return rows.reduce(
+    (acc, r) => ({
+      totalTokens: acc.totalTokens + (r.totalTokens || 0),
+      costUsd: acc.costUsd + (r.costUsd || 0),
+    }),
+    { totalTokens: 0, costUsd: 0 }
+  )
+}

--- a/tutorme-app/src/lib/db/schema/tables/analytics.ts
+++ b/tutorme-app/src/lib/db/schema/tables/analytics.ts
@@ -19,6 +19,34 @@ import { course } from './course'
 import { builderTask } from './builder'
 import { liveSession } from './live'
 
+// Per-call LLM token consumption, optionally attributed to a student + course.
+// Used (among other things) to compute the token-cost deduction when a student
+// unregisters from a paid course.
+export const llmTokenUsage = pgTable(
+  'LlmTokenUsage',
+  {
+    usageId: text('id').primaryKey().notNull(),
+    studentId: text('studentId').references(() => user.userId, { onDelete: 'set null' }),
+    courseId: text('courseId').references(() => course.courseId, { onDelete: 'set null' }),
+    provider: text('provider').notNull(),
+    model: text('model'),
+    promptTokens: integer('promptTokens').notNull().default(0),
+    completionTokens: integer('completionTokens').notNull().default(0),
+    totalTokens: integer('totalTokens').notNull().default(0),
+    costUsd: doublePrecision('costUsd').notNull().default(0),
+    feature: text('feature'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => ({
+    LlmTokenUsage_studentId_idx: index('LlmTokenUsage_studentId_idx').on(table.studentId),
+    LlmTokenUsage_courseId_idx: index('LlmTokenUsage_courseId_idx').on(table.courseId),
+    LlmTokenUsage_student_course_idx: index('LlmTokenUsage_student_course_idx').on(
+      table.studentId,
+      table.courseId
+    ),
+  })
+)
+
 export const performanceMetric = pgTable(
   'PerformanceMetric',
   {


### PR DESCRIPTION
## **User description**
Implements item 3: students can unregister from a course, with full cleanup, tutor notification, and a partial refund for paid courses based on sessions taken **and LLM tokens consumed**.

## Token ledger (the prerequisite you asked to build first)
- **`LlmTokenUsage` table + migration 0061**: per-call token consumption, optionally attributed to `studentId` + `courseId` (provider, model, prompt/completion/total tokens, estimated `costUsd`, feature).
- **`recordLlmUsage` / `sumLlmUsageForStudentCourse`** (`src/lib/ai/usage.ts`).
- **Instrumented the Kimi provider** (`generateWithKimi`, `generateWithKimiVision`) to capture the API's `usage` and record it whenever a `usageContext` is supplied. (Pass `usageContext: { studentId, courseId, feature }` from student-facing AI call sites to attribute consumption; calls without it are recorded unattributed.)

## Unregister flow
- **`POST /api/student/courses/[courseId]/unenroll`** (STUDENT + CSRF): in one transaction deletes the enrollment **and** its `courseProgress`, and releases the `CourseSchedule` seat (`GREATEST(enrolledCount-1,0)`). `payment.enrollmentId` auto-nulls via its `set null` FK, preserving the payment row for refund accounting — nothing left hanging.
- **Paid course → PENDING partial refund**: `paid × (1 − lessonsCompleted/totalLessons) − tokenCost`, where `tokenCost` is the summed `LlmTokenUsage.costUsd` for this student+course. Recorded as a `refund` row in `PENDING` status for tutor/admin to approve via the existing refund flow (no automatic gateway payout, per your choice).
- **Tutor notified** (course creator) of the departure + pending refund amount.
- **UI**: an "Unregister" button on the student course page (confirm dialog + result toast).

## Verification
`typecheck`, `lint` (0 errors), `build` pass; migration 0061 validated on an ephemeral Postgres.

### Follow-up note
The ledger is wired into the Kimi provider; to fully populate per-student/course attribution, student-facing AI call sites should pass `usageContext`. Until they do, the refund's token deduction is $0 and the refund is pure pro-rata — safe by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let students unregister from a course with cleanup, refund review, and tutor notice**

### What Changed
- Students can now unregister from a course from the course page, with a confirmation prompt and success/error toast.
- Unregistering removes the enrollment and progress, frees the course seat, and sends the student back to their course list.
- For paid courses, the system now creates a pending partial refund based on sessions completed, then subtracts the LLM token cost tied to that student and course.
- The course tutor now gets a notice when a student leaves, including the pending refund amount when one applies.
- LLM token use is now tracked per request so course-related AI usage can be counted toward refunds.

### Impact
`✅ Easier course withdrawal`
`✅ Fewer leftover enrollment records`
`✅ More accurate paid-course refund amounts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
