### PR TITLE
fix(live): allow Build/Test tabs during a live session

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -425,20 +425,15 @@ function CourseBuilderInsightsRouteInner({
     }
   }, [insightsProps.sessionId, tabFromUrl, isClassroomMode])
 
-  // Prevent tab switching away from live in classroom mode
-  const handleMainTabChange = useCallback(
-    (tab: 'live' | 'builder' | 'test-pci') => {
-      if (isClassroomMode) {
-        setActiveMainTab('live')
-        return
-      }
-      setActiveMainTab(tab)
-      if (tab === 'builder') setControlsMode('build')
-      if (tab === 'test-pci') setControlsMode('test')
-      if (tab === 'live') setControlsMode('classroom')
-    },
-    [isClassroomMode]
-  )
+  // Allow switching between Live / Build / Test even during a live session so
+  // tutors can edit and test the course mid-class. Classroom mode only sets the
+  // INITIAL tab to 'live' (see the effect above) — it no longer locks it.
+  const handleMainTabChange = useCallback((tab: 'live' | 'builder' | 'test-pci') => {
+    setActiveMainTab(tab)
+    if (tab === 'builder') setControlsMode('build')
+    if (tab === 'test-pci') setControlsMode('test')
+    if (tab === 'live') setControlsMode('classroom')
+  }, [])
 
   const handleControlsModeChange = useCallback(
     (mode: ControlsMode) => {


### PR DESCRIPTION
## **User description**
## Problem
During a live session, clicking **Build** or **Test** did nothing — only the Classroom page showed — so tutors couldn't edit or test courses mid-class.

## Cause
`CourseBuilderInsightsRoute.handleMainTabChange` force-reset the active tab to `'live'` whenever `isClassroomMode` was true. CourseBuilder's internal `mainTab` change notifies the parent via `onMainTabChange`, so any attempt to switch to Build/Test routed through that reset and **snapped the view back to Classroom**.

## Fix
Removed the classroom-mode lock in `handleMainTabChange`. Classroom mode still sets the **initial** tab to `'live'` (via the existing effect) — it just no longer forces it on every change, so Live/Build/Test switch freely during a live session.

## Verified end-to-end (local stack, tutor in a live session)
- Start in **Classroom** ✅ → click **Build** → builder UI (Task/Assessment Builder, "+ Lesson") renders ✅ → click **Test** → PCI test view renders ✅ → click **Classroom** → returns to the live classroom ✅ (returning to live is not broken).
- `typecheck` ✅ · `lint` ✅ · `build` ✅. No conflicts with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow Build and Test tabs during a live session**

### What Changed
- Tutors can now switch between Classroom, Build, and Test while a live session is running
- Build and Test no longer snap back to the Classroom view when opened mid-session
- Classroom mode still opens on the live tab at first, but it no longer blocks later tab changes

### Impact
`✅ Mid-class course editing`
`✅ Mid-class course testing`
`✅ Fewer tab-switching dead ends`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
