### PR TITLE
fix(tutors): don't surface incomplete tutor signups on Book-a-Tutor

### DIFF
--- a/tutorme-app/src/__tests__/integration/public-tutors-discovery.test.ts
+++ b/tutorme-app/src/__tests__/integration/public-tutors-discovery.test.ts
@@ -19,7 +19,8 @@ import { GET as getTutors } from '@/app/api/public/tutors/route'
 const stamp = Date.now()
 const courselessTutorId = crypto.randomUUID()
 const courseTutorId = crypto.randomUUID()
-const allUserIds = [courselessTutorId, courseTutorId]
+const namelessTutorId = crypto.randomUUID() // incomplete signup — must NOT appear
+const allUserIds = [courselessTutorId, courseTutorId, namelessTutorId]
 const courseId = `course_disc_${stamp}`
 
 function req() {
@@ -44,10 +45,19 @@ describe('public tutors discovery', () => {
         createdAt: now,
         updatedAt: now,
       },
+      {
+        userId: namelessTutorId,
+        email: `claude-disc-noname-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: now,
+        updatedAt: now,
+      },
     ])
     await drizzleDb.insert(profile).values([
       { profileId: `prof_nc_${stamp}`, userId: courselessTutorId, name: 'Course-less Tutor' },
       { profileId: `prof_c_${stamp}`, userId: courseTutorId, name: 'Course Tutor' },
+      // Incomplete signup: no name. Should be excluded from the public directory.
+      { profileId: `prof_nn_${stamp}`, userId: namelessTutorId, name: null },
     ])
     // Only the second tutor has a published course.
     await drizzleDb
@@ -76,6 +86,8 @@ describe('public tutors discovery', () => {
     expect(ids).toContain(courselessTutorId)
     // The tutor with a published course is still listed.
     expect(ids).toContain(courseTutorId)
+    // An incomplete signup (no name) must NOT appear on the public directory.
+    expect(ids).not.toContain(namelessTutorId)
 
     // The course-less tutor renders sensibly: zero courses, no crash.
     const courseless = data.tutors.find((t: { id: string }) => t.id === courselessTutorId)

--- a/tutorme-app/src/app/api/public/tutors/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/route.ts
@@ -175,6 +175,10 @@ export async function GET(request: NextRequest) {
       .where(
         and(
           eq(user.role, 'TUTOR'),
+          // Don't surface half-finished / test signups on the public directory:
+          // a discoverable tutor must at least have a real name on their profile.
+          // (Publishing a course is NOT required — every named tutor appears.)
+          sql`coalesce(trim(${profile.name}), '') <> ''`,
           searchPattern
             ? or(
                 ilike(profile.name, searchPattern),


### PR DESCRIPTION
## **User description**
## Follow-up B (refines #204)
Making **all tutors discoverable** (dropping the published-course requirement) had a side effect: the public Book-a-Tutor directory now also lists **half-finished / test tutor accounts** that have no profile name — rendered as "Anonymous Tutor" with no avatar/bio.

**Fix:** require a **non-empty profile name** in the directory query (`coalesce(trim(name),'') <> ''`). Publishing a course is still **not** required — every *named* tutor appears, course or not.

Chose "has a name" over `isOnboarded` because `isOnboarded` defaults `false` and isn't reliably set, so it would over-hide legitimate tutors. A name is the minimal real-profile signal and directly targets the "Anonymous Tutor" entries.

Only the browse/search path is filtered; the by-ids fast path (favorites/bookmarks) is untouched, since those tutors were explicitly requested.

## Testing
Integration test extended: a **named** tutor with **no courses** still appears; a tutor with **no name** is excluded. Passed. typecheck / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Hide incomplete tutor signups from the public tutor directory**

### What Changed
- The public Book-a-Tutor directory now skips tutor accounts with no real profile name, so half-finished or test signups no longer appear as anonymous profiles
- Tutors with a name still show up even if they have no published courses
- The discovery results now explicitly cover both cases in testing: named tutors without courses are included, and nameless tutors are excluded

### Impact
`✅ Fewer anonymous tutor listings`
`✅ Cleaner Book-a-Tutor search results`
`✅ Named tutors still discoverable without published courses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
