### PR TITLE
fix(tutor): live Understanding misses student submissions on template/published course split

### DIFF
--- a/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/comprehension/route.ts
+++ b/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/comprehension/route.ts
@@ -16,7 +16,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession, builderTask, taskSubmission } from '@/lib/db/schema'
+import { liveSession, builderTask, deployedMaterial, taskSubmission } from '@/lib/db/schema'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,13 +34,35 @@ export const GET = withAuth(
     if (session.user.role !== 'ADMIN' && sess.tutorId !== session.user.id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
-    if (!sess.courseId) return NextResponse.json({ comprehension: {} })
 
-    const tasks = await drizzleDb
-      .select({ taskId: builderTask.taskId })
-      .from(builderTask)
-      .where(eq(builderTask.courseId, sess.courseId))
-    const taskIds = tasks.map(t => t.taskId)
+    // Build the task set two ways and union them, so the live Understanding
+    // indicator is immune to the template-vs-published course-id split:
+    //   1. Tasks actually deployed into THIS session (deployedMaterial.itemId) —
+    //      session-scoped and independent of which courseId the BuilderTask row
+    //      happens to live under. This is what the submissions panel uses.
+    //   2. The session course's BuilderTasks (legacy path) — preserves behavior
+    //      for older sessions that predate deployedMaterial rows.
+    // Keying comprehension only off (2) silently dropped submissions whenever a
+    // deployed task's BuilderTask sat under the template course id rather than
+    // the published one the live session references.
+    const deployedRows = await drizzleDb
+      .select({ itemId: deployedMaterial.itemId, type: deployedMaterial.type })
+      .from(deployedMaterial)
+      .where(eq(deployedMaterial.sessionId, sessionId))
+    const courseTasks = sess.courseId
+      ? await drizzleDb
+          .select({ taskId: builderTask.taskId })
+          .from(builderTask)
+          .where(eq(builderTask.courseId, sess.courseId))
+      : []
+    const taskIds = Array.from(
+      new Set([
+        ...deployedRows
+          .filter(d => d.type === 'task' || d.type === 'assessment' || d.type === 'homework')
+          .map(d => d.itemId),
+        ...courseTasks.map(t => t.taskId),
+      ])
+    )
     if (taskIds.length === 0) return NextResponse.json({ comprehension: {} })
 
     const subs = await drizzleDb


### PR DESCRIPTION
## **User description**
## Symptom
A student submits a task during a live session, but it **does not reflect on the tutor side** (the live Monitor panel's per-student "Understanding" stays empty).

## Root cause (reproduced end-to-end)
The tutor's live Monitor reads `GET /api/tutor/live-sessions/[sessionId]/comprehension`, which built its task set as:
```ts
builderTask WHERE courseId == liveSession.courseId
```
But a deployed task's `BuilderTask` row commonly lives under the **template** course id, while the live session references the **published** course id (the established template/published variant split). So the filter matched **no tasks**, the submission query returned nothing, and the endpoint returned `{}` — the student's submission was invisible even though it was persisted and scored.

The submissions panel route (`/submissions`) was already immune because it derives tasks from `deployedMaterial.itemId` for the session; only the comprehension route used the brittle course-id filter. (`replay-artifact` and `submissions-tree` were checked — both already use `deployedMaterial`, so they're fine.)

## Fix
Derive the comprehension task set the same session-scoped way: from `deployedMaterial.itemId` for the session (split-proof), **unioned** with the course's `BuilderTask`s (legacy fallback for older sessions). Strictly additive — no task that matched before stops matching.

## Verification (ran the app — real tutor login + real API + real DB)
Built two live sessions under the published course, drove the authenticated tutor endpoints:

| Session | Deployed task's BuilderTask courseId | Before | After |
|---|---|---|---|
| Aligned | published (same as session) | understanding **80** | **80** (unchanged ✅) |
| Split | **template** (≠ session) | **`{}`** (submission hidden 🐞) | understanding **90** ✅ |

The `MonitoringPanel` already refetches this endpoint on the `task:completed` socket event, so with the endpoint fixed, a submission now surfaces live.

## Notes / out of scope
- Truly *ad-hoc* sessions (no `courseId` at all) still don't persist submissions (the socket handler bails early when a session has no course) — a separate, deeper limitation, not this symptom.
- `LiveSessionSubmissionsPanel` is currently dead code (defined, never rendered); left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show student submissions in the tutor live Understanding panel when a course is split between template and published versions**

### What Changed
- The tutor live Understanding panel now includes submissions from the task actually deployed in the live session, so student work shows up even when the task record belongs to the template course instead of the published course.
- It still keeps the older course-based lookup as a fallback for sessions created before deployed session records existed.
- If a session has no matching tasks, the panel still stays empty as before.

### Impact
`✅ Fewer missing tutor monitor updates`
`✅ Visible student submissions in split-course sessions`
`✅ Consistent live understanding scores`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
