### PR TITLE
feat(tutors): make all tutors discoverable on Book-a-Tutor (no publish required)

### DIFF
--- a/tutorme-app/src/__tests__/integration/public-tutors-discovery.test.ts
+++ b/tutorme-app/src/__tests__/integration/public-tutors-discovery.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration test: every tutor is discoverable on the Book-a-Tutor directory,
+ * regardless of whether they've published a course.
+ *
+ * Seeds a tutor with NO courses and a tutor WITH a published course, then calls
+ * the real GET /api/public/tutors handler and asserts BOTH are returned.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { NextRequest } from 'next/server'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, profile, course } from '@/lib/db/schema'
+import { GET as getTutors } from '@/app/api/public/tutors/route'
+
+const stamp = Date.now()
+const courselessTutorId = crypto.randomUUID()
+const courseTutorId = crypto.randomUUID()
+const allUserIds = [courselessTutorId, courseTutorId]
+const courseId = `course_disc_${stamp}`
+
+function req() {
+  return new NextRequest('http://localhost/api/public/tutors?pageSize=100')
+}
+
+describe('public tutors discovery', () => {
+  beforeAll(async () => {
+    const now = new Date()
+    await drizzleDb.insert(user).values([
+      {
+        userId: courselessTutorId,
+        email: `claude-disc-nocourse-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        userId: courseTutorId,
+        email: `claude-disc-course-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    await drizzleDb.insert(profile).values([
+      { profileId: `prof_nc_${stamp}`, userId: courselessTutorId, name: 'Course-less Tutor' },
+      { profileId: `prof_c_${stamp}`, userId: courseTutorId, name: 'Course Tutor' },
+    ])
+    // Only the second tutor has a published course.
+    await drizzleDb
+      .insert(course)
+      .values({ courseId, name: 'Published Course', creatorId: courseTutorId, isPublished: true })
+  })
+
+  afterAll(async () => {
+    const t = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn()
+      } catch {}
+    }
+    await t(() => drizzleDb.delete(course).where(eq(course.courseId, courseId)))
+    await t(() => drizzleDb.delete(profile).where(inArray(profile.userId, allUserIds)))
+    await t(() => drizzleDb.delete(user).where(inArray(user.userId, allUserIds)))
+  })
+
+  it('returns tutors with and without published courses', async () => {
+    const res = await getTutors(req())
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    const ids: string[] = (data.tutors || []).map((t: { id: string }) => t.id)
+
+    // The course-less tutor must be discoverable (the requirement).
+    expect(ids).toContain(courselessTutorId)
+    // The tutor with a published course is still listed.
+    expect(ids).toContain(courseTutorId)
+
+    // The course-less tutor renders sensibly: zero courses, no crash.
+    const courseless = data.tutors.find((t: { id: string }) => t.id === courselessTutorId)
+    expect(courseless.courseCount).toBe(0)
+    expect(Array.isArray(courseless.specialties)).toBe(true)
+  })
+})

--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -166,16 +166,20 @@ export default function StudentTutorDirectoryPage() {
   const filteredTutorCount = useMemo(() => {
     if (!searchQuery && !selectedRegion && !selectedCountryCode) return tutors.length
     return tutors.filter(t => {
-      const matchesSearch = !searchQuery ||
+      const matchesSearch =
+        !searchQuery ||
         t.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         t.bio.toLowerCase().includes(searchQuery.toLowerCase()) ||
         t.specialties.some(s => s.toLowerCase().includes(searchQuery.toLowerCase()))
-      const matchesRegion = !selectedRegion || selectedRegion === 'global' ||
+      const matchesRegion =
+        !selectedRegion ||
+        selectedRegion === 'global' ||
         t.tutorNationalities?.some(n => {
           const region = REGIONS.find(r => r.id === selectedRegion)
           return region?.countries.some(c => c.name.toLowerCase() === n.toLowerCase())
         })
-      const matchesCountry = !selectedCountryCode ||
+      const matchesCountry =
+        !selectedCountryCode ||
         t.tutorNationalities?.some(n => {
           const country = availableCountries.find(c => c.code === selectedCountryCode)
           return country?.name.toLowerCase() === n.toLowerCase()
@@ -332,67 +336,65 @@ export default function StudentTutorDirectoryPage() {
           contentClassName="min-h-0 flex-1 overflow-y-auto p-4 pt-3 sm:p-6 sm:pt-4"
         >
           <div className="grid items-stretch gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {loading ? (
-                Array.from({ length: 6 }).map((_, index) => (
-                  <Card
-                    key={`loading-${index}`}
-                    className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
-                  >
-                    <CardHeader className="space-y-2 p-4">
-                      <div className="h-5 w-2/3 rounded bg-white/10" />
-                      <div className="h-3 w-1/2 rounded bg-white/10" />
-                    </CardHeader>
-                    <CardContent className="space-y-2 p-4 pt-0">
-                      <div className="h-3 rounded bg-white/10" />
-                      <div className="h-3 rounded bg-white/10" />
-                    </CardContent>
-                  </Card>
-                ))
-              ) : tutors.length === 0 ? (
-                <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
-                  <CardHeader>
-                    <CardTitle className="text-white">
-                      No tutors match your current filters
-                    </CardTitle>
-                    <CardDescription className="text-white/70">
-                      Try broadening search terms or selecting a different region or country.
-                    </CardDescription>
+            {loading ? (
+              Array.from({ length: 6 }).map((_, index) => (
+                <Card
+                  key={`loading-${index}`}
+                  className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
+                >
+                  <CardHeader className="space-y-2 p-4">
+                    <div className="h-5 w-2/3 rounded bg-white/10" />
+                    <div className="h-3 w-1/2 rounded bg-white/10" />
                   </CardHeader>
+                  <CardContent className="space-y-2 p-4 pt-0">
+                    <div className="h-3 rounded bg-white/10" />
+                    <div className="h-3 rounded bg-white/10" />
+                  </CardContent>
                 </Card>
-              ) : (
-                tutors.map(tutor => (
-                  <TutorCard
-                    key={tutor.id}
-                    compact
-                    tutor={{
-                      id: tutor.id,
-                      username: tutor.username,
-                      name: tutor.name,
-                      avatar: tutor.avatarUrl,
-                      bio: tutor.bio,
-                      rating: tutor.averageRating || 0,
-                      reviewCount: tutor.totalReviewCount || 0,
-                      hourlyRate: tutor.hourlyRate,
-                      currency: 'SGD',
-                      nextAvailableSlot: null,
-                      totalStudents: tutor.totalEnrollments,
-                      totalClasses: tutor.courseCount,
-                      specialties: tutor.categories,
-                      countries: tutor.tutorNationalities,
-                    }}
-                    onClick={() => {
-                      showOverlay()
-                      router.push(`/${locale}/u/${tutor.username}`)
-                    }}
-                    followState={following.has(tutor.id) ? 'following' : 'not-following'}
-                    onFollowToggle={() => toggleFollow(tutor.id)}
-                    bookHref={`/${locale}/u/${tutor.username}?book=1`}
-                    countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
-                  />
-                ))
-              )}
-            </div>
-          </CollapsibleCard>
+              ))
+            ) : tutors.length === 0 ? (
+              <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
+                <CardHeader>
+                  <CardTitle className="text-white">No tutors match your current filters</CardTitle>
+                  <CardDescription className="text-white/70">
+                    Try broadening search terms or selecting a different region or country.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            ) : (
+              tutors.map(tutor => (
+                <TutorCard
+                  key={tutor.id}
+                  compact
+                  tutor={{
+                    id: tutor.id,
+                    username: tutor.username,
+                    name: tutor.name,
+                    avatar: tutor.avatarUrl,
+                    bio: tutor.bio,
+                    rating: tutor.averageRating || 0,
+                    reviewCount: tutor.totalReviewCount || 0,
+                    hourlyRate: tutor.hourlyRate,
+                    currency: 'SGD',
+                    nextAvailableSlot: null,
+                    totalStudents: tutor.totalEnrollments,
+                    totalClasses: tutor.courseCount,
+                    specialties: tutor.categories,
+                    countries: tutor.tutorNationalities,
+                  }}
+                  onClick={() => {
+                    showOverlay()
+                    router.push(`/${locale}/u/${tutor.username}`)
+                  }}
+                  followState={following.has(tutor.id) ? 'following' : 'not-following'}
+                  onFollowToggle={() => toggleFollow(tutor.id)}
+                  bookHref={`/${locale}/u/${tutor.username}?book=1`}
+                  countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
+                />
+              ))
+            )}
+          </div>
+        </CollapsibleCard>
       </div>
     </div>
   )

--- a/tutorme-app/src/app/api/public/tutors/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/route.ts
@@ -147,22 +147,33 @@ export async function GET(request: NextRequest) {
             ? desc(sql`max(${profile.hourlyRate})`)
             : desc(sql`count(distinct ${course.courseId})`)
 
+    // Root the directory on tutors (user/profile), LEFT JOINing their published
+    // courses, so EVERY tutor is discoverable — not only those who have published
+    // a course. The published/not-deleted filter lives on the JOIN condition (not
+    // the WHERE) so a course-less tutor isn't filtered out. Course-derived
+    // filters (subject/combination/nationality) still naturally restrict to
+    // tutors who have matching courses.
     const tutorAggSubq = drizzleDb
       .select({
-        creatorId: course.creatorId,
+        creatorId: user.userId,
         latestUpdatedAt: sql<Date>`max(${course.updatedAt})`.as('latestUpdatedAt'),
         courseCount: sql<number>`count(distinct ${course.courseId})::int`.as('courseCount'),
         hourlyRate: sql<number>`max(${profile.hourlyRate})`.as('hourlyRate'),
         totalCount: sql<number>`count(*) over()::int`.as('totalCount'),
       })
-      .from(course)
-      .innerJoin(user, eq(course.creatorId, user.userId))
+      .from(user)
       .innerJoin(profile, eq(user.userId, profile.userId))
+      .leftJoin(
+        course,
+        and(
+          eq(course.creatorId, user.userId),
+          eq(course.isPublished, true),
+          isNull(course.deletedAt)
+        )
+      )
       .leftJoin(courseVariant, eq(course.courseId, courseVariant.publishedCourseId))
       .where(
         and(
-          eq(course.isPublished, true),
-          isNull(course.deletedAt),
           eq(user.role, 'TUTOR'),
           searchPattern
             ? or(
@@ -197,8 +208,10 @@ export async function GET(request: NextRequest) {
             : undefined
         )
       )
-      .groupBy(course.creatorId)
-      .orderBy(orderByClause)
+      .groupBy(user.userId)
+      // Stable tiebreaker so pagination is deterministic when the primary metric
+      // ties (e.g. all the course-less tutors with 0 courses).
+      .orderBy(orderByClause, sql`${user.userId} asc`)
       .limit(pageSize)
       .offset(offset)
       .as('tutorAgg')


### PR DESCRIPTION
## **User description**
## Task 3
Tutors no longer need to publish a course to appear on the Book-a-Tutor page. **All tutors are discoverable.**

**Root cause:** the public directory query (`/api/public/tutors`) was rooted on the `course` table with an `innerJoin(user)` and `course.isPublished = true`, so only tutors with ≥1 published course could ever be returned.

**Fix:** re-root the listing on `user`/`profile` (`role = 'TUTOR'`) and **LEFT JOIN** published courses for the optional aggregates. The published/not-deleted filter moved onto the **JOIN condition**, so course-less tutors are still returned (with `courseCount: 0`, empty specialties). Subject/combination/nationality filters still naturally restrict to tutors with matching courses; grouped by `user.userId`; added a stable id tiebreaker for deterministic pagination. The downstream row mapping already tolerates zero courses.

This fixes both directories that use this endpoint (`/student/tutors` and `/tutors`).

## Testing
Integration test (throwaway Postgres): a tutor with **no courses** and a tutor with a **published course** are both returned by the real `GET /api/public/tutors` handler; the course-less tutor renders with `courseCount: 0` and no crash. **Passed.** typecheck / eslint (0 errors) / prettier / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make every tutor appear in the Book-a-Tutor directory**

### What Changed
- Tutors now show up in the public directory even if they have never published a course
- Tutors with published courses still appear as before, and course-based filters still narrow results to tutors with matching courses
- Search results now stay in a stable order when many tutors have the same course count
- Added an integration test that checks both a course-less tutor and a tutor with a published course are returned by the live directory request

### Impact
`✅ All tutors discoverable`
`✅ Fewer missing tutors in the Book-a-Tutor list`
`✅ Stable tutor page results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
