### PR TITLE
fix(live): restore End Session button on the floating Controls palette

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -33,6 +33,7 @@ import {
   PencilRuler,
   MonitorPlay,
   Wrench,
+  PhoneOff,
 } from 'lucide-react'
 import { BackButton } from '@/components/navigation/BackButton'
 import {
@@ -127,6 +128,8 @@ interface TutorControlsPanelProps {
   canGoLive: boolean
   hasSession: boolean
   hasUnsyncedChanges?: boolean
+  onEndSession?: () => void
+  endingSession?: boolean
 }
 
 function TutorControlsPanel({
@@ -144,6 +147,8 @@ function TutorControlsPanel({
   canGoLive,
   hasSession,
   hasUnsyncedChanges,
+  onEndSession,
+  endingSession,
 }: TutorControlsPanelProps) {
   const [open, setOpen] = useState(true)
   const [isDragging, setIsDragging] = useState(false)
@@ -334,6 +339,27 @@ function TutorControlsPanel({
                     </button>
                   </div>
                 </div>
+
+                {/* End the live session — finalizes recording + analytics. Only
+                    shown while a session is active. */}
+                {onEndSession && hasSession && (
+                  <button
+                    type="button"
+                    disabled={panelDisabled || endingSession}
+                    onClick={onEndSession}
+                    className={cn(
+                      actionButtonBase,
+                      'mt-2 justify-center bg-red-600 text-white hover:bg-red-700 active:bg-red-800'
+                    )}
+                  >
+                    {endingSession ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <PhoneOff className="h-4 w-4" />
+                    )}
+                    {endingSession ? 'Ending…' : 'End Session'}
+                  </button>
+                )}
               </motion.div>
             )}
           </AnimatePresence>
@@ -1058,6 +1084,8 @@ function CourseBuilderInsightsRouteInner({
             }
             hasSession={!!insightsProps.sessionId}
             hasUnsyncedChanges={hasUnsyncedChanges}
+            onEndSession={insightsProps.sessionId ? handleEndSession : undefined}
+            endingSession={endingSession}
           />
         )}
       </div>


### PR DESCRIPTION
## **User description**
## Problem
The tutor's **End Session** button disappeared from live sessions, so tutors couldn't end a class.

## Cause
`handleEndSession` (and its `onEndSession` wiring) still existed, but the button that called it had been removed from the UI.

## Fix
Added a full-width **End Session** button to the floating `TutorControlsPanel`, shown only when a live session is active. It calls the existing handler: confirm → `PATCH /api/tutor/classes/[id]` (finalizes recording + analytics) → navigate to `/tutor/sessions/[id]`.

## Verified end-to-end (local stack, tutor in a live session)
- Button appears at the bottom of the Controls palette (red, with the existing Save/Go Live/Delete/Sync). ✅
- Clicking it ends the session (DB `status` → `ended`) and navigates to the session page. ✅
- `typecheck` ✅ · `lint` ✅ · `build` ✅. No conflicts with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Restore the End Session button in live tutor controls**

### What Changed
- Added an **End Session** button to the floating tutor controls panel when a live session is active
- The button shows a loading state while the session is ending and is disabled during that process
- It uses the existing end-session flow so tutors can finish a live class from the controls palette again

### Impact
`✅ Tutors can end live sessions from the controls panel`
`✅ Fewer stuck live classes`
`✅ Clearer end-session feedback while the session closes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
