### PR TITLE
feat(live): auto-grade task completions against DMI answer key

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/MonitoringPanel.tsx
@@ -94,11 +94,18 @@ export function MonitoringPanel({
     }
     load()
     const id = setInterval(load, 20_000)
-    const onCompleted = () => load()
+    // The completion broadcast races the server-side live auto-grade write, so
+    // refetch immediately and again shortly after the score has landed.
+    const timers: ReturnType<typeof setTimeout>[] = []
+    const onCompleted = () => {
+      load()
+      timers.push(setTimeout(load, 2_500))
+    }
     socket?.on('task:completed', onCompleted)
     return () => {
       cancelled = true
       clearInterval(id)
+      timers.forEach(clearTimeout)
       socket?.off('task:completed', onCompleted)
     }
   }, [sessionId, socket])

--- a/tutorme-app/src/lib/grading/auto-grade.test.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { autoGradeDmi } from './auto-grade'
+
+const items = [
+  { id: 'q1', answer: 'Paris' },
+  { id: 'q2', answer: '42' },
+  { id: 'q3', answer: 'Photosynthesis' },
+]
+
+describe('autoGradeDmi', () => {
+  it('returns null score when there is no answer key', () => {
+    const r = autoGradeDmi([{ id: 'q1' }, { id: 'q2', answer: '' }], { q1: 'x' })
+    expect(r.score).toBeNull()
+    expect(r.gradable).toBe(0)
+  })
+
+  it('credits exact (normalized) matches', () => {
+    const r = autoGradeDmi(items, { q1: 'paris', q2: '42', q3: 'Photosynthesis.' })
+    expect(r.score).toBe(100)
+    expect(r.correct).toBe(3)
+  })
+
+  it('credits answers that contain the full expected answer', () => {
+    const r = autoGradeDmi(items, {
+      q1: 'It is Paris',
+      q2: 'the answer is 42',
+      q3: 'photosynthesis',
+    })
+    expect(r.score).toBe(100)
+  })
+
+  it('marks wrong/blank answers incorrect (conservative)', () => {
+    const r = autoGradeDmi(items, { q1: 'London', q2: '', q3: 'respiration' })
+    expect(r.score).toBe(0)
+    expect(r.questionResults?.q1.correct).toBe(false)
+  })
+
+  it('does not over-credit a single word against a long expected answer', () => {
+    const r = autoGradeDmi([{ id: 'q1', answer: 'Photosynthesis converts light into energy' }], {
+      q1: 'light',
+    })
+    expect(r.score).toBe(0)
+  })
+
+  it('computes a partial score', () => {
+    const r = autoGradeDmi(items, { q1: 'Paris', q2: '7', q3: 'photosynthesis' })
+    expect(r.score).toBe(67) // 2/3
+  })
+})

--- a/tutorme-app/src/lib/grading/auto-grade.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.ts
@@ -1,0 +1,67 @@
+/**
+ * Lightweight deterministic auto-grading for DMI answers.
+ *
+ * Grades a student's answers (keyed by DMI item id) against the tutor's answer
+ * key (the `answer` on each DMI item, stored server-side in BuilderTaskDmi.items
+ * and never sent to students). Intentionally CONSERVATIVE — it credits an item
+ * only on a normalized exact match or when the student's answer contains the
+ * full expected answer as a word sequence. This avoids over-crediting; verbose /
+ * open-ended answers that don't reproduce the key are left for graded review.
+ * It's a coarse, live signal, not a replacement for grading.
+ */
+
+export interface DmiAnswerItem {
+  id: string
+  answer?: string
+  questionText?: string
+}
+
+export interface AutoGradeResult {
+  /** 0–100, or null when nothing was gradable (no answer key). */
+  score: number | null
+  questionResults: Record<string, { correct: boolean; expected: string; given: string }> | null
+  gradable: number
+  correct: number
+}
+
+function normalize(s: unknown): string {
+  return String(s ?? '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function autoGradeDmi(
+  items: DmiAnswerItem[] | null | undefined,
+  answers: Record<string, string> | null | undefined
+): AutoGradeResult {
+  const list = Array.isArray(items) ? items : []
+  const given = answers || {}
+  const gradable = list.filter(i => i && typeof i.answer === 'string' && i.answer.trim().length > 0)
+  if (gradable.length === 0) {
+    return { score: null, questionResults: null, gradable: 0, correct: 0 }
+  }
+
+  let correct = 0
+  const questionResults: Record<string, { correct: boolean; expected: string; given: string }> = {}
+  for (const item of gradable) {
+    const rawGiven = given[item.id] ?? ''
+    const g = normalize(rawGiven)
+    const expected = normalize(item.answer)
+    const isCorrect = g.length > 0 && (g === expected || ` ${g} `.includes(` ${expected} `))
+    if (isCorrect) correct += 1
+    questionResults[item.id] = {
+      correct: isCorrect,
+      expected: String(item.answer ?? ''),
+      given: String(rawGiven),
+    }
+  }
+
+  return {
+    score: Math.round((correct / gradable.length) * 100),
+    questionResults,
+    gradable: gradable.length,
+    correct,
+  }
+}

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -7,7 +7,7 @@ import { Server as NetServer } from 'http'
 import { Server as SocketIOServer, Socket } from 'socket.io'
 import Redis from 'ioredis'
 import * as Sentry from '@sentry/nextjs'
-import { eq, and, inArray } from 'drizzle-orm'
+import { eq, and, inArray, desc } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import {
   liveSession,
@@ -20,8 +20,10 @@ import {
   courseLesson,
   message,
   builderTask,
+  builderTaskDmi,
   taskSubmission,
 } from '@/lib/db/schema'
+import { autoGradeDmi } from '@/lib/grading/auto-grade'
 import { initFeedbackHandlers, initPollHandlers } from './socket-server'
 import { activePolls, sessionPolls, cleanupStaleSocketState } from '@/lib/socket'
 import type { PollState } from '@/lib/socket'
@@ -1486,8 +1488,34 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 target: [sessionParticipant.sessionId, sessionParticipant.studentId],
               })
 
