### PR TITLE
fix(course-builder): show each extension's own PDF in the Classroom tab

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -166,16 +166,20 @@ export default function StudentTutorDirectoryPage() {
   const filteredTutorCount = useMemo(() => {
     if (!searchQuery && !selectedRegion && !selectedCountryCode) return tutors.length
     return tutors.filter(t => {
-      const matchesSearch = !searchQuery ||
+      const matchesSearch =
+        !searchQuery ||
         t.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         t.bio.toLowerCase().includes(searchQuery.toLowerCase()) ||
         t.specialties.some(s => s.toLowerCase().includes(searchQuery.toLowerCase()))
-      const matchesRegion = !selectedRegion || selectedRegion === 'global' ||
+      const matchesRegion =
+        !selectedRegion ||
+        selectedRegion === 'global' ||
         t.tutorNationalities?.some(n => {
           const region = REGIONS.find(r => r.id === selectedRegion)
           return region?.countries.some(c => c.name.toLowerCase() === n.toLowerCase())
         })
-      const matchesCountry = !selectedCountryCode ||
+      const matchesCountry =
+        !selectedCountryCode ||
         t.tutorNationalities?.some(n => {
           const country = availableCountries.find(c => c.code === selectedCountryCode)
           return country?.name.toLowerCase() === n.toLowerCase()
@@ -332,67 +336,65 @@ export default function StudentTutorDirectoryPage() {
           contentClassName="min-h-0 flex-1 overflow-y-auto p-4 pt-3 sm:p-6 sm:pt-4"
         >
           <div className="grid items-stretch gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {loading ? (
-                Array.from({ length: 6 }).map((_, index) => (
-                  <Card
-                    key={`loading-${index}`}
-                    className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
-                  >
-                    <CardHeader className="space-y-2 p-4">
-                      <div className="h-5 w-2/3 rounded bg-white/10" />
-                      <div className="h-3 w-1/2 rounded bg-white/10" />
-                    </CardHeader>
-                    <CardContent className="space-y-2 p-4 pt-0">
-                      <div className="h-3 rounded bg-white/10" />
-                      <div className="h-3 rounded bg-white/10" />
-                    </CardContent>
-                  </Card>
-                ))
-              ) : tutors.length === 0 ? (
-                <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
-                  <CardHeader>
-                    <CardTitle className="text-white">
-                      No tutors match your current filters
-                    </CardTitle>
-                    <CardDescription className="text-white/70">
-                      Try broadening search terms or selecting a different region or country.
-                    </CardDescription>
+            {loading ? (
+              Array.from({ length: 6 }).map((_, index) => (
+                <Card
+                  key={`loading-${index}`}
+                  className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
+                >
+                  <CardHeader className="space-y-2 p-4">
+                    <div className="h-5 w-2/3 rounded bg-white/10" />
+                    <div className="h-3 w-1/2 rounded bg-white/10" />
                   </CardHeader>
+                  <CardContent className="space-y-2 p-4 pt-0">
+                    <div className="h-3 rounded bg-white/10" />
+                    <div className="h-3 rounded bg-white/10" />
+                  </CardContent>
                 </Card>
-              ) : (
-                tutors.map(tutor => (
-                  <TutorCard
-                    key={tutor.id}
-                    compact
-                    tutor={{
-                      id: tutor.id,
-                      username: tutor.username,
-                      name: tutor.name,
-                      avatar: tutor.avatarUrl,
-                      bio: tutor.bio,
-                      rating: tutor.averageRating || 0,
-                      reviewCount: tutor.totalReviewCount || 0,
-                      hourlyRate: tutor.hourlyRate,
-                      currency: 'SGD',
-                      nextAvailableSlot: null,
-                      totalStudents: tutor.totalEnrollments,
-                      totalClasses: tutor.courseCount,
-                      specialties: tutor.categories,
-                      countries: tutor.tutorNationalities,
-                    }}
-                    onClick={() => {
-                      showOverlay()
-                      router.push(`/${locale}/u/${tutor.username}`)
-                    }}
-                    followState={following.has(tutor.id) ? 'following' : 'not-following'}
-                    onFollowToggle={() => toggleFollow(tutor.id)}
-                    bookHref={`/${locale}/u/${tutor.username}?book=1`}
-                    countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
-                  />
-                ))
-              )}
-            </div>
-          </CollapsibleCard>
+              ))
+            ) : tutors.length === 0 ? (
+              <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
+                <CardHeader>
+                  <CardTitle className="text-white">No tutors match your current filters</CardTitle>
+                  <CardDescription className="text-white/70">
+                    Try broadening search terms or selecting a different region or country.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            ) : (
+              tutors.map(tutor => (
+                <TutorCard
+                  key={tutor.id}
+                  compact
+                  tutor={{
+                    id: tutor.id,
+                    username: tutor.username,
+                    name: tutor.name,
+                    avatar: tutor.avatarUrl,
+                    bio: tutor.bio,
+                    rating: tutor.averageRating || 0,
+                    reviewCount: tutor.totalReviewCount || 0,
+                    hourlyRate: tutor.hourlyRate,
+                    currency: 'SGD',
+                    nextAvailableSlot: null,
+                    totalStudents: tutor.totalEnrollments,
+                    totalClasses: tutor.courseCount,
+                    specialties: tutor.categories,
+                    countries: tutor.tutorNationalities,
+                  }}
+                  onClick={() => {
+                    showOverlay()
+                    router.push(`/${locale}/u/${tutor.username}`)
+                  }}
+                  followState={following.has(tutor.id) ? 'following' : 'not-following'}
+                  onFollowToggle={() => toggleFollow(tutor.id)}
+                  bookHref={`/${locale}/u/${tutor.username}?book=1`}
+                  countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
+                />
+              ))
+            )}
+          </div>
+        </CollapsibleCard>
       </div>
     </div>
   )

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6686,6 +6686,11 @@ FEEDBACK: [your explanation]`
                                                                                     parentId:
                                                                                       task.id,
                                                                                     isExtension: true,
+                                                                                    // Carry the extension's OWN document so the
+                                                                                    // live session shows its content, not the
+                                                                                    // parent task's.
+                                                                                    sourceDocument:
+                                                                                      ext.sourceDocument,
                                                                                     deployedAt:
                                                                                       Date.now(),
                                                                                     polls: [],
@@ -8569,10 +8574,23 @@ FEEDBACK: [your explanation]`
                                                 ? findAssessmentById(loadedAssessmentId || '')
                                                 : null
 
+                                            // In the Classroom, honor the selected extension just
+                                            // like the Build tab: an extension shows its OWN
+                                            // document, not the parent task's. Falls back to the
+                                            // task document when no extension is active.
+                                            const liveTaskExtension =
+                                              liveTask && taskBuilder.activeExtensionId
+                                                ? liveTask.extensions?.find(
+                                                    e => e.id === taskBuilder.activeExtensionId
+                                                  ) || null
+                                                : null
+
                                             const doc =
                                               mainTab === 'live'
                                                 ? testPciSource === 'task'
-                                                  ? liveTask?.sourceDocument
+                                                  ? liveTaskExtension
+                                                    ? liveTaskExtension.sourceDocument
+                                                    : liveTask?.sourceDocument
                                                   : liveAssessment?.sourceDocument
                                                 : testPciSource === 'task'
                                                   ? currentTaskDocument


### PR DESCRIPTION
## **User description**
## Task 2
In the **Build** tab a task and each of its extensions correctly display their own PDF, but in the **Classroom** (live) tab every extension showed the parent **task's** PDF.

**Two causes, both fixed:**
- **Render:** the live-mode document resolution used `liveTask.sourceDocument` unconditionally (always the parent task). It now honors the selected extension (`taskBuilder.activeExtensionId`) and uses that extension's own `sourceDocument`, falling back to the task's when no extension is active — exactly mirroring the Build-tab logic.
- **Deploy:** deploying an extension to a live session omitted its document from the `LiveTask` payload, so the session never received the per-extension document. It now carries `sourceDocument: ext.sourceDocument` (the `LiveTask` type already supports it).

## Testing
`npm run typecheck`, `eslint` (0 errors), `prettier --check`, `npm run build` — all pass. (Also reformatted one unrelated file that had drifted on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show each extension’s own PDF in Classroom live mode**

### What Changed
- In Classroom, selecting an extension now opens that extension’s own PDF instead of always showing the parent task’s PDF.
- When an extension is deployed to a live session, its PDF is included so the live view can display the correct document.
- A separate formatting-only update cleaned up the tutor directory page layout without changing behavior.

### Impact
`✅ Correct PDFs for live classroom extensions`
`✅ Fewer wrong-document displays in sessions`
`✅ Smoother extension review in Classroom`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
