### PR TITLE
fix(student): real course progress on cards + populate Completed tab

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -398,10 +398,10 @@ function CoursePageInner() {
               slots: e.course?.schedule || [],
             },
             progress: {
-              lessonsCompleted: 0,
-              totalLessons: e.course?._count?.lessons || 0,
-              averageScore: null,
-              isCompleted: false,
+              lessonsCompleted: e.progress?.lessonsCompleted ?? 0,
+              totalLessons: e.progress?.totalLessons ?? e.course?._count?.lessons ?? 0,
+              averageScore: e.progress?.averageScore ?? null,
+              isCompleted: e.progress?.isCompleted ?? false,
             },
             enrollment: {
               startDate: startDate,

--- a/tutorme-app/src/app/api/student/enrollments/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/route.ts
@@ -13,12 +13,13 @@ import {
   course,
   courseLesson,
   courseEnrollment,
+  courseProgress,
   courseVariant,
   courseSchedule,
   liveSession,
   user,
 } from '@/lib/db/schema'
-import { eq, inArray, desc } from 'drizzle-orm'
+import { and, eq, inArray, desc } from 'drizzle-orm'
 import { sql } from 'drizzle-orm'
 import { enrollStudentInCourse, enrollmentPaymentRequiredResponse } from '@/lib/api/enrollments'
 
@@ -95,6 +96,28 @@ export const GET = withAuth(
         : []
     const lessonCountByCourse = new Map(lessonCounts.map(m => [m.courseId, m.count ?? 0]))
 
+    // Real per-course progress for this student. Completion mirrors dashboard-stats:
+    // courseProgress.isCompleted OR enrollment.completedAt is set.
+    const progressRows =
+      courseIds.length > 0
+        ? await drizzleDb
+            .select({
+              courseId: courseProgress.courseId,
+              lessonsCompleted: courseProgress.lessonsCompleted,
+              totalLessons: courseProgress.totalLessons,
+              averageScore: courseProgress.averageScore,
+              isCompleted: courseProgress.isCompleted,
+            })
+            .from(courseProgress)
+            .where(
+              and(
+                eq(courseProgress.studentId, session.user.id),
+                inArray(courseProgress.courseId, courseIds)
+              )
+            )
+        : []
+    const progressByCourse = new Map(progressRows.map(p => [p.courseId, p]))
+
     // Real session counts: a "session" is a materialized liveSession (one per
     // scheduled time slot, expanded over the schedule's weeks) — NOT a content
     // lesson. Count non-cancelled sessions per (course, schedule).
@@ -156,6 +179,13 @@ export const GET = withAuth(
         const weeks = chosen?.weeksToSchedule ?? 8
         sessionCount = slots.length * (weeks || 1)
       }
+      const p = progressByCourse.get(row.courseId)
+      const lessonTotal =
+        p?.totalLessons && p.totalLessons > 0
+          ? p.totalLessons
+          : (lessonCountByCourse.get(row.courseId) ?? 0)
+      const lessonsDone = Math.min(p?.lessonsCompleted ?? 0, lessonTotal)
+      const isCompleted = p?.isCompleted === true || row.enrollment.completedAt != null
       return {
         ...row.enrollment,
         chosenSchedule: chosen
@@ -166,6 +196,12 @@ export const GET = withAuth(
             }
           : null,
         sessionCount,
+        progress: {
+          lessonsCompleted: lessonsDone,
+          totalLessons: lessonTotal,
+          averageScore: p?.averageScore ?? null,
+          isCompleted,
+        },
         course: {
           courseId: row.courseId,
           name: row.courseName,


### PR DESCRIPTION
## **User description**
## Problem
`/student/courses` hardcoded progress in the enrollments→card mapping:
```ts
progress: { lessonsCompleted: 0, totalLessons: …, isCompleted: false }
```
Consequences:
- Every card's progress bar always showed **0%** (the prior `NaN%` fix only changed the symptom).
- The **Completed tab could never populate** (`isCompleted` was always `false`), and the Continue/Enter-Classroom label never flipped.

## Fix
- `GET /api/student/enrollments` now batch-loads real per-student `CourseProgress` and returns a `progress` object per enrollment: `lessonsCompleted`, `totalLessons`, `averageScore`, `isCompleted`. Completion mirrors `dashboard-stats` semantics: `courseProgress.isCompleted === true || enrollment.completedAt != null`. `totalLessons` falls back to the real lesson count; `lessonsCompleted` is clamped to the total.
- The courses page consumes `e.progress` instead of hardcoded zeros (with safe fallbacks).

## Verification (ran the app)
Student enrolled in a test course, driving the real UI:
1. ✅ **Partial progress (4/10)** → Ongoing card shows **40%** with a filled bar and a **Continue** button; no `NaN`; not in Completed.
2. ✅ **Marked completed (isCompleted=true)** → card leaves Ongoing, appears in the **Completed tab (1)** at **100%** with a **View Results** button, and the hero "Courses Completed" stat reads **1**.

| Ongoing (40%) | Completed (100%) |
|---|---|
| real progress + Continue | tab now populates + View Results |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show real course progress on student course cards and populate the Completed tab**

### What Changed
- Student course cards now use each student’s actual progress instead of showing 0% for every course
- Completed courses now appear in the Completed tab when the course is finished
- Progress counts are capped to the course total, and the card now carries the real score when available
- A course is treated as completed when progress says it is finished or when the enrollment already has a completion date

### Impact
`✅ Accurate course progress`
`✅ Completed courses appear in the right tab`
`✅ Fewer confusing 0% progress cards`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
