### PR TITLE
feat(live): real student activity metrics on the tutor Monitor

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -853,6 +853,63 @@ function StudentFeedbackContent() {
     socket.emit('student:state_sync', { roomId: selectedSessionId, payload })
   }, [socket, selectedSessionId, activeTab, activeTaskId])
 
+  // Track real interaction recency so we can report a live engagement signal to
+  // the tutor's Monitor (instead of a static placeholder).
+  const lastInteractionRef = useRef<number>(Date.now())
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const bump = () => {
+      lastInteractionRef.current = Date.now()
+    }
+    const events: (keyof WindowEventMap)[] = [
+      'pointerdown',
+      'pointermove',
+      'keydown',
+      'wheel',
+      'touchstart',
+    ]
+    events.forEach(e => window.addEventListener(e, bump, { passive: true }))
+    return () => events.forEach(e => window.removeEventListener(e, bump))
+  }, [])
+
+  // Periodically emit an activity_ping with a behaviour-derived engagement score
+  // and the student's current activity, so the tutor's Monitor reflects reality.
+  useEffect(() => {
+    if (!socket || !selectedSessionId) return
+    const computeAndEmit = () => {
+      const hidden = typeof document !== 'undefined' && document.hidden
+      const idleMs = Date.now() - lastInteractionRef.current
+      // Engagement: full when recently active and focused; decays while idle, and
+      // is low when the tab isn't focused.
+      let engagement: number
+      if (hidden) engagement = 20
+      else if (idleMs < 20_000) engagement = 100
+      else if (idleMs < 60_000) engagement = 75
+      else if (idleMs < 120_000) engagement = 50
+      else if (idleMs < 300_000) engagement = 30
+      else engagement = 10
+      const onBoard = activeTab === 'tutor-board' || rightPanelTab === 'my-board'
+      const activity = hidden
+        ? 'Away (tab not focused)'
+        : onBoard
+          ? 'On the whiteboard'
+          : activeTaskId
+            ? 'Working on a task'
+            : idleMs > 60_000
+              ? 'Idle'
+              : 'Active'
+      socket.emit('activity_ping', { roomId: selectedSessionId, engagement, activity })
+    }
+    computeAndEmit()
+    const id = setInterval(computeAndEmit, 12_000)
+    const onVis = () => computeAndEmit()
+    document.addEventListener('visibilitychange', onVis)
+    return () => {
+      clearInterval(id)
+      document.removeEventListener('visibilitychange', onVis)
+    }
+  }, [socket, selectedSessionId, activeTab, activeTaskId, rightPanelTab])
+
   useEffect(() => {
     if (!socket) return
 

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -948,6 +948,24 @@ export async function initEnhancedSocketServer(server: NetServer) {
           if (typeof data?.engagement === 'number') student.engagement = data.engagement
           if (typeof data?.understanding === 'number') student.understanding = data.understanding
           if (data?.activity) student.currentActivity = data.activity
+          // Recompute a coarse status from the (now live) engagement signal so the
+          // tutor's Monitor shows a real badge: engaged → on track, waning → needs
+          // a nudge, disengaged/away → idle.
+          const eng = student.engagement
+          student.status = eng >= 60 ? 'on_track' : eng >= 30 ? 'needs_help' : 'idle'
+          // Broadcast to tutors so the Monitor reflects the change immediately
+          // (room_state is only sent on join). use-socket maps this to the roster.
+          io.to(roomId).emit('student_state_update', {
+            userId: socket.data.userId,
+            state: {
+              engagement: student.engagement,
+              understanding: student.understanding,
+              frustration: student.frustration,
+              status: student.status,
+              currentActivity: student.currentActivity,
+              lastActivity: student.lastActivity,
+            },
+          })
         }
       }
     )


### PR DESCRIPTION
## **User description**
Makes the Monitor tab's engagement/status/activity genuinely live (follow-up to #175).

## Student side (`student/feedback/page.tsx`)
- Tracks **real interaction recency** (pointer / key / touch / wheel) and **tab focus** (`document.hidden`).
- Emits an **`activity_ping` every 12s** (and on visibility change) with:
  - a **behaviour-derived engagement score** (full when recently active + focused; decays while idle; low when the tab isn't focused),
  - the **current activity** (on the whiteboard / working on a task / idle / away).
  Previously the page only synced the active view, so engagement stayed a static seed (100).

## Server (`activity_ping` handler)
- Updates engagement + currentActivity (existing) and now **recomputes a coarse `status`** from the live engagement: `on_track` (≥60) / `needs_help` (≥30) / `idle` (<30 or away).
- **Broadcasts `student_state_update`** to the room after each ping (room_state was only sent on join), which `use-socket` maps into the insights roster → the Monitor card re-renders.

Net: on the Monitor tab, the **engagement bar**, **status badge**, and **activity** line now move in real time as a student engages, switches to a task/whiteboard, goes idle, or unfocuses the tab.

`typecheck`, `lint` (0 errors), `build` pass.

Note: engagement here is an honest *behavioural* signal (activity recency + focus), not an inferred "understanding" metric — understanding/frustration remain seed values and aren't shown on the card.


___

## **CodeAnt-AI Description**
**Show live student activity on the tutor Monitor**

### What Changed
- Student presence now updates from real interactions and tab focus, so the Monitor no longer shows a static engagement value.
- The tutor roster now refreshes immediately when a student’s engagement, status, or activity changes.
- Status badges now follow live engagement levels: engaged students show as on track, lower activity shifts to needs help, and very low activity appears as idle.

### Impact
`✅ Live Monitor updates`
`✅ Clearer student status signals`
`✅ Fewer stale engagement readings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
