### PR TITLE
chore(deploy): VAPID private key via Secret Manager + fix VAPID env in deploy workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -182,8 +182,14 @@ jobs:
             --memory=1Gi
             --min-instances=0
             --max-instances=10
-          # Cloud Run env vars (comma-separated to avoid gcloud multiline parsing issues)
-          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},AI_PROVIDER=${{ secrets.AI_PROVIDER }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},DAILY_API_KEY=${{ secrets.DAILY_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,ADK_BASE_URL=${{ steps.deploy-adk.outputs.url }},ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }}
+          # Cloud Run env vars (comma-separated to avoid gcloud multiline parsing issues).
+          # VAPID_PUBLIC_KEY is public (served to browsers) so it's a literal here;
+          # VAPID_SUBJECT is optional (web-push.ts falls back to a default mailto).
+          # VAPID_PRIVATE_KEY is mounted from Secret Manager via `secrets:` below.
+          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},AI_PROVIDER=${{ secrets.AI_PROVIDER }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},DAILY_API_KEY=${{ secrets.DAILY_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,ADK_BASE_URL=${{ steps.deploy-adk.outputs.url }},ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }},VAPID_PUBLIC_KEY=BLU03HUyohyMlSRHnva794Ea1Y7BKl76i8xZNLiwHgR0D5NI4AhQUURdgI_m6aZo931gW4LsoP7RwguNwkwklK0,VAPID_SUBJECT=${{ secrets.VAPID_SUBJECT }}
+          # Web-push private key, mounted from Secret Manager as an env var.
+          secrets: |-
+            VAPID_PRIVATE_KEY=VAPID_PRIVATE_KEY:latest
 
       - name: Route 100% traffic to latest
         run: |


### PR DESCRIPTION
## **User description**
Moves the web-push **private key** to Secret Manager and makes the VAPID config durable across deploys.

## Why
The deploy workflow's `env_vars` is the **complete (overwrite) set** for the Cloud Run service and didn't include the VAPID vars — so any VAPID values set in the console were **wiped on every deploy from `main`**. (So web push likely hasn't actually been configured in prod since the last deploy.)

## What
- `VAPID_PRIVATE_KEY` → mounted from **Secret Manager** via the action's `secrets:` input (I already created the secret `VAPID_PRIVATE_KEY`, version 1, in the prod project).
- `VAPID_PUBLIC_KEY` → literal in `env_vars` (it's public — served to browsers).
- `VAPID_SUBJECT` → `${{ secrets.VAPID_SUBJECT }}` (optional; `web-push.ts` falls back to a default `mailto:` if unset).

## ⚠️ Do these BEFORE merging (else the deploy fails when it can't read the secret)
1. **Grant the Cloud Run runtime service account access to the secret:**
   ```
   gcloud secrets add-iam-policy-binding VAPID_PRIVATE_KEY \
     --member="serviceAccount:267976186000-compute@developer.gserviceaccount.com" \
     --role="roles/secretmanager.secretAccessor" \
     --project="project-29e0fd29-a707-458c-bd1"
   ```
   (I couldn't run this — my authenticated SA lacks `secretmanager.secrets.setIamPolicy`.)
2. *(optional)* Add a GitHub Actions secret **`VAPID_SUBJECT`** = `mailto:your-real-email` (otherwise the code's default mailto is used).
3. After (1), merge this PR — the next deploy mounts the key from Secret Manager.

Then you can delete the plaintext `VAPID_*` console env vars (the workflow now manages them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep web push settings in place after deploys and restore notification support**

### What Changed
- The production deploy now keeps the web push configuration on every release instead of wiping it from the Cloud Run service.
- The private VAPID key is loaded from Secret Manager, while the public key is set in the deploy workflow and the subject is supplied as an optional secret.
- This makes web push configuration survive deploys and avoids manual re-entry of VAPID values in the console.

### Impact
`✅ Fewer lost notification settings after deploys`
`✅ More reliable web push delivery in production`
`✅ Less manual reconfiguration of VAPID values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
