### PR TITLE
feat(live): multi-student whiteboard view + wired Monitor tab

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -895,19 +895,23 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     }, [])
 
     const openVideoOverlay = useVideoOverlayStore(s => s.openOverlay)
-    const [monitorSelectedStudent, setMonitorSelectedStudent] = useState<{
-      id: string
-      name: string
-    } | null>(null)
-    // When viewing a student's board, follow their active page by default; the tutor
-    // can turn this off and page through the board manually to inspect any page.
-    const [followStudentPage, setFollowStudentPage] = useState(true)
-    const [viewedStudentPageIndex, setViewedStudentPageIndex] = useState(0)
-    // Re-enable follow whenever the tutor opens a (different) student's board.
-    useEffect(() => {
-      setFollowStudentPage(true)
-      setViewedStudentPageIndex(0)
-    }, [monitorSelectedStudent?.id])
+    // Students whose whiteboards the tutor is currently viewing (multi-view grid).
+    const [monitorSelectedStudents, setMonitorSelectedStudents] = useState<
+      { id: string; name: string }[]
+    >([])
+    const toggleMonitorStudent = useCallback((id: string, name: string) => {
+      setMonitorSelectedStudents(prev =>
+        prev.some(s => s.id === id) ? prev.filter(s => s.id !== id) : [...prev, { id, name }]
+      )
+    }, [])
+    const addMonitorStudent = useCallback((id: string, name: string) => {
+      setMonitorSelectedStudents(prev =>
+        prev.some(s => s.id === id) ? prev : [...prev, { id, name }]
+      )
+    }, [])
+    const removeMonitorStudent = useCallback((id: string) => {
+      setMonitorSelectedStudents(prev => prev.filter(s => s.id !== id))
+    }, [])
     const [liveRightPanelTab, setLiveRightPanelTab] = useState<'submissions' | 'insights'>(
       'submissions'
     )
