### PR TITLE
feat(admin): wire user management + content & security pages

### DIFF
--- a/tutorme-app/src/app/[locale]/admin/content/page.tsx
+++ b/tutorme-app/src/app/[locale]/admin/content/page.tsx
@@ -1,149 +1,136 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { FileText, Video, BookOpen, Upload, Filter, MoreHorizontal, Search } from 'lucide-react'
-import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { BookOpen, CheckCircle, FileEdit, Layers } from 'lucide-react'
+
+interface ContentOverview {
+  summary: {
+    totalCourses: number
+    publishedCourses: number
+    draftCourses: number
+    totalLessons: number
+  }
+  recentCourses: Array<{
+    id: string
+    name: string
+    isPublished: boolean
+    createdAt: string
+    creatorName: string | null
+  }>
+}
 
 export default function ContentPage() {
+  const [data, setData] = useState<ContentOverview | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/admin/content/overview', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(json => {
+        if (!cancelled) setData(json)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const s = data?.summary
+  const stats = [
+    {
+      label: 'Total Courses',
+      value: s?.totalCourses,
+      icon: BookOpen,
+      color: 'bg-blue-100 text-blue-600',
+    },
+    {
+      label: 'Published',
+      value: s?.publishedCourses,
+      icon: CheckCircle,
+      color: 'bg-emerald-100 text-emerald-600',
+    },
+    {
+      label: 'Drafts',
+      value: s?.draftCourses,
+      icon: FileEdit,
+      color: 'bg-amber-100 text-amber-600',
+    },
+    {
+      label: 'Lessons',
+      value: s?.totalLessons,
+      icon: Layers,
+      color: 'bg-violet-100 text-violet-600',
+    },
+  ]
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900">Content Management</h1>
-          <p className="text-slate-500">Manage courses, videos, and learning materials</p>
-        </div>
-        <Button>
-          <Upload className="mr-2 h-4 w-4" />
-          Upload Content
-        </Button>
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">Content Management</h1>
+        <p className="text-slate-500">Courses and learning materials across the platform</p>
       </div>
 
-      {/* Stats */}
-      <div className="grid gap-4 sm:grid-cols-3">
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100">
-                <Video className="h-5 w-5 text-blue-600" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {stats.map(stat => (
+          <Card key={stat.label}>
+            <CardContent className="p-6">
+              <div className="flex items-center gap-4">
+                <div
+                  className={`flex h-10 w-10 items-center justify-center rounded-lg ${stat.color}`}
+                >
+                  <stat.icon className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-sm text-slate-500">{stat.label}</p>
+                  {loading ? (
+                    <Skeleton className="mt-1 h-7 w-12" />
+                  ) : (
+                    <p className="text-2xl font-bold">{(stat.value ?? 0).toLocaleString()}</p>
+                  )}
+                </div>
               </div>
-              <div>
-                <p className="text-sm text-slate-500">Video Content</p>
-                <p className="text-2xl font-bold">24</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100">
-                <BookOpen className="h-5 w-5 text-green-600" />
-              </div>
-              <div>
-                <p className="text-sm text-slate-500">Courses</p>
-                <p className="text-2xl font-bold">12</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100">
-                <FileText className="h-5 w-5 text-purple-600" />
-              </div>
-              <div>
-                <p className="text-sm text-slate-500">Documents</p>
-                <p className="text-2xl font-bold">48</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
-      {/* Content List Placeholder */}
       <Card>
         <CardHeader>
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <CardTitle>Content Library</CardTitle>
-              <CardDescription>Manage all platform content</CardDescription>
-            </div>
-            <div className="flex gap-2">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                <Input placeholder="Search content..." className="w-64 pl-9" />
-              </div>
-              <Button variant="outline" size="icon">
-                <Filter className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+          <CardTitle>Recent courses</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            {[
-              {
-                title: 'Introduction to Algebra',
-                type: 'video',
-                subject: 'Mathematics',
-                status: 'published',
-              },
-              {
-                title: 'Physics: Motion and Forces',
-                type: 'course',
-                subject: 'Physics',
-                status: 'published',
-              },
-              { title: 'Chemistry Basics', type: 'video', subject: 'Chemistry', status: 'draft' },
-              {
-                title: 'Biology: Cell Structure',
-                type: 'document',
-                subject: 'Biology',
-                status: 'published',
-              },
-            ].map((item, i) => (
-              <div
-                key={i}
-                className="flex items-center justify-between rounded-lg border p-4 hover:bg-slate-50"
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className={`flex h-10 w-10 items-center justify-center rounded-lg ${
-                      item.type === 'video'
-                        ? 'bg-blue-100'
-                        : item.type === 'course'
-                          ? 'bg-green-100'
-                          : 'bg-purple-100'
-                    }`}
-                  >
-                    {item.type === 'video' ? (
-                      <Video className="h-5 w-5 text-blue-600" />
-                    ) : item.type === 'course' ? (
-                      <BookOpen className="h-5 w-5 text-green-600" />
-                    ) : (
-                      <FileText className="h-5 w-5 text-purple-600" />
-                    )}
+          {loading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : !data?.recentCourses?.length ? (
+            <p className="py-6 text-center text-slate-500">No courses yet</p>
+          ) : (
+            <div className="divide-y">
+              {data.recentCourses.map(c => (
+                <div key={c.id} className="flex items-center justify-between py-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-slate-900">{c.name}</p>
+                    <p className="text-sm text-slate-500">
+                      {c.creatorName || 'Unknown'} · {new Date(c.createdAt).toLocaleDateString()}
+                    </p>
                   </div>
-                  <div>
-                    <p className="font-medium">{item.title}</p>
-                    <p className="text-sm text-slate-500">{item.subject}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <Badge variant={item.status === 'published' ? 'default' : 'secondary'}>
-                    {item.status}
+                  <Badge variant={c.isPublished ? 'default' : 'secondary'} className="text-xs">
+                    {c.isPublished ? 'Published' : 'Draft'}
                   </Badge>
-                  <Button variant="ghost" size="icon">
-                    <MoreHorizontal className="h-4 w-4" />
-                  </Button>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/tutorme-app/src/app/[locale]/admin/security/page.tsx
+++ b/tutorme-app/src/app/[locale]/admin/security/page.tsx
@@ -1,207 +1,167 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Switch } from '@/components/ui/switch'
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Shield, Lock, Key, AlertTriangle, UserX, Eye, History, Plus } from 'lucide-react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ShieldAlert, Activity, Globe, KeyRound } from 'lucide-react'
+
+interface SecurityOverview {
+  summary: {
+    failedLogins24h: number
+    activeSessions: number
+    whitelistActive: number
+    whitelistEnforced: boolean
+  }
+  whitelist: Array<{
+    id: string
+    ipAddress: string
+    description: string | null
+    isActive: boolean
+    expiresAt: string | null
+  }>
+  recentActions: Array<{
+    id: string
+    action: string
+    adminId: string
+    ipAddress: string | null
+    createdAt: string
+  }>
+}
 
 export default function SecurityPage() {
+  const [data, setData] = useState<SecurityOverview | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/admin/security/overview', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(json => {
+        if (!cancelled) setData(json)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const s = data?.summary
+  const stats = [
+    {
+      label: 'Failed logins (24h)',
+      value: s?.failedLogins24h,
+      icon: ShieldAlert,
+      color: 'bg-red-100 text-red-600',
+    },
+    {
+      label: 'Active admin sessions',
+      value: s?.activeSessions,
+      icon: Activity,
+      color: 'bg-emerald-100 text-emerald-600',
+    },
+    {
+      label: 'Whitelisted IPs',
+      value: s?.whitelistActive,
+      icon: Globe,
+      color: 'bg-blue-100 text-blue-600',
+    },
+  ]
+
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold text-slate-900">Security</h1>
-        <p className="text-slate-500">Manage security settings and access controls</p>
+        <p className="text-slate-500">
+          IP whitelist {s?.whitelistEnforced ? 'enforced' : 'not enforced'} · audit logging active
+        </p>
       </div>
 
-      {/* Security Overview */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100">
-                <Shield className="h-5 w-5 text-green-600" />
+      <div className="grid gap-4 sm:grid-cols-3">
+        {stats.map(stat => (
+          <Card key={stat.label}>
+            <CardContent className="p-6">
+              <div className="flex items-center gap-4">
+                <div
+                  className={`flex h-10 w-10 items-center justify-center rounded-lg ${stat.color}`}
+                >
+                  <stat.icon className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-sm text-slate-500">{stat.label}</p>
+                  {loading ? (
+                    <Skeleton className="mt-1 h-7 w-12" />
+                  ) : (
+                    <p className="text-2xl font-bold">{(stat.value ?? 0).toLocaleString()}</p>
+                  )}
+                </div>
               </div>
-              <div>
-                <p className="text-sm text-slate-500">Security Score</p>
-                <p className="text-2xl font-bold text-green-600">92%</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100">
-                <Lock className="h-5 w-5 text-blue-600" />
-              </div>
-              <div>
-                <p className="text-sm text-slate-500">Failed Logins (24h)</p>
-                <p className="text-2xl font-bold">3</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-yellow-100">
-                <AlertTriangle className="h-5 w-5 text-yellow-600" />
-              </div>
-              <div>
-                <p className="text-sm text-slate-500">Active Alerts</p>
-                <p className="text-2xl font-bold">1</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100">
-                <Key className="h-5 w-5 text-purple-600" />
-              </div>
-              <div>
-                <p className="text-sm text-slate-500">API Keys</p>
-                <p className="text-2xl font-bold">5</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
-      {/* Security Settings */}
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Authentication Settings</CardTitle>
-            <CardDescription>Configure login and authentication</CardDescription>
+            <CardTitle className="flex items-center gap-2">
+              <Globe className="h-4 w-4" /> IP whitelist
+            </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">Two-Factor Authentication</p>
-                <p className="text-sm text-slate-500">Require 2FA for admin accounts</p>
+          <CardContent>
+            {loading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : !data?.whitelist?.length ? (
+              <p className="py-4 text-center text-sm text-slate-500">
+                No IP restrictions — admin access is open to any IP.
+              </p>
+            ) : (
+              <div className="divide-y">
+                {data.whitelist.map(w => (
+                  <div key={w.id} className="flex items-center justify-between py-2">
+                    <div>
+                      <p className="font-mono text-sm text-slate-900">{w.ipAddress}</p>
+                      {w.description && <p className="text-xs text-slate-500">{w.description}</p>}
+                    </div>
+                    <Badge variant={w.isActive ? 'default' : 'secondary'} className="text-xs">
+                      {w.isActive ? 'Active' : 'Inactive'}
+                    </Badge>
+                  </div>
+                ))}
               </div>
-              <Switch defaultChecked />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">IP Whitelist</p>
-                <p className="text-sm text-slate-500">Restrict admin access by IP</p>
-              </div>
-              <Switch />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">Session Timeout</p>
-                <p className="text-sm text-slate-500">Auto-logout after 8 hours</p>
-              </div>
-              <Switch defaultChecked />
-            </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium">Password Policy</p>
-                <p className="text-sm text-slate-500">Require strong passwords</p>
-              </div>
-              <Switch defaultChecked />
-            </div>
+            )}
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle>IP Whitelist</CardTitle>
-            <CardDescription>Manage allowed IP addresses</CardDescription>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4" /> Recent admin actions
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              <div className="flex gap-2">
-                <Input placeholder="IP Address (e.g., 192.168.1.1)" />
-                <Button size="icon">
-                  <Plus className="h-4 w-4" />
-                </Button>
-              </div>
-              <div className="space-y-2">
-                {[
-                  { ip: '192.168.1.0/24', description: 'Office Network', active: true },
-                  { ip: '10.0.0.1', description: 'VPN Gateway', active: true },
-                ].map((item, i) => (
-                  <div key={i} className="flex items-center justify-between rounded-lg border p-3">
-                    <div>
-                      <code className="text-sm font-medium">{item.ip}</code>
-                      <p className="text-xs text-slate-500">{item.description}</p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Badge variant={item.active ? 'default' : 'secondary'}>
-                        {item.active ? 'Active' : 'Inactive'}
-                      </Badge>
-                      <Button variant="ghost" size="icon">
-                        <UserX className="h-4 w-4 text-red-600" />
-                      </Button>
-                    </div>
+            {loading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : !data?.recentActions?.length ? (
+              <p className="py-4 text-center text-sm text-slate-500">No admin actions logged yet</p>
+            ) : (
+              <div className="divide-y">
+                {data.recentActions.map(a => (
+                  <div key={a.id} className="flex items-center justify-between py-2">
+                    <span className="font-mono text-xs text-slate-700">{a.action}</span>
+                    <span className="text-xs text-slate-400">
+                      {a.ipAddress || '—'} · {new Date(a.createdAt).toLocaleString()}
+                    </span>
                   </div>
                 ))}
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       </div>
-
-      {/* API Keys */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <div>
-            <CardTitle>API Keys</CardTitle>
-            <CardDescription>Manage API access keys</CardDescription>
-          </div>
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Key
-          </Button>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {[
-              {
-                name: 'Production API',
-                key: 'tm_live_...',
-                created: '2024-01-15',
-                lastUsed: '2 hours ago',
-              },
-              {
-                name: 'Staging API',
-                key: 'tm_test_...',
-                created: '2024-01-10',
-                lastUsed: '1 day ago',
-              },
-            ].map((key, i) => (
-              <div key={i} className="flex items-center justify-between rounded-lg border p-4">
-                <div>
-                  <p className="font-medium">{key.name}</p>
-                  <code className="text-xs text-slate-500">{key.key}xxxx</code>
-                </div>
-                <div className="flex items-center gap-4">
-                  <div className="text-right">
-                    <p className="text-xs text-slate-500">Created: {key.created}</p>
-                    <p className="text-xs text-slate-500">Last used: {key.lastUsed}</p>
-                  </div>
-                  <div className="flex gap-1">
-                    <Button variant="ghost" size="icon">
-                      <Eye className="h-4 w-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon">
-                      <History className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/tutorme-app/src/app/[locale]/admin/users/page.tsx
+++ b/tutorme-app/src/app/[locale]/admin/users/page.tsx
@@ -2,9 +2,21 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { useAdminUsers } from '@/lib/admin/hooks'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -43,6 +55,9 @@ import {
   Shield,
   GraduationCap,
   User,
+  UserPlus,
+  CheckCircle,
+  Loader2,
 } from 'lucide-react'
 
 const roles = [
@@ -67,10 +82,107 @@ export default function UsersPage() {
 
   const users = data?.users || []
   const pagination = data?.pagination
+  const queryClient = useQueryClient()
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ['admin-users'] })
 
   const handleSearch = () => {
     setSearch(searchInput)
     setPage(1)
+  }
+
+  // --- Add User ---
+  const [addOpen, setAddOpen] = useState(false)
+  const [addForm, setAddForm] = useState({
+    email: '',
+    name: '',
+    role: 'STUDENT',
+    password: '',
+  })
+  const [adding, setAdding] = useState(false)
+  const handleAddUser = async () => {
+    setAdding(true)
+    try {
+      const res = await fetch('/api/admin/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(addForm),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(json?.error || 'Failed to create user')
+        return
+      }
+      toast.success('User created')
+      setAddOpen(false)
+      setAddForm({ email: '', name: '', role: 'STUDENT', password: '' })
+      refresh()
+    } catch {
+      toast.error('Failed to create user')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  // --- Suspend / Activate ---
+  const [busyUserId, setBusyUserId] = useState<string | null>(null)
+  const handleToggleSuspend = async (u: { id: string; status?: string; name?: string }) => {
+    const action = u.status === 'suspended' ? 'activate' : 'suspend'
+    if (
+      action === 'suspend' &&
+      !window.confirm(`Suspend ${u.name || 'this user'}? They will be unable to sign in.`)
+    ) {
+      return
+    }
+    setBusyUserId(u.id)
+    try {
+      const res = await fetch(`/api/admin/users/${u.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ action }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(json?.error || 'Failed to update user')
+        return
+      }
+      toast.success(action === 'suspend' ? 'User suspended' : 'User reactivated')
+      refresh()
+    } catch {
+      toast.error('Failed to update user')
+    } finally {
+      setBusyUserId(null)
+    }
+  }
+
+  // --- Send Email ---
+  const [emailTarget, setEmailTarget] = useState<{ id: string; name?: string } | null>(null)
+  const [emailForm, setEmailForm] = useState({ subject: '', message: '' })
+  const [sending, setSending] = useState(false)
+  const handleSendEmail = async () => {
+    if (!emailTarget) return
+    setSending(true)
+    try {
+      const res = await fetch(`/api/admin/users/${emailTarget.id}/notify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(emailForm),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(json?.error || 'Failed to send message')
+        return
+      }
+      toast.success('Message sent')
+      setEmailTarget(null)
+      setEmailForm({ subject: '', message: '' })
+    } catch {
+      toast.error('Failed to send message')
+    } finally {
+      setSending(false)
+    }
   }
 
   const getRoleIcon = (role: string) => {
@@ -103,8 +215,8 @@ export default function UsersPage() {
           <h1 className="text-2xl font-bold text-slate-900">Users</h1>
           <p className="text-slate-500">Manage user accounts and permissions</p>
         </div>
-        <Button>
-          <UserCog className="mr-2 h-4 w-4" />
+        <Button onClick={() => setAddOpen(true)}>
+          <UserPlus className="mr-2 h-4 w-4" />
           Add User
         </Button>
       </div>
@@ -232,12 +344,18 @@ export default function UsersPage() {
                         )}
                       </TableCell>
                       <TableCell>
-                        <Badge
-                          variant={user.isVerified ? 'default' : 'secondary'}
-                          className="text-xs"
-                        >
-                          {user.isVerified ? 'Verified' : 'Unverified'}
-                        </Badge>
+                        {user.status === 'suspended' ? (
+                          <Badge variant="destructive" className="text-xs">
+                            Suspended
+                          </Badge>
+                        ) : (
+                          <Badge
+                            variant={user.isVerified ? 'default' : 'secondary'}
+                            className="text-xs"
+                          >
+                            {user.isVerified ? 'Verified' : 'Unverified'}
+                          </Badge>
+                        )}
                       </TableCell>
                       <TableCell>
                         <div className="text-sm text-slate-500">
@@ -269,14 +387,43 @@ export default function UsersPage() {
                                 View Details
                               </Link>
                             </DropdownMenuItem>
-                            <DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={() =>
+                                setEmailTarget({
+                                  id: user.id as string,
+                                  name: (user.name as string) || (user.email as string),
+                                })
+                              }
+                            >
                               <Mail className="mr-2 h-4 w-4" />
                               Send Email
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuItem className="text-red-600">
-                              <Ban className="mr-2 h-4 w-4" />
-                              Suspend User
+                            <DropdownMenuItem
+                              disabled={busyUserId === user.id}
+                              className={
+                                user.status === 'suspended' ? 'text-emerald-600' : 'text-red-600'
+                              }
+                              onSelect={e => {
+                                e.preventDefault()
+                                handleToggleSuspend({
+                                  id: user.id as string,
+                                  status: user.status as string,
+                                  name: (user.name as string) || (user.email as string),
+                                })
+                              }}
+                            >
+                              {user.status === 'suspended' ? (
+                                <>
+                                  <CheckCircle className="mr-2 h-4 w-4" />
+                                  Reactivate User
+                                </>
+                              ) : (
+                                <>
+                                  <Ban className="mr-2 h-4 w-4" />
+                                  Suspend User
+                                </>
+                              )}
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -316,6 +463,112 @@ export default function UsersPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Add User dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add user</DialogTitle>
+            <DialogDescription>Create a new student, tutor, or parent account.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="add-email">Email</Label>
+              <Input
+                id="add-email"
+                type="email"
+                value={addForm.email}
+                onChange={e => setAddForm(f => ({ ...f, email: e.target.value }))}
+                placeholder="user@example.com"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="add-name">Name</Label>
+              <Input
+                id="add-name"
+                value={addForm.name}
+                onChange={e => setAddForm(f => ({ ...f, name: e.target.value }))}
+                placeholder="Full name"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Role</Label>
+              <Select
+                value={addForm.role}
+                onValueChange={v => setAddForm(f => ({ ...f, role: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="STUDENT">Student</SelectItem>
+                  <SelectItem value="TUTOR">Tutor</SelectItem>
+                  <SelectItem value="PARENT">Parent</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="add-password">Temporary password</Label>
+              <Input
+                id="add-password"
+                type="text"
+                value={addForm.password}
+                onChange={e => setAddForm(f => ({ ...f, password: e.target.value }))}
+                placeholder="At least 8 characters"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)} disabled={adding}>
+              Cancel
+            </Button>
+            <Button onClick={handleAddUser} disabled={adding}>
+              {adding && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Create user
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Send Email dialog */}
+      <Dialog open={!!emailTarget} onOpenChange={open => !open && setEmailTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Send message{emailTarget?.name ? ` to ${emailTarget.name}` : ''}
+            </DialogTitle>
+            <DialogDescription>Delivered in-app and by email to the user.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="email-subject">Subject</Label>
+              <Input
+                id="email-subject"
+                value={emailForm.subject}
+                onChange={e => setEmailForm(f => ({ ...f, subject: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="email-message">Message</Label>
+              <Textarea
+                id="email-message"
+                rows={5}
+                value={emailForm.message}
+                onChange={e => setEmailForm(f => ({ ...f, message: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEmailTarget(null)} disabled={sending}>
+              Cancel
+            </Button>
+            <Button onClick={handleSendEmail} disabled={sending}>
+              {sending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Send
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/tutorme-app/src/app/api/admin/auth/login/route.ts
+++ b/tutorme-app/src/app/api/admin/auth/login/route.ts
@@ -69,6 +69,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }
 
+    if (foundUser.status === 'suspended') {
+      await logFailedLogin(clientIp, email || undefined)
+      return NextResponse.json({ error: 'This account is suspended' }, { status: 403 })
+    }
+
     const passwordCandidates = Array.from(
       new Set(
         [

--- a/tutorme-app/src/app/api/admin/content/overview/route.ts
+++ b/tutorme-app/src/app/api/admin/content/overview/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/admin/content/overview
+ * Content stats for the admin Content page: course/lesson counts + recent courses.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { handleApiError } from '@/lib/api/middleware'
+import { requireAdmin } from '@/lib/admin/auth'
+import { Permissions } from '@/lib/admin/permissions'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { course, courseLesson, user, profile } from '@/lib/db/schema'
+import { and, eq, isNull, desc, sql } from 'drizzle-orm'
+
+export async function GET(req: NextRequest) {
+  const { session, response } = await requireAdmin(req, Permissions.CONTENT_READ)
+  if (!session) return response!
+
+  try {
+    const one = async (q: Promise<{ c: number }[]>) => (await q)[0]?.c ?? 0
+
+    const totalCourses = await one(
+      drizzleDb
+        .select({ c: sql<number>`count(*)::int` })
+        .from(course)
+        .where(isNull(course.deletedAt))
+    )
+    const publishedCourses = await one(
+      drizzleDb
+        .select({ c: sql<number>`count(*)::int` })
+        .from(course)
+        .where(and(isNull(course.deletedAt), eq(course.isPublished, true)))
+    )
+    const totalLessons = await one(
+      drizzleDb.select({ c: sql<number>`count(*)::int` }).from(courseLesson)
+    )
+
+    const recentCourses = await drizzleDb
+      .select({
+        id: course.courseId,
+        name: course.name,
+        isPublished: course.isPublished,
+        createdAt: course.createdAt,
+        creatorName: profile.name,
+      })
+      .from(course)
+      .leftJoin(user, eq(user.userId, course.creatorId))
+      .leftJoin(profile, eq(profile.userId, course.creatorId))
+      .where(isNull(course.deletedAt))
+      .orderBy(desc(course.createdAt))
+      .limit(10)
+
+    return NextResponse.json({
+      summary: {
+        totalCourses,
+        publishedCourses,
+        draftCourses: Math.max(0, totalCourses - publishedCourses),
+        totalLessons,
+      },
+      recentCourses,
+    })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to load content overview',
+      'api/admin/content/overview/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/app/api/admin/security/overview/route.ts
+++ b/tutorme-app/src/app/api/admin/security/overview/route.ts
@@ -1,0 +1,81 @@
+/**
+ * GET /api/admin/security/overview
+ * Security posture for the admin Security page: failed-login volume, active
+ * admin sessions, IP whitelist, and recent admin actions.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { handleApiError } from '@/lib/api/middleware'
+import { requireAdmin } from '@/lib/admin/auth'
+import { Permissions } from '@/lib/admin/permissions'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { securityEvent } from '@/lib/db/schema'
+import { adminSession, ipWhitelist, adminAuditLog } from '@/lib/db/schema'
+import { and, eq, gte, gt, desc, sql } from 'drizzle-orm'
+
+export async function GET(req: NextRequest) {
+  const { session, response } = await requireAdmin(req, Permissions.SECURITY_READ)
+  if (!session) return response!
+
+  try {
+    const now = new Date()
+    const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+    const one = async (q: Promise<{ c: number }[]>) => (await q)[0]?.c ?? 0
+
+    const failedLogins24h = await one(
+      drizzleDb
+        .select({ c: sql<number>`count(*)::int` })
+        .from(securityEvent)
+        .where(
+          and(eq(securityEvent.eventType, 'auth_failed'), gte(securityEvent.createdAt, dayAgo))
+        )
+    )
+
+    const activeSessions = await one(
+      drizzleDb
+        .select({ c: sql<number>`count(*)::int` })
+        .from(adminSession)
+        .where(and(eq(adminSession.isRevoked, false), gt(adminSession.expiresAt, now)))
+    )
+
+    const whitelist = await drizzleDb
+      .select({
+        id: ipWhitelist.whitelistId,
+        ipAddress: ipWhitelist.ipAddress,
+        description: ipWhitelist.description,
+        isActive: ipWhitelist.isActive,
+        expiresAt: ipWhitelist.expiresAt,
+      })
+      .from(ipWhitelist)
+      .orderBy(desc(ipWhitelist.createdAt))
+      .limit(50)
+
+    const recentActions = await drizzleDb
+      .select({
+        id: adminAuditLog.auditLogId,
+        action: adminAuditLog.action,
+        adminId: adminAuditLog.adminId,
+        ipAddress: adminAuditLog.ipAddress,
+        createdAt: adminAuditLog.createdAt,
+      })
+      .from(adminAuditLog)
+      .orderBy(desc(adminAuditLog.createdAt))
+      .limit(15)
+
+    return NextResponse.json({
+      summary: {
+        failedLogins24h,
+        activeSessions,
+        whitelistActive: whitelist.filter(w => w.isActive).length,
+        whitelistEnforced: whitelist.some(w => w.isActive),
+      },
+      whitelist,
+      recentActions,
+    })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to load security overview',
+      'api/admin/security/overview/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/app/api/admin/users/[id]/notify/route.ts
+++ b/tutorme-app/src/app/api/admin/users/[id]/notify/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /api/admin/users/[id]/notify — send a message to a user.
+ * Delivered in-app + SSE + email (via notify.ts). Body: { subject, message }
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { handleApiError } from '@/lib/api/middleware'
+import { requireAdmin, logAdminAction, getClientIp } from '@/lib/admin/auth'
+import { Permissions } from '@/lib/admin/permissions'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { notify } from '@/lib/notifications/notify'
+
+export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { session, response } = await requireAdmin(req, Permissions.USERS_WRITE)
+  if (!session) return response!
+
+  try {
+    const id = await getParamAsync(context.params, 'id')
+    if (!id) return NextResponse.json({ error: 'User id is required' }, { status: 400 })
+
+    const body = await req.json().catch(() => ({}))
+    const subject = typeof body.subject === 'string' ? body.subject.trim().slice(0, 150) : ''
+    const message = typeof body.message === 'string' ? body.message.trim().slice(0, 2000) : ''
+    if (!subject || !message) {
+      return NextResponse.json({ error: 'Subject and message are required' }, { status: 400 })
+    }
+
+    const [target] = await drizzleDb
+      .select({ id: user.userId })
+      .from(user)
+      .where(eq(user.userId, id))
+      .limit(1)
+    if (!target) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    // force: bypass the recipient's notification prefs/quiet-hours — this is a
+    // direct admin message, not a routine notification.
+    await notify({
+      userId: id,
+      type: 'message',
+      title: subject,
+      message,
+      data: { fromAdmin: true },
+      force: true,
+    })
+
+    await logAdminAction(session.adminId, 'admin.user.notify', {
+      ipAddress: getClientIp(req),
+      resourceType: 'user',
+      resourceId: id,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error, 'Failed to send message', 'api/admin/users/[id]/notify/route.ts')
+  }
+}

--- a/tutorme-app/src/app/api/admin/users/[id]/route.ts
+++ b/tutorme-app/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,63 @@
+/**
+ * PATCH /api/admin/users/[id] — suspend or reactivate a user account.
+ * Body: { action: 'suspend' | 'activate' }
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { handleApiError } from '@/lib/api/middleware'
+import { requireAdmin, logAdminAction, getClientIp } from '@/lib/admin/auth'
+import { Permissions } from '@/lib/admin/permissions'
+import { getParamAsync } from '@/lib/api/params'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, adminSession } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { session, response } = await requireAdmin(req, Permissions.USERS_BAN)
+  if (!session) return response!
+
+  try {
+    const id = await getParamAsync(context.params, 'id')
+    if (!id) return NextResponse.json({ error: 'User id is required' }, { status: 400 })
+
+    const body = await req.json().catch(() => ({}))
+    const action = body?.action
+    if (action !== 'suspend' && action !== 'activate') {
+      return NextResponse.json({ error: "action must be 'suspend' or 'activate'" }, { status: 400 })
+    }
+
+    if (id === session.adminId && action === 'suspend') {
+      return NextResponse.json({ error: 'You cannot suspend your own account' }, { status: 400 })
+    }
+
+    const [target] = await drizzleDb
+      .select({ id: user.userId, status: user.status })
+      .from(user)
+      .where(eq(user.userId, id))
+      .limit(1)
+    if (!target) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const newStatus = action === 'suspend' ? 'suspended' : 'active'
+    await drizzleDb
+      .update(user)
+      .set({ status: newStatus, updatedAt: new Date() })
+      .where(eq(user.userId, id))
+
+    // Revoke any active NextAuth-independent admin sessions for a suspended admin.
+    if (newStatus === 'suspended') {
+      await drizzleDb
+        .update(adminSession)
+        .set({ isRevoked: true })
+        .where(eq(adminSession.adminId, id))
+    }
+
+    await logAdminAction(session.adminId, `admin.user.${action}`, {
+      ipAddress: getClientIp(req),
+      resourceType: 'user',
+      resourceId: id,
+    })
+
+    return NextResponse.json({ success: true, id, status: newStatus })
+  } catch (error) {
+    return handleApiError(error, 'Failed to update user', 'api/admin/users/[id]/route.ts')
+  }
+}

--- a/tutorme-app/src/app/api/admin/users/route.ts
+++ b/tutorme-app/src/app/api/admin/users/route.ts
@@ -18,8 +18,12 @@ import {
   liveSession,
 } from '@/lib/db/schema'
 import { and, eq, ilike, or, inArray, sql, desc } from 'drizzle-orm'
+import { logAdminAction, getClientIp } from '@/lib/admin/auth'
+import bcrypt from 'bcryptjs'
+import crypto from 'crypto'
 
 const ROLES = ['STUDENT', 'TUTOR', 'PARENT', 'ADMIN']
+const CREATABLE_ROLES = ['STUDENT', 'TUTOR', 'PARENT']
 
 export async function GET(req: NextRequest) {
   const { session, response } = await requireAdmin(req, Permissions.USERS_READ)
@@ -27,7 +31,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const url = new URL(req.url)
-    const role = url.searchParams.get('role') || undefined
+    const role = url.searchParams.get('role')?.toUpperCase() || undefined
     const search = url.searchParams.get('search')?.trim() || undefined
     const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10) || 1)
     const limit = Math.min(
@@ -54,6 +58,7 @@ export async function GET(req: NextRequest) {
         id: user.userId,
         email: user.email,
         role: user.role,
+        status: user.status,
         emailVerified: user.emailVerified,
         createdAt: user.createdAt,
         name: profile.name,
@@ -117,6 +122,7 @@ export async function GET(req: NextRequest) {
       role: r.role,
       adminRoles: adminByUser.get(r.id) || [],
       isVerified: r.emailVerified != null,
+      status: r.status,
       stats: { enrollments: enrByUser.get(r.id) || 0, sessions: sessByUser.get(r.id) || 0 },
       createdAt: r.createdAt,
     }))
@@ -125,5 +131,79 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ users, pagination: { total, page, totalPages, limit } })
   } catch (error) {
     return handleApiError(error, 'Failed to fetch users', 'api/admin/users/route.ts')
+  }
+}
+
+/**
+ * POST /api/admin/users — create a new (non-admin) user account.
+ * Body: { email, name, role: STUDENT|TUTOR|PARENT, password }
+ */
+export async function POST(req: NextRequest) {
+  const { session, response } = await requireAdmin(req, Permissions.USERS_WRITE)
+  if (!session) return response!
+
+  try {
+    const body = await req.json().catch(() => ({}))
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : ''
+    const name = typeof body.name === 'string' ? body.name.trim().slice(0, 100) : ''
+    const role = typeof body.role === 'string' ? body.role.toUpperCase() : ''
+    const password = typeof body.password === 'string' ? body.password : ''
+
+    if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+      return NextResponse.json({ error: 'A valid email is required' }, { status: 400 })
+    }
+    if (!CREATABLE_ROLES.includes(role)) {
+      return NextResponse.json({ error: 'Role must be STUDENT, TUTOR, or PARENT' }, { status: 400 })
+    }
+    if (password.length < 8) {
+      return NextResponse.json({ error: 'Password must be at least 8 characters' }, { status: 400 })
+    }
+
+    const [existing] = await drizzleDb
+      .select({ id: user.userId })
+      .from(user)
+      .where(eq(user.email, email))
+      .limit(1)
+    if (existing) {
+      return NextResponse.json({ error: 'Email already registered' }, { status: 409 })
+    }
+
+    const hashed = await bcrypt.hash(password, 10)
+    const userId = crypto.randomUUID()
+    const now = new Date()
+
+    await drizzleDb.transaction(async tx => {
+      await tx.insert(user).values({
+        userId,
+        email,
+        password: hashed,
+        role: role as 'STUDENT' | 'TUTOR' | 'PARENT',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      })
+      await tx.insert(profile).values({
+        profileId: crypto.randomUUID(),
+        userId,
+        name: name || email.split('@')[0],
+        timezone: 'UTC',
+        createdAt: now,
+        updatedAt: now,
+      })
+    })
+
+    await logAdminAction(session.adminId, 'admin.user.create', {
+      ipAddress: getClientIp(req),
+      resourceType: 'user',
+      resourceId: userId,
+      metadata: { role },
+    })
+
+    return NextResponse.json(
+      { success: true, user: { id: userId, email, name, role, status: 'active' } },
+      { status: 201 }
+    )
+  } catch (error) {
+    return handleApiError(error, 'Failed to create user', 'api/admin/users/route.ts')
   }
 }

--- a/tutorme-app/src/lib/auth.ts
+++ b/tutorme-app/src/lib/auth.ts
@@ -47,6 +47,11 @@ export const authOptions: NextAuthOptions = {
             return null
           }
 
+          // Suspended accounts cannot sign in.
+          if (userRow.status === 'suspended') {
+            throw new Error('ACCOUNT_SUSPENDED')
+          }
+
           // Get profile for onboarding/tos
           const [profileRow] = await drizzleDb
             .select()

--- a/tutorme-app/src/lib/db/schema/tables/auth.ts
+++ b/tutorme-app/src/lib/db/schema/tables/auth.ts
@@ -23,6 +23,8 @@ export const user = pgTable(
     password: text('password'),
     handle: text('handle'),
     role: enums.roleEnum('role').notNull(),
+    /** 'active' | 'suspended' — admins can suspend accounts to block sign-in. */
+    status: text('status').notNull().default('active'),
     emailVerified: timestamp('emailVerified', { withTimezone: true }),
     image: text('image'),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -179,6 +179,9 @@ BEGIN
   END IF;
 END $$;
 CREATE INDEX IF NOT EXISTS "PushSubscription_userId_idx" ON "PushSubscription" ("userId");
+
+-- Account status (admins can suspend accounts to block sign-in).
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';
 `)
 
 export async function applyStartupSchemaFixes(): Promise<void> {


### PR DESCRIPTION
## **User description**
Follow-up to #199 (admin panel data layer). Wires the remaining admin functions I'd noted as out-of-scope.

## User management (Users page)
- **Add User** — `POST /api/admin/users` creates a STUDENT/TUTOR/PARENT account (modal with email/name/role/temp password).
- **Suspend / Reactivate** — new `User.status` column (`active`|`suspended`); `PATCH /api/admin/users/[id]`. Suspended accounts are **blocked at both sign-in paths** (NextAuth `authorize` + admin login → 403) and have their admin sessions revoked. UI shows a **Suspended** badge and a toggle action (can't suspend yourself).
- **Send message** — `POST /api/admin/users/[id]/notify` (in-app + email via `notify()`).
- The previously-dead **Add User / Send Email / Suspend** buttons are now wired with modals.

## Stub pages → live data
- **Content** — `GET /api/admin/content/overview`: course/lesson counts + recent courses.
- **Security** — `GET /api/admin/security/overview`: failed logins (24h), active admin sessions, IP whitelist, recent admin actions.

## Schema
`User.status` added to the Drizzle model **and** to `startup-schema-fix` (`ADD COLUMN IF NOT EXISTS … DEFAULT 'active'`) so prod gets it on boot (consistent with the repo's drift-safety pattern).

## Verification (ran the app — real admin auth + DB + UI)
- API: add-user 201, suspend 200 → **suspended user login 403**, activate 200, notify 200, security/content overviews 200 with real data.
- UI: Users page rows 7→8 after Add User; **Suspended** badge appears after suspend; Content & Security pages render live stats (screenshots captured).

All admin endpoints continue to enforce `requireAdmin` + the right permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Wire the admin Content and Security pages to live data, and add user account create, suspend, and message actions

### What Changed
- Admin Content now shows real course and lesson counts, plus a live list of recent courses with published or draft status.
- Admin Security now shows failed logins, active admin sessions, IP whitelist status, whitelist entries, and recent admin actions.
- Admins can create new student, tutor, or parent accounts, suspend or reactivate users, and send a direct message from the Users page.
- Suspended accounts are blocked from signing in, and the login flow now returns a clear suspended-account error.
- The Users page now shows suspended users with a clear badge and exposes the new actions in the row menu.

### Impact
`✅ Live admin dashboards`
`✅ Fewer manual account handoffs`
`✅ Clearer suspended-account login errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
