### PR TITLE
fix(calendar): drag-to-reschedule actually persists (+ standalone sessions, broken reschedule button)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -882,30 +882,67 @@ export function InteractiveCalendar({
   )
 
   const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
+    async (event: DragEndEvent) => {
       const { active, over } = event
+      setActiveDragEvent(null)
 
-      if (over && active.id !== over.id) {
-        const draggedEvent = events.find(e => e.id === active.id)
-        const dropData = over.data.current as { date?: Date; hour?: number } | undefined
+      if (!over || active.id === over.id) return
 
-        if (draggedEvent && dropData?.date) {
-          const newDate = new Date(dropData.date)
-          if (dropData.hour !== undefined) {
-            newDate.setHours(dropData.hour, draggedEvent.date.getMinutes(), 0, 0)
-          } else {
-            newDate.setHours(draggedEvent.date.getHours(), draggedEvent.date.getMinutes(), 0, 0)
-          }
+      const draggedEvent = events.find(e => e.id === active.id)
+      const dropData = over.data.current as { date?: Date; hour?: number } | undefined
+      if (!draggedEvent || !dropData?.date) return
 
-          const updatedEvent = { ...draggedEvent, date: newDate }
-
-          setEvents(prev => prev.map(e => (e.id === draggedEvent.id ? updatedEvent : e)))
-          onEventUpdate?.(updatedEvent)
-          toast.success(`Rescheduled: ${draggedEvent.title} to ${format(newDate, 'MMM d, h:mm a')}`)
-        }
+      const previousDate = draggedEvent.date
+      const newDate = new Date(dropData.date)
+      if (dropData.hour !== undefined) {
+        newDate.setHours(dropData.hour, draggedEvent.date.getMinutes(), 0, 0)
+      } else {
+        newDate.setHours(draggedEvent.date.getHours(), draggedEvent.date.getMinutes(), 0, 0)
       }
 
-      setActiveDragEvent(null)
+      // Optimistically move the event, then persist. Revert on failure so the
+      // calendar never shows a reschedule that didn't actually happen.
+      const updatedEvent = { ...draggedEvent, date: newDate }
+      setEvents(prev => prev.map(e => (e.id === draggedEvent.id ? updatedEvent : e)))
+
+      try {
+        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
+        const res = await fetch(`/api/tutor/calendar/events/${draggedEvent.id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+          },
+          credentials: 'include',
+          body: JSON.stringify({
+            newStartTime: newDate.toISOString(),
+            durationMinutes: draggedEvent.duration,
+          }),
+        })
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}))
+          // Revert the optimistic move.
+          setEvents(prev =>
+            prev.map(e => (e.id === draggedEvent.id ? { ...draggedEvent, date: previousDate } : e))
+          )
+          if (res.status === 409) {
+            toast.error(err.error || 'That time conflicts with another session.')
+          } else {
+            toast.error(err.error || 'Failed to reschedule')
+          }
+          return
+        }
+
+        onEventUpdate?.(updatedEvent)
+        toast.success(`Rescheduled: ${draggedEvent.title} to ${format(newDate, 'MMM d, h:mm a')}`)
+      } catch {
+        setEvents(prev =>
+          prev.map(e => (e.id === draggedEvent.id ? { ...draggedEvent, date: previousDate } : e))
+        )
+        toast.error('Failed to reschedule')
+      }
     },
     [events, onEventUpdate]
   )
@@ -1791,14 +1828,27 @@ export function InteractiveCalendar({
                                           onClick={async () => {
                                             setRescheduling(ev.id)
                                             try {
+                                              const csrfRes = await fetch('/api/csrf', {
+                                                credentials: 'include',
+                                              })
+                                              const csrfToken =
+                                                (await csrfRes.json().catch(() => ({})))?.token ??
+                                                null
                                               const res = await fetch(
-                                                `/api/tutor/calendar/events/${ev.id}/reschedule`,
+                                                `/api/tutor/calendar/events/${ev.id}`,
                                                 {
                                                   method: 'PATCH',
-                                                  headers: { 'Content-Type': 'application/json' },
+                                                  headers: {
+                                                    'Content-Type': 'application/json',
+                                                    ...(csrfToken
+                                                      ? { 'X-CSRF-Token': csrfToken }
+                                                      : {}),
+                                                  },
                                                   credentials: 'include',
                                                   body: JSON.stringify({
-                                                    newStartTime: `${rec.date}T${rec.startTime}:00`,
+                                                    newStartTime: new Date(
+                                                      `${rec.date}T${rec.startTime}:00`
+                                                    ).toISOString(),
                                                   }),
                                                 }
                                               )

--- a/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
@@ -57,7 +57,57 @@ export const PATCH = withCsrf(
         .limit(1)
 
       if (!calEvent) {
-        return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+        // The calendar merges standalone LiveSessions that have no CalendarEvent
+        // row, surfacing them with id === sessionId. Dragging one sends that id
+        // here, so fall back to rescheduling the session directly.
+        const [sess] = await drizzleDb
+          .select()
+          .from(liveSession)
+          .where(and(eq(liveSession.sessionId, eventId), eq(liveSession.tutorId, tutorId)))
+          .limit(1)
+
+        if (!sess) {
+          return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+        }
+
+        const sessDuration = durationMinutes ?? sess.durationMinutes ?? 60
+        const sessEnd = new Date(newStart.getTime() + sessDuration * 60000)
+
+        const sessConflicts = await findConflicts(tutorId, newStart, sessEnd, {
+          excludeSessionId: eventId,
+        })
+        if (sessConflicts.length > 0) {
+          const alternativeSlots = await findAlternativeSlots(tutorId, newStart, sessDuration, {
+            maxSuggestions: 3,
+            excludeSessionId: eventId,
+          })
+          return NextResponse.json(
+            {
+              error: 'This time slot conflicts with an existing session.',
+              conflicts: sessConflicts.map(c => ({
+                type: c.type,
+                title: c.title,
+                startTime: c.startTime.toISOString(),
+                endTime: c.endTime.toISOString(),
+              })),
+              suggestedTimes: alternativeSlots,
+            },
+            { status: 409 }
+          )
+        }
+
+        await drizzleDb
+          .update(liveSession)
+          .set({ scheduledAt: newStart, durationMinutes: sessDuration })
+          .where(and(eq(liveSession.sessionId, eventId), eq(liveSession.tutorId, tutorId)))
+
+        return NextResponse.json({
+          success: true,
+          eventId,
+          newStartTime: newStart.toISOString(),
+          newEndTime: sessEnd.toISOString(),
+          durationMinutes: sessDuration,
+        })
       }
 
       const actualDuration =


### PR DESCRIPTION
## **User description**
## Symptom
On the tutor dashboard calendar, dragging a session to a new time slot **moved it visually but didn't actually reschedule** — it would snap back / not persist.

## Root cause
`handleDragEnd` in `InteractiveCalendar.tsx` only updated local React state and showed a success toast — it never called any API. (The toast made it look like it worked.) On top of that, there was **no working reschedule endpoint** for the calendar's events.

## Fix
**Client (`InteractiveCalendar.tsx`)** — `handleDragEnd` now:
- optimistically moves the event, then `PATCH /api/tutor/calendar/events/[id]` with CSRF + an ISO `newStartTime` (and the event's duration),
- **reverts** the move and toasts on failure, including `409` time conflicts.

**Server (`PATCH /api/tutor/calendar/events/[id]`)** — the route only handled `CalendarEvent` rows, but the calendar also renders **standalone `LiveSession`s** (surfaced with `id === sessionId`). It now falls back to rescheduling the `LiveSession` directly — same conflict check — when no `CalendarEvent` matches the id. (The draggable id is `event.id`, confirmed to match.)

**Bonus** — the conflict-recommendation "reschedule" button was broken three ways and silently failing: it called `.../events/[id]/reschedule` (no such route → 404), sent a non-ISO datetime the zod schema rejected, and omitted the CSRF header. Pointed it at the real endpoint with an ISO time + CSRF.

## Verification (ran the app — real tutor API, real DB)
| Scenario | Result |
|---|---|
| Drag a **standalone session** (new fallback path) | 200 — `LiveSession.scheduledAt` 10:00 → **15:00** in DB ✅ |
| Drag a **CalendarEvent-backed** session | 200 — both `CalendarEvent.startTime` **and** backing `LiveSession.scheduledAt` updated ✅ |
| Drag onto an **occupied slot** | **409** with conflict details + suggestions; client reverts ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Calendar rescheduling now saves the new time and handles standalone sessions**

### What Changed
- Dragging a session on the tutor calendar now actually saves the new time instead of only moving it on screen
- If the moved time conflicts with another session, the calendar restores the original slot and shows a conflict message
- Sessions that do not have a calendar event can now still be rescheduled from the calendar
- The suggested reschedule button now uses the working reschedule path, so recommended times apply correctly

### Impact
`✅ Fewer calendar moves that snap back`
`✅ Fewer reschedule failures for standalone sessions`
`✅ Clearer conflict handling when a slot is already taken`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
