### PR TITLE
feat(notifications): send upcoming-session reminders to the bell

### DIFF
--- a/tutorme-app/drizzle/0062_session_reminder_sent_at.sql
+++ b/tutorme-app/drizzle/0062_session_reminder_sent_at.sql
@@ -1,0 +1,3 @@
+-- Track when an upcoming-session reminder notification has been sent, so the
+-- in-process reminder scheduler sends exactly one per session (race-safe).
+ALTER TABLE "LiveSession" ADD COLUMN IF NOT EXISTS "reminderSentAt" timestamp with time zone;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781600000000,
       "tag": "0061_llm_token_usage",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781700000000,
+      "tag": "0062_session_reminder_sent_at",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/server.ts
+++ b/tutorme-app/server.ts
@@ -11,6 +11,7 @@ import { config as dotenvConfig } from 'dotenv'
 import { initEnhancedSocketServer } from './src/lib/socket-server-enhanced'
 import { validateEnv } from './src/lib/env'
 import { applyStartupSchemaFixes } from './src/lib/db/startup-schema-fix'
+import { startSessionReminderScheduler } from './src/lib/notifications/session-reminder-scheduler'
 
 // Load environment variables from .env.local before validation
 // .env.local takes precedence over .env
@@ -53,7 +54,9 @@ const hostname = process.env.HOSTNAME || '0.0.0.0'
  * In monorepos, standalone output is nested. We ensure 'dir' points to where .next is.
  */
 const appDir = resolve(__dirname)
