### PR TITLE
fix(notifications): dedup reminders across instances + scope web-push + lobby entry

### DIFF
--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/[courseId]/page.tsx
@@ -318,6 +318,11 @@ function CourseEnrollPageInner() {
                 <p className="text-sm font-medium">You&apos;re already enrolled in this course.</p>
                 <div className="flex flex-wrap gap-2">
                   <Button asChild>
+                    <Link href={`/student/classroom/${encodeURIComponent(courseId)}`}>
+                      Enter classroom
+                    </Link>
+                  </Button>
+                  <Button variant="outline" asChild>
                     <Link href="/student/dashboard">Go to dashboard</Link>
                   </Button>
                   <Button variant="outline" asChild>

--- a/tutorme-app/src/lib/notifications/notify.ts
+++ b/tutorme-app/src/lib/notifications/notify.ts
@@ -22,6 +22,15 @@ export type NotificationType =
   | 'achievement'
   | 'grade'
 
+// Types worth an OS-level browser push (time-sensitive or interruptive). Other
+// transactional types still go in-app/SSE/email but not browser push.
+const WEB_PUSH_TYPES = new Set<NotificationType>([
+  'reminder', // session start/countdown reminders
+  'class', // live class / session events
+  'message', // direct messages
+  'mention', // @-mentions
+])
+
 interface NotifyParams {
   userId: string
   type: NotificationType
@@ -240,13 +249,17 @@ export async function notify(params: NotifyParams) {
       userId,
       inAppRecord ?? { type, title, message, actionUrl, createdAt: new Date() }
     )
-    // Browser web-push (best-effort; no-op when VAPID is unconfigured).
-    void sendWebPushToUser(userId, {
-      title,
-      body: message,
-      url: actionUrl ?? undefined,
-      tag: type,
-    }).catch(e => console.error('[notify] web-push error:', e))
+    // Browser web-push only for time-sensitive / interruptive types — avoids
+    // turning every transactional in-app notification into an OS-level push.
+    // (best-effort; no-op when VAPID is unconfigured.)
+    if (WEB_PUSH_TYPES.has(type)) {
+      void sendWebPushToUser(userId, {
+        title,
+        body: message,
+        url: actionUrl ?? undefined,
+        tag: type,
+      }).catch(e => console.error('[notify] web-push error:', e))
+    }
   }
 
   if (channels.email) {

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -607,7 +607,23 @@ export async function initEnhancedSocketServer(server: NetServer) {
   // 'session:starting-soon' for anyone already in the lobby/room). Fires once per
   // (session, threshold). Auto-start is NOT done here — a class only goes live
   // when the tutor takes it live (their presence). This just reminds everyone.
+  // Cross-instance dedup: with >1 app instance each runs this sweep, so guard
+  // each (session, threshold) with a Redis NX claim — only one instance sends.
+  // Falls back to a per-process Set when Redis is unavailable.
   const startAlertSent = new Set<string>()
+  const claimStartAlert = async (key: string): Promise<boolean> => {
+    if (redisClient && redisClient.status === 'ready') {
+      try {
+        const res = await redisClient.set(`notif:startalert:${key}`, '1', 'EX', 3600, 'NX')
+        return res === 'OK'
+      } catch {
+        // fall through to local dedup
+      }
+    }
+    if (startAlertSent.has(key)) return false
+    startAlertSent.add(key)
+    return true
+  }
   const START_THRESHOLDS = [20, 10, 5, 1] // minutes
   intervalHandles.push(
     setInterval(async () => {
@@ -631,10 +647,10 @@ export async function initEnhancedSocketServer(server: NetServer) {
 
           for (const t of START_THRESHOLDS) {
             const key = `${s.sessionId}:${t}`
-            // 30s window aligned to the interval, deduped by key.
+            // 30s window aligned to the interval; one send per (session, threshold)
+            // across all instances via the Redis-backed claim.
             if (remaining <= t * 60_000 && remaining > t * 60_000 - 30_000) {
-              if (startAlertSent.has(key)) continue
-              startAlertSent.add(key)
+              if (!(await claimStartAlert(key))) continue
 
               const minLabel = t === 1 ? '1 minute' : `${t} minutes`
               io.to(s.sessionId).emit('session:starting-soon', {


### PR DESCRIPTION
## **User description**
Polish/hardening follow-ups to the classroom-lobby + web-push work.

1. **Duplicate-reminder fix (scale)** — the start-reminder sweep deduped each `(session, threshold)` with an in-process `Set`, so with >1 app instance each would send → duplicate in-app/push reminders. Now claimed via a **Redis `SET NX`** (only one instance sends), falling back to the local Set when Redis is unavailable.
2. **Scope web-push types** — `notify()` was sending a browser push for *every* push-enabled notification type. Limited to time-sensitive/interruptive types (`reminder`, `class`, `message`, `mention`) so transactional notifications don't all become OS-level pushes.
3. **Lobby entry point** — added an "Enter classroom" button on the enrolled student's course page → `/student/classroom/[id]`.

### Notes
- **Tutor lobby entry** intentionally deferred: the tutor course page's `id` has a template-vs-published-variant ambiguity that could point the lobby at an empty session list. Tutors already reach the lobby via the reminder deep-link (which uses the real `liveSession.courseId`). Happy to wire a verified tutor button once the id mapping is confirmed.
- The pre-existing "ending-soon"/auto-end timer has the same per-process dedup pattern (latent duplicate risk at scale) — left untouched to stay surgical; can harden it the same way if you want.

`typecheck` ✅ · `lint` (changed files) ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent duplicate session reminders, limit browser pushes, and add a classroom entry button

### What Changed
- Session start reminders are now sent once across app instances, reducing duplicate alerts during busy periods
- Browser push notifications now appear only for time-sensitive messages like reminders, live class updates, direct messages, and mentions
- Enrolled students now see an “Enter classroom” button on their course page for quicker access to the lobby

### Impact
`✅ Fewer duplicate class reminders`
`✅ Less noisy browser notifications`
`✅ Faster classroom entry for enrolled students`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
