### PR TITLE
fix: account page Billing History merge + panel collapse fix

### DIFF
--- a/tutorme-app/src/app/[locale]/student/account/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/account/page.tsx
@@ -280,7 +280,7 @@ export default function StudentAccount() {
   }
 
   const sectionCardClass =
-    'min-h-full overflow-hidden rounded-[16px] border border-slate-200 bg-white shadow-elevation-3'
+    'overflow-hidden rounded-[16px] border border-slate-200 bg-white shadow-elevation-3'
 
   if (loading) {
     return (
@@ -312,7 +312,6 @@ export default function StudentAccount() {
           tabs={[
             { value: 'profile', label: 'Profile', icon: User },
             { value: 'billing', label: 'Billing', icon: CreditCard },
-            { value: 'history', label: 'History', icon: FileText },
             { value: 'notifications', label: 'Notifications', icon: Bell },
             { value: 'security', label: 'Security', icon: Shield },
             { value: 'controls', label: 'Controls', icon: Power },
@@ -503,15 +502,7 @@ export default function StudentAccount() {
                   </Button>
                 </CardContent>
               </CollapsibleCard>
-            </div>
-          </TabsContent>
 
-          {/* Billing History */}
-          <TabsContent
-            value="history"
-            className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-          >
-            <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
               <CollapsibleCard
                 title="Billing History"
                 description="View and download your invoices and receipts"

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -68,7 +68,7 @@ const LANGUAGES = [
 ]
 
 const SECTION_CARD_CLASS =
-  'min-h-full overflow-hidden rounded-[16px] border border-slate-200 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]'
+  'overflow-hidden rounded-[16px] border border-slate-200 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]'
 
 interface PaymentMethod {
   id: string
@@ -642,7 +642,6 @@ export default function TutorSettings() {
           tabs={[
             { value: 'profile', label: 'Profile', icon: User },
             { value: 'billing', label: 'Billing', icon: CreditCard },
-            { value: 'history', label: 'History', icon: FileText },
             { value: 'refunds', label: 'Refunds', icon: DollarSign },
             { value: 'notifications', label: 'Notifications', icon: Bell },
             { value: 'security', label: 'Security', icon: Shield },
@@ -1230,15 +1229,7 @@ export default function TutorSettings() {
                   </div>
                 </div>
               </CollapsibleCard>
-            </div>
-          </TabsContent>
 
-          {/* Billing History */}
-          <TabsContent
-            value="history"
-            className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-          >
-            <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
               <CollapsibleCard
                 flush
                 className={SECTION_CARD_CLASS}

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -54,8 +54,10 @@ export function CollapsibleCard({
           open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
         )}
       >
-        <div ref={contentRef} className={cn('overflow-hidden', contentClassName)}>
-          {children}
+        <div className="overflow-hidden">
+          <div ref={contentRef} className={contentClassName}>
+            {children}
+          </div>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## **User description**
- Remove History tab from both student and tutor account pages
- Move Billing History panel into Billing mode for both pages
- Fix collapsible panels to shrink to header height when collapsed
- Remove min-h-full from card classes
- Fix CollapsibleCard grid-rows-[0fr] collapse behavior


___

## **CodeAnt-AI Description**
**Move Billing History into Billing and fix collapsed panels shrinking properly**

### What Changed
- Removed the separate History tab from student and tutor account pages
- Billing History now appears inside the Billing section on both pages
- Collapsed panels now shrink down to their header instead of leaving extra empty space
- Account cards no longer keep a full-height layout when collapsed, which improves how the page packs content

### Impact
`✅ Fewer account-page tabs to switch through`
`✅ Easier access to billing history`
`✅ Tighter collapsed panels with less empty space`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