@@ -8311,121 +8315,102 @@ FEEDBACK: [your explanation]`
                                       <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden bg-white p-0">
                                         {(() => {
                                           if (mainTab === 'live' && tab.id === 'student1') {
-                                            if (monitorSelectedStudent) {
-                                              const studentBoard =
-                                                insightsProps?.studentBoards?.[
-                                                  monitorSelectedStudent.id
-                                                ]
-                                              const studentPages =
-                                                (studentBoard?.pages as WhiteboardPages) ||
-                                                createDefaultWhiteboardPages()
-                                              const studentPageIndex =
-                                                typeof studentBoard?.pageIndex === 'number'
-                                                  ? studentBoard.pageIndex
-                                                  : 0
-                                              const pageCount = Math.max(studentPages.length, 1)
-                                              const clamp = (i: number) =>
-                                                Math.min(Math.max(i, 0), pageCount - 1)
-                                              // Follow → mirror the student's active page; otherwise
-                                              // show whatever page the tutor picked.
-                                              const viewedPageIndex = followStudentPage
-                                                ? clamp(studentPageIndex)
-                                                : clamp(viewedStudentPageIndex)
-                                              const gotoPage = (i: number) => {
-                                                setFollowStudentPage(false)
-                                                setViewedStudentPageIndex(clamp(i))
-                                              }
+                                            if (monitorSelectedStudents.length > 0) {
+                                              const count = monitorSelectedStudents.length
+                                              const gridCols =
+                                                count === 1
+                                                  ? 'grid-cols-1'
+                                                  : count === 2
+                                                    ? 'grid-cols-1 lg:grid-cols-2'
+                                                    : 'grid-cols-1 md:grid-cols-2'
                                               return (
                                                 <Dialog
                                                   open
                                                   onOpenChange={open => {
                                                     if (!open) {
-                                                      setMonitorSelectedStudent(null)
+                                                      setMonitorSelectedStudents([])
                                                       setTestPciActiveTab('student-monitor')
                                                     }
                                                   }}
                                                 >
-                                                  <DialogContent className="h-[90vh] w-[90vw] max-w-none overflow-hidden p-6">
-                                                    <div className="flex h-full w-full flex-col overflow-hidden rounded-[14px] border border-[rgba(226,232,240,0.9)] bg-white shadow-[0_10px_24px_rgba(15,23,42,0.16)]">
-                                                      <div className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-2 text-sm">
-                                                        <div className="font-semibold text-slate-800">
-                                                          Viewing: {monitorSelectedStudent.name}
+                                                  <DialogContent className="h-[92vh] w-[94vw] max-w-none overflow-hidden p-4">
+                                                    <div className="flex h-full w-full flex-col overflow-hidden">
+                                                      <div className="mb-2 flex items-center justify-between">
+                                                        <div className="text-sm font-semibold text-slate-800">
+                                                          Viewing {count} student whiteboard
+                                                          {count === 1 ? '' : 's'}
                                                         </div>
-                                                        <div className="flex items-center gap-2">
-                                                          {/* Page navigation: prev / indicator / next */}
-                                                          <div className="flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-1 py-0.5">
-                                                            <Button
-                                                              variant="ghost"
-                                                              size="icon"
-                                                              className="h-6 w-6 text-slate-600 hover:bg-white disabled:opacity-30"
-                                                              disabled={viewedPageIndex <= 0}
-                                                              onClick={() =>
-                                                                gotoPage(viewedPageIndex - 1)
-                                                              }
-                                                              title="Previous page"
-                                                            >
-                                                              <ChevronLeft className="h-4 w-4" />
-                                                            </Button>
-                                                            <span className="min-w-[64px] text-center text-xs font-medium text-slate-600">
-                                                              Page {viewedPageIndex + 1} /{' '}
-                                                              {pageCount}
-                                                            </span>
-                                                            <Button
-                                                              variant="ghost"
-                                                              size="icon"
-                                                              className="h-6 w-6 text-slate-600 hover:bg-white disabled:opacity-30"
-                                                              disabled={
-                                                                viewedPageIndex >= pageCount - 1
-                                                              }
-                                                              onClick={() =>
-                                                                gotoPage(viewedPageIndex + 1)
-                                                              }
-                                                              title="Next page"
-                                                            >
-                                                              <ChevronRight className="h-4 w-4" />
-                                                            </Button>
-                                                          </div>
-                                                          {/* Follow toggle */}
-                                                          <Button
-                                                            variant={
-                                                              followStudentPage
-                                                                ? 'default'
-                                                                : 'outline'
-                                                            }
-                                                            size="sm"
-                                                            className="h-8 text-xs"
-                                                            onClick={() =>
-                                                              setFollowStudentPage(f => !f)
-                                                            }
-                                                            title={
-                                                              followStudentPage
-                                                                ? "Following the student's page — click to browse freely"
-                                                                : "Jump to and follow the student's current page"
-                                                            }
-                                                          >
-                                                            {followStudentPage
-                                                              ? 'Following'
-                                                              : 'Follow student'}
-                                                          </Button>
-                                                          <Button
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            className="h-8 text-xs text-slate-600 hover:bg-slate-50 hover:text-slate-900"
-                                                            onClick={() =>
-                                                              setMonitorSelectedStudent(null)
-                                                            }
-                                                          >
-                                                            Clear
-                                                          </Button>
-                                                        </div>
+                                                        <Button
+                                                          variant="ghost"
+                                                          size="sm"
+                                                          className="h-8 text-xs text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                                                          onClick={() =>
+                                                            setMonitorSelectedStudents([])
+                                                          }
+                                                        >
+                                                          Close all
+                                                        </Button>
                                                       </div>
-                                                      <div className="min-h-0 flex-1">
-                                                        <EnhancedWhiteboard
-                                                          videoOverlay={false}
-                                                          pages={studentPages}
-                                                          currentPageIndex={viewedPageIndex}
-                                                          readOnly
-                                                        />
+                                                      <div
+                                                        className={cn(
+                                                          'grid min-h-0 flex-1 gap-3 overflow-auto',
+                                                          gridCols
+                                                        )}
+                                                      >
+                                                        {monitorSelectedStudents.map(s => {
+                                                          const board =
+                                                            insightsProps?.studentBoards?.[s.id]
+                                                          const pages =
+                                                            (board?.pages as WhiteboardPages) ||
+                                                            createDefaultWhiteboardPages()
+                                                          const pageCount = Math.max(
+                                                            pages.length,
+                                                            1
+                                                          )
+                                                          const pageIndex =
+                                                            typeof board?.pageIndex === 'number'
+                                                              ? Math.min(
+                                                                  Math.max(board.pageIndex, 0),
+                                                                  pageCount - 1
+                                                                )
+                                                              : 0
+                                                          return (
+                                                            <div
+                                                              key={s.id}
+                                                              className="flex min-h-[300px] flex-col overflow-hidden rounded-[12px] border border-slate-200 bg-white shadow-sm"
+                                                            >
+                                                              <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-3 py-1.5 text-xs">
+                                                                <span className="min-w-0 truncate font-semibold text-slate-700">
+                                                                  {s.name}
+                                                                </span>
+                                                                <div className="flex items-center gap-2">
+                                                                  <span className="text-slate-400">
+                                                                    Page {pageIndex + 1}/{pageCount}
+                                                                  </span>
+                                                                  <Button
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    className="h-6 w-6 text-slate-500 hover:bg-white hover:text-slate-800"
+                                                                    onClick={() =>
+                                                                      removeMonitorStudent(s.id)
+                                                                    }
+                                                                    title={`Stop viewing ${s.name}`}
+                                                                  >
+                                                                    <X className="h-4 w-4" />
+                                                                  </Button>
+                                                                </div>
+                                                              </div>
+                                                              <div className="min-h-0 flex-1">
+                                                                <EnhancedWhiteboard
+                                                                  videoOverlay={false}
+                                                                  pages={pages}
+                                                                  currentPageIndex={pageIndex}
+                                                                  readOnly
+                                                                />
+                                                              </div>
+                                                            </div>
+                                                          )
+                                                        })}
                                                       </div>
                                                     </div>
                                                   </DialogContent>
@@ -8477,23 +8462,18 @@ FEEDBACK: [your explanation]`
                                                     sessionId={insightsProps.sessionId}
                                                     tutorId={insightsProps.tutorId}
                                                     students={insightsProps?.students || []}
