### PR TITLE
fix(course-builder): remove parent container padding for flush headers

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -211,7 +211,7 @@ export default function StudentTutorDirectoryPage() {
 
       {/* Bottom panel: filters + results */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
-        <div className="flex h-full flex-col overflow-hidden rounded-2xl bg-white shadow-[0_18px_60px_rgba(0,0,0,0.28)] ring-1 ring-black/5 transition-shadow duration-300 hover:shadow-[0_24px_80px_rgba(0,0,0,0.32)]">
+        <div className="flex h-full flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
           {/* Filters */}
           <div className="grid grid-cols-1 gap-3 p-4 pb-0 sm:p-6 sm:pb-0 md:grid-cols-4">
             <div className="relative">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5796,9 +5796,9 @@ FEEDBACK: [your explanation]`
               onMainTabChange(v as 'live' | 'builder' | 'test-pci')
             }
           }}
-          className="flex h-full w-full flex-1 flex-col bg-gray-50/50 px-3 pt-0 sm:px-4"
+          className="flex h-full w-full flex-1 flex-col bg-gray-50/50 pt-0"
         >
-          <div className="relative flex h-full w-full min-w-0 flex-1 gap-0 pb-4 pt-0">
+          <div className="relative flex h-full w-full min-w-0 flex-1 gap-0 pt-0">
             {/* LEFT PANEL - Course Structure (resizable, ~75% of original width) */}
             {/* Floating collapsed/expanded pill */}
             <div


### PR DESCRIPTION
## **User description**
Remove px-3 sm:px-4 horizontal padding from main Tabs container and pb-4 bottom padding from the relative flex wrapper. These were creating gaps that prevented the center panel headers from being flush against the panel edges in all three modes (Build, Test, Classroom).


___

## **CodeAnt-AI Description**
**Remove extra padding so course builder headers sit flush with the panel edges**

### What Changed
- Removed the outer horizontal and bottom spacing around the main course builder panels
- The center panel headers now align flush with the edge in Build, Test, and Classroom views

### Impact
`✅ Flush panel headers`
`✅ Consistent layout across course builder modes`
`✅ Less awkward empty space around the main panels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
