### PR TITLE
feat: student token attribution + tutor one-click refund approval

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/enrollments/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/enrollments/page.tsx
@@ -5,7 +5,7 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Loader2, Users } from 'lucide-react'
+import { Loader2, Users, DollarSign } from 'lucide-react'
 import { BackButton } from '@/components/navigation'
 import { toast } from 'sonner'
 
@@ -22,6 +22,15 @@ interface EnrollmentItem {
   completedAt: string | null
 }
 
+interface PendingRefund {
+  refundId: string
+  amount: number
+  currency: string
+  reason: string | null
+  createdAt: string
+  courseName: string | null
+}
+
 export default function TutorCourseEnrollmentsPage() {
   const params = useParams()
   const pathname = usePathname()
@@ -33,6 +42,43 @@ export default function TutorCourseEnrollmentsPage() {
 
   const [loading, setLoading] = useState(true)
   const [enrollments, setEnrollments] = useState<EnrollmentItem[]>([])
+  const [refunds, setRefunds] = useState<PendingRefund[]>([])
+  const [approvingId, setApprovingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!courseId) return
+    fetch(`/api/tutor/refunds?courseId=${encodeURIComponent(courseId)}`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { refunds: [] }))
+      .then(d => setRefunds(Array.isArray(d?.refunds) ? d.refunds : []))
+      .catch(() => setRefunds([]))
+  }, [courseId])
+
+  const handleApproveRefund = async (refundId: string) => {
+    setApprovingId(refundId)
+    try {
+      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
+      const res = await fetch(`/api/tutor/refunds/${refundId}/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+        },
+        credentials: 'include',
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not approve refund')
+        return
+      }
+      toast.success('Refund approved and sent to the gateway')
+      setRefunds(prev => prev.filter(r => r.refundId !== refundId))
+    } catch {
+      toast.error('Could not approve refund')
+    } finally {
+      setApprovingId(null)
+    }
+  }
 
   useEffect(() => {
     if (!courseId) return
@@ -69,6 +115,48 @@ export default function TutorCourseEnrollmentsPage() {
         </div>
         <BackButton href={coursePath} iconDirection="right" />
       </div>
+
+      {refunds.length > 0 && (
+        <Card className="border-amber-200">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-amber-700">
+              <DollarSign className="h-5 w-5" />
+              Pending refunds ({refunds.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {refunds.map(r => (
+              <div
+                key={r.refundId}
+                className="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50/50 p-4"
+              >
+                <div className="min-w-0">
+                  <p className="font-semibold text-slate-900">
+                    {r.currency} {Number(r.amount).toFixed(2)}
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    {r.reason || 'Refund requested'}
+                  </p>
+                  <p className="text-muted-foreground mt-1 text-[11px]">
+                    Requested {new Date(r.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => handleApproveRefund(r.refundId)}
+                  disabled={approvingId !== null}
+                  className="bg-amber-600 text-white hover:bg-amber-700"
+                >
+                  {approvingId === r.refundId ? (
+                    <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                  ) : null}
+                  Approve refund
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
 
       <Card>
         <CardHeader>

--- a/tutorme-app/src/app/api/courses/[id]/lessons/[lessonId]/chat/route.ts
+++ b/tutorme-app/src/app/api/courses/[id]/lessons/[lessonId]/chat/route.ts
@@ -52,7 +52,7 @@ export const POST = withCsrf(
   withAuth(
     async (req, session, routeContext: any) => {
       const params = await routeContext?.params
-      const { lessonId } = await params
+      const { id: routeCourseId, lessonId } = await params
       const body = await req.json()
       const { message, sessionId, currentSection } = body
 
@@ -142,6 +142,11 @@ export const POST = withCsrf(
       const aiResult = await generateWithFallback(prompt, {
         temperature: 0.7,
         maxTokens: 2000,
+        usageContext: {
+          studentId: session.user.id,
+          courseId: courseId || routeCourseId || null,
+          feature: 'lesson-chat',
+        },
       })
 
       const aiResponse = aiResult.content

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -120,6 +120,7 @@ export async function POST(
       const request_ = {
         studentId,
         submissionId,
+        courseId: task.courseId,
         type: 'task_feedback' as const,
         context: { taskId, recentPerformance: score ?? undefined },
         priority: 'medium' as const,

--- a/tutorme-app/src/app/api/tutor/refunds/[refundId]/approve/route.ts
+++ b/tutorme-app/src/app/api/tutor/refunds/[refundId]/approve/route.ts
@@ -1,0 +1,122 @@
+/**
+ * POST /api/tutor/refunds/[refundId]/approve
+ *
+ * Approves and processes an EXISTING pending refund row (e.g. created when a
+ * student unregistered). Verifies the tutor owns the course, calls the payment
+ * gateway, then UPDATES the existing refund row (and the payment) — unlike
+ * /api/payments/refund which CREATES a new refund from a paymentId.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import {
+  withAuth,
+  withCsrf,
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+} from '@/lib/api/middleware'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { refund, payment, course } from '@/lib/db/schema'
+import { getPaymentGateway, type GatewayName } from '@/lib/payments'
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session, context) => {
+      const role = session.user.role
+      const refundId = await getParamAsync(context.params, 'refundId')
+      if (!refundId) throw new ValidationError('refundId is required')
+
+      const [refundRow] = await drizzleDb
+        .select()
+        .from(refund)
+        .where(eq(refund.refundId, refundId))
+        .limit(1)
+      if (!refundRow) throw new NotFoundError('Refund not found')
+      if (refundRow.status !== 'PENDING') {
+        throw new ValidationError(`Refund is already ${refundRow.status.toLowerCase()}`)
+      }
+
+      const [paymentRow] = await drizzleDb
+        .select()
+        .from(payment)
+        .where(eq(payment.paymentId, refundRow.paymentId))
+        .limit(1)
+      if (!paymentRow) throw new NotFoundError('Payment not found')
+
+      // Authorize: tutor must own the course behind this payment (admins exempt).
+      if (role !== 'ADMIN') {
+        let owns = paymentRow.tutorId === session.user.id
+        if (!owns) {
+          const meta = paymentRow.metadata as { courseId?: string } | null
+          const courseId = paymentRow.courseId ?? meta?.courseId
+          if (courseId) {
+            const [courseRow] = await drizzleDb
+              .select({ creatorId: course.creatorId })
+              .from(course)
+              .where(eq(course.courseId, courseId))
+              .limit(1)
+            owns = courseRow?.creatorId === session.user.id
+          }
+        }
+        if (!owns) {
+          throw new ForbiddenError('You can only approve refunds for your own courses')
+        }
+      }
+
+      // Process via the gateway (same resolution as /api/payments/refund).
+      const gateway = getPaymentGateway(paymentRow.gateway as GatewayName)
+      const meta = paymentRow.metadata as { payment_attempt_id?: string } | null
+      const refundPaymentId =
+        paymentRow.gateway === 'AIRWALLEX' && meta?.payment_attempt_id
+          ? meta.payment_attempt_id
+          : (paymentRow.gatewayPaymentId ?? paymentRow.paymentId)
+
+      let gatewayResp
+      try {
+        gatewayResp = await gateway.refundPayment(refundPaymentId, refundRow.amount)
+      } catch (err) {
+        return NextResponse.json(
+          { error: err instanceof Error ? err.message : 'Gateway refund failed' },
+          { status: 502 }
+        )
+      }
+      if (gatewayResp.error) {
+        return NextResponse.json(
+          { error: gatewayResp.error, status: gatewayResp.status },
+          { status: 400 }
+        )
+      }
+
+      const succeeded = gatewayResp.status === 'succeeded' || gatewayResp.status === 'RECEIVED'
+      const newStatus = succeeded ? 'COMPLETED' : 'PROCESSING'
+
+      // UPDATE the existing refund row (do not create a duplicate).
+      await drizzleDb
+        .update(refund)
+        .set({
+          status: newStatus,
+          gatewayRefundId: gatewayResp.refundId,
+          processedAt: succeeded ? new Date() : null,
+        })
+        .where(and(eq(refund.refundId, refundId), eq(refund.status, 'PENDING')))
+
+      const fullRefund = refundRow.amount >= paymentRow.amount
+      if (fullRefund && succeeded) {
+        await drizzleDb
+          .update(payment)
+          .set({ status: 'REFUNDED', refundedAt: new Date() })
+          .where(eq(payment.paymentId, paymentRow.paymentId))
+      }
+
+      return NextResponse.json({
+        success: true,
+        refundId,
+        status: newStatus,
+        amountRefunded: gatewayResp.amountRefunded ?? refundRow.amount,
+      })
+    },
+    { role: 'TUTOR' }
+  )
+)

--- a/tutorme-app/src/app/api/tutor/refunds/route.ts
+++ b/tutorme-app/src/app/api/tutor/refunds/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/tutor/refunds?status=PENDING&courseId=...
+ *
+ * Lists refunds for the logged-in tutor's course payments (default: PENDING),
+ * so they can review and approve them. Created e.g. when a student unregisters
+ * from a paid course.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, desc, eq } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { refund, payment, course, type RefundStatus } from '@/lib/db/schema'
+
+export const dynamic = 'force-dynamic'
+
+const VALID_STATUSES: RefundStatus[] = ['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED']
+
+export const GET = withAuth(
+  async (req: NextRequest, session) => {
+    const url = new URL(req.url)
+    const statusParam = url.searchParams.get('status')
+    const courseId = url.searchParams.get('courseId')
+    const status: RefundStatus =
+      statusParam && (VALID_STATUSES as string[]).includes(statusParam)
+        ? (statusParam as RefundStatus)
+        : 'PENDING'
+
+    const filters = [eq(payment.tutorId, session.user.id), eq(refund.status, status)]
+    if (courseId) filters.push(eq(payment.courseId, courseId))
+
+    const rows = await drizzleDb
+      .select({
+        refundId: refund.refundId,
+        amount: refund.amount,
+        reason: refund.reason,
+        status: refund.status,
+        createdAt: refund.createdAt,
+        paymentId: payment.paymentId,
+        currency: payment.currency,
+        paymentAmount: payment.amount,
+        courseId: payment.courseId,
+        courseName: course.name,
+      })
+      .from(refund)
+      .innerJoin(payment, eq(payment.paymentId, refund.paymentId))
+      .leftJoin(course, eq(course.courseId, payment.courseId))
+      .where(and(...filters))
+      .orderBy(desc(refund.createdAt))
+      .limit(100)
+
+    return NextResponse.json({ refunds: rows })
+  },
+  { role: 'TUTOR' }
+)

--- a/tutorme-app/src/lib/agents/orchestrator-llm.ts
+++ b/tutorme-app/src/lib/agents/orchestrator-llm.ts
@@ -7,6 +7,7 @@
  */
 
 import { generateWithKimi, chatWithKimi } from '@/lib/ai/kimi'
+import type { UsageContext } from '@/lib/ai/usage'
 import { cache } from '@/lib/db'
 import { adkGenerate, adkChat } from '@/lib/adk-client'
 import { isGeminiActive } from '@/lib/ai/provider'
@@ -24,6 +25,8 @@ interface AIOptions {
   timeoutMs?: number
   /** Skip response cache (default false for generate, true when cache not desired) */
   skipCache?: boolean
+  /** Attribute token usage to a student/course/feature (recorded by the Kimi provider). */
+  usageContext?: UsageContext
 }
 
 interface GenerationResult {

--- a/tutorme-app/src/lib/ai/kimi.ts
+++ b/tutorme-app/src/lib/ai/kimi.ts
@@ -126,6 +126,7 @@ export async function chatWithKimi(
     maxTokens?: number
     timeoutMs?: number
     retries?: number
+    usageContext?: UsageContext
   } = {}
 ): Promise<string> {
   if (isGeminiActive()) {
@@ -166,6 +167,14 @@ export async function chatWithKimi(
     }
 
     const data: KimiResponse = await response.json()
+    void recordLlmUsage({
+      provider: 'kimi',
+      model: options.model || DEFAULT_MODEL,
+      promptTokens: data.usage?.prompt_tokens,
+      completionTokens: data.usage?.completion_tokens,
+      totalTokens: data.usage?.total_tokens,
+      context: options.usageContext,
+    })
     return data.choices[0]?.message?.content || ''
   } catch (error) {
     console.error('Kimi chat error:', error)

--- a/tutorme-app/src/lib/feedback/workflow.ts
+++ b/tutorme-app/src/lib/feedback/workflow.ts
@@ -19,6 +19,8 @@ export type FeedbackStatus =
 export interface FeedbackRequest {
   studentId: string
   submissionId: string // Required by schema
+  /** Course this feedback belongs to — used to attribute LLM token usage. */
+  courseId?: string
   type: FeedbackType
   context: {
     taskId?: string
@@ -71,7 +73,14 @@ export async function generateFeedback(
         return { success: false, error: '未知的反馈类型' }
     }
 
-    const result = await generateWithFallback(prompt, { temperature: 0.7 })
+    const result = await generateWithFallback(prompt, {
+      temperature: 0.7,
+      usageContext: {
+        studentId: request.studentId,
+        courseId: request.courseId ?? null,
+        feature: 'submission-feedback',
+      },
+    })
     const parsed = parseFeedbackResponse(result.content, request.type)
 
     // Calculate confidence based on context completeness


### PR DESCRIPTION
## **User description**
Follow-up (a) + (b) to the unregister/refund work.

## (a) Token attribution
Threads `usageContext { studentId, courseId, feature }` through the AI layer so a student's LLM consumption is recorded against a course — which is exactly what the unenroll refund's token-cost deduction (`sumLlmUsageForStudentCourse`) reads.
- `AIOptions` (orchestrator) gains `usageContext`; forwarded to `generateWithKimi`/`chatWithKimi`.
- `chatWithKimi` now records usage too (previously only the generate* functions did).
- **Submission feedback** path (`feedback/workflow` + submit route): attributed to `task.courseId` — the most refund-relevant path.
- **Lesson AI chat**: attributed to the route's courseId.

(ADK and cached responses don't double-count; the ADK remote path can't capture usage — noted.)

## (b) Tutor one-click refund approval
- **`GET /api/tutor/refunds`** (default `PENDING`, optional `?courseId`): lists the tutor's refunds via `refund ⋈ payment` on `payment.tutorId`, enriched with course name.
- **`POST /api/tutor/refunds/[refundId]/approve`**: processes an **existing** PENDING refund — verifies the tutor owns the course, calls the payment gateway, then **UPDATEs the existing row** (status/gatewayRefundId/processedAt) and flips the payment to REFUNDED if full. (Unlike `/api/payments/refund`, which creates a new row — that would have duplicated the unenroll-created refund.)
- **UI**: a "Pending refunds" panel with a one-click **Approve refund** button on the tutor course enrollments page — where the student-unenroll notification already deep-links.

`typecheck`, `lint` (0 errors), `build` all pass.


___

## **CodeAnt-AI Description**
**Attribute student AI usage to courses and let tutors approve pending refunds in one click**

### What Changed
- Student AI usage is now recorded against the relevant course for lesson chat and submission feedback, so course-related token costs can be tied to the right student and course.
- Tutors now have a pending refunds view for each course, with refund amount, reason, and date, plus a one-click approval action.
- Approving a refund now updates the existing refund record and sends the refund through the payment gateway, instead of creating a duplicate refund entry.
- Refund approval is limited to the tutor who owns the course.

### Impact
`✅ More accurate course refund deductions`
`✅ Fewer duplicate refund records`
`✅ Faster refund handling for tutors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
