### PR TITLE
feat(notifications): also send session reminders to enrolled students

### DIFF
--- a/tutorme-app/src/__tests__/integration/session-reminders.test.ts
+++ b/tutorme-app/src/__tests__/integration/session-reminders.test.ts
@@ -2,9 +2,9 @@
  * Integration test: session-reminder scheduler writes reminders into the bell.
  *
  * Verifies the scan: an upcoming session within the lead window produces a
- * `reminder` notification (the row the bell reads) for the tutor, sets
- * reminderSentAt, and is idempotent (a second scan sends nothing). Sessions
- * outside the window or already reminded are left alone.
+ * `reminder` notification (the row the bell reads) for the tutor AND every
+ * enrolled student, sets reminderSentAt, and is idempotent (a second scan sends
+ * nothing). Sessions outside the window or already reminded are left alone.
  *
  * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
  */
@@ -13,38 +13,63 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import crypto from 'crypto'
 import { and, eq, inArray } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { user, liveSession, notification } from '@/lib/db/schema'
+import { user, course, courseEnrollment, liveSession, notification } from '@/lib/db/schema'
 import { runSessionReminderScan } from '@/lib/notifications/session-reminder-scheduler'
 
 const stamp = Date.now()
 const tutorId = crypto.randomUUID()
-const tutorEmail = `claude-remind-tutor-${stamp}@example.com`
+const studentAId = crypto.randomUUID()
+const studentBId = crypto.randomUUID()
+const allUserIds = [tutorId, studentAId, studentBId]
+const courseId = `course_remind_${stamp}`
 
-const soonId = `sess_soon_${stamp}` // within the 60-min lead window
+const soonId = `sess_soon_${stamp}` // within the 60-min lead window (has a course)
 const laterId = `sess_later_${stamp}` // outside the window
 const doneId = `sess_done_${stamp}` // already reminded
 
