### PR TITLE
fix(push): create PushSubscription table on every boot (past drift early-exit)

### DIFF
--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -152,7 +152,12 @@ BEGIN
     ALTER TABLE "TaskDeployment" ALTER COLUMN "status" TYPE "TaskDeploymentStatus" USING ("status"::"TaskDeploymentStatus");
   END IF;
 END $$;
+`)
 
+// Tables that must be ensured on EVERY boot — independent of the LiveSession
+// drift early-exit below. Without this, a prod DB whose LiveSession already
+// looks fine would skip the whole drift block and never get these tables.
+const ENSURE_TABLES_SQL = sql.raw(`
 -- Web Push subscriptions (browser push for session reminders)
 CREATE TABLE IF NOT EXISTS "PushSubscription" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
@@ -177,6 +182,14 @@ CREATE INDEX IF NOT EXISTS "PushSubscription_userId_idx" ON "PushSubscription" (
 `)
 
 export async function applyStartupSchemaFixes(): Promise<void> {
+  // Always ensure new standalone tables exist, even when the drift check below
+  // short-circuits (prod DBs whose LiveSession columns already look fine).
+  try {
+    await drizzleDb.execute(ENSURE_TABLES_SQL)
+  } catch (err: any) {
+    console.error('[SchemaFix] ❌ Failed to ensure tables:', err?.message)
+  }
+
   try {
     console.log('[SchemaFix] Checking for schema drift...')
 


### PR DESCRIPTION
## **User description**
Follow-up to #166. The `PushSubscription` table wasn't actually being created in production.

## Bug
`applyStartupSchemaFixes()` early-exits when `LiveSession` already has its columns (always true on an established prod DB) — which **skips `FIXES_SQL`**, where #166 put the `PushSubscription` `CREATE TABLE`. So the table was never created in prod and `POST /api/push/subscribe` would fail → no push, even with VAPID env vars set.

## Fix
Moved the `PushSubscription` creation into an `ENSURE_TABLES_SQL` block that runs **unconditionally**, before the drift early-exit.

## Verified
With a DB where `LiveSession` looks OK (early-exit fires: log shows *"LiveSession schema looks OK. Skipping."*) and `PushSubscription` dropped, running `applyStartupSchemaFixes()` **recreates** the table with its pkey / unique(endpoint) / FK(userId) / index. ✅

After this deploys, the table is created on boot — combined with the VAPID env vars you added, web push is ready (each user still grants the notification permission once, via the lobby).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Create push subscription tables on every boot**

### What Changed
- The app now creates the push subscription table at startup even when schema-drift checks stop early.
- This prevents existing production databases from skipping the table setup and breaking push subscription requests.
- If the table setup fails, the app logs a clear startup error and continues checking the rest of the schema.

### Impact
`✅ Fewer push signup failures`
`✅ Reliable push setup after deployment`
`✅ Clearer startup errors when table creation fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
