### PR TITLE
feat(pci): Apply-to-PCI button on the live builder path (+ envelope tests)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -823,6 +823,37 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [assessmentPciErrorHintMap, setAssessmentPciErrorHintMap] = useState<
       Record<string, string>
     >({})
+    // Finalized rubric the PCI assistant produced (after the tutor approves
+    // finalizing). Held as a draft until the tutor clicks "Apply to PCI".
+    const [taskPciDraft, setTaskPciDraft] = useState('')
+    const [assessmentPciDraftMap, setAssessmentPciDraftMap] = useState<Record<string, string>>({})
+    const applyTaskPciDraft = () => {
+      if (!taskPciDraft) return
+      setTaskBuilder(prev => {
+        if (prev.activeExtensionId) {
+          return {
+            ...prev,
+            extensions: prev.extensions.map(ext =>
+              ext.id === prev.activeExtensionId ? { ...ext, pci: taskPciDraft } : ext
+            ),
+          }
+        }
+        return { ...prev, taskPci: taskPciDraft }
+      })
+      setTaskPciDraft('')
+      toast.success('Rubric applied to PCI')
+    }
+    const applyAssessmentPciDraft = (assessmentId: string) => {
+      const draft = assessmentPciDraftMap[assessmentId]
+      if (!draft) return
+      setAssessmentBuilder(prev => ({ ...prev, taskPci: draft }))
+      setAssessmentPciDraftMap(prev => {
+        const next = { ...prev }
+        delete next[assessmentId]
+        return next
+      })
+      toast.success('Rubric applied to PCI')
+    }
     // Warn-only guardrail violations returned by the PCI/DMI endpoints, surfaced
     // to the tutor so they can confirm/correct (e.g. an invented retry policy or
     // a paraphrased exam question) before relying on the output.
@@ -1974,11 +2005,6 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       [collectTaskFileKeys, collectAssessmentFileKeys]
     )
 
-    const formatPciTranscript = (messages: { role: 'user' | 'assistant'; content: string }[]) =>
-      messages
-        .map(msg => `${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.content}`)
-        .join('\n')
-
     const cloneTask = (task: Task): Task => ({
       ...task,
       id: `task-${generateId()}`,
@@ -2200,24 +2226,6 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         role: 'user',
         content: userMessage,
       })