-function reminderRows() {
+function reminderRowsFor(userId: string) {
   return drizzleDb
-    .select({ id: notification.notificationId, type: notification.type, data: notification.data })
+    .select({ id: notification.notificationId, data: notification.data })
     .from(notification)
-    .where(and(eq(notification.userId, tutorId), eq(notification.type, 'reminder')))
+    .where(and(eq(notification.userId, userId), eq(notification.type, 'reminder')))
 }
 
 describe('session reminder scheduler', () => {
   beforeAll(async () => {
     const now = Date.now()
-    await drizzleDb.insert(user).values({
-      userId: tutorId,
-      email: tutorEmail,
-      role: 'TUTOR',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    })
+    await drizzleDb.insert(user).values([
+      {
+        userId: tutorId,
+        email: `claude-remind-tutor-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: studentAId,
+        email: `claude-remind-stuA-${stamp}@example.com`,
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: studentBId,
+        email: `claude-remind-stuB-${stamp}@example.com`,
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    await drizzleDb.insert(course).values({ courseId, name: 'Reminder Course', creatorId: tutorId })
+    await drizzleDb.insert(courseEnrollment).values([
+      { enrollmentId: `enr_a_${stamp}`, studentId: studentAId, courseId },
+      { enrollmentId: `enr_b_${stamp}`, studentId: studentBId, courseId },
+    ])
     await drizzleDb.insert(liveSession).values([
       {
         sessionId: soonId,
         tutorId,
+        courseId,
         title: 'Algebra (soon)',
         category: 'general',
         status: 'scheduled',
@@ -76,21 +101,28 @@ describe('session reminder scheduler', () => {
         await fn()
       } catch {}
     }
-    await t(() => drizzleDb.delete(notification).where(eq(notification.userId, tutorId)))
+    await t(() => drizzleDb.delete(notification).where(inArray(notification.userId, allUserIds)))
     await t(() =>
       drizzleDb.delete(liveSession).where(inArray(liveSession.sessionId, [soonId, laterId, doneId]))
     )
-    await t(() => drizzleDb.delete(user).where(eq(user.userId, tutorId)))
+    await t(() => drizzleDb.delete(courseEnrollment).where(eq(courseEnrollment.courseId, courseId)))
+    await t(() => drizzleDb.delete(course).where(eq(course.courseId, courseId)))
+    await t(() => drizzleDb.delete(user).where(inArray(user.userId, allUserIds)))
   })
 
-  it('sends one reminder for the imminent session only, and is idempotent', async () => {
+  it('reminds the tutor and every enrolled student once, idempotently', async () => {
     await runSessionReminderScan()
 
-    const rows = await reminderRows()
-    expect(rows).toHaveLength(1)
-    expect((rows[0].data as { sessionId?: string })?.sessionId).toBe(soonId)
+    // Tutor reminded for the imminent session.
+    const tutorRows = await reminderRowsFor(tutorId)
+    expect(tutorRows).toHaveLength(1)
+    expect((tutorRows[0].data as { sessionId?: string })?.sessionId).toBe(soonId)
 
-    // reminderSentAt claimed on the imminent session; window/already-done untouched.
+    // Both enrolled students reminded.
+    expect(await reminderRowsFor(studentAId)).toHaveLength(1)
+    expect(await reminderRowsFor(studentBId)).toHaveLength(1)
+
+    // The imminent session is claimed; the out-of-window one is untouched.
     const [soon] = await drizzleDb
       .select({ reminderSentAt: liveSession.reminderSentAt })
       .from(liveSession)
@@ -105,9 +137,10 @@ describe('session reminder scheduler', () => {
       .limit(1)
     expect(later?.reminderSentAt).toBeNull()
 
-    // Second scan must not create a duplicate (claim already taken).
+    // Second scan must not duplicate any reminder (claim already taken).
     await runSessionReminderScan()
-    const after = await reminderRows()
-    expect(after).toHaveLength(1)
+    expect(await reminderRowsFor(tutorId)).toHaveLength(1)
+    expect(await reminderRowsFor(studentAId)).toHaveLength(1)
+    expect(await reminderRowsFor(studentBId)).toHaveLength(1)
   })
 })

--- a/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
+++ b/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
@@ -2,9 +2,10 @@
  * Session reminder scheduler.
  *
  * Periodically finds upcoming live sessions entering a short lead window and
- * sends the tutor a `reminder` notification via the central notify() service —
- * which writes it to the notification table (so it shows in the bell), pushes it
- * over SSE, and optionally emails / web-pushes.
+ * sends the tutor AND the course's enrolled students a `reminder` notification
+ * via the central notify() service — which writes it to the notification table
+ * (so it shows in the bell), pushes it over SSE, and optionally emails /
+ * web-pushes.
  *
  * Runs in the long-running custom server (server.ts). It is:
  *  - Idempotent / race-safe: each session is "claimed" with an atomic
@@ -17,8 +18,8 @@
 
 import { and, eq, gte, lte, inArray, isNull } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession } from '@/lib/db/schema'
-import { notify } from './notify'
+import { liveSession, courseEnrollment } from '@/lib/db/schema'
+import { notify, notifyMany } from './notify'
 
 /** How far ahead of a session's start to send the reminder. */
 const REMINDER_LEAD_MINUTES = 60
@@ -43,6 +44,7 @@ export async function runSessionReminderScan(): Promise<void> {
     .select({
       sessionId: liveSession.sessionId,
       tutorId: liveSession.tutorId,
+      courseId: liveSession.courseId,
       title: liveSession.title,
       scheduledAt: liveSession.scheduledAt,
     })
@@ -70,21 +72,51 @@ export async function runSessionReminderScan(): Promise<void> {
     if (claimed.length === 0) continue
 
     const minutes = Math.max(1, Math.round((s.scheduledAt.getTime() - Date.now()) / 60000))
+    const message = `"${s.title}" starts in about ${minutes} minute${minutes === 1 ? '' : 's'}.`
+    const data = {
+      sessionId: s.sessionId,
+      scheduledAt: s.scheduledAt.toISOString(),
+      kind: 'session-reminder',
+    }
+
+    // Tutor reminder.
     try {
       await notify({
         userId: s.tutorId,
         type: 'reminder',
         title: 'Upcoming session',
-        message: `"${s.title}" starts in about ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+        message,
         actionUrl: `/tutor/insights?sessionId=${encodeURIComponent(s.sessionId)}&view=classroom`,
-        data: {
-          sessionId: s.sessionId,
-          scheduledAt: s.scheduledAt.toISOString(),
-          kind: 'session-reminder',
-        },
+        data,
       })
     } catch (err) {
-      console.error('[session-reminders] notify failed for session', s.sessionId, err)
+      console.error('[session-reminders] tutor notify failed for session', s.sessionId, err)
+    }
+
+    // Enrolled-student reminders (course sessions only). Excludes the tutor in
+    // case they're also enrolled, so they don't get two reminders.
+    if (s.courseId) {
+      try {
+        const enrolled = await drizzleDb
+          .select({ studentId: courseEnrollment.studentId })
+          .from(courseEnrollment)
+          .where(eq(courseEnrollment.courseId, s.courseId))
+        const studentIds = Array.from(
+          new Set(enrolled.map(e => e.studentId).filter(id => id && id !== s.tutorId))
+        )
+        if (studentIds.length > 0) {
+          await notifyMany({
+            userIds: studentIds,
+            type: 'reminder',
+            title: 'Upcoming session',
+            message,
+            actionUrl: `/student/live/${encodeURIComponent(s.sessionId)}`,
+            data,
+          })
+        }
+      } catch (err) {
+        console.error('[session-reminders] student notify failed for session', s.sessionId, err)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to the session-reminder feature: enrolled **students** now get the reminder too, not just the tutor.

When the scheduler claims an upcoming session, it looks up `CourseEnrollment` for the session's course and `notifyMany()`s the students with a `reminder` notification pointing at their live page (`/student/live/[id]`). So the reminder lands in **each student's bell** (and SSE / web-push / email) the same way the tutor's does.

## Details
- Only for **course** sessions (a `courseId` is present); ad-hoc/1:1 sessions with no course still just notify the tutor.
- The **tutor is excluded** from the student fan-out, so if they're also enrolled they don't get two reminders.
- Reuses the same race-safe per-session claim, so the whole fan-out (tutor + students) happens **exactly once** per session.

## Testing
Integration test extended (throwaway Postgres): a tutor + two enrolled students each receive exactly one reminder for the imminent session; out-of-window / already-reminded sessions untouched; a second scan is a no-op for everyone. **Passed.** typecheck / eslint / prettier / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)