### PR TITLE
feat(student-calendar): grey out unavailable hours from the student's availability

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -552,6 +552,54 @@ export function InteractiveCalendar({
     loadExceptions()
   }, [mode, timezoneProp])
 
+  // Load the STUDENT's own availability so the calendar can grey out the hours
+  // they haven't marked free. Student model is INVERTED vs. tutor: a slot is
+  // available only when explicitly marked free (tutors are available unless
+  // blocked), so we build a full grid with isAvailable = "marked free". We only
+  // apply greying once the student has set some availability — otherwise a brand
+  // new student would see an all-grey calendar.
+  useEffect(() => {
+    if (mode !== 'student') return
+    const loadStudentAvailability = async () => {
+      setAvailabilityLoading(true)
+      try {
+        const res = await fetch('/api/student/calendar/availability', { credentials: 'include' })
+        if (!res.ok) return
+        const data = await res.json().catch(() => ({}))
+        const rows = Array.isArray(data?.availability) ? data.availability : []
+        const freeSet = new Set<string>()
+        for (const r of rows) {
+          if (r?.isAvailable) freeSet.add(`${r.dayOfWeek}-${r.startTime}`)
+        }
+        if (freeSet.size === 0) {
+          setAvailability([])
+        } else {
+          setAvailability(
+            generateAvailability().map(block => ({
+              ...block,
+              isAvailable: freeSet.has(`${block.dayOfWeek}-${block.startTime}`),
+            }))
+          )
+        }
+        const exRows = Array.isArray(data?.exceptions) ? data.exceptions : []
+        setCalendarExceptions(
+          exRows.map((e: any) => ({
+            date: typeof e.date === 'string' ? e.date : new Date(e.date).toISOString(),
+            isAvailable: !!e.isAvailable,
+            startTime: e.startTime ?? null,
+            endTime: e.endTime ?? null,
+            reason: e.reason ?? null,
+          }))
+        )
+      } catch {
+        // ignore — leave calendar un-shaded on failure
+      } finally {
+        setAvailabilityLoading(false)
+      }
+    }
+    loadStudentAvailability()
+  }, [mode])
+
   // Load calendar events for the visible month (tutor mode)
   useEffect(() => {
     if (mode !== 'tutor') return
@@ -1125,8 +1173,8 @@ export function InteractiveCalendar({
                       isToday={isToday}
                       getEventsForDate={getEventsForDate}
                       conflicts={showConflictWarning}
-                      availability={isStudent ? [] : availability}
-                      exceptions={isStudent ? [] : calendarExceptions}
+                      availability={availability}
+                      exceptions={calendarExceptions}
                     />
                   )}
 
@@ -1137,8 +1185,8 @@ export function InteractiveCalendar({
                       onEventClick={handleEventClick}
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
-                      availability={isStudent ? [] : availability}
-                      exceptions={isStudent ? [] : calendarExceptions}
+                      availability={availability}
+                      exceptions={calendarExceptions}
                     />
                   )}
 
@@ -1149,8 +1197,8 @@ export function InteractiveCalendar({
                       onEventClick={handleEventClick}
                       conflicts={showConflictWarning}
                       readOnly={isStudent}
-                      availability={isStudent ? [] : availability}
-                      exceptions={isStudent ? [] : calendarExceptions}
+                      availability={availability}
+                      exceptions={calendarExceptions}
                     />
                   )}
 

--- a/tutorme-app/src/app/api/push/subscribe/route.ts
+++ b/tutorme-app/src/app/api/push/subscribe/route.ts
@@ -57,9 +57,7 @@ export const DELETE = withCsrf(
       if (!endpoint) throw new ValidationError('endpoint required')
       await drizzleDb
         .delete(pushSubscription)
-        .where(
-          and(eq(pushSubscription.endpoint, endpoint), eq(pushSubscription.userId, userId))
-        )
+        .where(and(eq(pushSubscription.endpoint, endpoint), eq(pushSubscription.userId, userId)))
       return NextResponse.json({ ok: true })
     } catch (error) {
       if (error instanceof ValidationError) {

--- a/tutorme-app/src/components/classroom/ClassroomLobby.tsx
+++ b/tutorme-app/src/components/classroom/ClassroomLobby.tsx
@@ -30,7 +30,13 @@ interface LobbySession {
 
 const ALERT_THRESHOLDS = [20, 10, 5, 1] // minutes before start
 
-export function ClassroomLobby({ courseId, role }: { courseId: string; role: 'student' | 'tutor' }) {
+export function ClassroomLobby({
+  courseId,
+  role,
+}: {
+  courseId: string
+  role: 'student' | 'tutor'
+}) {
   const router = useRouter()
   const params = useParams()
   const locale = (params?.locale as string) || 'en'
@@ -96,7 +102,9 @@ export function ClassroomLobby({ courseId, role }: { courseId: string; role: 'st
       .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
     const past = sessions
       .filter(s => s.status === 'ended' || (s.endedAt != null && !s.isVirtual))
-      .sort((a, b) => new Date(b.scheduledAt || 0).getTime() - new Date(a.scheduledAt || 0).getTime())
+      .sort(
+        (a, b) => new Date(b.scheduledAt || 0).getTime() - new Date(a.scheduledAt || 0).getTime()
+      )
     return { nextSession: active || upcoming[0] || null, pastSessions: past }
   }, [sessions])
 
@@ -142,7 +150,10 @@ export function ClassroomLobby({ courseId, role }: { courseId: string; role: 'st
         const res = await fetch(`/api/tutor/classes/${sessionId}`, {
           method: 'POST',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json', ...(csrf ? { 'X-CSRF-Token': csrf } : {}) },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
+          },
         })
         if (!res.ok) {
           const e = await res.json().catch(() => ({}))
@@ -261,7 +272,9 @@ export function ClassroomLobby({ courseId, role }: { courseId: string; role: 'st
               ) : (
                 <span className="inline-flex items-center gap-2 text-2xl font-bold tabular-nums text-slate-900">
                   <Clock className="h-5 w-5 text-slate-400" />
-                  {msUntilStart != null && msUntilStart > 0 ? countdownLabel(msUntilStart) : '0m 0s'}
+                  {msUntilStart != null && msUntilStart > 0
+                    ? countdownLabel(msUntilStart)
+                    : '0m 0s'}
                 </span>
               )}
               {role === 'tutor' ? (

--- a/tutorme-app/src/lib/push/client.ts
+++ b/tutorme-app/src/lib/push/client.ts
@@ -38,9 +38,7 @@ async function getCsrfToken(): Promise<string | null> {
  *  - 'denied'      — the user blocked notifications
  *  - 'unsupported' — push not available / VAPID not configured
  */
-export async function ensurePushSubscription(): Promise<
-  'subscribed' | 'denied' | 'unsupported'
-> {
+export async function ensurePushSubscription(): Promise<'subscribed' | 'denied' | 'unsupported'> {
   if (!isPushSupported()) return 'unsupported'
 
   // Need the VAPID public key from the server.


### PR DESCRIPTION
## **User description**
Item 1: the student dashboard **Calendar** tab now greys out the hours the student hasn't marked free, wired to their availability.

## What
- In student mode, `InteractiveCalendar` loads the student's availability from `/api/student/calendar/availability` (previously it forced availability/exceptions to `[]`, so nothing was shaded).
- Student availability is **inverted** vs. tutors (a slot is free only when explicitly marked; tutors are available-unless-blocked), so a full weekly grid is built with `isAvailable = "marked free"` and fed into the existing day/week/month off-hour shading.
- Greying applies **only once the student has set some availability** — an empty set leaves the calendar un-shaded so new students don't see an all-grey calendar.
- Exceptions are loaded too. Read-only — editing stays in the **My Availability** tab.

This closes the loop with the My Availability tab: free slots there → ungreyed on the calendar; everything else → greyed.

(Also formats 3 files that drifted on main.)

`typecheck`, `lint` (0 errors), `build` pass.


___

## **CodeAnt-AI Description**
**Grey out unavailable hours in the student calendar**

### What Changed
- The student calendar now shades hours the student has not marked as free, instead of showing the calendar as fully open.
- Shading only appears after a student has saved some availability; new students with no saved hours still see a clear calendar.
- Student calendar exceptions are now shown in the read-only calendar view as well.
- If loading the student availability fails, the calendar stays unshaded rather than showing incorrect blocked hours.

### Impact
`✅ Clearer student calendar availability`
`✅ Fewer misleading open-hour displays`
`✅ Safer new-student calendar setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
