### PR TITLE
fix(student): My Availability sessions list + visible calendar off-hour shading

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/StudentAvailabilityTab.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/StudentAvailabilityTab.tsx
@@ -96,7 +96,8 @@ export function StudentAvailabilityTab() {
             .map((e: Record<string, unknown>) => ({
               id: String(e.id ?? e.eventId ?? Math.random()),
               title: String(e.title ?? 'Session'),
-              startTime: String(e.startTime ?? e.scheduledAt ?? ''),
+              // The events endpoint names the time field `start` (ISO string).
+              startTime: String(e.start ?? e.startTime ?? e.scheduledAt ?? ''),
               courseName: (e.courseName as string) ?? null,
             }))
             .filter((e: SessionItem) => e.startTime)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -275,8 +275,10 @@ function isDayFullyOff(
   return dayBlocks.every(b => !b.isAvailable)
 }
 
+// Clear grey base + a diagonal hatch so unavailable/off hours are obviously
+// shaded (the previous near-transparent hatch was easy to miss).
 const OFF_HOURS_HATCH =
-  'bg-[repeating-linear-gradient(45deg,rgba(148,163,184,0.12),rgba(148,163,184,0.12)_6px,transparent_6px,transparent_12px)]'
+  'bg-slate-200/70 bg-[repeating-linear-gradient(45deg,rgba(100,116,139,0.28),rgba(100,116,139,0.28)_6px,transparent_6px,transparent_12px)]'
 
 export type CalendarView = 'month' | 'week' | 'day' | 'availability'
 


### PR DESCRIPTION
## **User description**
Two fixes for the student availability/calendar.

**1. "No upcoming sessions" in My Availability** — the tab read the event time as `startTime`/`scheduledAt`, but `/api/student/calendar/events` returns it as **`start`**. Now mapped correctly, so upcoming course sessions show.

**2. Calendar greying not visible** — the off-hour shading logic and student-availability wiring are correct across Day/Week (per-hour) and Month (fully-off days), but `OFF_HOURS_HATCH` was a near-transparent hatch (alpha 0.12 over a transparent base) that was easy to miss. Gave it a clear grey base + stronger hatch so unavailable hours are obviously shaded in all three views.

How greying works (for reference): in **My Availability**, tap the hours you're free → the **Calendar** tab greys everything you haven't marked (student model is "unavailable unless marked free"). Greying applies once you've set some availability; Day/Week show per-hour shading, Month shades fully-unavailable days.

`typecheck`, `lint` (0 errors), `build` pass.


___

## **CodeAnt-AI Description**
Fix upcoming sessions in My Availability and make unavailable time easier to see

### What Changed
- My Availability now shows upcoming sessions again by reading the event start time from the calendar events response
- Calendar off-hours and unavailable days now use a clearer grey shade and hatch, so blocked time is easier to spot in day, week, and month views

### Impact
`✅ Fewer "No upcoming sessions" misreports`
`✅ Clearer unavailable-time shading`
`✅ Easier to spot blocked hours in the calendar`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
