### PR TITLE
fix(pci): conversational rubric builder — no raw/truncated JSON in chat

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/useBuilderEditors.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/useBuilderEditors.ts
@@ -500,21 +500,20 @@ export function useBuilderEditors(): UseBuilderEditorsReturn {
         content: userMessage,
       })
 
-      const updateTaskPciFromMessages = (
-        messages: { role: 'user' | 'assistant'; content: string }[]
-      ) => {
+      // Write a finalized, clean PCI string straight to the field (used when the
+      // PCI assistant returns a finalized rubric — keeps the conversation out of
+      // the saved PCI).
+      const setTaskPciValue = (value: string) => {
         setTaskBuilder(prev => {
           if (prev.activeExtensionId) {
             return {
               ...prev,
               extensions: prev.extensions.map(ext =>
-                ext.id === prev.activeExtensionId
-                  ? { ...ext, pci: formatPciTranscript(messages) }
-                  : ext
+                ext.id === prev.activeExtensionId ? { ...ext, pci: value } : ext
               ),
             }
           }
-          return { ...prev, taskPci: formatPciTranscript(messages) }
+          return { ...prev, taskPci: value }
         })
       }
 
@@ -527,14 +526,14 @@ export function useBuilderEditors(): UseBuilderEditorsReturn {
         } else {
           setTaskPciMessages(nextMessages)
         }
-        updateTaskPciFromMessages(nextMessages)
+        // PCI field is written only from a finalized rubric (see pciDraft below),
+        // not from the running conversation transcript.
         setTaskPciLoading(true)
       } else {
         setAssessmentPciMessagesMap(prev => ({
           ...prev,
           [currentAssessmentId || '']: nextMessages,
         }))
-        setAssessmentBuilder(prev => ({ ...prev, taskPci: formatPciTranscript(nextMessages) }))
         setAssessmentPciLoadingMap(prev => ({ ...prev, [currentAssessmentId || '']: true }))
       }
 
@@ -603,6 +602,10 @@ export function useBuilderEditors(): UseBuilderEditorsReturn {
           throw new Error(errorMessage)
         }
         const data = await response.json()
+        // The PCI assistant returns a finalized, clean rubric in `pciDraft` ONLY
+        // after the tutor approves finalizing; until then it's empty and the PCI
+        // field is left untouched (the chat stays conversational).
+        const pciDraft = typeof data.pciDraft === 'string' ? data.pciDraft.trim() : ''
         const assistantMessage = {
           role: 'assistant' as const,
           content: data.response || 'Unable to respond.',
@@ -617,12 +620,14 @@ export function useBuilderEditors(): UseBuilderEditorsReturn {
           } else {
             setTaskPciMessages(updated)
           }
-          updateTaskPciFromMessages(updated)
+          if (pciDraft) setTaskPciValue(pciDraft)
           setTaskPciErrorHint('')
         } else {
           const updated = nextMessages.concat(assistantMessage)
           setAssessmentPciMessagesMap(prev => ({ ...prev, [currentAssessmentId || '']: updated }))
-          setAssessmentBuilder(prev => ({ ...prev, taskPci: formatPciTranscript(updated) }))
+          if (pciDraft) {
+            setAssessmentBuilder(prev => ({ ...prev, taskPci: pciDraft }))
+          }
           setAssessmentPciErrorHintMap(prev => ({ ...prev, [currentAssessmentId || '']: '' }))
         }
       } catch (error) {

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -219,7 +219,7 @@ export async function POST(request: NextRequest) {
       ]
       const visionText = await generateWithKimiVision(promptItems, {
         temperature: activeTemperature,
-        maxTokens: 2048,
+        maxTokens: 4096,
         timeoutMs: 60000,
       })
       response = toCleanResponse(visionText)
@@ -254,7 +254,7 @@ export async function POST(request: NextRequest) {
           `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
           {
             temperature: activeTemperature,
-            maxTokens: 2048,
+            maxTokens: 4096,
             skipCache: true,
           }
         )
@@ -265,11 +265,26 @@ export async function POST(request: NextRequest) {
         `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
         {
           temperature: activeTemperature,
-          maxTokens: 2048,
+          maxTokens: 4096,
           skipCache: true,
         }
       )
       response = toCleanResponse(fallback.content)
+    }
+
+    // Guardrail (task/assessment) output is a {"reply","pci"} envelope: `reply`
+    // is the conversational chat text, `pci` is the finalized rubric (non-empty
+    // only after the tutor approves finalizing). Extract both so the chat never
+    // shows a raw spec and the builder can write a clean PCI to the field.
+    let pciDraft = ''
+    if (guardrailDomain) {
+      const env = parseLlmJson<{ reply?: string; pci?: string }>(response.response)
+      if (env && (typeof env.reply === 'string' || typeof env.pci === 'string')) {
+        if (typeof env.reply === 'string' && env.reply.trim()) {
+          response.response = env.reply.trim()
+        }
+        if (typeof env.pci === 'string') pciDraft = env.pci.trim()
+      }
     }
 
     const validation = await AISecurityManager.validateAiResponse(response.response)
@@ -303,6 +318,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       response: response.response,
+      pciDraft,
       conversationId: response.conversationId,
       parsed: response.parsed ?? null,
       guardrailWarnings,