-      const updateTaskPciFromMessages = (
-        messages: { role: 'user' | 'assistant'; content: string }[]
-      ) => {
-        setTaskBuilder(prev => {
-          if (prev.activeExtensionId) {
-            return {
-              ...prev,
-              extensions: prev.extensions.map(ext =>
-                ext.id === prev.activeExtensionId
-                  ? { ...ext, pci: formatPciTranscript(messages) }
-                  : ext
-              ),
-            }
-          }
-          return { ...prev, taskPci: formatPciTranscript(messages) }
-        })
-      }
-
       if (isTask) {
         if (taskBuilder.activeExtensionId) {
           setTaskExtensionPciMessages(prev => ({
@@ -2227,11 +2235,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         } else {
           setTaskPciMessages(nextMessages)
         }
-        updateTaskPciFromMessages(nextMessages)
+        // PCI field is written only from a finalized rubric (pciDraft + Apply),
+        // not from the running conversation transcript.
         setTaskPciLoading(true)
       } else {
         setAssessmentPciMessagesMap(prev => ({ ...prev, [assessmentId || '']: nextMessages }))
-        setAssessmentBuilder(prev => ({ ...prev, taskPci: formatPciTranscript(nextMessages) }))
         setAssessmentPciLoadingMap(prev => ({ ...prev, [assessmentId || '']: true }))
       }
 
@@ -2330,6 +2338,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         const warnings: GuardrailWarning[] = Array.isArray(data.guardrailWarnings)
           ? data.guardrailWarnings
           : []
+        // The PCI assistant returns a finalized, clean rubric in `pciDraft` ONLY
+        // after the tutor approves finalizing; until then it's empty. We hold it
+        // as a draft and write it to the PCI field only when the tutor clicks
+        // "Apply to PCI" — the conversation never pollutes the saved PCI.
+        const pciDraft = typeof data.pciDraft === 'string' ? data.pciDraft.trim() : ''
         const assistantMessage = {
           role: 'assistant' as const,
           content: data.response || 'Unable to respond.',
@@ -2344,13 +2357,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           } else {
             setTaskPciMessages(updated)
           }
-          updateTaskPciFromMessages(updated)
+          if (pciDraft) setTaskPciDraft(pciDraft)
           setTaskPciErrorHint('')
           setTaskPciGuardrailWarnings(warnings)
         } else {
           const updated = nextMessages.concat(assistantMessage)
           setAssessmentPciMessagesMap(prev => ({ ...prev, [assessmentId || '']: updated }))
-          setAssessmentBuilder(prev => ({ ...prev, taskPci: formatPciTranscript(updated) }))
+          if (pciDraft) {
+            setAssessmentPciDraftMap(prev => ({ ...prev, [assessmentId || '']: pciDraft }))
+          }
           setAssessmentPciErrorHintMap(prev => ({ ...prev, [assessmentId || '']: '' }))
           setAssessmentPciGuardrailWarningsMap(prev => ({
             ...prev,
@@ -9442,6 +9457,20 @@ FEEDBACK: [your explanation]`
                                           )}
                                         </div>
                                         <div className="mt-auto p-0">
+                                          {taskPciDraft && (
+                                            <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+                                              <span>
+                                                Finalized rubric ready to apply to the PCI field.
+                                              </span>
+                                              <Button
+                                                size="sm"
+                                                className="h-7 bg-emerald-600 text-white hover:bg-emerald-500"
+                                                onClick={applyTaskPciDraft}
+                                              >
+                                                Apply to PCI
+                                              </Button>
+                                            </div>
+                                          )}
                                           {taskPciErrorHint && (
                                             <div className="mb-px rounded-md border border-rose-200 bg-rose-50 px-px py-px text-xs text-rose-700">
                                               PCI assistant error: {taskPciErrorHint}
@@ -9922,6 +9951,22 @@ FEEDBACK: [your explanation]`
                                           )}
                                         </div>
                                         <div className="mt-auto p-0">
+                                          {assessmentPciDraftMap[loadedAssessmentId || ''] && (
+                                            <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+                                              <span>
+                                                Finalized rubric ready to apply to the PCI field.
+                                              </span>
+                                              <Button
+                                                size="sm"
+                                                className="h-7 bg-emerald-600 text-white hover:bg-emerald-500"
+                                                onClick={() =>
+                                                  applyAssessmentPciDraft(loadedAssessmentId || '')
+                                                }
+                                              >
+                                                Apply to PCI
+                                              </Button>
+                                            </div>
+                                          )}
                                           {(assessmentPciErrorHintMap[loadedAssessmentId || ''] ||
                                             '') && (
                                             <div className="mb-px rounded-md border border-rose-200 bg-rose-50 px-px py-px text-xs text-rose-700">

--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -99,4 +99,76 @@ describe('/api/ai/pci-master', () => {
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(401)
   })
+
+  const postBody = async (body: Record<string, unknown>) => {
+    const req = new Request('http://localhost/api/ai/pci-master', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return POST(req as unknown as NextRequest)
+  }
+
+  it('task domain: extracts {reply,pci} — chat shows reply, pciDraft holds the finalized rubric', async () => {
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.adkPciMasterChat.mockResolvedValue({
+      response: '{"reply":"What counts as a correct answer?","pci":"FINAL RUBRIC TEXT"}',
+      conversationId: 'c1',
+      parsed: null,
+    })
+
+    const res = await postBody({ message: 'help', context: { type: 'task' } })
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    // chat shows only the conversational reply — never the raw JSON envelope
+    expect(data.response).toBe('What counts as a correct answer?')
+    expect(data.response).not.toContain('{')
+    expect(data.pciDraft).toBe('FINAL RUBRIC TEXT')
+  })
+
+  it('task domain: empty pci until finalized (no draft surfaced)', async () => {
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.adkPciMasterChat.mockResolvedValue({
+      response: '{"reply":"Here is the summary, is it right?","pci":""}',
+      conversationId: 'c1',
+      parsed: null,
+    })
+
+    const res = await postBody({ message: 'summarize', context: { type: 'task' } })
+    const data = await res.json()
+
+    expect(data.response).toBe('Here is the summary, is it right?')
+    expect(data.pciDraft).toBe('')
+  })
+
+  it('task domain: falls back gracefully when the model ignores the envelope', async () => {
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.adkPciMasterChat.mockResolvedValue({
+      response: 'Just plain prose, no JSON at all.',
+      conversationId: 'c1',
+      parsed: null,
+    })
+
+    const res = await postBody({ message: 'hi', context: { type: 'task' } })
+    const data = await res.json()
+
+    expect(data.response).toBe('Just plain prose, no JSON at all.')
+    expect(data.pciDraft).toBe('')
+  })
+
+  it('non-guardrail domain: no pciDraft extraction', async () => {
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.adkPciMasterChat.mockResolvedValue({
+      response: 'ok',
+      conversationId: 'c1',
+      parsed: null,
+    })
+
+    const res = await postBody({ message: 'hi' }) // no context.type
+    const data = await res.json()
+
+    expect(data.response).toBe('ok')
+    expect(data.pciDraft).toBe('')
+  })
 })


### PR DESCRIPTION
## **User description**
Implements the two follow-ups from the PCI review (#207).

## Important correction
While building this I found that **#207's client-side fix landed in dead code**: `CourseBuilder` imports `useBuilderEditors` but **never calls it** — the live PCI chat is the inline `handlePciSend` in `CourseBuilder`. So #207's route + prompt changes are live (the chat is conversational), but the "clean PCI to field" change had no effect — the live path still dumped the whole transcript into the PCI field and ignored `pciDraft`. This PR fixes the **live** path.

## #1 — Apply-to-PCI button (live `handlePciSend`)
- Stops writing the running conversation transcript into the PCI field.
- Captures the route's `pciDraft` (the finalized rubric — present only after the tutor approves finalizing) and holds it as a draft.
- Adds an **"Apply to PCI"** button to both the task and assessment PCI chats; clicking it writes the rubric into the PCI field and toasts **"Rubric applied to PCI"**. The conversation never pollutes the saved PCI.
- Removed the now-dead inline `formatPciTranscript` / `updateTaskPciFromMessages`.

## #2 — Unit tests for the envelope wiring
4 new cases on `/api/ai/pci-master`:
- task domain extracts `{reply,pci}` → `response` = reply (asserts **no `{` in chat**), `pciDraft` = finalized rubric.
- empty `pci` until finalized → no draft surfaced.
- model ignores the envelope (non-JSON) → graceful fallback, `pciDraft: ''`.
- non-guardrail domain → no extraction.

## Verification
- `vitest` — all 6 pci-master tests pass (4 new).
- `npm run build` — ✓ compiled, 1170 pages; typecheck clean.
- ⚠️ The deep PCI-tab UI click wasn't driven end-to-end (no AI key on this stack + very deep builder navigation); the route contract is unit-tested and the button wiring is small + typechecked. A real-document run in prod is still the recommended final check.

Note: `useBuilderEditors.ts` remains dead code (unused). I left #207's edits there untouched; worth deleting the unused hook in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let tutors apply a finalized PCI rubric from the builder**

### What Changed
- PCI chats now keep the assistant’s finalized rubric separate from the running conversation, so the saved PCI field is no longer filled with chat history.
- A new “Apply to PCI” button appears when a finalized rubric is ready; clicking it writes the rubric into the PCI field and shows a confirmation message.
- Task and assessment PCI flows both use this apply step, and the rubric draft is cleared after it is applied.
- The PCI API now returns the chat reply separately from the rubric draft, and it leaves the draft empty until a finalized rubric is available or when the request is outside the PCI flow.

### Impact
`✅ Cleaner PCI fields`
`✅ Fewer accidental transcript saves`
`✅ Clearer rubric handoff in task and assessment builders`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
