### PR TITLE
feat(tutor-dashboard): make the calendar notification indicator clickable

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -289,7 +289,9 @@ function CourseCard({
         <div className="mt-2 flex items-center gap-2 text-xs text-slate-300">
           <div className="flex items-center gap-1 font-medium text-slate-200">
             <BookOpen className="h-3.5 w-3.5 text-slate-400" />
-            <span>{course.sessionCount ?? 0} session{course.sessionCount === 1 ? '' : 's'}</span>
+            <span>
+              {course.sessionCount ?? 0} session{course.sessionCount === 1 ? '' : 's'}
+            </span>
           </div>
           <div className="h-3 w-px bg-white/15" />
           <button
@@ -569,7 +571,9 @@ export default function StudentCoursesPage() {
   }
 
   const ongoingCourses = courses.filter(
-    c => !c.progress?.isCompleted && (!c.enrollment?.startDate || new Date(c.enrollment.startDate) <= new Date())
+    c =>
+      !c.progress?.isCompleted &&
+      (!c.enrollment?.startDate || new Date(c.enrollment.startDate) <= new Date())
   )
   const completedCourses = courses.filter(c => c.progress?.isCompleted)
 
@@ -667,7 +671,10 @@ export default function StudentCoursesPage() {
   )
 }
 
-function formatCourseVariantName(variantCategory?: string | null, variantNationality?: string | null) {
+function formatCourseVariantName(
+  variantCategory?: string | null,
+  variantNationality?: string | null
+) {
   if (!variantCategory && !variantNationality) return undefined
   const parts = []
   if (variantCategory) parts.push(variantCategory)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -13,6 +13,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 
 import {
   Dialog,
@@ -698,9 +699,9 @@ export function InteractiveCalendar({
       return timeDiff > 0 && timeDiff < 24 * 60 * 60 * 1000 && e.status === 'scheduled'
     })
 
-    if (upcoming.length > 0) {
-      setNotifications(upcoming.map(e => `${e.title} at ${e.date.toLocaleTimeString()}`))
-    }
+    // Always sync (including to empty) so the indicator clears when there are no
+    // longer any upcoming sessions, instead of showing a stale count.
+    setNotifications(upcoming.map(e => `${e.title} at ${e.date.toLocaleTimeString()}`))
   }, [events])
 
   const filteredEvents = useMemo(() => {
@@ -1077,10 +1078,43 @@ export function InteractiveCalendar({
                     </SelectContent>
                   </Select>
                   {notifications.length > 0 && (
-                    <Badge variant="destructive" className="text-xs">
-                      <Bell className="mr-1 h-3 w-3" />
-                      {notifications.length}
-                    </Badge>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`${notifications.length} upcoming session notifications`}
+                          className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                        >
+                          <Badge
+                            variant="destructive"
+                            className="cursor-pointer text-xs transition-transform hover:scale-105"
+                          >
+                            <Bell className="mr-1 h-3 w-3" />
+                            {notifications.length}
+                          </Badge>
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-72 p-0">
+                        <div className="border-b px-3 py-2">
+                          <p className="text-sm font-semibold text-slate-800">Notifications</p>
+                          <p className="text-xs text-slate-500">
+                            {notifications.length} session{notifications.length === 1 ? '' : 's'} in
+                            the next 24 hours
+                          </p>
+                        </div>
+                        <ul className="max-h-72 divide-y overflow-y-auto">
+                          {notifications.map((note, idx) => (
+                            <li
+                              key={`${note}-${idx}`}
+                              className="flex items-start gap-2 px-3 py-2 text-sm text-slate-700"
+                            >
+                              <Bell className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-500" />
+                              <span className="min-w-0 break-words">{note}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </PopoverContent>
+                    </Popover>
                   )}
                 </div>
 


### PR DESCRIPTION
## **User description**
## Summary
The tutor dashboard's calendar showed a red **notification count badge** (e.g. "🔔 4") for upcoming sessions in the next 24 hours, but it was a static `Badge` — not clickable — so there was no way to read what the notifications were.

Now it's a **clickable Popover**: clicking the badge opens a list of the upcoming sessions (title + time).

## Changes (`InteractiveCalendar.tsx`)
- Wrapped the count badge in a `Popover` / `PopoverTrigger` / `PopoverContent`. The trigger is a real button (keyboard-focusable, `aria-label`), and the content lists each reminder with a bell icon and scrolls if long.
- Fixed a latent bug: the effect only called `setNotifications` when the upcoming list was non-empty, so the count never cleared once sessions passed — leaving a stale badge. It now syncs unconditionally (including to empty).

## Notes
- These notifications are the calendar's own "session starting within 24h" reminders (derived from `events`), which is what the indicator was already counting — so the popover shows exactly what the number refers to.
- Routine merge of latest `main` included (no conflicts); also reformatted one unrelated drifted file to keep CI's Format check green.

## Testing
`npm run typecheck` ✅, `eslint` (no new errors) ✅, `prettier --check` ✅, `npm run build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make the calendar notification badge clickable and keep its count accurate

### What Changed
- The tutor dashboard calendar notification badge now opens a popover showing each upcoming session when clicked
- The popover lists the session title and time, and the badge is keyboard focusable for easier access
- The notification count now clears when there are no upcoming sessions, so old reminders no longer stay visible

### Impact
`✅ Easier review of upcoming session alerts`
`✅ Fewer stale notification counts`
`✅ Clearer access to calendar reminders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
