### PR TITLE
test(live): integration test for live auto-grading chain

### DIFF
--- a/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
+++ b/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Integration test: live auto-grading end-to-end (the path a live session drives).
+ *
+ * When a student fires `task:complete` in a live session, the socket handler
+ * (socket-server-enhanced.ts) fetches the task's DMI answer key from
+ * BuilderTaskDmi.items, grades the answers with autoGradeDmi, and persists the
+ * resulting score + questionResults on the taskSubmission. The tutor Monitor's
+ * "Understanding" indicator then reads that score via the comprehension route.
+ *
+ * This test reproduces that exact chain against a real DB:
+ *   1. Seed a task with a DMI answer key (the server-only key).
+ *   2. Run the handler's exact fetch-latest-DMI + autoGradeDmi + insert sequence.
+ *   3. Assert the submission row carries the computed score + per-item results.
+ *   4. Call the REAL /api/tutor/live-sessions/[id]/comprehension handler and
+ *      assert it surfaces that score as the student's live Understanding.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { desc, eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  user,
+  course,
+  courseLesson,
+  builderTask,
+  builderTaskDmi,
+  liveSession,
+  taskSubmission,
+} from '@/lib/db/schema'
+import { autoGradeDmi } from '@/lib/grading/auto-grade'
+
+const stamp = Date.now()
+const tutorEmail = `claude-grade-tutor-${stamp}@example.com`
+const studentEmail = `claude-grade-student-${stamp}@example.com`
+
+const tutorId = crypto.randomUUID()
+const studentId = crypto.randomUUID()
+const courseId = `c_${stamp}`
+const lessonId = `l_${stamp}`
+const sessionId = `sess_${stamp}`
+const taskId = `task_${stamp}`
+const dmiId = `dmi_${stamp}`
+
+// The tutor's answer key — stored server-side in BuilderTaskDmi.items, never
+// sent to students. Keyed by item id, which is what the student answers map to.
+const answerKey = [
+  { id: 'q1', questionNumber: 1, questionText: 'Capital of France?', answer: 'Paris' },
+  { id: 'q2', questionNumber: 2, questionText: '6 x 7?', answer: '42' },
+  { id: 'q3', questionNumber: 3, questionText: 'Plant energy process?', answer: 'Photosynthesis' },
+]
+// Student gets 2 of 3 right (q2 wrong) -> 67.
+const studentAnswers: Record<string, string> = {
+  q1: 'It is Paris',
+  q2: '7',
+  q3: 'photosynthesis',
+}
+const EXPECTED_SCORE = 67
+
+// Mock auth so the real comprehension handler runs as our tutor.
+const mockSession = {
+  user: { id: tutorId, email: tutorEmail, role: 'TUTOR' as const },
+  expires: new Date(Date.now() + 86400 * 1000).toISOString(),
+}
+vi.mock('@/lib/auth', () => ({
+  getServerSession: vi.fn(() => Promise.resolve(mockSession)),
+  authOptions: {},
+}))
+
+// Imported after the mock is registered (hoisted by vitest anyway).
+import { GET as getComprehension } from '@/app/api/tutor/live-sessions/[sessionId]/comprehension/route'
+
+/**
+ * Reproduces exactly what the live `task:complete` socket handler does to grade
+ * and persist a completion: fetch the latest DMI answer key for the task, grade
+ * the student's answers, and write the score + per-item results.
+ */
+async function gradeAndPersistCompletion(answers: Record<string, string>) {
+  const now = new Date()
+  let autoScore: number | null = null
+  let autoResults: Record<string, unknown> | null = null
+  const [dmi] = await drizzleDb
+    .select({ items: builderTaskDmi.items })
+    .from(builderTaskDmi)
+    .where(eq(builderTaskDmi.taskId, taskId))
+    .orderBy(desc(builderTaskDmi.updatedAt))
+    .limit(1)
+  if (dmi?.items) {
+    const graded = autoGradeDmi(dmi.items as { id: string; answer?: string }[], answers)
+    autoScore = graded.score
+    autoResults = graded.questionResults
+  }
+  await drizzleDb
+    .insert(taskSubmission)
+    .values({
+      submissionId: `s_${stamp}`,
+      taskId,
+      studentId,
+      answers,
+      timeSpent: 0,
+      attempts: 1,
+      questionResults: autoResults,
+      score: autoScore,
+      maxScore: 100,
+      status: 'submitted',
+      tutorApproved: false,
+      submittedAt: now,
+    })
+    .onConflictDoNothing({ target: [taskSubmission.taskId, taskSubmission.studentId] })
+  return autoScore
+}
+
+function request(url: string): Request {
+  return new Request(url, { headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('Live auto-grading end-to-end', () => {
+  beforeAll(async () => {
+    const now = new Date()
+    await drizzleDb.insert(user).values([
+      { userId: tutorId, email: tutorEmail, role: 'TUTOR', createdAt: now, updatedAt: now },
+      { userId: studentId, email: studentEmail, role: 'STUDENT', createdAt: now, updatedAt: now },
+    ])
+    await drizzleDb
+      .insert(course)
+      .values({ courseId, name: 'Claude Grade Course', creatorId: tutorId })
+    await drizzleDb
+      .insert(courseLesson)
+      .values({ lessonId, courseId, title: 'Live Session', order: 0 })
+    await drizzleDb.insert(builderTask).values({
+      taskId,
+      courseId,
+      lessonId,
+      tutorId,
+      title: 'Graded task',
+      content: 'content',
+      pci: '',
+      type: 'task',
+      status: 'published',
+    })
+    await drizzleDb.insert(builderTaskDmi).values({
+      dmiId,
+      taskId,
+      type: 'assessment',
+      items: answerKey,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await drizzleDb.insert(liveSession).values({
+      sessionId,
+      tutorId,
+      courseId,
+      title: 'Claude Grade Session',
+      category: 'general',
+      status: 'active',
+      scheduledAt: now,
+    })
+  })
+
+  afterAll(async () => {
+    // FK-safe teardown (children first).
+    const t = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn()
+      } catch {}
+    }
+    await t(() => drizzleDb.delete(taskSubmission).where(eq(taskSubmission.taskId, taskId)))
+    await t(() => drizzleDb.delete(builderTaskDmi).where(eq(builderTaskDmi.taskId, taskId)))
+    await t(() => drizzleDb.delete(builderTask).where(eq(builderTask.taskId, taskId)))
+    await t(() => drizzleDb.delete(courseLesson).where(eq(courseLesson.courseId, courseId)))
+    await t(() => drizzleDb.delete(liveSession).where(eq(liveSession.sessionId, sessionId)))
+    await t(() => drizzleDb.delete(course).where(eq(course.courseId, courseId)))
+    await t(() => drizzleDb.delete(user).where(inArray(user.userId, [tutorId, studentId])))
+  })
+
+  it('grades the completion against the DMI answer key and persists the score', async () => {
+    const score = await gradeAndPersistCompletion(studentAnswers)
+    expect(score).toBe(EXPECTED_SCORE)
+
+    const [row] = await drizzleDb
+      .select({
+        score: taskSubmission.score,
+        questionResults: taskSubmission.questionResults,
+        status: taskSubmission.status,
+      })
+      .from(taskSubmission)
+      .where(eq(taskSubmission.taskId, taskId))
+      .limit(1)
+
+    expect(row?.score).toBe(EXPECTED_SCORE)
+    // Per-item correctness recorded; stays 'submitted' so the tutor can override.
+    expect(row?.status).toBe('submitted')
+    const qr = row?.questionResults as Record<string, { correct: boolean }> | null
+    expect(qr?.q1.correct).toBe(true)
+    expect(qr?.q2.correct).toBe(false)
+    expect(qr?.q3.correct).toBe(true)
+  })
+
+  it('surfaces the score as live Understanding via the real comprehension route', async () => {
+    const res = await getComprehension(
+      request(`http://localhost/api/tutor/live-sessions/${sessionId}/comprehension`) as never,
+      { params: Promise.resolve({ sessionId }) } as never
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.comprehension?.[studentId]).toBeTruthy()
+    expect(data.comprehension[studentId].understanding).toBe(EXPECTED_SCORE)
+    expect(data.comprehension[studentId].scored).toBe(1)
+  })
+})


### PR DESCRIPTION
## **User description**
## Summary
Adds an integration test that verifies the **live auto-grading** chain end-to-end against a real Postgres — the path a live session drives when a student completes a task.

It reproduces the exact sequence the `task:complete` socket handler runs:
1. Seed a task with a **DMI answer key** (`BuilderTaskDmi.items`, the server-only key).
2. Fetch the latest DMI for the task → `autoGradeDmi(items, answers)` → insert the submission with the computed `score` + `questionResults`.
3. Assert the row carries the score (student gets 2/3 → **67**), per-item correctness, and stays `submitted` (tutor can override).
4. Call the **real** `/api/tutor/live-sessions/[id]/comprehension` handler and assert it surfaces 67 as the student's live **Understanding**.

## Testing
Ran against a throwaway Postgres (schema pushed from source of truth):
- `npx vitest run --config vitest.integration.config.ts` — **8/8 pass** (3 files, including the new one)
- `npm run typecheck`, eslint, prettier — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add an end-to-end test for live auto-grading and comprehension scoring**

### What Changed
- Added a real Postgres integration test that follows the same flow as a live task completion: uses the task’s hidden answer key, grades student answers, and saves the score and per-question results
- Verifies the saved submission stays in a submitted state so tutors can still override it
- Confirms the live comprehension page returns the same score as the student’s Understanding value

### Impact
`✅ Verified live grading matches stored scores`
`✅ Fewer scoring regressions in live sessions`
`✅ Clearer tutor Understanding values`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
