### PR TITLE
feat(student/tutors): paginated grid with 8 cards per page

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { BookOpen, Search, Users } from 'lucide-react'
+import { BookOpen, ChevronLeft, ChevronRight, Search, Users } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { REGIONS } from '@/lib/data/tutor-categories'
@@ -62,6 +62,8 @@ export default function StudentTutorDirectoryPage() {
   const [selectedRegion, setSelectedRegion] = useState('')
   const [selectedCountryCode, setSelectedCountryCode] = useState('')
   const [sortBy, setSortBy] = useState<'popular' | 'newest' | 'courses' | 'rate'>('popular')
+  const [currentPage, setCurrentPage] = useState(1)
+  const ITEMS_PER_PAGE = 8
 
   const availableCountries = useMemo(() => {
     const region = REGIONS.find(r => r.id === selectedRegion)
@@ -70,6 +72,10 @@ export default function StudentTutorDirectoryPage() {
   const [following, setFollowing] = useState<Set<string>>(new Set())
 
   // Load following from API on mount
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [searchQuery, selectedRegion, selectedCountryCode, sortBy])
+
   useEffect(() => {
     const loadFollowing = async () => {
       try {
@@ -161,6 +167,12 @@ export default function StudentTutorDirectoryPage() {
       active = false
     }
   }, [searchQuery, selectedRegion, selectedCountryCode, sortBy])
+
+  const totalPages = Math.max(1, Math.ceil(tutors.length / ITEMS_PER_PAGE))
+  const paginatedTutors = tutors.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  )
 
   const headlineMetrics = useMemo(() => {
     const totalCourses = tutors.reduce((sum, tutor) => sum + tutor.courseCount, 0)
@@ -299,68 +311,117 @@ export default function StudentTutorDirectoryPage() {
           </div>
 
           {/* Tutor grid */}
-          <div className="min-h-0 flex-1 overflow-y-auto p-4 pt-3 sm:p-6 sm:pt-4">
-            <div className="grid items-stretch gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {loading ? (
-                Array.from({ length: 6 }).map((_, index) => (
-                  <Card
-                    key={`loading-${index}`}
-                    className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
-                  >
-                    <CardHeader className="space-y-2 p-4">
-                      <div className="h-5 w-2/3 rounded bg-white/10" />
-                      <div className="h-3 w-1/2 rounded bg-white/10" />
+          <div className="flex flex-1 flex-col p-4 pt-3 sm:p-6 sm:pt-4">
+            <div className="flex flex-1 flex-col justify-around">
+              <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                {loading ? (
+                  Array.from({ length: 8 }).map((_, index) => (
+                    <Card
+                      key={`loading-${index}`}
+                      className="animate-pulse overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]"
+                    >
+                      <CardHeader className="space-y-2 p-4">
+                        <div className="h-5 w-2/3 rounded bg-white/10" />
+                        <div className="h-3 w-1/2 rounded bg-white/10" />
+                      </CardHeader>
+                      <CardContent className="space-y-2 p-4 pt-0">
+                        <div className="h-3 rounded bg-white/10" />
+                        <div className="h-3 rounded bg-white/10" />
+                      </CardContent>
+                    </Card>
+                  ))
+                ) : tutors.length === 0 ? (
+                  <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
+                    <CardHeader>
+                      <CardTitle className="text-white">
+                        No tutors match your current filters
+                      </CardTitle>
+                      <CardDescription className="text-white/70">
+                        Try broadening search terms or selecting a different region or country.
+                      </CardDescription>
                     </CardHeader>
-                    <CardContent className="space-y-2 p-4 pt-0">
-                      <div className="h-3 rounded bg-white/10" />
-                      <div className="h-3 rounded bg-white/10" />
-                    </CardContent>
                   </Card>
-                ))
-              ) : tutors.length === 0 ? (
-                <Card className="col-span-full overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-[0_12px_30px_rgba(0,0,0,0.25)]">
-                  <CardHeader>
-                    <CardTitle className="text-white">
-                      No tutors match your current filters
-                    </CardTitle>
-                    <CardDescription className="text-white/70">
-                      Try broadening search terms or selecting a different region or country.
-                    </CardDescription>
-                  </CardHeader>
-                </Card>
-              ) : (
-                tutors.map(tutor => (
-                  <TutorCard
-                    key={tutor.id}
-                    compact
-                    tutor={{
-                      id: tutor.id,
-                      username: tutor.username,
-                      name: tutor.name,
-                      avatar: tutor.avatarUrl,
-                      bio: tutor.bio,
-                      rating: tutor.averageRating || 0,
-                      reviewCount: tutor.totalReviewCount || 0,
-                      hourlyRate: tutor.hourlyRate,
-                      currency: 'SGD',
-                      nextAvailableSlot: null,
-                      totalStudents: tutor.totalEnrollments,
-                      totalClasses: tutor.courseCount,
-                      specialties: tutor.categories,
-                      countries: tutor.tutorNationalities,
-                    }}
-                    onClick={() => {
-                      showOverlay()
-                      router.push(`/${locale}/u/${tutor.username}`)
-                    }}
-                    followState={following.has(tutor.id) ? 'following' : 'not-following'}
-                    onFollowToggle={() => toggleFollow(tutor.id)}
-                    bookHref={`/${locale}/u/${tutor.username}?book=1`}
-                    countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
-                  />
-                ))
-              )}
+                ) : (
+                  paginatedTutors.map(tutor => (
+                    <TutorCard
+                      key={tutor.id}
+                      compact
+                      tutor={{
+                        id: tutor.id,
+                        username: tutor.username,
+                        name: tutor.name,
+                        avatar: tutor.avatarUrl,
+                        bio: tutor.bio,
+                        rating: tutor.averageRating || 0,
+                        reviewCount: tutor.totalReviewCount || 0,
+                        hourlyRate: tutor.hourlyRate,
+                        currency: 'SGD',
+                        nextAvailableSlot: null,
+                        totalStudents: tutor.totalEnrollments,
+                        totalClasses: tutor.courseCount,
+                        specialties: tutor.categories,
+                        countries: tutor.tutorNationalities,
+                      }}
+                      onClick={() => {
+                        showOverlay()
+                        router.push(`/${locale}/u/${tutor.username}`)
+                      }}
+                      followState={following.has(tutor.id) ? 'following' : 'not-following'}
+                      onFollowToggle={() => toggleFollow(tutor.id)}
+                      bookHref={`/${locale}/u/${tutor.username}?book=1`}
+                      countryLabel={tutor.tutorNationalities?.[0] ?? '--'}
+                    />
+                  ))
+                )}
+              </div>
             </div>
+
+            {/* Pagination */}
+            {!loading && tutors.length > 0 && (
+              <div className="flex items-center justify-center gap-2 pt-4">
+                <button
+                  type="button"
+                  disabled={currentPage === 1}
+                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  className={cn(
+                    'flex h-8 w-8 items-center justify-center rounded-lg text-sm transition-colors',
+                    currentPage === 1
+                      ? 'cursor-not-allowed text-slate-300'
+                      : 'text-slate-600 hover:bg-slate-100'
+                  )}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+                  <button
+                    key={page}
+                    type="button"
+                    onClick={() => setCurrentPage(page)}
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition-colors',
+                      page === currentPage
+                        ? 'bg-[#2563EB] text-white'
+                        : 'text-slate-600 hover:bg-slate-100'
+                    )}
+                  >
+                    {page}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  disabled={currentPage === totalPages}
+                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  className={cn(
+                    'flex h-8 w-8 items-center justify-center rounded-lg text-sm transition-colors',
+                    currentPage === totalPages
+                      ? 'cursor-not-allowed text-slate-300'
+                      : 'text-slate-600 hover:bg-slate-100'
+                  )}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## **User description**
- Add pagination state with 8 items per page (2 rows x 4 columns)\n- Reset to page 1 when filters change\n- Replace infinite scroll with fixed-height paginated layout\n- Use justify-around to evenly distribute 2 rows of cards\n- Add pagination controls with prev/next arrows and numbered buttons\n- Update loading skeleton to show 8 placeholder cards\n- Remove overflow-y-auto from grid container


___

## **CodeAnt-AI Description**
**Show tutors in a paginated grid with visible page controls**

### What Changed
- Tutor results now display 8 cards per page instead of loading into a scrollable list.
- Added previous/next buttons and numbered pages so students can move through tutor results directly.
- Changing search, region, country, or sort resets the view back to the first page.
- Loading now shows 8 placeholder cards, and the empty-state message remains when no tutors match.

### Impact
`✅ Easier browsing of tutor results`
`✅ Fewer long scroll sessions`
`✅ Clearer page-by-page navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
