### PR TITLE
fix(live): persist task submissions for course-less (ad-hoc) sessions

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -22,6 +22,7 @@ import {
   builderTask,
   builderTaskDmi,
   taskSubmission,
+  course,
 } from '@/lib/db/schema'
 import { autoGradeDmi } from '@/lib/grading/auto-grade'
 import { initFeedbackHandlers, initPollHandlers } from './socket-server'
@@ -418,6 +419,39 @@ async function getRoomFromRedis(roomId: string): Promise<ClassRoom | null> {
     console.error('Failed to retrieve room from Redis:', error)
     return null
   }
+}
+
+// A live session can legitimately have no courseId — it is nullable, and is
+// even nulled out (onDelete: 'set null') when the course is deleted. But
+// BuilderTask.courseId and DeployedMaterial.courseId are NOT NULL, so without a
+// course we previously couldn't persist a submission at all, and ad-hoc-session
+// completions vanished. Anchor those rows to a single hidden system course so
+// the submission persists and reaches the tutor. The real ownership/scoping is
+// preserved elsewhere: BuilderTask.tutorId (Grading page) and
+// DeployedMaterial.sessionId (live Understanding) — so anchored rows never leak
+// across tutors or sessions. The anchor is creatorId=null + isPublished=false,
+// so it shows up in no tutor "My courses" list and no student/published list.
+const ADHOC_ANCHOR_COURSE_ID = '__system_adhoc_course__'
+let adhocAnchorEnsured = false
+async function ensureAdhocAnchorCourseId(): Promise<string> {
+  if (adhocAnchorEnsured) return ADHOC_ANCHOR_COURSE_ID
+  const now = new Date()
+  // Explicit createdAt/updatedAt: those columns are notNull().defaultNow() in
+  // the schema, but the prod DB has drifted and lacks the column DEFAULT, so
+  // relying on the default inserts NULL and violates the constraint.
+  await drizzleDb
+    .insert(course)
+    .values({
+      courseId: ADHOC_ANCHOR_COURSE_ID,
+      name: 'Ad-hoc Sessions (system)',
+      isPublished: false,
+      creatorId: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing({ target: course.courseId })
+  adhocAnchorEnsured = true
+  return ADHOC_ANCHOR_COURSE_ID
 }
 
 // Per-event rate limiting middleware
@@ -1394,18 +1428,20 @@ export async function initEnhancedSocketServer(server: NetServer) {
               where: eq(liveSession.sessionId, roomId),
               columns: { courseId: true, tutorId: true },
             })
-            const courseId = sess?.courseId
             const tutorId = sess?.tutorId || room.tutorId
-            // builderTask/deployedMaterial both require a NOT NULL courseId, and
-            // the tree readers are course-scoped — so without a course we can't
-            // make the submission visible. Log loudly so this is diagnosable.
-            if (!courseId || !tutorId) {
+            // builderTask/deployedMaterial both require a NOT NULL courseId. A
+            // live session may have none (ad-hoc, or the course was deleted →
+            // courseId set null). Anchor those rows to a hidden system course so
+            // the completion still persists and reaches the tutor. We only need
+            // a tutorId to own the BuilderTask; without one we truly can't.
+            if (!tutorId) {
               console.warn(
-                '[task:complete] NOT persisting — live session has no courseId/tutor (ad-hoc session). Submissions require a course.',
-                { roomId, taskId, studentId, hasSessionRow: !!sess, courseId, tutorId }
+                '[task:complete] NOT persisting — no tutor for session (cannot own the task).',
+                { roomId, taskId, studentId, hasSessionRow: !!sess }
               )
               return
             }
+            const courseId = sess?.courseId || (await ensureAdhocAnchorCourseId())
 
             // Set createdAt/updatedAt/etc. explicitly throughout. These columns
             // are notNull().defaultNow() in the schema, but the prod DB has


### PR DESCRIPTION
## **User description**
Follow-up to #189. Closes the remaining gap I flagged there: student submissions in **course-less (ad-hoc) sessions** never reached the tutor at all.

## Problem
`liveSession.courseId` is nullable, and is even nulled out (`onDelete: 'set null'`) when a course is deleted. The `task:complete` self-heal block bailed out entirely when a session had no `courseId` ("ad-hoc session"), so the submission was **never persisted** and the tutor never saw it. (The `task:deploy` persist block has the same guard — but `task:complete` self-heals all rows, so fixing it covers the deploy gap too.)

The structural blocker: `BuilderTask.courseId` and `DeployedMaterial.courseId` are `NOT NULL`, so persisting requires *some* course.

## Fix
Anchor course-less submissions to a single **hidden system course** (`__system_adhoc_course__`, `creatorId=null` + `isPublished=false`), created lazily/idempotently. It shows up in no tutor "My courses" list (those filter `creatorId = me`) and no student/published list (filter `isPublished = true`). Real ownership/scoping is preserved elsewhere, so anchored rows never leak across tutors or sessions:
- `BuilderTask.tutorId` → the real tutor (Grading page scoping)
- `DeployedMaterial.sessionId` → the real session (live Understanding scoping, via the #189 fix)

The early bail now only triggers when there's no `tutorId` at all (no one to own the task).

## Verification (ran the app — real Socket.io flow end-to-end)
Created a live session with `courseId = NULL`, then drove real sockets: tutor `join_class` + `task:deploy`, student `join_class` + `task:complete`.

| Check | Before | After |
|---|---|---|
| `TaskSubmission` row | none | persisted (`status=submitted`) ✅ |
| `BuilderTask` | none | anchored to system course, `tutorId`=real tutor ✅ |
| `DeployedMaterial` | none | row for the session ✅ |
| Tutor comprehension API | `{}` | `{ student: { total: 1, … } }` ✅ |

Course sessions are unchanged — the real `courseId` is used whenever present (re-confirmed; no regression). Score is `null` for ad-hoc tasks because they have no answer key — same as any course task without a DMI key; the submission itself is now recorded and visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Persist ad-hoc session submissions**

### What Changed
- Student task completions in live sessions without a course now get saved instead of being dropped.
- When a session has no course, the submission is anchored to a hidden system course so the tutor can still see it.
- If a session has no tutor, the completion is still skipped because there is no owner for the task.

### Impact
`✅ Fewer missing ad-hoc submissions`
`✅ Clearer tutor visibility for course-less sessions`
`✅ Fewer lost live-session completions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
