### PR TITLE
fix(deploy): retry migrations on transient (Neon cold-start) connection errors

### DIFF
--- a/tutorme-app/scripts/migrate.js
+++ b/tutorme-app/scripts/migrate.js
@@ -2,12 +2,68 @@
 /**
  * Database migration script for production (no tsx required)
  * Usage: node scripts/migrate.js
+ *
+ * Resilient to transient connection errors. Neon (serverless Postgres) can drop
+ * the connection during cold-start / auto-suspend scale-up — e.g.
+ * "terminating connection due to administrator command" on the first query.
+ * That is NOT a migration failure, so we retry the whole (idempotent) migrate
+ * with backoff on connection-level errors, while failing fast on real SQL errors
+ * (syntax, constraint, missing relation, etc.) which retrying could never fix.
  */
 const path = require('node:path')
 const fs = require('node:fs')
 const { Pool } = require('pg')
 const { drizzle } = require('drizzle-orm/node-postgres')
 const { migrate } = require('drizzle-orm/node-postgres/migrator')
+
+const MAX_ATTEMPTS = 5
+
+// Substrings (lowercased) and SQLSTATE codes that indicate a transient
+// connection problem worth retrying — not a deterministic SQL error.
+const TRANSIENT_MESSAGES = [
+  'terminating connection due to administrator command',
+  'connection terminated',
+  'connection terminated unexpectedly',
+  'server closed the connection unexpectedly',
+  'connection reset by peer',
+  'econnreset',
+  'etimedout',
+  'econnrefused',
+  'enotfound',
+  'eai_again',
+  'client has encountered a connection error',
+  'timeout exceeded when trying to connect',
+  'connection timeout',
+  'could not connect',
+  'sorry, too many clients already',
+]
+// 57P01 admin_shutdown, 08xxx connection exceptions, 53300 too_many_connections.
+const TRANSIENT_CODES = new Set(['57P01', '08000', '08003', '08006', '08001', '08004', '53300'])
+
+function isTransient(error) {
+  if (!error) return false
+  const codes = [error.code, error.cause && error.cause.code].filter(Boolean)
+  if (codes.some(c => TRANSIENT_CODES.has(String(c)))) return true
+  const text = [error.message, error.cause && error.cause.message]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return TRANSIENT_MESSAGES.some(m => text.includes(m))
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function logError(error) {
+  const message =
+    error && error.stack ? error.stack : error && error.message ? error.message : error
+  console.error('[Migrations] Failed:', message)
+  if (error && error.cause) {
+    const causeMessage = error.cause.stack || error.cause.message || error.cause
+    console.error('[Migrations] Cause:', causeMessage)
+  }
+}
 
 function writeTerminationMessage(message) {
   try {
@@ -19,6 +75,27 @@ function writeTerminationMessage(message) {
   } catch {}
 }
 
+/**
+ * Run migrate once with a FRESH pool — a pool whose connection was killed can be
+ * left in a bad state, so each attempt gets a clean one. migrate() is idempotent
+ * (already-applied migrations are skipped, and a migration interrupted by a
+ * dropped connection is rolled back by Postgres), so re-running is safe.
+ */
+async function attemptOnce(databaseUrl, migrationsFolder) {
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    max: 1,
+    // Wait for Neon to wake from cold start instead of failing instantly.
+    connectionTimeoutMillis: 30000,
+  })
+  try {
+    const db = drizzle(pool)
+    await migrate(db, { migrationsFolder })
+  } finally {
+    await pool.end().catch(() => {})
+  }
+}
+
 async function runMigrations() {
   const databaseUrl = process.env.DIRECT_URL || process.env.DATABASE_URL
   if (!databaseUrl) {
@@ -26,38 +103,56 @@ async function runMigrations() {
   }
 
   const migrationsFolder = path.join(process.cwd(), 'drizzle')
-  const pool = new Pool({ connectionString: databaseUrl, max: 1 })
-  const db = drizzle(pool)
-
   console.log('[Migrations] Running migrations from:', migrationsFolder)
   console.log('[Migrations] Database:', databaseUrl.replace(/:\/\/[^:]+:[^@]+@/, '://***:***@'))
 
-  try {
-    await migrate(db, { migrationsFolder })
-    console.log('[Migrations] Completed successfully')
-  } catch (error) {
-    const message =
-      error && error.stack ? error.stack : error && error.message ? error.message : error
-    console.error('[Migrations] Failed:', message)
-    if (error.cause) {
-      const causeMessage = error.cause.stack || error.cause.message || error.cause
-      console.error('[Migrations] Cause:', causeMessage)
+  let lastError
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      console.log(`[Migrations] Attempt ${attempt}/${MAX_ATTEMPTS}...`)
+      await attemptOnce(databaseUrl, migrationsFolder)
+      console.log('[Migrations] Completed successfully')
+      return
+    } catch (error) {
+      lastError = error
+      logError(error)
+
+      const transient = isTransient(error)
+      if (attempt < MAX_ATTEMPTS && transient) {
+        // Exponential backoff with jitter: ~2s, 4s, 8s, 16s (capped).
+        const delayMs = Math.min(16000, 2000 * 2 ** (attempt - 1)) + Math.floor(Math.random() * 500)
+        console.warn(
+          `[Migrations] Transient connection error — retrying in ${Math.round(delayMs / 1000)}s ` +
+            `(attempt ${attempt + 1}/${MAX_ATTEMPTS})...`
+        )
+        await sleep(delayMs)
+        continue
+      }
+
+      const message =
+        error && error.stack ? error.stack : error && error.message ? error.message : error
+      writeTerminationMessage(
+        `[Migrations] Failed${transient ? ' (exhausted retries)' : ''}\n${message}`
+      )
+      throw error
     }
-    writeTerminationMessage(`[Migrations] Failed\n${message}`)
-    throw error
-  } finally {
-    await pool.end()
   }
+  throw lastError
 }
 
-runMigrations()
-  .then(() => {
-    process.exit(0)
-  })
-  .catch(error => {
-    const message =
-      error && error.stack ? error.stack : error && error.message ? error.message : error
-    console.error('[Migrations] Fatal error:', message)
-    writeTerminationMessage(`[Migrations] Fatal error\n${message}`)
-    process.exit(1)
-  })
+// Allow importing { isTransient } in tests without running migrations.
+module.exports = { isTransient, runMigrations }
+
+if (require.main === module) {
+  runMigrations()
+    .then(() => {
+      process.exit(0)
+    })
+    .catch(error => {
+      const message =
+        error && error.stack ? error.stack : error && error.message ? error.message : error
+      console.error('[Migrations] Fatal error:', message)
+      writeTerminationMessage(`[Migrations] Fatal error\n${message}`)
+      process.exit(1)
+    })
+}

--- a/tutorme-app/src/__tests__/migrate-retry.test.ts
+++ b/tutorme-app/src/__tests__/migrate-retry.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+
+// scripts/migrate.js is plain CJS; require avoids a declaration-file lookup.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { isTransient } = require('../../scripts/migrate.js')
+
+describe('migrate retry classifier (isTransient)', () => {
+  it('treats Neon connection-termination as transient (the deploy flake)', () => {
+    expect(isTransient(new Error('terminating connection due to administrator command'))).toBe(true)
+    expect(isTransient({ code: '57P01', message: 'admin shutdown' })).toBe(true)
+  })
+
+  it('treats network/connection errors as transient', () => {
+    for (const msg of [
+      'Connection terminated unexpectedly',
+      'ECONNRESET',
+      'timeout exceeded when trying to connect',
+      'Client has encountered a connection error',
+    ]) {
+      expect(isTransient(new Error(msg)), msg).toBe(true)
+    }
+    expect(isTransient({ code: '08006', message: 'connection failure' })).toBe(true)
+  })
+
+  it('inspects error.cause as well (drizzle wraps the driver error)', () => {
+    const wrapped = new Error('Failed query: select ... from __drizzle_migrations')
+    ;(wrapped as unknown as { cause: unknown }).cause = new Error(
+      'terminating connection due to administrator command'
+    )
+    expect(isTransient(wrapped)).toBe(true)
+  })
+
+  it('does NOT retry deterministic SQL errors', () => {
+    expect(isTransient(new Error('relation "Foo" does not exist'))).toBe(false)
+    expect(isTransient(new Error('column "bar" already exists'))).toBe(false)
+    expect(isTransient(new Error('syntax error at or near "SELCT"'))).toBe(false)
+    expect(isTransient({ code: '42P01', message: 'undefined_table' })).toBe(false)
+    expect(isTransient(null)).toBe(false)
+    expect(isTransient(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## **User description**
## Context
Investigation of #205's "migration failure" found it was **not** a bad migration — the migrate step died on its first bookkeeping query with:

> `[Migrations] Cause: error: terminating connection due to administrator command`

That's **Neon** (serverless Postgres) dropping the connection during cold-start / auto-suspend scale-up. The migration SQL never ran; it just needed a retry (and succeeded on re-run). `scripts/migrate.js` had **no retry**, so any such blip failed the whole deploy — for any PR, not just #205.

## Fix (Option A)
`scripts/migrate.js` now retries the whole (idempotent) `migrate()` with **exponential backoff + jitter** (~2s, 4s, 8s, 16s; 5 attempts), but only on **transient connection errors**:
- SQLSTATEs `57P01` (admin_shutdown), `08xxx` (connection exceptions), `53300` (too_many_connections)
- connection messages: `terminating connection…`, `connection terminated`, `ECONNRESET`, connect timeouts, etc.
- inspects `error.cause` too (drizzle wraps the driver error)

Each attempt uses a **fresh pool** (a killed connection leaves the pool unusable) and a **30s connect timeout** so it waits for Neon to wake. `migrate()` is idempotent — applied migrations are skipped and a migration interrupted mid-flight is rolled back by Postgres — so re-running is safe.

**Deterministic SQL errors** (syntax, constraint, missing relation) still **fail fast** — retrying could never fix them.

## Testing
- New unit test for the `isTransient` classifier: Neon termination / `08xxx` / `ECONNRESET` / wrapped `cause` → retry; `relation does not exist` / `already exists` / syntax / `42P01` / null → no retry. **4/4 pass.**
- Full unit suite: **301 passed**.
- `isTransient` is exported and the migrate run is guarded behind `require.main`, so importing it in tests never executes migrations (verified).
- typecheck / eslint (0 errors) / prettier / build — all pass.

Note: this is purely deploy-reliability; it doesn't change which migrations run or their order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Retry database migrations when Neon drops the connection during deploy**

### What Changed
- Migrations now retry automatically when the database connection is lost during startup or cold wake-up
- Retry only happens for connection problems; SQL errors like missing tables, syntax mistakes, or duplicate fields still fail immediately
- Each retry starts with a fresh connection and waits longer before trying again, up to five attempts
- The migration logic is now safe to import in tests, with coverage for transient and non-transient failures

### Impact
`✅ Fewer deploy failures from Neon cold starts`
`✅ Fewer migration retries needed by hand`
`✅ Clearer failure handling for real SQL errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
