### PR TITLE
ci: run integration tests against an ephemeral Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,35 +151,48 @@ jobs:
       - name: Security audit
         run: npm run security:check
 
-  # Optional: run integration tests when a test database is configured (e.g. service container).
-  # integration:
-  #   name: Integration tests
-  #   runs-on: ubuntu-latest
-  #   services:
-  #     postgres:
-  #       image: postgres:16-alpine
-  #       env:
-  #         POSTGRES_USER: tutorme
-  #         POSTGRES_PASSWORD: tutorme_password
-  #         POSTGRES_DB: tutorme_test
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #       ports:
-  #         - 5432:5432
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: '20'
-  #         cache: 'npm'
-  #         cache-dependency-path: tutorme-app/package-lock.json
-  #     - run: npm ci --legacy-peer-deps
-  #     - run: npx drizzle-kit push --force
-  #       env:
-  #         DATABASE_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
-  #     - run: npm run test:integration
-  #       env:
-  #         DATABASE_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
+  # Integration tests run against an ephemeral Postgres. Schema is built from the
+  # source of truth via `drizzle-kit push` (no migration replay), so these tests
+  # protect the real DB-backed flows (grading, reminders, tutor discovery, etc.).
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: tutorme
+          POSTGRES_PASSWORD: tutorme_password
+          POSTGRES_DB: tutorme_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
+      DIRECT_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
+      NEXTAUTH_SECRET: integration-ci-secret-insecure-but-long-enough-32chars
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tutorme-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Rollup Linux native binding (Vitest on ubuntu-latest)
+        run: npm install --no-save --legacy-peer-deps @rollup/rollup-linux-x64-gnu
+
+      - name: Push schema to test database
+        run: npx drizzle-kit push --force
+
+      - name: Run integration tests
+        run: npm run test:integration


### PR DESCRIPTION
## **User description**
## Follow-up D
The integration tests I've added (grading, session reminders, tutor discovery, live-auto-grading, submission persistence) only ran **locally** against a throwaway DB — so they could silently rot.

This enables the (previously commented-out) **`integration`** CI job:
- A **Postgres service container** (`postgres:16-alpine`, db `tutorme_test`).
- Schema built from the **source of truth** via `drizzle-kit push --force` — no migration replay, so it's unaffected by the legacy from-zero migration gap.
- Runs `npm run test:integration`.
- Adds the `@rollup/rollup-linux-x64-gnu` native binding install that Vitest needs on ubuntu (mirrors the unit-test job).

Validated locally: the **full** integration suite (5 files, 10 tests) passes against a fresh `drizzle-kit push`'d `tutorme_test` DB. This PR's own CI run exercises the new job end-to-end.

## Note on the deferred item (C)
Making migrations replay from an empty DB is a **bigger project than a quick guard**: `TutorApplication` (and other legacy tables) were created via `drizzle-kit push`, never by a migration (`0003` is an empty placeholder), and there are dozens of unguarded `ALTER … ADD CONSTRAINT`/rename ops across `0021`–`0036`. The right fix is a squashed **baseline migration**, done as its own tested effort — not a fragile multi-file patch. Prod is unaffected (fully migrated), and this CI job sidesteps the issue entirely by using `drizzle-kit push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run integration tests in CI against a fresh Postgres database**

### What Changed
- CI now runs the integration test suite automatically instead of leaving it commented out
- The job starts a temporary Postgres database, loads the schema into it, and then runs the DB-backed tests
- The workflow now includes the settings needed for these tests to connect and run on GitHub Actions
- A required Rollup native package is installed so the tests can run on Ubuntu CI

### Impact
`✅ Fewer broken integration tests slipping through`
`✅ Earlier detection of database flow regressions`
`✅ More reliable CI for grading, reminders, and tutor discovery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
