### PR TITLE
feat(live): tutors can start/enter a session at any time

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -317,10 +317,7 @@ function TutorInsightsPageInner() {
         toast.error('Session has ended')
         return
       }
-      if (new Date(currentSession.scheduledAt).getTime() > Date.now()) {
-        toast.error('Session has not started yet')
-        return
-      }
+      // No scheduledAt gate — a tutor can start (and record) the session early.
 
       setIsRecording(true)
       setRecordingDurationSeconds(0)

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -74,14 +74,11 @@ export const GET = withAuth(
       )
     }
 
-    // Tutor entering the live classroom starts the session — same guard as the
-    // explicit POST /start (not before scheduledAt, not once ended) — so students
-    // can join regardless of how the tutor opened the room. Unifies the start path
-    // (previously this GET left the session 'scheduled' while POST flipped it).
-    if (
-      liveSessionRow.status === 'scheduled' &&
-      !(liveSessionRow.scheduledAt && new Date(liveSessionRow.scheduledAt).getTime() > Date.now())
-    ) {
+    // Tutor entering the live classroom starts the session at any time — the
+    // tutor's presence is what takes a class live (students can then join). No
+    // scheduledAt gate for the tutor; unifies the start path so the session is
+    // 'active' however the tutor opened the room.
+    if (liveSessionRow.status === 'scheduled') {
       const startedAt = liveSessionRow.startedAt || new Date()
       await drizzleDb
         .update(liveSession)
@@ -315,16 +312,9 @@ export const POST = withCsrf(
         return NextResponse.json({ error: 'Cannot start a completed class' }, { status: 400 })
       }
 
-      // Enforce scheduled time: cannot start before scheduledAt
-      if (
-        liveSessionRow.scheduledAt &&
-        new Date(liveSessionRow.scheduledAt).getTime() > Date.now()
-      ) {
-        return NextResponse.json(
-          { error: 'Cannot start before the scheduled time' },
-          { status: 403 }
-        )
-      }
+      // Tutors may start at any time — even before scheduledAt. The tutor's
+      // presence is what takes a class live; students remain gated to the 20-minute
+      // early-entry window in the room join route.
 
       const [updated] = await drizzleDb
         .update(liveSession)


### PR DESCRIPTION
## **User description**
## Part 1 of the live-classroom work (#1 + #2 "why" investigation findings)

### Investigation answers
- **"Upcoming" vs "Start Session"** (tutor sessions modal): "Start Session" = a real materialized `LiveSession` row (`status='scheduled'`, created at publish ~8 weeks ahead). "Upcoming" (disabled) = a *virtual* schedule slot not yet materialized into a row — it becomes startable once published into range. ("Join Session" = active, "Ended" = ended.)
- **Why tutors couldn't enter early but students could**: tutor start was hard-blocked before `scheduledAt` (POST `/api/tutor/classes/[id]` → 403), while the room join route admits students from 20 min before. Inverted.

### This PR
Lets tutors start/enter at any time (their presence takes the class live); students keep the 20-minute early-entry window.
- `POST` & `GET /api/tutor/classes/[id]` now activate a `scheduled` session regardless of `scheduledAt`.
- Removed the recording "Session has not started yet" time gate in `tutor/insights`.
- `checkSessionActive` already permitted active-but-early sessions (unchanged).

`typecheck` ✅ · `lint` ✅ (0 errors) · `build` ✅.

### Coming next (separate branch, larger)
The per-course **lobby** (review past sessions, 20/10/5/1-min countdown alerts, auto-navigate into the live session when the tutor starts) + **in-app & push reminders**. Note: web-push will need VAPID keys provisioned in the production env to actually fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Tutors can start and record a class before its scheduled time**

### What Changed
- Tutors can now open a class and make it live at any time, even before the scheduled start.
- Starting a class from either the tutor room or the start flow now follows the same behavior.
- Tutor insights recording can now begin before the scheduled time, instead of showing a “session has not started yet” error.

### Impact
`✅ Fewer blocked live-class starts`
`✅ Tutors can begin sessions early`
`✅ Clearer recording start flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
