### PR TITLE
feat(calendar): notify students on reschedule + sync their calendars

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
@@ -1,10 +1,73 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { calendarEvent, liveSession } from '@/lib/db/schema'
+import { calendarEvent, liveSession, courseEnrollment, sessionParticipant } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
+import { notifyMany } from '@/lib/notifications/notify'
+
+/**
+ * Notify every student of a rescheduled session (in-app + SSE + web push +
+ * email, via notify.ts). Students come from the course enrollment (the
+ * reliable roster) plus anyone already added as a session participant.
+ * Best-effort: never throws into the reschedule request.
+ */
+async function notifyStudentsOfReschedule(opts: {
+  sessionId: string
+  courseId: string | null
+  title: string | null
+  newStart: Date
+  timezone?: string | null
+}): Promise<void> {
+  try {
+    const { sessionId, courseId, title, newStart, timezone } = opts
+    const ids = new Set<string>()
+    if (courseId) {
+      const enrolled = await drizzleDb
+        .select({ studentId: courseEnrollment.studentId })
+        .from(courseEnrollment)
+        .where(eq(courseEnrollment.courseId, courseId))
+      for (const r of enrolled) if (r.studentId) ids.add(r.studentId)
+    }
+    const participants = await drizzleDb
+      .select({ studentId: sessionParticipant.studentId })
+      .from(sessionParticipant)
+      .where(eq(sessionParticipant.sessionId, sessionId))
+    for (const r of participants) if (r.studentId) ids.add(r.studentId)
+
+    const userIds = Array.from(ids)
+    if (userIds.length === 0) return
+
+    let when: string
+    try {
+      // NB: timeZoneName can't be combined with dateStyle/timeStyle (throws),
+      // so spell out the fields explicitly.
+      when = new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: timezone || 'UTC',
+        timeZoneName: 'short',
+      }).format(newStart)
+    } catch {
+      when = `${newStart.toISOString().replace('T', ' ').slice(0, 16)} UTC`
+    }
+
+    await notifyMany({
+      userIds,
+      type: 'class',
+      title: 'Session rescheduled',
+      message: `"${title || 'Your session'}" has been moved to ${when}.`,
+      data: { sessionId, scheduledAt: newStart.toISOString() },
+      actionUrl: courseId ? `/student/classroom/${courseId}` : '/student/schedule',
+    })
+  } catch (err) {
+    console.warn('[reschedule] student notification failed (non-critical):', err)
+  }
+}
 
 export const GET = withAuth(async () => {
   return NextResponse.json(
@@ -101,6 +164,21 @@ export const PATCH = withCsrf(
           .set({ scheduledAt: newStart, durationMinutes: sessDuration })
           .where(and(eq(liveSession.sessionId, eventId), eq(liveSession.tutorId, tutorId)))
 
+        // Keep any CalendarEvent projection for this session in sync too, so the
+        // student calendar (which prefers CalendarEvent.startTime) never shows a
+        // stale time.
+        await drizzleDb
+          .update(calendarEvent)
+          .set({ startTime: newStart, endTime: sessEnd, updatedAt: new Date() })
+          .where(eq(calendarEvent.externalId, eventId))
+
+        await notifyStudentsOfReschedule({
+          sessionId: eventId,
+          courseId: sess.courseId,
+          title: sess.title,
+          newStart,
+        })
+
         return NextResponse.json({
           success: true,
           eventId,
@@ -167,6 +245,16 @@ export const PATCH = withCsrf(
           .where(
             and(eq(liveSession.sessionId, calEvent.externalId), eq(liveSession.tutorId, tutorId))
           )
+
+        // Notify the session's students (only sessions have a roster; pure
+        // personal calendar events with no externalId have nobody to notify).
+        await notifyStudentsOfReschedule({
+          sessionId: calEvent.externalId,
+          courseId: calEvent.courseId,
+          title: calEvent.title,
+          newStart,
+          timezone: calEvent.timezone,
+        })
       }
 
       return NextResponse.json({


### PR DESCRIPTION
## **User description**
Follow-up to #192. When a tutor reschedules a session, **all of its students are now notified** and the change **reflects in their schedules and calendars**.

## What
On a successful reschedule (`PATCH /api/tutor/calendar/events/[id]`, both the CalendarEvent path and the standalone-LiveSession fallback):
- **Notify students** via `notifyMany` (type `class` → in-app + SSE + browser web push + email) with the new time, e.g. *"Algebra Live" has been moved to Jul 10, 2026, 4:30 PM UTC.* Roster = course enrollment ∪ session participants (deduped). Best-effort — never breaks the reschedule.
- **Keep calendars in sync.** The student calendar and dashboard prefer `CalendarEvent.startTime` over `liveSession.scheduledAt`, so a reschedule must update both. The CalendarEvent path already updated the backing `liveSession`; the standalone fallback now also updates any `CalendarEvent` whose `externalId` matches the session (so no stale cached time).

## Verification (ran the app — real tutor + student APIs)
Tutor rescheduled a session enrolled by a student:
1. ✅ Student's `GET /api/student/calendar/events` returned the **new** time (10:00Z → **16:30Z**).
2. ✅ A `Session rescheduled` notification row was created for the enrolled student (type `class`, actionUrl `/student/classroom/[courseId]`).
3. ✅ Message formats cleanly with timezone (fixed an `Intl` option clash — `timeZoneName` can't combine with `dateStyle`/`timeStyle`).

Notes: pure personal calendar events (no `externalId`, no roster) notify nobody, as intended. Students need a refresh/navigation to pick up the new time on already-open calendar views (those views don't live-poll) — the push/in-app notification is the live nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Notify students and keep rescheduled classes in sync**

### What Changed
- When a tutor moves a class session, all affected students now get a reschedule notice with the new time.
- Student lists come from both course enrollment and existing session participants, so the right students are reached even if the roster is spread across sources.
- Rescheduled sessions now update the student calendar time as well, preventing old times from showing after a change.
- Pure personal calendar events without a linked session are left without student notifications.

### Impact
`✅ Fewer missed class updates`
`✅ Fewer stale calendar times`
`✅ Clearer reschedule alerts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