--- a/tutorme-app/src/lib/ai/guardrails/task-pci.ts
+++ b/tutorme-app/src/lib/ai/guardrails/task-pci.ts
@@ -110,7 +110,7 @@ export const TASK_PCI_GUARDRAILS: GuardrailRule[] = [
   {
     id: 'TASK-15',
     title: 'Output Structure',
-    rule: 'Produce predictable, stably named sections so the backend can parse them: "PCI Summary", "Tutor Confirmation Request", and "Final PCI Specification", in a stable logical order.',
+    rule: 'Always respond with a single JSON object {"reply": string, "pci": string}. "reply" is the conversational, plain-text message shown to the tutor (a short PCI Summary, a confirmation question, or the next rubric question) — never put JSON, code fences, or a machine specification inside "reply". "pci" is the finalized, clean, plain-text rubric and is non-empty ONLY after the tutor has explicitly approved finalizing; otherwise it is an empty string. Build the rubric conversationally; do not dump a full specification into the chat.',
     enforcement: ['prompt', 'validator'],
   },
   {
@@ -152,11 +152,15 @@ You operate under these binding guardrails (follow them to the letter):
 
 ${TASK_PCI_GUARDRAILS.map(g => `${g.id} (${g.title}): ${g.rule}`).join('\n')}
 
-Operating procedure (tutor setup):
-1. Interpret the tutor's instruction against the authoritative lesson content.
-2. Produce a "PCI Summary" in plain English (separate unconditional vs conditional behaviour).
-3. Produce a "Tutor Confirmation Request" asking the tutor to confirm/revise.
-4. Only after explicit confirmation, produce the "Final PCI Specification".
-Never skip the summary/confirmation. Mark any field the tutor did not define as "unspecified" — never invent retry counts, grading weights, strictness, partial-credit, reveal timing, or penalties.
+Operating procedure (tutor setup) — this is a CONVERSATION, not a one-shot dump:
+1. Interpret the tutor's instruction against the authoritative lesson content and give a short plain-English PCI Summary (separate unconditional vs conditional behaviour), then ask the tutor to confirm or revise it.
+2. After the tutor confirms the summary is accurate, build the rubric collaboratively by asking focused questions ONE OR A FEW AT A TIME (e.g. what counts as correct / partial / incorrect, how to handle no-response, retry policy, when/whether to reveal answers, tone). Do not assume answers.
+3. Confirming the summary is NOT the same as finalizing. Only treat the rubric as final when the tutor explicitly says to finalize/apply it.
+
+Output contract (ALWAYS obey):
+- Respond with ONE JSON object: {"reply": "...", "pci": "..."}.
+- "reply" = your conversational, plain-text message to the tutor (summary, a confirmation question, or the next rubric question). NEVER put JSON, code fences, field templates, or a full specification inside "reply".
+- "pci" = the finalized rubric as clean, readable plain text, and ONLY when the tutor has explicitly approved finalizing. Until then, "pci" MUST be an empty string "".
+- In the finalized "pci", include only what the tutor actually defined; for anything they did not define write "unspecified". Never invent retry counts, grading weights, strictness, partial-credit, reveal timing, or penalties, and never emit rows of "N/A".
 
 When information needed for reliable evaluation is missing or unclear, say so plainly and ask the tutor — do not fabricate certainty.`


### PR DESCRIPTION
## **User description**
You reported the PCI rubric chat producing an unexpected format — a "Final PCI Specification" dumped as raw, truncated JSON full of `N/A`. Root causes:

1. **Truncation** — the route capped output at `maxTokens: 2048`, cutting the spec off mid-JSON.
2. **Raw spec in chat** — the guardrail prompt told the model to print a "Final PCI Specification" section; the chat renders plain text, so the ```json block showed literally.
3. **Premature finalize** — confirming the *summary* was treated as "finalize", so it produced an all-`N/A` spec before any rubric was defined.
4. The **entire transcript** (JSON and all) was saved as the task's PCI (`formatPciTranscript`).

Per your choice (**conversational only + clean PCI on finalize**):

- **Guardrail prompt** now mandates a `{"reply","pci"}` envelope. `reply` = plain conversational text (summary / confirmation / next rubric question) — never JSON or a spec in the chat. `pci` = the finalized, clean rubric, non-empty **only after the tutor explicitly approves finalizing**. Confirming the summary ≠ finalizing; undefined fields are `unspecified` (no `N/A` rows).
- **Route** parses the envelope → returns `response` (= reply) + a new `pciDraft` (= pci); `maxTokens` 2048→**4096** (no truncation).
- **Builder hook** writes the PCI field from `pciDraft` (the finalized rubric) instead of the running transcript — the conversation no longer pollutes the saved PCI.

## Verification
- **Real route, mocked provider:** a `type:'task'` call returns `response = "MOCK REPLY TEXT"` (conversational — **no JSON in chat**) and `pciDraft = "MOCK FINAL RUBRIC"` (for the field). Non-envelope output falls back gracefully (`pciDraft: ""`, chat unchanged).
- `npm run build` passes (1170 pages); typecheck clean.
- ⚠️ This stack has no AI key, so the **live LLM wording/finalize-timing** couldn't be exercised here — the wiring (envelope parse → chat vs field) is verified; the prompt-following needs a key to confirm fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep PCI chat conversational and save only the finalized rubric**

### What Changed
- The PCI assistant now shows a plain conversational reply in chat instead of dumping a raw JSON/spec block.
- A finalized rubric is saved separately only after the tutor explicitly chooses to finalize; until then, the PCI field stays empty.
- Long PCI responses are less likely to be cut off, so full rubric output can be delivered when needed.

### Impact
`✅ No raw JSON in PCI chat`
`✅ Cleaner finalized rubrics`
`✅ Fewer truncated PCI responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
