### PR TITLE
fix(calendar): localize reschedule notifications per student's timezone (+ tz audit)

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
@@ -1,16 +1,56 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { calendarEvent, liveSession, courseEnrollment, sessionParticipant } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import {
+  calendarEvent,
+  liveSession,
+  courseEnrollment,
+  sessionParticipant,
+  profile,
+} from '@/lib/db/schema'
+import { eq, and, inArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
-import { notifyMany } from '@/lib/notifications/notify'
+import { notify } from '@/lib/notifications/notify'
+
+/** Format an instant in a specific IANA timezone, with the zone labelled. */
+function formatInZone(date: Date, tz: string): string {
+  try {
+    // NB: timeZoneName can't be combined with dateStyle/timeStyle (throws),
+    // so spell out the fields explicitly.
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: tz,
+      timeZoneName: 'short',
+    }).format(date)
+  } catch {
+    // Invalid/unknown tz → fall back to UTC, still labelled.
+    try {
+      return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: 'UTC',
+        timeZoneName: 'short',
+      }).format(date)
+    } catch {
+      return `${date.toISOString().replace('T', ' ').slice(0, 16)} UTC`
+    }
+  }
+}
 
 /**
  * Notify every student of a rescheduled session (in-app + SSE + web push +
  * email, via notify.ts). Students come from the course enrollment (the
- * reliable roster) plus anyone already added as a session participant.
+ * reliable roster) plus anyone already added as a session participant. The new
+ * time is formatted in EACH student's own profile timezone so it reads as their
+ * local time; the session's timezone (or UTC) is the fallback.
  * Best-effort: never throws into the reschedule request.
  */
 async function notifyStudentsOfReschedule(opts: {
@@ -39,31 +79,30 @@ async function notifyStudentsOfReschedule(opts: {
     const userIds = Array.from(ids)
     if (userIds.length === 0) return
 
-    let when: string
-    try {
-      // NB: timeZoneName can't be combined with dateStyle/timeStyle (throws),
-      // so spell out the fields explicitly.
-      when = new Intl.DateTimeFormat('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZone: timezone || 'UTC',
-        timeZoneName: 'short',
-      }).format(newStart)
-    } catch {
-      when = `${newStart.toISOString().replace('T', ' ').slice(0, 16)} UTC`
-    }
+    // Each student's own timezone (default 'UTC' in schema) → localize per user.
+    const tzRows = await drizzleDb
+      .select({ userId: profile.userId, timezone: profile.timezone })
+      .from(profile)
+      .where(inArray(profile.userId, userIds))
+    const tzByUser = new Map(tzRows.map(r => [r.userId, r.timezone]))
+    const fallbackTz = timezone || 'UTC'
 
-    await notifyMany({
-      userIds,
-      type: 'class',
-      title: 'Session rescheduled',
-      message: `"${title || 'Your session'}" has been moved to ${when}.`,
-      data: { sessionId, scheduledAt: newStart.toISOString() },
-      actionUrl: courseId ? `/student/classroom/${courseId}` : '/student/schedule',
-    })
+    const name = title || 'Your session'
+    const actionUrl = courseId ? `/student/classroom/${courseId}` : '/student/schedule'
+
+    await Promise.allSettled(
+      userIds.map(userId => {
+        const when = formatInZone(newStart, tzByUser.get(userId) || fallbackTz)
+        return notify({
+          userId,
+          type: 'class',
+          title: 'Session rescheduled',
+          message: `"${name}" has been moved to ${when}.`,
+          data: { sessionId, scheduledAt: newStart.toISOString() },
+          actionUrl,
+        })
+      })
+    )
   } catch (err) {
     console.warn('[reschedule] student notification failed (non-critical):', err)
   }


### PR DESCRIPTION
## **User description**
You asked me to confirm and ensure timezones are properly wired. I audited the full calendar/scheduling flow, verified it across multiple timezones, and fixed the one real gap.

## Audit result

| Layer | Finding |
|---|---|
| **Storage** | `liveSession.scheduledAt` / `CalendarEvent.startTime` are `timestamptz` (UTC). ✅ |
| **Calendar grid render** | Positions/labels events with `getHours()` / `toLocaleTimeString()` on the stored instant → each viewer sees their own local time. ✅ |
| **Drag-to-reschedule** | Builds the new time with local `setHours` then `toISOString()` → correct UTC instant regardless of the tutor's browser tz. ✅ |
| **Cross-user** | Tutor drags in their tz → stored as one UTC instant → student's calendar renders it in the student's local tz. ✅ |
| **Reschedule notification** | 🐞 **Was** formatted once in the session/tutor tz (or UTC) for everyone — a student in another tz saw a non-local time. **Fixed.** |

## Fix
The reschedule notification now formats the new time in **each student's `profile.timezone`** (session tz, then UTC, as fallbacks), with the zone labelled so it's always unambiguous. (Switched from a single `notifyMany` to per-student `notify` so each message can be localized.)

## Verification (ran the app)
- **Per-student localization** — one reschedule (16:30 UTC) notified two students in different zones, each with their own local time:
  - stu1 `Asia/Shanghai` → *Jul 11, 2026, 12:30 AM GMT+8*
  - stu2 `America/New_York` → *Jul 10, 2026, 12:30 PM EDT*
- **Render mechanism** — the same 16:30 UTC instant in real browser contexts: New York → 12:30 PM (Jul 10), Shanghai → 12:30 AM (Jul 11), London → 5:30 PM (Jul 10). Confirms the grid/drag are tz-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make reschedule notifications show the time in each student’s own timezone

### What Changed
- Reschedule notifications now show the new session time in each student’s profile timezone instead of one shared timezone for everyone
- If a student has no saved timezone, the message falls back to the session timezone or UTC, and still labels the time clearly
- Reschedule notifications are sent individually so each student receives a localized message

### Impact
`✅ Clearer reschedule times for students in different timezones`
`✅ Fewer confused reschedule notifications`
`✅ More reliable session reminders after schedule changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
