### PR TITLE
feat(live): tutor lobby button + recording review + alert dedup + tests

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -36,6 +36,7 @@ import {
   Ban,
   Eye,
   CalendarClock,
+  Presentation,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
@@ -790,6 +791,21 @@ function TutorDashboardContent() {
                                   </Button>
                                 ) : null
                               })()}
+                            {/* Classroom lobby: review past sessions, see the next
+                                session's countdown, and get pulled in when it
+                                starts. Uses the published course id (course.id) —
+                                the one live sessions live under. */}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                router.push(withLocalePath(`/tutor/classroom/${course.id}`))
+                              }
+                              className="transition-all duration-200"
+                            >
+                              <Presentation className="mr-1 h-3 w-3" />
+                              Classroom
+                            </Button>
                             {hasViewableSessions ? (
                               <Button
                                 variant="default"

--- a/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
@@ -71,6 +71,7 @@ export const GET = withAuth(
         status: s.status,
         roomId: s.roomId,
         roomUrl: s.roomUrl,
+        recordingUrl: s.recordingUrl ?? null,
         tutorId: s.tutorId,
         isVirtual: false,
         durationMinutes: s.durationMinutes ?? 120,

--- a/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
@@ -103,6 +103,7 @@ export const GET = withAuth(
         enrolledStudents: s.participants?.length || 0,
         status: s.status,
         roomUrl: s.roomUrl,
+        recordingUrl: s.recordingUrl ?? null,
         isVirtual: false,
         // null scheduleId = a one-time/ad-hoc session (not tied to the recurring schedule)
         scheduleId: s.scheduleId ?? null,

--- a/tutorme-app/src/components/classroom/ClassroomLobby.tsx
+++ b/tutorme-app/src/components/classroom/ClassroomLobby.tsx
@@ -16,6 +16,7 @@ import { Bell, Calendar, Clock, Loader2, PlayCircle, Video } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { ensurePushSubscription, isPushSupported } from '@/lib/push/client'
+import { categorizeLobbySessions } from '@/lib/classroom/lobby-sessions'
 
 interface LobbySession {
   id: string
@@ -26,6 +27,7 @@ interface LobbySession {
   status: string
   isVirtual?: boolean
   durationMinutes?: number
+  recordingUrl?: string | null
 }
 
 const ALERT_THRESHOLDS = [20, 10, 5, 1] // minutes before start
@@ -95,18 +97,10 @@ export function ClassroomLobby({
     })
   }, [])
 
-  const { nextSession, pastSessions } = useMemo(() => {
-    const active = sessions.find(s => s.status === 'active' || s.status === 'live')
-    const upcoming = sessions
-      .filter(s => s.status === 'scheduled' && s.scheduledAt)
-      .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
-    const past = sessions
-      .filter(s => s.status === 'ended' || (s.endedAt != null && !s.isVirtual))
-      .sort(
-        (a, b) => new Date(b.scheduledAt || 0).getTime() - new Date(a.scheduledAt || 0).getTime()
-      )
-    return { nextSession: active || upcoming[0] || null, pastSessions: past }
-  }, [sessions])
+  const { nextSession, pastSessions } = useMemo(
+    () => categorizeLobbySessions(sessions),
+    [sessions]
+  )
 
   const msUntilStart =
     nextSession?.scheduledAt != null ? new Date(nextSession.scheduledAt).getTime() - now : null
@@ -308,20 +302,30 @@ export function ClassroomLobby({
         ) : (
           <div className="mt-3 space-y-2">
             {pastSessions.map(s => (
-              <button
+              <div
                 key={s.id}
-                onClick={() => goToSession(s.id)}
-                className={cn(
-                  'flex w-full items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 text-left transition-colors',
-                  'hover:border-indigo-200 hover:bg-indigo-50/40'
-                )}
+                className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 transition-colors hover:border-indigo-200 hover:bg-indigo-50/40"
               >
-                <div className="min-w-0">
+                <button
+                  onClick={() => goToSession(s.id)}
+                  className="min-w-0 flex-1 text-left"
+                >
                   <p className="truncate text-sm font-medium text-slate-800">{s.title}</p>
                   <p className="text-xs text-slate-500">{fmt(s.scheduledAt)}</p>
-                </div>
-                <PlayCircle className="h-4 w-4 shrink-0 text-indigo-500" />
-              </button>
+                </button>
+                {s.recordingUrl ? (
+                  <a
+                    href={s.recordingUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex shrink-0 items-center gap-1 rounded-md bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+                  >
+                    <PlayCircle className="h-3.5 w-3.5" /> Recording
+                  </a>
+                ) : (
+                  <PlayCircle className="h-4 w-4 shrink-0 text-slate-300" />
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/tutorme-app/src/lib/classroom/lobby-sessions.test.ts
+++ b/tutorme-app/src/lib/classroom/lobby-sessions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { categorizeLobbySessions, type LobbySessionLike } from './lobby-sessions'
+
+const mk = (o: Partial<LobbySessionLike> & { id: string }): LobbySessionLike => ({
+  scheduledAt: null,
+  endedAt: null,
+  status: 'scheduled',
+  isVirtual: false,
+  ...o,
+})
+
+describe('categorizeLobbySessions', () => {
+  it('returns null next + empty past for no sessions', () => {
+    expect(categorizeLobbySessions([])).toEqual({ nextSession: null, pastSessions: [] })
+  })
+
+  it('picks the soonest upcoming scheduled session as next', () => {
+    const soon = mk({ id: 'soon', status: 'scheduled', scheduledAt: '2030-01-01T10:00:00Z' })
+    const later = mk({ id: 'later', status: 'scheduled', scheduledAt: '2030-01-02T10:00:00Z' })
+    const { nextSession } = categorizeLobbySessions([later, soon])
+    expect(nextSession?.id).toBe('soon')
+  })
+
+  it('prefers a live session over a sooner scheduled one', () => {
+    const live = mk({ id: 'live', status: 'active', scheduledAt: '2030-01-05T10:00:00Z' })
+    const scheduled = mk({ id: 'sched', status: 'scheduled', scheduledAt: '2030-01-01T10:00:00Z' })
+    const { nextSession } = categorizeLobbySessions([scheduled, live])
+    expect(nextSession?.id).toBe('live')
+  })
+
+  it('lists ended sessions as past, newest first, and excludes them from next', () => {
+    const older = mk({ id: 'old', status: 'ended', scheduledAt: '2020-01-01T10:00:00Z' })
+    const newer = mk({ id: 'new', status: 'ended', scheduledAt: '2020-06-01T10:00:00Z' })
+    const upcoming = mk({ id: 'up', status: 'scheduled', scheduledAt: '2030-01-01T10:00:00Z' })
+    const { nextSession, pastSessions } = categorizeLobbySessions([older, upcoming, newer])
+    expect(nextSession?.id).toBe('up')
+    expect(pastSessions.map(s => s.id)).toEqual(['new', 'old'])
+  })
+
+  it('treats a real session with endedAt as past, but not a virtual one', () => {
+    const realEnded = mk({ id: 'r', status: 'scheduled', endedAt: '2020-01-01T11:00:00Z', isVirtual: false })
+    const virtual = mk({ id: 'v', status: 'scheduled', endedAt: '2020-01-01T11:00:00Z', isVirtual: true })
+    const { pastSessions } = categorizeLobbySessions([realEnded, virtual])
+    expect(pastSessions.map(s => s.id)).toEqual(['r'])
+  })
+})

--- a/tutorme-app/src/lib/classroom/lobby-sessions.ts
+++ b/tutorme-app/src/lib/classroom/lobby-sessions.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers for the classroom lobby — kept out of the React component so the
+ * "which session is next / which are past" logic can be unit-tested.
+ */
+
+export interface LobbySessionLike {
+  id: string
+  scheduledAt: string | null
+  endedAt?: string | null
+  status: string
+  isVirtual?: boolean
+}
+
+/**
+ * Split the course's sessions into the single "next" session and the list of
+ * past sessions to review.
+ *  - next = a currently-live session if any, else the soonest upcoming scheduled one
+ *  - past = ended sessions (or real sessions with an endedAt), newest first
+ */
+export function categorizeLobbySessions<T extends LobbySessionLike>(
+  sessions: T[]
+): { nextSession: T | null; pastSessions: T[] } {
+  const active = sessions.find(s => s.status === 'active' || s.status === 'live')
+
+  const upcoming = sessions
+    .filter(s => s.status === 'scheduled' && s.scheduledAt)
+    .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
+
+  const past = sessions
+    .filter(s => s.status === 'ended' || (s.endedAt != null && !s.isVirtual))
+    .sort(
+      (a, b) => new Date(b.scheduledAt || 0).getTime() - new Date(a.scheduledAt || 0).getTime()
+    )
+
+  return { nextSession: active || upcoming[0] || null, pastSessions: past }
+}

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -537,8 +537,24 @@ export async function initEnhancedSocketServer(server: NetServer) {
     }
   }
 
-  // Track which sessions have already received the 5-min warning
-  const sessionAlertSent = new Set<string>()
+  // Cross-instance dedup for one-shot session alerts (end warning + start
+  // reminders): with >1 app instance each runs these sweeps, so guard each key
+  // with a Redis NX claim — only one instance sends. Falls back to a per-process
+  // Set when Redis is unavailable.
+  const alertClaimFallback = new Set<string>()
+  const claimAlertOnce = async (key: string): Promise<boolean> => {
+    if (redisClient && redisClient.status === 'ready') {
+      try {
+        const res = await redisClient.set(`notif:alert:${key}`, '1', 'EX', 3600, 'NX')
+        return res === 'OK'
+      } catch {
+        // fall through to local dedup
+      }
+    }
+    if (alertClaimFallback.has(key)) return false
+    alertClaimFallback.add(key)
+    return true
+  }
 
   // Session end alert: warn tutors when 5 minutes remain
   intervalHandles.push(
@@ -567,10 +583,10 @@ export async function initEnhancedSocketServer(server: NetServer) {
           const endTime = startTime + durationMs
           const remaining = endTime - now
 
-          // Alert when between 5 min and 4 min 30 sec remaining (to avoid duplicate alerts)
+          // Alert when between 5 min and 4 min 30 sec remaining (deduped across
+          // instances so only one sends the warning).
           if (remaining <= 5 * 60 * 1000 && remaining > 4.5 * 60 * 1000) {
-            if (!sessionAlertSent.has(s.sessionId)) {
-              sessionAlertSent.add(s.sessionId)
+            if (await claimAlertOnce(`ending:${s.sessionId}`)) {
               io.to(s.sessionId).emit('session:ending-soon', {
                 sessionId: s.sessionId,
                 minutesRemaining: 5,
@@ -585,15 +601,6 @@ export async function initEnhancedSocketServer(server: NetServer) {
               .set({ status: 'ended', endedAt: new Date() })
               .where(eq(liveSession.sessionId, s.sessionId))
             io.to(s.sessionId).emit('session:ended', { sessionId: s.sessionId, reason: 'timeout' })
-            sessionAlertSent.delete(s.sessionId)
-          }
-        }
-
-        // Clean up alerts for sessions that are no longer active
-        const activeSessionIds = new Set(activeSessions.map(s => s.sessionId))
-        for (const id of Array.from(sessionAlertSent)) {
-          if (!activeSessionIds.has(id)) {
-            sessionAlertSent.delete(id)
           }
         }
       } catch (err) {
@@ -603,27 +610,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
   )
 
   // Session START reminders: notify the tutor + enrolled students at 20/10/5/1
-  // minutes before scheduledAt (in-app + web-push via notify(); also a socket
-  // 'session:starting-soon' for anyone already in the lobby/room). Fires once per
-  // (session, threshold). Auto-start is NOT done here — a class only goes live
-  // when the tutor takes it live (their presence). This just reminds everyone.
-  // Cross-instance dedup: with >1 app instance each runs this sweep, so guard
-  // each (session, threshold) with a Redis NX claim — only one instance sends.
-  // Falls back to a per-process Set when Redis is unavailable.
-  const startAlertSent = new Set<string>()
-  const claimStartAlert = async (key: string): Promise<boolean> => {
-    if (redisClient && redisClient.status === 'ready') {
-      try {
-        const res = await redisClient.set(`notif:startalert:${key}`, '1', 'EX', 3600, 'NX')
-        return res === 'OK'
-      } catch {
-        // fall through to local dedup
-      }
-    }
-    if (startAlertSent.has(key)) return false
-    startAlertSent.add(key)
-    return true
-  }
+  // minutes before scheduledAt (in-app + web-push via notify()). Fires once per
+  // (session, threshold), deduped across instances via claimAlertOnce. Auto-start
+  // is NOT done here — a class only goes live when the tutor takes it live.
   const START_THRESHOLDS = [20, 10, 5, 1] // minutes
   intervalHandles.push(
     setInterval(async () => {
@@ -650,13 +639,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
             // 30s window aligned to the interval; one send per (session, threshold)
             // across all instances via the Redis-backed claim.
             if (remaining <= t * 60_000 && remaining > t * 60_000 - 30_000) {
-              if (!(await claimStartAlert(key))) continue
+              if (!(await claimAlertOnce(`start:${key}`))) continue
 
               const minLabel = t === 1 ? '1 minute' : `${t} minutes`
-              io.to(s.sessionId).emit('session:starting-soon', {
-                sessionId: s.sessionId,
-                minutesRemaining: t,
-              })
 
               // Tutor reminder → tutor lobby.
               void notifyMany({
@@ -690,13 +675,6 @@ export async function initEnhancedSocketServer(server: NetServer) {
               }
             }
           }
-        }
-
-        // Prune dedup keys for sessions no longer scheduled/upcoming.
-        const upcomingIds = new Set(upcoming.map(s => s.sessionId))
-        for (const key of Array.from(startAlertSent)) {
-          const sid = key.split(':')[0]
-          if (!upcomingIds.has(sid)) startAlertSent.delete(key)
         }
       } catch (err) {
         console.error('[Session Start Alert] Error:', err)


### PR DESCRIPTION
## **User description**
The remaining lobby/notifications polish items.

1. **Verified tutor lobby button** — a "Classroom" button on the tutor dashboard course card → `/tutor/classroom/{course.id}`. Uses the **published** `course.id` (the id live sessions actually live under), avoiding the template-vs-variant ambiguity of the course-builder page id — so the lobby loads the correct session list.
2. **Recording in "review"** — added `recordingUrl` to the student + tutor course-sessions APIs and a **"Recording"** link on past sessions in the lobby (opens the recording when one exists).
3. **Dedup the session END warning across instances** — extracted a shared `claimAlertOnce` (Redis `SET NX`) used by **both** the end-warning and start-reminder sweeps, so with >1 app instance only one sends. Removed the now-vestigial per-process sets/prune.
4. **Dropped the unused `session:starting-soon` socket emit** (no client consumed it — the lobby runs its own countdown).
5. **Tests** — extracted the lobby's next/past session categorization into a pure helper (`lib/classroom/lobby-sessions.ts`) with **5 unit tests** (live-over-scheduled, soonest-upcoming, past ordering, real-vs-virtual ended).

**VAPID → Secret Manager** (the last item) is ops-only and needs no code: the app already reads `VAPID_PRIVATE_KEY` from the env, so just back that env var with a Secret Manager secret on Cloud Run instead of plaintext.

Verified: new unit tests pass (5/5), `typecheck` ✅ · `lint` (changed files) ✅ · `build` ✅. No conflicts with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Improve the tutor and student classroom lobby with direct access to sessions and recordings**

### What Changed
- Added a **Classroom** button on tutor course cards that opens the course’s lobby using the published course page, so tutors reach the correct live session list.
- Past sessions in the lobby now show a **Recording** link when a replay is available.
- Session start and end alerts are now sent only once across app instances, reducing duplicate classroom notifications.
- Added tests for how lobby sessions are split into the next session and past sessions.

### Impact
`✅ Faster access to the classroom lobby`
`✅ Easier replay review for past sessions`
`✅ Fewer duplicate session alerts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
