### PR TITLE
fix(db): add numbered migration for User.status

### DIFF
--- a/tutorme-app/drizzle/0063_user_status.sql
+++ b/tutorme-app/drizzle/0063_user_status.sql
@@ -1,0 +1,7 @@
+-- User.status ('active' | 'suspended') for admin account-suspension.
+-- It was previously created only via startup-schema-fix.ts (at server boot);
+-- this applies it through the numbered-migration path too, so a fresh revision
+-- has the column before it serves traffic (closing a brief sign-in window) and
+-- so the schema is reproducible from migrations. Idempotent: a no-op where the
+-- column already exists.
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1781700000000,
       "tag": "0062_session_reminder_sent_at",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1781800000000,
+      "tag": "0063_user_status",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## **User description**
## Option A (from the investigation of #205)
#205 added `User.status` (`'active' | 'suspended'`, for admin suspension) **only** via `startup-schema-fix.ts`, which runs at server **boot** — *after* a new revision starts serving. Since `auth.ts` (NextAuth) reads `status`, a fresh revision could briefly fail sign-in before the boot-time ALTER lands, and the column wasn't reproducible from the migration history.

**Fix:** add migration **0063** — an idempotent `ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active'` — so the column is applied through the **pre-traffic-switch** migration path too.

- **No-op on prod** (the column already exists via startup-fix; verified `ADD COLUMN IF NOT EXISTS` skips cleanly).
- **Creates it on fresh databases**, so the schema is reproducible from migrations.
- `when` = 1781800000000 (idx 63), the next slot after 0062.

## Testing
Applied the migration twice against a throwaway Postgres: first run adds the column, second run skips (`already exists, skipping`) — idempotent. Journal JSON validates; typecheck / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Apply the User account status column before new versions start serving traffic**

### What Changed
- Adds a numbered database migration that creates the `User.status` field for admin suspension
- Makes the change available through the migration path, so fresh deployments have the field before sign-in requests arrive
- Keeps existing databases safe by skipping the change when the field is already present

### Impact
`✅ Fewer sign-in failures after deployment`
`✅ Reliable admin suspension on fresh installs`
`✅ Consistent database setup from migrations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
