### PR TITLE
feat(student): Unregister button on enrolled course cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -446,7 +446,47 @@ function CoursePageInner() {
   const [detailCourse, setDetailCourse] = useState<Course | null>(null)
   const [scheduleCourse, setScheduleCourse] = useState<Course | null>(null)
   const [enteringClass, setEnteringClass] = useState<string | null>(null)
+  const [unregisteringId, setUnregisteringId] = useState<string | null>(null)
   const router = useRouter()
+
+  const handleUnregister = useCallback(
+    async (course: Course) => {
+      if (
+        !window.confirm(
+          `Unregister from "${course.name}"? You'll lose access to its sessions and materials. If you paid, a partial refund may apply.`
+        )
+      ) {
+        return
+      }
+      setUnregisteringId(course.id)
+      try {
+        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrf = (await csrfRes.json().catch(() => ({})))?.token ?? null
+        const res = await fetch(`/api/student/courses/${course.id}/unenroll`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...(csrf && { 'X-CSRF-Token': csrf }) },
+          credentials: 'include',
+        })
+        const json = await res.json().catch(() => ({}))
+        if (!res.ok) {
+          toast.error(json?.message ?? 'Failed to unregister from the course')
+          return
+        }
+        if (json?.refund) {
+          toast.success('Unregistered — a partial refund has been issued')
+        } else {
+          toast.success('Unregistered from the course')
+        }
+        await loadCourses()
+      } catch {
+        toast.error('Failed to unregister from the course')
+      } finally {
+        setUnregisteringId(null)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const handleEnterClass = useCallback(
     async (courseId: string) => {
@@ -618,6 +658,8 @@ function CoursePageInner() {
                     onSchedule={setScheduleCourse}
                     enteringClass={enteringClass}
                     onEnterClass={handleEnterClass}
+                    onUnregister={handleUnregister}
+                    unregisteringId={unregisteringId}
                   />
                 )}
                 {activeTab === 'pending' && (
@@ -631,6 +673,8 @@ function CoursePageInner() {
                     onSchedule={setScheduleCourse}
                     enteringClass={enteringClass}
                     onEnterClass={handleEnterClass}
+                    onUnregister={handleUnregister}
+                    unregisteringId={unregisteringId}
                   />
                 )}
                 {activeTab === 'completed' && (
@@ -644,6 +688,8 @@ function CoursePageInner() {
                     onSchedule={setScheduleCourse}
                     enteringClass={enteringClass}
                     onEnterClass={handleEnterClass}
+                    onUnregister={handleUnregister}
+                    unregisteringId={unregisteringId}
                   />
                 )}
                 {activeTab === 'favorites' && (
@@ -925,6 +971,8 @@ function CourseSection({
   onSchedule,
   enteringClass,
   onEnterClass,
+  onUnregister,
+  unregisteringId,
 }: {
   title: string
   description?: string
@@ -935,6 +983,8 @@ function CourseSection({
   onSchedule: (c: Course) => void
   enteringClass: string | null
   onEnterClass: (courseId: string) => void
+  onUnregister?: (c: Course) => void
+  unregisteringId?: string | null
 }) {
   return (
     <section>
@@ -958,6 +1008,8 @@ function CourseSection({
             onSchedule={() => onSchedule(course)}
             enteringClass={enteringClass}
             onEnterClass={onEnterClass}
+            onUnregister={onUnregister}
+            unregisteringId={unregisteringId}
           />
         ))}
       </div>
@@ -973,6 +1025,8 @@ function CourseCard({
   onSchedule,
   enteringClass,
   onEnterClass,
+  onUnregister,
+  unregisteringId,
 }: {
   course: Course
   isFavorite: boolean
@@ -981,6 +1035,8 @@ function CourseCard({
   onSchedule: () => void
   enteringClass: string | null
   onEnterClass: (courseId: string) => void
+  onUnregister?: (c: Course) => void
+  unregisteringId?: string | null
 }) {
   const SubjectIcon = SUBJECT_ICONS[course.subject] || SUBJECT_ICONS.default
   const progress = course.progress
@@ -1147,6 +1203,20 @@ function CourseCard({
         >
           Details
         </Button>
+        {onUnregister && course.enrollment && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-9 border-rose-500/30 bg-rose-500/10 px-3 text-rose-300 hover:bg-rose-500/20 hover:text-rose-200"
+            disabled={unregisteringId === course.id}
+            onClick={e => {
+              e.stopPropagation()
+              onUnregister(course)
+            }}
+          >
+            {unregisteringId === course.id ? 'Unregistering...' : 'Unregister'}
+          </Button>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## **User description**
## What
Adds an **Unregister** action to enrolled course cards on `/student/courses` (Ongoing / Pending / Completed sections).

The course-level unenroll-with-refund flow already existed (the `/api/student/courses/[id]/unenroll` route + the course detail page button), but the main **My Courses** card grid had no entry point — students couldn't unregister from the place they actually browse their courses.

## How
- Threaded `onUnregister` + `unregisteringId` through `CourseSection` → `CourseCard`.
- Added `handleUnregister` in `CoursePageInner`: `window.confirm` → POST `/api/student/courses/[id]/unenroll` with CSRF → refund-aware toast → `loadCourses()` refresh.
- Button is gated on `course.enrollment` so it only appears on enrolled cards (not Favorites/Following/Browse). `e.stopPropagation()` keeps the card's open-details click from firing.

## Verification (ran the app)
Local stack (dev mode, Postgres + Redis), logged in as a student enrolled in a test course:
1. ✅ `/student/courses` Ongoing tab → card shows **Enter Classroom · Details · Unregister**.
2. ✅ Click Unregister → confirm dialog with refund-aware copy.
3. ✅ Confirm → card disappears, section shows "No courses", URL stays on the list (no accidental navigate-to-details).
4. ✅ DB: the `CourseEnrollment` row was deleted.

### Findings (pre-existing, not from this change)
- Card shows `Progress NaN%` when `totalLessons` is 0 (divide-by-zero in `progressPercent`).
- The hero "Courses Enrolled" stat doesn't live-refresh after unregister (separate fetch); corrects on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add unregister actions to enrolled course cards**

### What Changed
- Added an **Unregister** button to enrolled course cards in Ongoing, Pending, and Completed sections on My Courses.
- Unregister now asks for confirmation, removes the course from the list after success, and shows a refund-aware success message when a partial refund is issued.
- The button shows a loading state while the request is in progress and stays limited to enrolled courses only.

### Impact
`✅ Quicker course unenrollment from My Courses`
`✅ Clearer refund-aware unregister flow`
`✅ Fewer accidental course removals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
