### PR TITLE
feat(tutor): global /tutor/refunds view + Decline action

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/enrollments/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/enrollments/page.tsx
@@ -5,8 +5,9 @@ import { useParams, usePathname, useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Loader2, Users, DollarSign } from 'lucide-react'
+import { Loader2, Users } from 'lucide-react'
 import { BackButton } from '@/components/navigation'
+import { PendingRefundsPanel } from '@/components/tutor/pending-refunds-panel'
 import { toast } from 'sonner'
 
 interface EnrollmentItem {
@@ -22,15 +23,6 @@ interface EnrollmentItem {
   completedAt: string | null
 }
 
-interface PendingRefund {
-  refundId: string
-  amount: number
-  currency: string
-  reason: string | null
-  createdAt: string
-  courseName: string | null
-}
-
 export default function TutorCourseEnrollmentsPage() {
   const params = useParams()
   const pathname = usePathname()
@@ -42,43 +34,6 @@ export default function TutorCourseEnrollmentsPage() {
 
   const [loading, setLoading] = useState(true)
   const [enrollments, setEnrollments] = useState<EnrollmentItem[]>([])
-  const [refunds, setRefunds] = useState<PendingRefund[]>([])
-  const [approvingId, setApprovingId] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!courseId) return
-    fetch(`/api/tutor/refunds?courseId=${encodeURIComponent(courseId)}`, { credentials: 'include' })
-      .then(r => (r.ok ? r.json() : { refunds: [] }))
-      .then(d => setRefunds(Array.isArray(d?.refunds) ? d.refunds : []))
-      .catch(() => setRefunds([]))
-  }, [courseId])
-
-  const handleApproveRefund = async (refundId: string) => {
-    setApprovingId(refundId)
-    try {
-      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
-      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
-      const res = await fetch(`/api/tutor/refunds/${refundId}/approve`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
-        },
-        credentials: 'include',
-      })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        toast.error(data?.error || 'Could not approve refund')
-        return
-      }
-      toast.success('Refund approved and sent to the gateway')
-      setRefunds(prev => prev.filter(r => r.refundId !== refundId))
-    } catch {
-      toast.error('Could not approve refund')
-    } finally {
-      setApprovingId(null)
-    }
-  }
 
   useEffect(() => {
     if (!courseId) return
@@ -116,47 +71,7 @@ export default function TutorCourseEnrollmentsPage() {
         <BackButton href={coursePath} iconDirection="right" />
       </div>
 
-      {refunds.length > 0 && (
-        <Card className="border-amber-200">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-amber-700">
-              <DollarSign className="h-5 w-5" />
-              Pending refunds ({refunds.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {refunds.map(r => (
-              <div
-                key={r.refundId}
-                className="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50/50 p-4"
-              >
-                <div className="min-w-0">
-                  <p className="font-semibold text-slate-900">
-                    {r.currency} {Number(r.amount).toFixed(2)}
-                  </p>
-                  <p className="text-muted-foreground mt-0.5 text-xs">
-                    {r.reason || 'Refund requested'}
-                  </p>
-                  <p className="text-muted-foreground mt-1 text-[11px]">
-                    Requested {new Date(r.createdAt).toLocaleDateString()}
-                  </p>
-                </div>
-                <Button
-                  size="sm"
-                  onClick={() => handleApproveRefund(r.refundId)}
-                  disabled={approvingId !== null}
-                  className="bg-amber-600 text-white hover:bg-amber-700"
-                >
-                  {approvingId === r.refundId ? (
-                    <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-                  ) : null}
-                  Approve refund
-                </Button>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-      )}
+      <PendingRefundsPanel courseId={courseId} />
 
       <Card>
         <CardHeader>

--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { UserNav } from '@/components/user-nav'
 import {
   LayoutDashboard,
+  DollarSign,
   BarChart3,
   MessageSquare,
   Settings,
@@ -62,6 +63,7 @@ const navItems: NavItem[] = [
     iconColor: 'text-[#16A34A]',
   },
   { href: '/tutor/reports', label: 'Analytics', icon: BarChart3, iconColor: 'text-[#F59E0B]' },
+  { href: '/tutor/refunds', label: 'Refunds', icon: DollarSign, iconColor: 'text-[#D97706]' },
   { href: '/tutor/support', label: 'Support', icon: HelpCircle, iconColor: 'text-[#8B5CF6]' },
 
   // Whiteboard audit links

--- a/tutorme-app/src/app/[locale]/tutor/refunds/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/refunds/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { DollarSign } from 'lucide-react'
+import { BackButton } from '@/components/navigation'
+import { PendingRefundsPanel } from '@/components/tutor/pending-refunds-panel'
+
+export default function TutorRefundsPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 p-4 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-slate-900">
+            <DollarSign className="h-5 w-5" />
+            Refunds
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Pending refund requests across all your courses — approve to process via the payment
+            gateway, or decline.
+          </p>
+        </div>
+        <BackButton href="/tutor/dashboard" iconDirection="right" />
+      </div>
+
+      <PendingRefundsPanel showCourse hideWhenEmpty={false} />
+    </div>
+  )
+}

--- a/tutorme-app/src/app/api/student/courses/[courseId]/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[courseId]/unenroll/route.ts
@@ -124,7 +124,7 @@ export const POST = withCsrf(
           message: refundInfo
             ? `A student unregistered from "${courseRow.name}". A partial refund of ${refundInfo.currency} ${refundInfo.amount.toFixed(2)} is pending your review.`
             : `A student unregistered from "${courseRow.name}".`,
-          actionUrl: `/tutor/courses/${courseId}/enrollments`,
+          actionUrl: refundInfo ? `/tutor/refunds` : `/tutor/courses/${courseId}/enrollments`,
         }).catch(err => console.warn('[unenroll] tutor notify failed (non-critical):', err))
       }
 

--- a/tutorme-app/src/app/api/tutor/refunds/[refundId]/decline/route.ts
+++ b/tutorme-app/src/app/api/tutor/refunds/[refundId]/decline/route.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /api/tutor/refunds/[refundId]/decline
+ *
+ * Declines an existing PENDING refund — marks it FAILED with no gateway/money
+ * movement. Verifies the tutor owns the course behind the payment.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import {
+  withAuth,
+  withCsrf,
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+} from '@/lib/api/middleware'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { refund, payment, course } from '@/lib/db/schema'
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session, context) => {
+      const role = session.user.role
+      const refundId = await getParamAsync(context.params, 'refundId')
+      if (!refundId) throw new ValidationError('refundId is required')
+
+      const [refundRow] = await drizzleDb
+        .select()
+        .from(refund)
+        .where(eq(refund.refundId, refundId))
+        .limit(1)
+      if (!refundRow) throw new NotFoundError('Refund not found')
+      if (refundRow.status !== 'PENDING') {
+        throw new ValidationError(`Refund is already ${refundRow.status.toLowerCase()}`)
+      }
+
+      const [paymentRow] = await drizzleDb
+        .select({
+          paymentId: payment.paymentId,
+          tutorId: payment.tutorId,
+          courseId: payment.courseId,
+          metadata: payment.metadata,
+        })
+        .from(payment)
+        .where(eq(payment.paymentId, refundRow.paymentId))
+        .limit(1)
+      if (!paymentRow) throw new NotFoundError('Payment not found')
+
+      if (role !== 'ADMIN') {
+        let owns = paymentRow.tutorId === session.user.id
+        if (!owns) {
+          const meta = paymentRow.metadata as { courseId?: string } | null
+          const courseId = paymentRow.courseId ?? meta?.courseId
+          if (courseId) {
+            const [courseRow] = await drizzleDb
+              .select({ creatorId: course.creatorId })
+              .from(course)
+              .where(eq(course.courseId, courseId))
+              .limit(1)
+            owns = courseRow?.creatorId === session.user.id
+          }
+        }
+        if (!owns) {
+          throw new ForbiddenError('You can only manage refunds for your own courses')
+        }
+      }
+
+      await drizzleDb
+        .update(refund)
+        .set({ status: 'FAILED', processedAt: new Date() })
+        .where(and(eq(refund.refundId, refundId), eq(refund.status, 'PENDING')))
+
+      return NextResponse.json({ success: true, refundId, status: 'FAILED' })
+    },
+    { role: 'TUTOR' }
+  )
+)

--- a/tutorme-app/src/components/tutor/pending-refunds-panel.tsx
+++ b/tutorme-app/src/components/tutor/pending-refunds-panel.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Loader2, DollarSign } from 'lucide-react'
+import { toast } from 'sonner'
+
+interface PendingRefund {
+  refundId: string
+  amount: number
+  currency: string
+  reason: string | null
+  createdAt: string
+  courseId: string | null
+  courseName: string | null
+}
+
+interface PendingRefundsPanelProps {
+  /** Limit to a single course (omit for all of the tutor's courses). */
+  courseId?: string
+  /** Show the course name per row (useful in the global view). */
+  showCourse?: boolean
+  /** Hide the card entirely when there are no pending refunds (default true). */
+  hideWhenEmpty?: boolean
+}
+
+/**
+ * Lists the tutor's PENDING refunds with one-click Approve / Decline.
+ * Approve processes the existing refund via the gateway; Decline marks it FAILED.
+ */
+export function PendingRefundsPanel({
+  courseId,
+  showCourse = false,
+  hideWhenEmpty = true,
+}: PendingRefundsPanelProps) {
+  const [loading, setLoading] = useState(true)
+  const [refunds, setRefunds] = useState<PendingRefund[]>([])
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    const qs = courseId ? `?courseId=${encodeURIComponent(courseId)}` : ''
+    fetch(`/api/tutor/refunds${qs}`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { refunds: [] }))
+      .then(d => {
+        if (!cancelled) setRefunds(Array.isArray(d?.refunds) ? d.refunds : [])
+      })
+      .catch(() => {
+        if (!cancelled) setRefunds([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [courseId])
+
+  const act = useCallback(async (refundId: string, action: 'approve' | 'decline') => {
+    setBusyId(refundId)
+    try {
+      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
+      const res = await fetch(`/api/tutor/refunds/${refundId}/${action}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+        },
+        credentials: 'include',
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(data?.error || `Could not ${action} refund`)
+        return
+      }
+      toast.success(
+        action === 'approve' ? 'Refund approved and sent to the gateway' : 'Refund declined'
+      )
+      setRefunds(prev => prev.filter(r => r.refundId !== refundId))
+    } catch {
+      toast.error(`Could not ${action} refund`)
+    } finally {
+      setBusyId(null)
+    }
+  }, [])
+
+  if (hideWhenEmpty && !loading && refunds.length === 0) return null
+
+  return (
+    <Card className="border-amber-200">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-amber-700">
+          <DollarSign className="h-5 w-5" />
+          Pending refunds{refunds.length > 0 ? ` (${refunds.length})` : ''}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {loading ? (
+          <div className="flex h-24 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-amber-600" />
+          </div>
+        ) : refunds.length === 0 ? (
+          <div className="text-muted-foreground rounded-lg border border-dashed p-6 text-center text-sm">
+            No pending refunds.
+          </div>
+        ) : (
+          refunds.map(r => (
+            <div
+              key={r.refundId}
+              className="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50/50 p-4"
+            >
+              <div className="min-w-0">
+                <p className="font-semibold text-slate-900">
+                  {r.currency} {Number(r.amount).toFixed(2)}
+                  {showCourse && r.courseName ? (
+                    <span className="text-muted-foreground font-normal"> · {r.courseName}</span>
+                  ) : null}
+                </p>
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  {r.reason || 'Refund requested'}
+                </p>
+                <p className="text-muted-foreground mt-1 text-[11px]">
+                  Requested {new Date(r.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => act(r.refundId, 'decline')}
+                  disabled={busyId !== null}
+                  className="border-slate-300 text-slate-600 hover:bg-slate-50"
+                >
+                  Decline
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => act(r.refundId, 'approve')}
+                  disabled={busyId !== null}
+                  className="bg-amber-600 text-white hover:bg-amber-700"
+                >
+                  {busyId === r.refundId ? (
+                    <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                  ) : null}
+                  Approve refund
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## **User description**
Both follow-ups requested.

- **Decline action**: `POST /api/tutor/refunds/[refundId]/decline` marks an existing PENDING refund `FAILED` (no gateway/money movement), with the same course-ownership auth as approve. A **Decline** button now sits next to **Approve refund**.
- **Global view**: new **`/tutor/refunds`** page listing all pending refunds across the tutor's courses (with course name per row), plus a **Refunds** item in the tutor nav.
- Refactored the per-course panel and the global page to share one `PendingRefundsPanel` component (Approve + Decline; `courseId` / `showCourse` props).
- The student-unenroll refund notification now deep-links to `/tutor/refunds` (central landing).

`typecheck`, `lint` (0 errors), `build` pass.


___

## **CodeAnt-AI Description**
**Add a central refunds page with approve and decline actions**

### What Changed
- Tutors can now open a new Refunds page to see all pending refund requests across their courses in one place.
- Each refund can be approved or declined from the same list; declining marks the request as closed without sending money.
- The course enrollments page now reuses the same refunds view, so refund actions appear consistently in both places.
- The tutor menu now includes a Refunds link, and refund alerts for student unenrollments now go directly to the central Refunds page.

### Impact
`✅ Faster refund handling`
`✅ Fewer missed refund requests`
`✅ Clearer refund review flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
