### PR TITLE
fix(student): no NaN% progress + live-refresh hero stat after unregister

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -447,6 +447,7 @@ function CoursePageInner() {
   const [scheduleCourse, setScheduleCourse] = useState<Course | null>(null)
   const [enteringClass, setEnteringClass] = useState<string | null>(null)
   const [unregisteringId, setUnregisteringId] = useState<string | null>(null)
+  const [statsRefreshKey, setStatsRefreshKey] = useState(0)
   const router = useRouter()
 
   const handleUnregister = useCallback(
@@ -478,6 +479,7 @@ function CoursePageInner() {
           toast.success('Unregistered from the course')
         }
         await loadCourses()
+        setStatsRefreshKey(k => k + 1)
       } catch {
         toast.error('Failed to unregister from the course')
       } finally {
@@ -526,7 +528,11 @@ function CoursePageInner() {
     <div className="text-foreground flex min-h-full flex-col bg-white px-3 lg:h-full lg:overflow-hidden lg:px-4">
       {/* Hero */}
       <div className="mb-4 flex-shrink-0">
-        <StudentHeroSection title="My Courses" showGreeting={false} />
+        <StudentHeroSection
+          title="My Courses"
+          showGreeting={false}
+          refreshSignal={statsRefreshKey}
+        />
       </div>
 
       {/* Course Details Modal */}
@@ -1040,9 +1046,10 @@ function CourseCard({
 }) {
   const SubjectIcon = SUBJECT_ICONS[course.subject] || SUBJECT_ICONS.default
   const progress = course.progress
-  const progressPercent = progress
-    ? Math.round((progress.lessonsCompleted / progress.totalLessons) * 100)
-    : 0
+  const progressPercent =
+    progress && progress.totalLessons > 0
+      ? Math.round((progress.lessonsCompleted / progress.totalLessons) * 100)
+      : 0
   const isPending =
     course.enrollment?.startDate && new Date(course.enrollment.startDate) > new Date()
   const isOngoing = !isPending && (!progress || !progress.isCompleted)

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/StudentHeroSection.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/StudentHeroSection.tsx
@@ -19,6 +19,8 @@ interface StudentHeroSectionProps {
   showGreeting?: boolean
   stats?: StudentDashboardStats
   statsLoading?: boolean
+  /** Bump this to force a re-fetch of internally-managed stats (e.g. after an unregister). */
+  refreshSignal?: number
 }
 
 interface CalendarEventItem {
@@ -48,6 +50,7 @@ export function StudentHeroSection({
   showGreeting = true,
   stats: statsProp,
   statsLoading: statsLoadingProp,
+  refreshSignal,
 }: StudentHeroSectionProps) {
   const { data: session } = useSession()
   const [greeting, setGreeting] = useState('Good morning')
@@ -94,7 +97,7 @@ export function StudentHeroSection({
     return () => {
       cancelled = true
     }
-  }, [statsProp])
+  }, [statsProp, refreshSignal])
 
   // Fetch upcoming sessions with a wide date range (today to +90 days)
   useEffect(() => {


### PR DESCRIPTION
## **User description**
Follow-up to #182 — fixes the two pre-existing issues noticed while verifying the Unregister button.

## Fixes
1. **`NaN%` progress** — `CourseCard` computed `lessonsCompleted / totalLessons` which is `0/0 = NaN` for courses with no lessons. Now guarded on `totalLessons > 0` → shows `0%`.
2. **Hero "Courses Enrolled" stat didn't live-refresh** — `StudentHeroSection` fetches `/api/student/dashboard-stats` once on mount, so the count stayed stale after an unregister until reload. Added an optional `refreshSignal` prop that re-fetches internal stats when bumped; the courses page bumps it after a successful unregister.

## Verification (ran the app)
Local stack, student enrolled in a test course on `/student/courses`:
1. ✅ Before: card progress reads `0%` (was `NaN%`), hero "Courses Enrolled" = **1**.
2. ✅ Click Unregister → card disappears, hero "Courses Enrolled" updates to **0** with no page reload.
3. ✅ No `NaN` text anywhere on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix lesson progress and course count updates on the student courses page**

### What Changed
- Courses with no lessons now show `0%` progress instead of `NaN%`
- After unregistering from a course, the "Courses Enrolled" stat updates immediately without a page reload
- The student hero section now refreshes its own stats when the courses page signals a change

### Impact
`✅ No NaN progress labels`
`✅ Live course count after unregister`
`✅ Fewer stale dashboard stats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