-console.log(`[Server] Environment: ${process.env.NODE_ENV}, Port: ${port}, Hostname: ${hostname}, App Dir: ${appDir}`)
+console.log(
+  `[Server] Environment: ${process.env.NODE_ENV}, Port: ${port}, Hostname: ${hostname}, App Dir: ${appDir}`
+)
 
 const app = next({
   dev,
@@ -214,6 +217,9 @@ server
 
         console.log(`🎉 [Server] FULLY OPERATIONAL in ${elapsed(startupStart)}.`)
         isReady = true
+
+        // Background: send upcoming-session reminders into the notification bell.
+        startSessionReminderScheduler()
       } catch (err: unknown) {
         const error = err instanceof Error ? err : new Error('Background initialization failed')
         console.error('❌ [Server] Background Initialization Failed:', error)

--- a/tutorme-app/src/__tests__/integration/session-reminders.test.ts
+++ b/tutorme-app/src/__tests__/integration/session-reminders.test.ts
@@ -34,15 +34,13 @@ function reminderRows() {
 describe('session reminder scheduler', () => {
   beforeAll(async () => {
     const now = Date.now()
-    await drizzleDb
-      .insert(user)
-      .values({
-        userId: tutorId,
-        email: tutorEmail,
-        role: 'TUTOR',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
+    await drizzleDb.insert(user).values({
+      userId: tutorId,
+      email: tutorEmail,
+      role: 'TUTOR',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
     await drizzleDb.insert(liveSession).values([
       {
         sessionId: soonId,

--- a/tutorme-app/src/__tests__/integration/session-reminders.test.ts
+++ b/tutorme-app/src/__tests__/integration/session-reminders.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration test: session-reminder scheduler writes reminders into the bell.
+ *
+ * Verifies the scan: an upcoming session within the lead window produces a
+ * `reminder` notification (the row the bell reads) for the tutor, sets
+ * reminderSentAt, and is idempotent (a second scan sends nothing). Sessions
+ * outside the window or already reminded are left alone.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { and, eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, liveSession, notification } from '@/lib/db/schema'
+import { runSessionReminderScan } from '@/lib/notifications/session-reminder-scheduler'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const tutorEmail = `claude-remind-tutor-${stamp}@example.com`
+
+const soonId = `sess_soon_${stamp}` // within the 60-min lead window
+const laterId = `sess_later_${stamp}` // outside the window
+const doneId = `sess_done_${stamp}` // already reminded
+
+function reminderRows() {
+  return drizzleDb
+    .select({ id: notification.notificationId, type: notification.type, data: notification.data })
+    .from(notification)
+    .where(and(eq(notification.userId, tutorId), eq(notification.type, 'reminder')))
+}
+
+describe('session reminder scheduler', () => {
+  beforeAll(async () => {
+    const now = Date.now()
+    await drizzleDb
+      .insert(user)
+      .values({
+        userId: tutorId,
+        email: tutorEmail,
+        role: 'TUTOR',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    await drizzleDb.insert(liveSession).values([
+      {
+        sessionId: soonId,
+        tutorId,
+        title: 'Algebra (soon)',
+        category: 'general',
+        status: 'scheduled',
+        scheduledAt: new Date(now + 30 * 60 * 1000),
+      },
+      {
+        sessionId: laterId,
+        tutorId,
+        title: 'History (later)',
+        category: 'general',
+        status: 'scheduled',
+        scheduledAt: new Date(now + 5 * 60 * 60 * 1000),
+      },
+      {
+        sessionId: doneId,
+        tutorId,
+        title: 'Already reminded',
+        category: 'general',
+        status: 'scheduled',
+        scheduledAt: new Date(now + 20 * 60 * 1000),
+        reminderSentAt: new Date(now - 60 * 1000),
+      },
+    ])
+  })
+
+  afterAll(async () => {
+    const t = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn()
+      } catch {}
+    }
+    await t(() => drizzleDb.delete(notification).where(eq(notification.userId, tutorId)))
+    await t(() =>
+      drizzleDb.delete(liveSession).where(inArray(liveSession.sessionId, [soonId, laterId, doneId]))
+    )
+    await t(() => drizzleDb.delete(user).where(eq(user.userId, tutorId)))
+  })
+
+  it('sends one reminder for the imminent session only, and is idempotent', async () => {
+    await runSessionReminderScan()
+
+    const rows = await reminderRows()
+    expect(rows).toHaveLength(1)
+    expect((rows[0].data as { sessionId?: string })?.sessionId).toBe(soonId)
+
+    // reminderSentAt claimed on the imminent session; window/already-done untouched.
+    const [soon] = await drizzleDb
+      .select({ reminderSentAt: liveSession.reminderSentAt })
+      .from(liveSession)
+      .where(eq(liveSession.sessionId, soonId))
+      .limit(1)
+    expect(soon?.reminderSentAt).toBeTruthy()
+
+    const [later] = await drizzleDb
+      .select({ reminderSentAt: liveSession.reminderSentAt })
+      .from(liveSession)
+      .where(eq(liveSession.sessionId, laterId))
+      .limit(1)
+    expect(later?.reminderSentAt).toBeNull()
+
+    // Second scan must not create a duplicate (claim already taken).
+    await runSessionReminderScan()
+    const after = await reminderRows()
+    expect(after).toHaveLength(1)
+  })
+})

--- a/tutorme-app/src/lib/db/schema/tables/live.ts
+++ b/tutorme-app/src/lib/db/schema/tables/live.ts
@@ -44,6 +44,9 @@ export const liveSession = pgTable(
     recordingAvailableAt: timestamp('recordingAvailableAt', { withTimezone: true }),
     maxStudents: integer('maxStudents').notNull().default(50),
     durationMinutes: integer('durationMinutes').notNull().default(120),
+    // Set when an upcoming-session reminder notification has been sent, so the
+    // reminder scheduler sends exactly one per session (race-safe across workers).
+    reminderSentAt: timestamp('reminderSentAt', { withTimezone: true }),
   },
   table => ({
     LiveSession_tutorId_idx: index('LiveSession_tutorId_idx').on(table.tutorId),

--- a/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
+++ b/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
@@ -1,0 +1,109 @@
+/**
+ * Session reminder scheduler.
+ *
+ * Periodically finds upcoming live sessions entering a short lead window and
+ * sends the tutor a `reminder` notification via the central notify() service —
+ * which writes it to the notification table (so it shows in the bell), pushes it
+ * over SSE, and optionally emails / web-pushes.
+ *
+ * Runs in the long-running custom server (server.ts). It is:
+ *  - Idempotent / race-safe: each session is "claimed" with an atomic
+ *    `UPDATE ... SET reminderSentAt = now WHERE reminderSentAt IS NULL`, so only
+ *    one tick (and one server instance) ever sends a given reminder.
+ *  - Resilient to brief sleeps: the lead window is wide, so a session that was
+ *    missed while the instance was scaled down is still picked up on the next
+ *    tick as long as it hasn't started yet.
+ */
+
+import { and, eq, gte, lte, inArray, isNull } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { liveSession } from '@/lib/db/schema'
+import { notify } from './notify'
+
+/** How far ahead of a session's start to send the reminder. */
+const REMINDER_LEAD_MINUTES = 60
+/** How often to scan for due reminders. */
+const CHECK_INTERVAL_MS = 5 * 60 * 1000
+/** Delay the first scan so it doesn't compete with cold-start work. */
+const INITIAL_DELAY_MS = 30 * 1000
+/** Cap per tick so a backlog can't fan out unbounded work. */
+const MAX_PER_TICK = 100
+
+let started = false
+
+/**
+ * One scan: claim + notify for every session entering the lead window. Exported
+ * for tests; the scheduler calls it on each tick.
+ */
+export async function runSessionReminderScan(): Promise<void> {
+  const now = new Date()
+  const windowEnd = new Date(now.getTime() + REMINDER_LEAD_MINUTES * 60 * 1000)
+
+  const due = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      tutorId: liveSession.tutorId,
+      title: liveSession.title,
+      scheduledAt: liveSession.scheduledAt,
+    })
+    .from(liveSession)
+    .where(
+      and(
+        inArray(liveSession.status, ['scheduled', 'preparing']),
+        isNull(liveSession.reminderSentAt),
+        gte(liveSession.scheduledAt, now),
+        lte(liveSession.scheduledAt, windowEnd)
+      )
+    )
+    .limit(MAX_PER_TICK)
+
+  for (const s of due) {
+    if (!s.scheduledAt) continue
+
+    // Atomically claim the reminder. Only the worker that flips reminderSentAt
+    // from NULL gets to send — prevents duplicates across ticks and instances.
+    const claimed = await drizzleDb
+      .update(liveSession)
+      .set({ reminderSentAt: now })
+      .where(and(eq(liveSession.sessionId, s.sessionId), isNull(liveSession.reminderSentAt)))
+      .returning({ id: liveSession.sessionId })
+    if (claimed.length === 0) continue
+
+    const minutes = Math.max(1, Math.round((s.scheduledAt.getTime() - Date.now()) / 60000))
+    try {
+      await notify({
+        userId: s.tutorId,
+        type: 'reminder',
+        title: 'Upcoming session',
+        message: `"${s.title}" starts in about ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+        actionUrl: `/tutor/insights?sessionId=${encodeURIComponent(s.sessionId)}&view=classroom`,
+        data: {
+          sessionId: s.sessionId,
+          scheduledAt: s.scheduledAt.toISOString(),
+          kind: 'session-reminder',
+        },
+      })
+    } catch (err) {
+      console.error('[session-reminders] notify failed for session', s.sessionId, err)
+    }
+  }
+}
+
+/** Idempotent — starts the periodic scan once per process. */
+export function startSessionReminderScheduler(): void {
+  if (started) return
+  started = true
+
+  const tick = () => {
+    void runSessionReminderScan().catch(err =>
+      console.error('[session-reminders] tick error:', err)
+    )
+  }
+
+  setTimeout(tick, INITIAL_DELAY_MS)
+  const handle = setInterval(tick, CHECK_INTERVAL_MS)
+  // Don't keep the process alive solely for this timer.
+  if (typeof handle.unref === 'function') handle.unref()
+
+  console.log('[session-reminders] scheduler started')
+}


### PR DESCRIPTION
## **User description**
## Summary
Session reminders now appear in the notification bell. Previously the only "upcoming session" surface was the calendar's ephemeral 24h list (client-derived, not in the notifications DB), so nothing reached the bell. This adds real `reminder` notifications.

## How it works
- A scheduler in the long-running custom server (`server.ts`) scans every **5 min** for sessions starting within the next **60 min** and sends the tutor a `reminder` notification via the central `notify()` service — which writes the notification row the bell reads, broadcasts over **SSE**, and (for the `reminder` type) also web-pushes/emails.
- New **`reminderSentAt`** column on `LiveSession` (migration **0062**, a trivial idempotent `ADD COLUMN IF NOT EXISTS`) is used for a **race-safe atomic claim** (`UPDATE … SET reminderSentAt = now WHERE reminderSentAt IS NULL RETURNING`), so each session is reminded **exactly once** — even across multiple instances or repeated ticks.
- The lead window is wide and the claim is idempotent, so a brief Cloud Run scale-to-zero doesn't drop a reminder; it's picked up on the next tick while the session is still upcoming. (The server is kept warm by the existing keep-alive workflow.)

## Scope
Reminders target the session's **tutor**. Notifying enrolled **students** too is a small follow-up (`notifyMany` + enrollment query) if you want it.

## Testing
- Integration test (throwaway Postgres): imminent session → exactly one reminder + claim set; out-of-window and already-reminded sessions untouched; a second scan is a no-op (idempotent). **Passed.**
- `npm run typecheck` ✅, `eslint` (no new errors) ✅, `prettier --check` ✅, `npm run build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Send upcoming session reminders to tutors**

### What Changed
- Tutors now get a notification about sessions starting within the next hour, and it appears in the notification bell
- Each session is marked after its reminder is sent, so the same reminder is not sent twice
- The reminder scan runs automatically in the main server after startup
- Added an integration test that confirms only the upcoming session gets a reminder, already-reminded sessions are skipped, and repeat scans do not create duplicates

### Impact
`✅ Session reminders in the notification bell`
`✅ Fewer duplicate reminder alerts`
`✅ Fewer missed upcoming-session reminders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