+            // Live auto-grade: score the answers against the task's DMI answer
+            // key (stored server-side in BuilderTaskDmi.items; never sent to
+            // students). Conservative + best-effort — leaves score null when
+            // there's no answer key. This feeds the tutor's live Understanding.
+            let autoScore: number | null = null
+            let autoResults: Record<string, unknown> | null = null
+            try {
+              const [dmi] = await drizzleDb
+                .select({ items: builderTaskDmi.items })
+                .from(builderTaskDmi)
+                .where(eq(builderTaskDmi.taskId, taskId))
+                .orderBy(desc(builderTaskDmi.updatedAt))
+                .limit(1)
+              if (dmi?.items) {
+                const graded = autoGradeDmi(
+                  dmi.items as { id: string; answer?: string }[],
+                  (answers ?? {}) as Record<string, string>
+                )
+                autoScore = graded.score
+                autoResults = graded.questionResults
+              }
+            } catch (gradeErr) {
+              console.warn('[task:complete] auto-grade failed (non-critical):', gradeErr)
+            }
+
             // 5) The submission itself. onConflictDoNothing preserves the
             //    one-per-(task,student) rule and never overwrites a graded row.
+            //    Status stays 'submitted' so the tutor can still review/override.
             await drizzleDb
               .insert(taskSubmission)
               .values({
@@ -1497,8 +1525,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 answers: answers ?? {},
                 timeSpent: 0,
                 attempts: 1,
-                questionResults: null,
-                score: null,
+                questionResults: autoResults,
+                score: autoScore,
                 maxScore: 100,
                 status: 'submitted',
                 tutorApproved: false,


### PR DESCRIPTION
## **User description**
## Summary
Implements live auto-grading so the tutor Monitor's **Understanding** indicator populates *during* a live session, instead of only after manual/AI grading.

When a student fires `task:complete`, the server now scores their answers against the task's DMI answer key (`BuilderTaskDmi.items`, which is stored server-side and never sent to students) and persists `score` + `questionResults` on the `taskSubmission`. The existing comprehension endpoint already averages scored submissions, so the live signal flows straight through.

## Changes
- **`src/lib/grading/auto-grade.ts`** (new) — conservative, deterministic grader. Credits an item on a normalized exact match or when the student's answer contains the full expected answer. Returns `null` score when there's no answer key (nothing fabricated). Unit-tested.
- **`socket-server-enhanced.ts`** — in the `task:complete` persistence block, fetch the latest `BuilderTaskDmi` for the task, grade the answers, and write `score`/`questionResults`. Best-effort (failures are non-fatal). Status stays `submitted` so the tutor can still review/override.
- **`MonitoringPanel.tsx`** — refetch comprehension immediately and again ~2.5s after a completion, since the completion broadcast races the async score write.

## Testing
- `npx vitest run src/lib/grading/auto-grade.test.ts` — 6/6 pass
- `npm run typecheck`, `eslint` (0 errors), `prettier`, `npm run build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show live task understanding scores as students finish tasks**

### What Changed
- Student task completions are now scored right away against the teacher’s stored answer key, so the tutor dashboard can show an Understanding score during the live session
- If a task has no answer key, the score stays blank instead of showing a made-up result
- The live panel now refreshes immediately and again a few seconds later after a completion, so the new score appears without waiting for the next manual refresh
- Submissions still stay open for tutor review and override

### Impact
`✅ Faster live comprehension updates`
`✅ Fewer delays after task completion`
`✅ Clearer tutor monitoring during sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
