### PR TITLE
fix(live): align auto-grade questionResults to canonical array shape

### DIFF
--- a/tutorme-app/e2e/live-auto-grading.spec.ts
+++ b/tutorme-app/e2e/live-auto-grading.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * E2E: live auto-grading, two-user flow (tutor + student).
+ *
+ * Verifies the full live-session path that the auto-grading feature drives:
+ * a student completes a task in a live session, the server grades their answers
+ * against the task's DMI answer key, and the tutor's Monitor tab shows the
+ * resulting "Understanding" within seconds — no manual grading.
+ *
+ * This test exercises real infrastructure, so (like live-task-policy-toggle) it
+ * is ENV-GATED and skips unless prerequisites are provided.
+ *
+ * PREREQUISITES
+ *   1. The app must run with the FULL socket server (`npm run dev`, NOT
+ *      `dev:next`) — point Playwright at it via PLAYWRIGHT_BASE_URL, or start it
+ *      on :3003 before running. `task:complete` is a Socket.io event.
+ *   2. An ACTIVE live session whose course has a deployed task that carries a
+ *      DMI answer key (BuilderTaskDmi.items with `answer`s).
+ *   3. A tutor account that owns the session and a student enrolled in its
+ *      course.
+ *
+ * REQUIRED ENV
+ *   E2E_LIVE_SESSION_ID   the active session id (also the socket roomId)
+ *   E2E_LIVE_TASK_ID      id of a deployed task in that session with an answer key
+ *
+ * OPTIONAL ENV
+ *   E2E_LIVE_ROOM_ID            socket room id (default: session id)
+ *   E2E_TUTOR_EMAIL / _PASSWORD (default tutor@example.com / Password1)
+ *   E2E_STUDENT_EMAIL / _PASSWORD (default student@example.com / Password1)
+ *   E2E_STUDENT_NAME            student display name, to locate their roster card
+ *   E2E_LIVE_TASK_ANSWERS       JSON object of answers keyed by DMI item id,
+ *                               e.g. '{"q1":"Paris","q2":"42"}' (default: {})
+ *   E2E_EXPECTED_UNDERSTANDING  exact expected percentage to assert (e.g. "67")
+ *   E2E_LOCALE                  locale segment (default: en)
+ *
+ * RUN
+ *   E2E_LIVE_SESSION_ID=... E2E_LIVE_TASK_ID=... \
+ *   E2E_TUTOR_EMAIL=... E2E_TUTOR_PASSWORD=... \
+ *   E2E_STUDENT_EMAIL=... E2E_STUDENT_PASSWORD=... \
+ *   npx playwright test e2e/live-auto-grading.spec.ts
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+interface TestSocket {
+  connected: boolean
+  on: (event: string, cb: (payload?: unknown) => void) => void
+  emit: (event: string, payload: unknown) => void
+  disconnect: () => void
+}
+
+interface SocketIoFactory {
+  (options: { path: string; transports: string[]; auth: { token: string } }): TestSocket
+}
+
+interface WindowWithIo extends Window {
+  io?: SocketIoFactory
+  __e2eGradingSocket?: TestSocket
+}
+
+async function login(page: Page, email: string, password: string, expectedPath: RegExp) {
+  await page.goto('/login')
+  await page.getByLabel(/email/i).fill(email)
+  await page.getByLabel(/password/i).fill(password)
+  await page.getByRole('button', { name: /login/i }).click()
+  await expect(page).toHaveURL(expectedPath, { timeout: 15000 })
+}
+
+/**
+ * Joins the live room as the authenticated student and completes a task — the
+ * exact two emits the real student client sends (`join_class`, then
+ * `task:complete` with answers keyed by DMI item id). The socket is kept alive
+ * on `window.__e2eGradingSocket` so the student stays in the roster while the
+ * tutor reads it; disconnect with `disconnectStudentSocket` afterwards.
+ *
+ * Returns the server's response: 'completed', 'error:...', or 'timeout'.
+ */
+async function joinAndCompleteTask(
+  page: Page,
+  payload: { roomId: string; taskId: string; answers: Record<string, string> }
+): Promise<string> {
+  return page.evaluate(async args => {
+    const ensureIo = async (): Promise<SocketIoFactory | undefined> => {
+      const w = window as WindowWithIo
+      if (w.io) return w.io
+      await new Promise<void>((resolve, reject) => {
+        const script = document.createElement('script')
+        script.src = '/socket.io/socket.io.js'
+        script.onload = () => resolve()
+        script.onerror = () => reject(new Error('Failed to load socket.io client'))
+        document.head.appendChild(script)
+      })
+      return (window as WindowWithIo).io
+    }
+
+    const tokenRes = await fetch('/api/socket-token', { credentials: 'include' })
+    if (!tokenRes.ok) throw new Error(`socket-token fetch failed: ${tokenRes.status}`)
+    const { token } = (await tokenRes.json()) as { token?: string }
+    if (!token) throw new Error('No socket token returned')
+
+    const io = await ensureIo()
+    if (!io) throw new Error('Socket.io client unavailable in page context')
+
+    const socket = io({
+      path: '/api/socket',
+      transports: ['websocket', 'polling'],
+      auth: { token },
+    })
+    ;(window as WindowWithIo).__e2eGradingSocket = socket
+
+    return await new Promise<string>(resolve => {
+      let settled = false
+      const finish = (msg: string) => {
+        if (!settled) {
+          settled = true
+          resolve(msg)
+        }
+      }
+      socket.on('connect', () => {
+        socket.emit('join_class', { roomId: args.roomId })
+        // Small delay so the join is processed (room membership) before completing.
+        setTimeout(() => {
+          socket.emit('task:complete', {
+            roomId: args.roomId,
+            taskId: args.taskId,
+            answers: args.answers,
+          })
+        }, 800)
+      })
+      // task:completed is broadcast to the whole room, including the emitter.
+      socket.on('task:completed', () => finish('completed'))
+      socket.on('task:complete:error', p => finish(`error:${JSON.stringify(p)}`))
+      socket.on('connect_error', e => finish(`connect_error:${JSON.stringify(e)}`))
+      setTimeout(() => finish('timeout'), 10000)
+    })
+  }, payload)
+}
+
+async function disconnectStudentSocket(page: Page) {
+  await page.evaluate(() => {
+    ;(window as WindowWithIo).__e2eGradingSocket?.disconnect()
+  })
+}
+
+async function openTutorMonitor(page: Page, locale: string, sessionId: string) {
+  // /tutor/classroom redirects to the canonical insights classroom (view=classroom).
+  await page.goto(`/${locale}/tutor/classroom?sessionId=${encodeURIComponent(sessionId)}`)
+  await expect(page).toHaveURL(/\/tutor\/insights/, { timeout: 20000 })
+
+  // Open the Monitor tab (CourseBuilder live tab id 'student-monitor', label 'Monitor').
+  const tab = page.getByRole('tab', { name: /^Monitor$/ })
+  const button = page.getByRole('button', { name: /^Monitor$/ })
+  if (await tab.count()) {
+    await tab.first().click()
+  } else if (await button.count()) {
+    await button.first().click()
+  } else {
+    await page.getByText('Monitor', { exact: true }).first().click()
+  }
+}
+
+test.describe('Live auto-grading (tutor + student)', () => {
+  test('student task completion populates the tutor Monitor Understanding', async ({ browser }) => {
+    test.skip(
+      !process.env.E2E_LIVE_SESSION_ID || !process.env.E2E_LIVE_TASK_ID,
+      'Set E2E_LIVE_SESSION_ID and E2E_LIVE_TASK_ID to run this test.'
+    )
+
+    const locale = process.env.E2E_LOCALE ?? 'en'
+    const sessionId = process.env.E2E_LIVE_SESSION_ID as string
+    const taskId = process.env.E2E_LIVE_TASK_ID as string
+    const roomId = process.env.E2E_LIVE_ROOM_ID ?? sessionId
+
+    const tutorEmail = process.env.E2E_TUTOR_EMAIL ?? 'tutor@example.com'
+    const tutorPassword = process.env.E2E_TUTOR_PASSWORD ?? 'Password1'
+    const studentEmail = process.env.E2E_STUDENT_EMAIL ?? 'student@example.com'
+    const studentPassword = process.env.E2E_STUDENT_PASSWORD ?? 'Password1'
+    const studentName = process.env.E2E_STUDENT_NAME
+    const expectedUnderstanding = process.env.E2E_EXPECTED_UNDERSTANDING
+
+    let answers: Record<string, string> = {}
+    if (process.env.E2E_LIVE_TASK_ANSWERS) {
+      answers = JSON.parse(process.env.E2E_LIVE_TASK_ANSWERS) as Record<string, string>
+    }
+
+    const tutorCtx = await browser.newContext()
+    const studentCtx = await browser.newContext()
+    const tutorPage = await tutorCtx.newPage()
+    const studentPage = await studentCtx.newPage()
+
+    try {
+      await login(tutorPage, tutorEmail, tutorPassword, /\/tutor\//)
+      await login(studentPage, studentEmail, studentPassword, /\/student\//)
+
+      // 1) Tutor opens the live Monitor first, so it receives the student_joined
+      //    and task:completed broadcasts that drive the live roster + refetch.
+      await openTutorMonitor(tutorPage, locale, sessionId)
+
+      // 2) Student must be on a same-origin authenticated page to mint a socket
+      //    token; the dashboard is enough. The socket itself does the join.
+      await studentPage.goto(`/${locale}/student`)
+      await expect(studentPage).toHaveURL(/\/student/, { timeout: 15000 })
+
+      // 3) Student joins the room and completes the task (real socket events).
+      const result = await joinAndCompleteTask(studentPage, { roomId, taskId, answers })
+      expect(result, `task:complete server response was "${result}"`).toBe('completed')
+
+      // 4) Roster shows the student (if a name was provided to locate them).
+      if (studentName) {
+        await expect(tutorPage.getByText(studentName, { exact: false })).toBeVisible({
+          timeout: 30000,
+        })
+      }
+
+      // 5) The Monitor's Understanding fills from the live auto-grade. The label
+      //    "Understanding (N graded)" only renders once a real score exists
+      //    (vs. "awaiting grading"), so it's the precise success signal. Allow
+      //    for the ~3s post-completion refetch and the 20s poll backstop.
+      await expect(tutorPage.getByText(/Understanding \(\d+ graded\)/i).first()).toBeVisible({
+        timeout: 45000,
+      })
+
+      // 6) If an exact value was supplied, assert the rendered percentage.
+      if (expectedUnderstanding) {
+        await expect(
+          tutorPage.getByText(new RegExp(`\\b${expectedUnderstanding}%`)).first()
+        ).toBeVisible({ timeout: 10000 })
+      }
+    } finally {
+      await disconnectStudentSocket(studentPage).catch(() => {})
+      await tutorCtx.close()
+      await studentCtx.close()
+    }
+  })
+})

--- a/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
+++ b/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
@@ -80,7 +80,7 @@ import { GET as getComprehension } from '@/app/api/tutor/live-sessions/[sessionI
 async function gradeAndPersistCompletion(answers: Record<string, string>) {
   const now = new Date()
   let autoScore: number | null = null
-  let autoResults: Record<string, unknown> | null = null
+  let autoResults: ReturnType<typeof autoGradeDmi>['questionResults'] = null
   const [dmi] = await drizzleDb
     .select({ items: builderTaskDmi.items })
     .from(builderTaskDmi)
@@ -192,10 +192,13 @@ describe('Live auto-grading end-to-end', () => {
     expect(row?.score).toBe(EXPECTED_SCORE)
     // Per-item correctness recorded; stays 'submitted' so the tutor can override.
     expect(row?.status).toBe('submitted')
-    const qr = row?.questionResults as Record<string, { correct: boolean }> | null
-    expect(qr?.q1.correct).toBe(true)
-    expect(qr?.q2.correct).toBe(false)
-    expect(qr?.q3.correct).toBe(true)
+    const qr = row?.questionResults as { questionId: string; correct: boolean }[] | null
+    expect(Array.isArray(qr)).toBe(true)
+    expect(qr?.find(x => x.questionId === 'q1')?.correct).toBe(true)
+    expect(qr?.find(x => x.questionId === 'q2')?.correct).toBe(false)
+    expect(qr?.find(x => x.questionId === 'q3')?.correct).toBe(true)
+    // The answer key must never be persisted in the student-readable results.
+    expect(JSON.stringify(qr)).not.toContain('Photosynthesis')
   })
 
   it('surfaces the score as live Understanding via the real comprehension route', async () => {

--- a/tutorme-app/src/lib/grading/auto-grade.test.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.test.ts
@@ -32,7 +32,25 @@ describe('autoGradeDmi', () => {
   it('marks wrong/blank answers incorrect (conservative)', () => {
     const r = autoGradeDmi(items, { q1: 'London', q2: '', q3: 'respiration' })
     expect(r.score).toBe(0)
-    expect(r.questionResults?.q1.correct).toBe(false)
+    const q1 = r.questionResults?.find(x => x.questionId === 'q1')
+    expect(q1?.correct).toBe(false)
+  })
+
+  it('returns the canonical QuestionResultItem array shape without the answer key', () => {
+    const r = autoGradeDmi(items, { q1: 'Paris', q2: '7', q3: 'photosynthesis' })
+    expect(Array.isArray(r.questionResults)).toBe(true)
+    expect(r.questionResults).toHaveLength(3)
+    const q1 = r.questionResults?.find(x => x.questionId === 'q1')
+    expect(q1).toMatchObject({
+      questionId: 'q1',
+      correct: true,
+      pointsEarned: 100,
+      pointsMax: 100,
+      selectedAnswer: 'Paris',
+    })
+    // The expected answer key must never be embedded (questionResults is
+    // student-readable).
+    expect(JSON.stringify(r.questionResults)).not.toContain('Photosynthesis')
   })
 
   it('does not over-credit a single word against a long expected answer', () => {

--- a/tutorme-app/src/lib/grading/auto-grade.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.ts
@@ -8,6 +8,12 @@
  * full expected answer as a word sequence. This avoids over-crediting; verbose /
  * open-ended answers that don't reproduce the key are left for graded review.
  * It's a coarse, live signal, not a replacement for grading.
+ *
+ * `questionResults` uses the same array shape (QuestionResultItem) the REST quiz
+ * /assignment submit path writes, so every tutor/student view that reads a
+ * submission's results renders consistently. The expected answer is deliberately
+ * NOT included — questionResults is readable by the student, so it must never
+ * carry the answer key.
  */
 
 export interface DmiAnswerItem {
@@ -16,13 +22,24 @@ export interface DmiAnswerItem {
   questionText?: string
 }
 
+/** Structurally compatible with QuestionResultItem (components/quiz/quiz-modal). */
+export interface AutoGradeQuestionResult {
+  questionId: string
+  correct: boolean
+  pointsEarned: number
+  pointsMax: number
+  selectedAnswer?: string
+}
+
 export interface AutoGradeResult {
   /** 0–100, or null when nothing was gradable (no answer key). */
   score: number | null
-  questionResults: Record<string, { correct: boolean; expected: string; given: string }> | null
+  questionResults: AutoGradeQuestionResult[] | null
   gradable: number
   correct: number
 }
+
+const POINTS_PER_ITEM = 100
 
 function normalize(s: unknown): string {
   return String(s ?? '')
@@ -44,18 +61,20 @@ export function autoGradeDmi(
   }
 
   let correct = 0
-  const questionResults: Record<string, { correct: boolean; expected: string; given: string }> = {}
+  const questionResults: AutoGradeQuestionResult[] = []
   for (const item of gradable) {
     const rawGiven = given[item.id] ?? ''
     const g = normalize(rawGiven)
     const expected = normalize(item.answer)
     const isCorrect = g.length > 0 && (g === expected || ` ${g} `.includes(` ${expected} `))
     if (isCorrect) correct += 1
-    questionResults[item.id] = {
+    questionResults.push({
+      questionId: item.id,
       correct: isCorrect,
-      expected: String(item.answer ?? ''),
-      given: String(rawGiven),
-    }
+      pointsEarned: isCorrect ? POINTS_PER_ITEM : 0,
+      pointsMax: POINTS_PER_ITEM,
+      selectedAnswer: String(rawGiven),
+    })
   }
 
   return {

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1493,7 +1493,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
             // students). Conservative + best-effort — leaves score null when
             // there's no answer key. This feeds the tutor's live Understanding.
             let autoScore: number | null = null
-            let autoResults: Record<string, unknown> | null = null
+            let autoResults: ReturnType<typeof autoGradeDmi>['questionResults'] = null
             try {
               const [dmi] = await drizzleDb
                 .select({ items: builderTaskDmi.items })


### PR DESCRIPTION
## **User description**
## Summary
While reviewing the live auto-grading feature for gaps, found that it wrote `questionResults` in a **different shape** than the rest of the app — a real latent bug plus an answer-key leak.

- **Everywhere else** (`/api/student/assignments/[taskId]/submit`, `quiz-modal`) writes `questionResults` as a **`QuestionResultItem[]` array**, and every reader (student `quizzes`/`work`/`assignments` pages) consumes it with `.map()`.
- **The live auto-grader** wrote an **object keyed by item id** with an `expected` field.

### Two problems fixed
1. **Consistency/correctness** — any view that `.map()`s a live-graded submission's results would break on the object shape.
2. **Security** — `questionResults` is student-readable, and the object shape embedded the tutor's answer key (`expected`), leaking answers to students.

### Change
`autoGradeDmi` now returns `QuestionResultItem[]` (`{questionId, correct, pointsEarned, pointsMax, selectedAnswer}`) and never includes the expected answer. The socket handler + tests are updated, with a regression assertion (unit + integration) that the answer key never appears in `questionResults`.

## Testing
- Unit: **7/7** pass (added a shape + no-answer-key-leak test)
- Integration (throwaway Postgres, schema pushed): **2/2** pass, including the no-leak assertion on the persisted row
- `npm run typecheck`, eslint (0 errors), prettier, `npm run build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep live auto-grading results consistent and stop answer-key leaks**

### What Changed
- Live auto-graded submissions now store question results in the same array format used elsewhere, so tutor and student views can render them consistently.
- The saved results no longer include the expected answer, preventing students from seeing the answer key in readable submission data.
- Tests now check both the array shape and that the answer key is not present, and a new end-to-end flow verifies live grading updates the tutor Monitor view.

### Impact
`✅ Consistent live grading results`
`✅ Fewer broken result views`
`✅ No answer-key exposure in student-readable submissions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