-                                                    selectedStudentId={
-                                                      monitorSelectedStudent?.id ?? null
-                                                    }
-                                                    onNavigateToWhiteboard={(
+                                                    liveTasks={insightsProps?.liveTasks || []}
+                                                    selectedStudentIds={monitorSelectedStudents.map(
+                                                      s => s.id
+                                                    )}
+                                                    onToggleWhiteboardSelection={(
                                                       studentId,
                                                       studentName
                                                     ) => {
-                                                      setMonitorSelectedStudent({
-                                                        id: studentId,
-                                                        name: studentName,
-                                                      })
+                                                      toggleMonitorStudent(studentId, studentName)
                                                     }}
-                                                    onOpenWhiteboard={(studentId, studentName) => {
-                                                      setMonitorSelectedStudent({
-                                                        id: studentId,
-                                                        name: studentName,
-                                                      })
+                                                    onOpenWhiteboards={(studentId, studentName) => {
+                                                      addMonitorStudent(studentId, studentName)
                                                       setTestPciActiveTab('student1')
                                                     }}
                                                   />

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
@@ -19,14 +19,17 @@ type StudentUpdate = {
   payload: StudentState
 }
 
+type LiveTaskLite = { id?: string; completedBy?: string[] }
+
 type MonitoringPanelProps = {
   socket: Socket
   sessionId: string
   tutorId?: string // Optional: exclude tutor from participant list
   students?: any[] // Optional: pass the room's student list if available
-  selectedStudentId?: string | null
-  onNavigateToWhiteboard?: (studentId: string, studentName: string) => void
-  onOpenWhiteboard?: (studentId: string, studentName: string) => void
+  liveTasks?: LiveTaskLite[] // Deployed tasks, for per-student completion progress
+  selectedStudentIds?: string[] // Students currently open in the multi-whiteboard view
+  onToggleWhiteboardSelection?: (studentId: string, studentName: string) => void
+  onOpenWhiteboards?: (studentId: string, studentName: string) => void
 }
 
 export function MonitoringPanel({
@@ -34,9 +37,10 @@ export function MonitoringPanel({
   sessionId,
   tutorId,
   students,
-  selectedStudentId,
-  onNavigateToWhiteboard,
-  onOpenWhiteboard,
+  liveTasks,
+  selectedStudentIds = [],
+  onToggleWhiteboardSelection,
+  onOpenWhiteboards,
 }: MonitoringPanelProps) {
   const [studentStates, setStudentStates] = useState<Record<string, StudentUpdate>>({})
 
@@ -177,22 +181,75 @@ export function MonitoringPanel({
   }, [isAIOpen, sessionId])
 
   const activeStudents = Object.values(studentStates)
-  const rosterStudents: { id: string; name: string; status: string | null }[] = (students || [])
-    .map((s: any) => ({
-      id: (s as any)?.id ?? (s as any)?.studentId ?? (s as any)?.userId,
-      name: (s as any)?.name ?? (s as any)?.studentName ?? 'Student',
-      status: (s as any)?.status ?? null,
-    }))
-    .filter((s: any) => !!s.id && s.id !== tutorId)
+  const num = (v: unknown): number | null => (typeof v === 'number' && !Number.isNaN(v) ? v : null)
+  const totalTasks = Array.isArray(liveTasks) ? liveTasks.length : 0
+  const completedTaskCount = (id: string) =>
+    Array.isArray(liveTasks)
+      ? liveTasks.filter(t => Array.isArray(t.completedBy) && t.completedBy.includes(id)).length
+      : 0
+  const minutesSince = (joinedAt: unknown): number | null => {
+    const t =
+      typeof joinedAt === 'number'
+        ? joinedAt
+        : joinedAt
+          ? new Date(joinedAt as string).getTime()
+          : NaN
+    if (Number.isNaN(t)) return null
+    return Math.max(0, Math.round((Date.now() - t) / 60000))
+  }
 
-  const displayStudents =
+  type RosterStudent = {
+    id: string
+    name: string
+    status: string | null
+    engagement: number | null
+    understanding: number | null
+    frustration: number | null
+    joinedAt: unknown
+    currentActivity: string | null
+  }
+  const rosterStudents: RosterStudent[] = (students || [])
+    .map((s: any) => ({
+      id: s?.id ?? s?.studentId ?? s?.userId,
+      name: s?.name ?? s?.studentName ?? 'Student',
+      status: s?.status ?? null,
+      engagement: num(s?.engagement) ?? num(s?.engagementScore),
+      understanding: num(s?.understanding),
+      frustration: num(s?.frustration),
+      joinedAt: s?.joinedAt ?? null,
+      currentActivity: typeof s?.currentActivity === 'string' ? s.currentActivity : null,
+    }))
+    .filter((s: RosterStudent) => !!s.id && s.id !== tutorId)
+
+  const displayStudents: RosterStudent[] =
     rosterStudents.length > 0
       ? rosterStudents
       : activeStudents.map(s => ({
           id: s.studentId,
           name: s.studentName,
-          status: null as string | null,
+          status: null,
+          engagement: null,
+          understanding: null,
+          frustration: null,
+          joinedAt: null,
+          currentActivity: null,
         }))
+
+  // Map the server's student status to a small colored badge.
+  const statusBadge = (status: string | null): { label: string; cls: string } | null => {
+    switch (status) {
+      case 'needs_help':
+        return { label: 'Needs help', cls: 'bg-amber-100 text-amber-700' }
+      case 'struggling':
+        return { label: 'Struggling', cls: 'bg-red-100 text-red-700' }
+      case 'idle':
+        return { label: 'Idle', cls: 'bg-slate-100 text-slate-500' }
+      case 'on_track':
+        return { label: 'On track', cls: 'bg-emerald-100 text-emerald-700' }
+      default:
+        return null
+    }
+  }
 
   if (displayStudents.length === 0) {
     return (
@@ -213,15 +270,27 @@ export function MonitoringPanel({
   return (
     <div className="animate-in fade-in relative h-full w-full duration-300">
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {displayStudents.map((student: any) => {
+        {displayStudents.map((student: RosterStudent) => {
           const stateUpdate = studentStates[student.id]
           const activeTab = stateUpdate?.payload?.activeTab
           const activeTaskId = stateUpdate?.payload?.activeTaskId
           const isWhiteboard = activeTab === 'my-board' || activeTab === 'tutor-board'
           // The roster only contains currently-present students (departed ones
-          // are removed), so anyone here is online unless explicitly 'offline' —
-          // don't gate on having received a state-sync event yet.
+          // are removed), so anyone here is online unless explicitly 'offline'.
           const isOnline = student.status !== 'offline'
+          const isViewing = selectedStudentIds.includes(student.id)
+          const badge = statusBadge(student.status)
+          const activityLabel =
+            student.currentActivity ||
+            (isWhiteboard
+              ? 'Drawing'
+              : activeTaskId
+                ? 'Working on a task'
+                : isOnline
+                  ? 'Idle'
+                  : 'Offline')
+          const mins = minutesSince(student.joinedAt)
+          const done = completedTaskCount(student.id)
 
           return (
             <Card
@@ -232,70 +301,102 @@ export function MonitoringPanel({
                   target: 'studentBoard',
                   studentId: student.id,
                 })
-                onNavigateToWhiteboard?.(student.id, student.name)
+                onToggleWhiteboardSelection?.(student.id, student.name)
               }}
               className={cn(
                 'cursor-pointer overflow-hidden border-slate-200 bg-white/50 backdrop-blur-sm transition-all hover:shadow-md',
-                selectedStudentId === student.id && 'ring-2 ring-indigo-200'
+                isViewing && 'ring-2 ring-indigo-300'
               )}
             >
               <CardHeader className="border-b bg-slate-50/50 px-4 py-3">
                 <CardTitle className="flex min-w-0 items-center justify-between gap-2 text-base">
-                  <span className="min-w-0 truncate font-semibold text-slate-800">
-                    {student.name}
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span
+                      className={cn(
+                        'flex h-2 w-2 flex-shrink-0 rounded-full',
+                        isOnline ? 'animate-pulse bg-green-500' : 'bg-slate-300'
+                      )}
+                      title={isOnline ? 'Online' : 'Offline'}
+                    />
+                    <span className="min-w-0 truncate font-semibold text-slate-800">
+                      {student.name}
+                    </span>
                   </span>
-                  <span
-                    className={cn(
-                      'flex h-2 w-2 rounded-full',
-                      isOnline ? 'animate-pulse bg-green-500' : 'bg-slate-300'
-                    )}
-                    title="Live"
-                  />
+                  {badge && (
+                    <span
+                      className={cn(
+                        'flex-shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                        badge.cls
+                      )}
+                    >
+                      {badge.label}
+                    </span>
+                  )}
                 </CardTitle>
               </CardHeader>
               <CardContent className="p-4">
-                <div className="space-y-4">
-                  <div className="rounded-lg bg-slate-50 p-3 text-sm">
-                    <div className="mb-1 flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
-                      <span className="flex-shrink-0 text-slate-500">Current View:</span>
-                      <span className="min-w-0 font-medium capitalize text-indigo-600">
-                        {activeTab?.replace('-', ' ') || 'No data yet'}
-                      </span>
-                    </div>
-                    <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
-                      <span className="flex-shrink-0 text-slate-500">Activity:</span>
-                      <span
-                        className="min-w-0 max-w-[120px] truncate font-medium text-slate-700"
-                        title={activeTaskId || 'None'}
-                      >
-                        {isWhiteboard
-                          ? 'Drawing'
-                          : activeTaskId
-                            ? 'Reading Task'
-                            : isOnline
-                              ? 'Idle'
-                              : 'Offline'}
-                      </span>
-                    </div>
+                <div className="space-y-3">
+                  <div className="space-y-1 rounded-lg bg-slate-50 p-3 text-sm">
+                    <Row
+                      label="Current view"
+                      value={activeTab?.replace('-', ' ') || '—'}
+                      valueClass="capitalize text-indigo-600"
+                    />
+                    <Row label="Activity" value={activityLabel} title={activeTaskId || undefined} />
+                    <Row label="In session" value={mins != null ? `${mins} min` : '—'} />
+                    <Row
+                      label="Tasks done"
+                      value={totalTasks > 0 ? `${done}/${totalTasks}` : '—'}
+                    />
                   </div>
+
+                  {student.engagement != null && (
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between text-[11px] text-slate-500">
+                        <span>Engagement</span>
+                        <span className="font-medium text-slate-700">
+                          {Math.round(student.engagement)}%
+                        </span>
+                      </div>
+                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+                        <div
+                          className={cn(
+                            'h-full rounded-full',
+                            student.engagement >= 66
+                              ? 'bg-emerald-500'
+                              : student.engagement >= 33
+                                ? 'bg-amber-500'
+                                : 'bg-red-500'
+                          )}
+                          style={{
+                            width: `${Math.min(100, Math.max(0, student.engagement))}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
 
                   <div className="flex flex-wrap gap-2">
                     <Button
                       onClick={e => {
                         e.stopPropagation()
-                        // Request the student's latest board snapshot before opening
                         socket.emit('whiteboard:state:request', {
                           roomId: sessionId,
                           target: 'studentBoard',
                           studentId: student.id,
                         })
-                        onOpenWhiteboard?.(student.id, student.name)
+                        onOpenWhiteboards?.(student.id, student.name)
                       }}
-                      variant="outline"
-                      className="min-w-[100px] flex-1 gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:text-slate-900"
+                      variant={isViewing ? 'default' : 'outline'}
+                      className={cn(
+                        'min-w-[110px] flex-1 gap-2',
+                        isViewing
+                          ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+                          : 'border-slate-200 text-slate-700 hover:bg-slate-50 hover:text-slate-900'
+                      )}
                     >
                       <MonitorPlay className="h-4 w-4 flex-shrink-0" />
-                      Whiteboard
+                      {isViewing ? 'Viewing' : 'View board'}
                     </Button>
                     <Button
                       onClick={e => {
@@ -438,6 +539,30 @@ export function MonitoringPanel({
           <Sparkles className="h-6 w-6 text-white" />
         </Button>
       </div>
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  valueClass,
+  title,
+}: {
+  label: string
+  value: string
+  valueClass?: string
+  title?: string
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-0.5">
+      <span className="flex-shrink-0 text-slate-500">{label}:</span>
+      <span
+        className={cn('min-w-0 max-w-[150px] truncate font-medium text-slate-700', valueClass)}
+        title={title}
+      >
+        {value}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## **User description**
Two live-session tutor improvements.

## 1. View multiple students' whiteboards at once
Previously the tutor could open only one student's board (single `monitorSelectedStudent` + one full-screen dialog). Now:
- Replaced the single selection with a **set** of students.
- The **Whiteboards** tab renders a **responsive grid of read-only boards**, each fed from the live `studentBoards` map, with a per-tile header (name, page) and a **remove (×)** button + "Close all".
- No server/socket changes needed: `studentBoards` already held *every* student's board concurrently and updates them all live; this was purely a selection/render change. Read-only `EnhancedWhiteboard` instances are safe to mount multiple times (prop-fed, no socket).

## 2. Wire the Monitor tab
`MonitoringPanel` was receiving the rich per-student roster data but **discarding** it (only name + a dot). Now each card shows **real** data:
- **Status badge** (on_track / needs_help / struggling / idle) from the server `StudentState`.
- **Online presence** + **time in session** (from `joinedAt`).
- **Current view** + **Activity** (uses server `currentActivity`, falls back to the activeTab heuristic).
- **Tasks done** — per-student `X/Y` from `liveTasks.completedBy` (now passed into the panel).
- **Engagement** bar (from the tracked engagement value).
- Cards **multi-select** into the whiteboard grid (click to toggle; "View board" adds + opens the grid).

`typecheck`, `lint` (0 errors), `build` pass.

### Note
Engagement/understanding/frustration are surfaced from the server's tracked values, which are seeded and updated via the student client's `activity_ping`; if a student client doesn't emit rich metrics, those show their seed values. Presence, time-in-session, current view/activity, and task-completion are fully live.


___

## **CodeAnt-AI Description**
**View several student whiteboards at once and show richer student progress in Monitor**

### What Changed
- Tutors can now open multiple student whiteboards in a grid instead of switching one at a time, with controls to remove individual boards or close them all.
- Clicking a student card in Monitor now toggles that student into the whiteboard view, and the “View board” button opens the multi-board view.
- Monitor cards now show live student details: status, online presence, time in session, current view, activity, tasks completed, and an engagement bar.

### Impact
`✅ Faster review of multiple student boards`
`✅ Clearer at-a-glance student progress`
`✅ Less switching between students during live sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
