### PR TITLE
feat(register): redesign role selection page with dark translucent cards

### DIFF
--- a/tutorme-app/src/app/[locale]/register/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/page.tsx
@@ -65,9 +65,7 @@ export default function RoleSelectionPage() {
               <Card className="h-full cursor-pointer border border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-3">
-                    <div
-                      className={`${role.color} rounded-xl p-3 text-white shadow-lg`}
-                    >
+                    <div className={`${role.color} rounded-xl p-3 text-white shadow-lg`}>
                       <role.icon className="h-7 w-7" />
                     </div>
                     <div className="flex-1">

--- a/tutorme-app/src/app/[locale]/register/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/page.tsx
@@ -3,53 +3,41 @@
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { GraduationCap, Users, BookOpen, Shield } from 'lucide-react'
+import { GraduationCap, Users, Presentation, Shield } from 'lucide-react'
 import { useParams } from 'next/navigation'
 
 const roles = [
   {
     id: 'student',
     title: 'Student',
-    description: 'Learn with AI tutors and live classes',
-    icon: BookOpen,
+    icon: GraduationCap,
     href: '/register/student',
     color: 'bg-primary',
-    hoverBg: 'hover:bg-primary/90',
-    shadow: 'shadow-primary/20',
-    hoverShadow: 'hover:shadow-primary/30',
+    textColor: 'text-primary',
   },
   {
     id: 'parent',
     title: 'Parent',
-    description: "Monitor and support your child's learning",
     icon: Users,
     href: '/register/parent',
     color: 'bg-success',
-    hoverBg: 'hover:bg-success/90',
-    shadow: 'shadow-success/20',
-    hoverShadow: 'hover:shadow-success/30',
+    textColor: 'text-success',
   },
   {
     id: 'tutor',
     title: 'Tutor',
-    description: 'Teach students and grow your reach',
-    icon: GraduationCap,
+    icon: Presentation,
     href: '/register/tutor',
     color: 'bg-warning',
-    hoverBg: 'hover:bg-warning/90',
-    shadow: 'shadow-warning/20',
-    hoverShadow: 'hover:shadow-warning/30',
+    textColor: 'text-warning',
   },
   {
     id: 'admin',
     title: 'Administrator',
-    description: 'Manage your institution',
     icon: Shield,
     href: '/register/admin',
     color: 'bg-secondary',
-    hoverBg: 'hover:bg-secondary/90',
-    shadow: 'shadow-secondary/20',
-    hoverShadow: 'hover:shadow-secondary/30',
+    textColor: 'text-secondary',
   },
 ]
 
@@ -68,28 +56,26 @@ export default function RoleSelectionPage() {
           >
             Create Your Account
           </h1>
-          <p className="text-muted-foreground">Choose how you want to join Solocorn</p>
         </div>
 
         {/* Role Cards */}
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {roles.map(role => (
             <Link key={role.id} href={`${localePrefix}${role.href}`}>
-              <Card className="card-translucent duration-250 h-full cursor-pointer border-0 transition-all hover:-translate-y-0.5">
+              <Card className="h-full cursor-pointer border border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
                 <CardContent className="p-5">
                   <div className="flex items-center gap-3">
                     <div
-                      className={`${role.color} ${role.hoverBg} rounded-xl p-3 text-white shadow-lg ${role.shadow} transition-all duration-200 hover:shadow-xl ${role.hoverShadow}`}
+                      className={`${role.color} rounded-xl p-3 text-white shadow-lg`}
                     >
                       <role.icon className="h-7 w-7" />
                     </div>
                     <div className="flex-1">
-                      <h2 className="text-foreground text-xl font-bold">{role.title}</h2>
-                      <p className="text-muted-foreground text-sm">{role.description}</p>
+                      <h2 className="text-xl font-bold text-white">{role.title}</h2>
                     </div>
                   </div>
                   <Button
-                    className={`mt-5 h-10 w-full border-0 text-sm font-semibold text-white ${role.color} ${role.hoverBg} shadow-md transition-all duration-200 hover:shadow-lg active:scale-[0.98]`}
+                    className={`mt-5 h-10 w-full border-0 text-sm font-semibold text-white ${role.color} hover:bg-white hover:${role.textColor} shadow-md`}
                   >
                     Register
                   </Button>

--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/components/TutorCard.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/components/TutorCard.tsx
@@ -66,7 +66,7 @@ export function TutorCard({
   const cardContent = (
     <div
       className={cn(
-        'relative flex w-full flex-col overflow-hidden rounded-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] text-white shadow-[0_8px_24px_rgba(0,0,0,0.14)]',
+        'relative flex w-full flex-col overflow-hidden rounded-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] text-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]',
         compact ? 'h-[280px] gap-2 p-4' : 'h-[420px] gap-4 p-5',
         onClick && 'cursor-pointer',
         className

--- a/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/components/TutorCard.tsx
+++ b/tutorme-app/src/app/[locale]/student/subjects/[subjectCode]/courses/components/TutorCard.tsx
@@ -66,7 +66,7 @@ export function TutorCard({
   const cardContent = (
     <div
       className={cn(
-        'relative flex w-full flex-col overflow-hidden rounded-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] text-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]',
+        'relative flex w-full flex-col overflow-hidden rounded-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] text-white shadow-[0_8px_24px_rgba(0,0,0,0.14)]',
         compact ? 'h-[280px] gap-2 p-4' : 'h-[420px] gap-4 p-5',
         onClick && 'cursor-pointer',
         className

--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -223,7 +223,7 @@ export default function StudentTutorDirectoryPage() {
 
       {/* Bottom panel: filters + results */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-4">
-        <div className="flex h-full flex-col overflow-hidden rounded-[18px] border border-slate-200/80 bg-white shadow-[0_8px_30px_rgba(0,0,0,0.08)]">
+        <div className="flex h-full flex-col overflow-hidden rounded-[18px] border border-slate-200/80 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
           {/* Filters */}
           <div className="grid grid-cols-1 gap-3 p-4 pb-0 sm:p-6 sm:pb-0 md:grid-cols-4">
             <div className="relative">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7773,203 +7773,207 @@ FEEDBACK: [your explanation]`
                                   {insightsProps ? (
                                     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-blue-200/70 bg-gradient-to-br from-white via-slate-50 to-blue-50 p-1 shadow-[0_10px_40px_-20px_rgba(29,78,216,0.45)] ring-1 ring-blue-200/60">
                                       <Tabs
-                                  value={insightsTab}
-                                  onValueChange={value =>
-                                    setInsightsTab(value as 'analytics' | 'poll' | 'question')
-                                  }
-                                  className="flex h-full min-h-0 flex-col"
-                                >
-                                  <TabsList className="mb-1 grid w-full grid-cols-3 gap-1 border-0 bg-transparent shadow-none">
-                                    <TabsTrigger
-                                      value="analytics"
-                                      className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
-                                    >
-                                      Analytics
-                                    </TabsTrigger>
-                                    <TabsTrigger
-                                      value="poll"
-                                      className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
-                                    >
-                                      Poll
-                                    </TabsTrigger>
-                                    <TabsTrigger
-                                      value="question"
-                                      className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
-                                    >
-                                      Question
-                                    </TabsTrigger>
-                                  </TabsList>
-                                  <TabsContent
-                                    value="analytics"
-                                    className="mx-[-16px] flex-1 overflow-auto data-[state=active]:flex data-[state=inactive]:hidden"
-                                  >
-                                    <AnalyticsPanel
-                                      students={insightsProps.students}
-                                      metrics={insightsProps.metrics}
-                                      liveTasks={insightsProps.liveTasks}
-                                      classDuration={insightsProps.classDuration}
-                                      isRecording={insightsProps.isRecording}
-                                      recordingDuration={insightsProps.recordingDuration}
-                                      sessionId={insightsProps.sessionId}
-                                    />
-                                  </TabsContent>
-                                  <TabsContent
-                                    value="poll"
-                                    className="flex flex-1 flex-col justify-end overflow-hidden pt-2 data-[state=active]:flex data-[state=inactive]:hidden"
-                                  >
-                                    <InsightsReportView
-                                      type="poll"
-                                      pollResults={pollResults}
-                                      onMentionStudent={name =>
-                                        setPollPrompt(
-                                          pollPrompt
-                                            ? `${pollPrompt} @[${name}](student:${name}) `
-                                            : `@[${name}](student:${name}) `
-                                        )
-                                      }
-                                    />
-                                    <div className="rounded-2xl border border-blue-100 bg-white/40 p-2 shadow-xl backdrop-blur-md">
-                                      <div className="relative">
-                                        <MentionTextarea
-                                          mentionItems={mentionItems}
-                                          className="min-h-[110px] w-full border-0 bg-transparent py-3 pl-3 pr-24 text-sm shadow-none focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                                          placeholder="What should students answer?"
-                                          disableAutoResize
-                                          value={pollPrompt}
-                                          onChange={event => setPollPrompt(event.target.value)}
-                                        />
-                                        <div className="absolute bottom-2 right-2 flex items-center gap-1">
-                                          <Button
-                                            size="icon"
-                                            variant="ghost"
-                                            className={cn(
-                                              'h-8 w-8 rounded-xl hover:bg-blue-100 hover:text-blue-700 disabled:opacity-30',
-                                              showAIPoll
-                                                ? 'bg-blue-100 text-blue-700'
-                                                : 'text-blue-600'
-                                            )}
-                                            title="Generate with Socratic AI"
-                                            onClick={() => setShowAIPoll(!showAIPoll)}
-                                            disabled={!activeInsightsTaskId}
+                                        value={insightsTab}
+                                        onValueChange={value =>
+                                          setInsightsTab(value as 'analytics' | 'poll' | 'question')
+                                        }
+                                        className="flex h-full min-h-0 flex-col"
+                                      >
+                                        <TabsList className="mb-1 grid w-full grid-cols-3 gap-1 border-0 bg-transparent shadow-none">
+                                          <TabsTrigger
+                                            value="analytics"
+                                            className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
                                           >
-                                            <Sparkles className="h-4 w-4" />
-                                          </Button>
-                                          <Button
-                                            size="icon"
-                                            className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
-                                            disabled={
-                                              !activeInsightsTaskId ||
-                                              !activeInsightsTask ||
-                                              !insightsProps.sessionId ||
-                                              !pollPrompt.trim()
-                                            }
-                                            onClick={() => {
-                                              if (
-                                                !activeInsightsTaskId ||
-                                                !activeInsightsTask ||
-                                                !insightsProps.sessionId
+                                            Analytics
+                                          </TabsTrigger>
+                                          <TabsTrigger
+                                            value="poll"
+                                            className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
+                                          >
+                                            Poll
+                                          </TabsTrigger>
+                                          <TabsTrigger
+                                            value="question"
+                                            className="w-full rounded-lg border-transparent bg-transparent px-1 text-xs text-[#667085] transition-all hover:bg-white hover:text-[#344054] hover:shadow-sm data-[state=active]:border-blue-200/70 data-[state=active]:bg-blue-100 data-[state=active]:text-blue-900 data-[state=active]:shadow-sm"
+                                          >
+                                            Question
+                                          </TabsTrigger>
+                                        </TabsList>
+                                        <TabsContent
+                                          value="analytics"
+                                          className="mx-[-16px] flex-1 overflow-auto data-[state=active]:flex data-[state=inactive]:hidden"
+                                        >
+                                          <AnalyticsPanel
+                                            students={insightsProps.students}
+                                            metrics={insightsProps.metrics}
+                                            liveTasks={insightsProps.liveTasks}
+                                            classDuration={insightsProps.classDuration}
+                                            isRecording={insightsProps.isRecording}
+                                            recordingDuration={insightsProps.recordingDuration}
+                                            sessionId={insightsProps.sessionId}
+                                          />
+                                        </TabsContent>
+                                        <TabsContent
+                                          value="poll"
+                                          className="flex flex-1 flex-col justify-end overflow-hidden pt-2 data-[state=active]:flex data-[state=inactive]:hidden"
+                                        >
+                                          <InsightsReportView
+                                            type="poll"
+                                            pollResults={pollResults}
+                                            onMentionStudent={name =>
+                                              setPollPrompt(
+                                                pollPrompt
+                                                  ? `${pollPrompt} @[${name}](student:${name}) `
+                                                  : `@[${name}](student:${name}) `
                                               )
-                                                return
-                                              insightsProps.onSendPoll({
-                                                taskId: currentInsightsId,
-                                                question: pollPrompt,
-                                              })
-                                              setPollPrompt('')
-                                            }}
-                                          >
-                                            <Send className="h-4 w-4" />
-                                          </Button>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TabsContent>
-                                  <TabsContent
-                                    value="question"
-                                    className="flex flex-1 flex-col justify-end overflow-hidden pt-2 data-[state=active]:flex data-[state=inactive]:hidden"
-                                  >
-                                    <InsightsReportView
-                                      type="question"
-                                      questionAnswers={questionAnswers}
-                                      onMentionStudent={name =>
-                                        setQuestionPrompt(
-                                          questionPrompt
-                                            ? `${questionPrompt} @[${name}](student:${name}) `
-                                            : `@[${name}](student:${name}) `
-                                        )
-                                      }
-                                    />
-                                    <div className="rounded-2xl border border-blue-100 bg-white/40 p-2 shadow-xl backdrop-blur-md">
-                                      <div className="relative">
-                                        <MentionTextarea
-                                          mentionItems={mentionItems}
-                                          className="min-h-[110px] w-full border-0 bg-transparent py-3 pl-3 pr-24 text-sm shadow-none focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                                          placeholder="Ask your AI coach or share a reflection..."
-                                          disableAutoResize
-                                          value={questionPrompt}
-                                          onChange={event => setQuestionPrompt(event.target.value)}
-                                        />
-                                        <div className="absolute bottom-2 right-2 flex items-center gap-1">
-                                          <Button
-                                            size="icon"
-                                            variant="ghost"
-                                            className={cn(
-                                              'h-8 w-8 rounded-xl hover:bg-blue-100 hover:text-blue-700 disabled:opacity-30',
-                                              showAIQuestion
-                                                ? 'bg-blue-100 text-blue-700'
-                                                : 'text-blue-600'
-                                            )}
-                                            title="Generate with Socratic AI"
-                                            onClick={() => setShowAIQuestion(!showAIQuestion)}
-                                            disabled={!activeInsightsTaskId}
-                                          >
-                                            <Sparkles className="h-4 w-4" />
-                                          </Button>
-                                          <Button
-                                            size="icon"
-                                            className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
-                                            disabled={
-                                              !activeInsightsTaskId ||
-                                              !activeInsightsTask ||
-                                              !insightsProps.sessionId ||
-                                              !questionPrompt.trim()
                                             }
-                                            onClick={() => {
-                                              if (
-                                                !activeInsightsTaskId ||
-                                                !activeInsightsTask ||
-                                                !insightsProps.sessionId
+                                          />
+                                          <div className="rounded-2xl border border-blue-100 bg-white/40 p-2 shadow-xl backdrop-blur-md">
+                                            <div className="relative">
+                                              <MentionTextarea
+                                                mentionItems={mentionItems}
+                                                className="min-h-[110px] w-full border-0 bg-transparent py-3 pl-3 pr-24 text-sm shadow-none focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                                                placeholder="What should students answer?"
+                                                disableAutoResize
+                                                value={pollPrompt}
+                                                onChange={event =>
+                                                  setPollPrompt(event.target.value)
+                                                }
+                                              />
+                                              <div className="absolute bottom-2 right-2 flex items-center gap-1">
+                                                <Button
+                                                  size="icon"
+                                                  variant="ghost"
+                                                  className={cn(
+                                                    'h-8 w-8 rounded-xl hover:bg-blue-100 hover:text-blue-700 disabled:opacity-30',
+                                                    showAIPoll
+                                                      ? 'bg-blue-100 text-blue-700'
+                                                      : 'text-blue-600'
+                                                  )}
+                                                  title="Generate with Socratic AI"
+                                                  onClick={() => setShowAIPoll(!showAIPoll)}
+                                                  disabled={!activeInsightsTaskId}
+                                                >
+                                                  <Sparkles className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                  size="icon"
+                                                  className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
+                                                  disabled={
+                                                    !activeInsightsTaskId ||
+                                                    !activeInsightsTask ||
+                                                    !insightsProps.sessionId ||
+                                                    !pollPrompt.trim()
+                                                  }
+                                                  onClick={() => {
+                                                    if (
+                                                      !activeInsightsTaskId ||
+                                                      !activeInsightsTask ||
+                                                      !insightsProps.sessionId
+                                                    )
+                                                      return
+                                                    insightsProps.onSendPoll({
+                                                      taskId: currentInsightsId,
+                                                      question: pollPrompt,
+                                                    })
+                                                    setPollPrompt('')
+                                                  }}
+                                                >
+                                                  <Send className="h-4 w-4" />
+                                                </Button>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </TabsContent>
+                                        <TabsContent
+                                          value="question"
+                                          className="flex flex-1 flex-col justify-end overflow-hidden pt-2 data-[state=active]:flex data-[state=inactive]:hidden"
+                                        >
+                                          <InsightsReportView
+                                            type="question"
+                                            questionAnswers={questionAnswers}
+                                            onMentionStudent={name =>
+                                              setQuestionPrompt(
+                                                questionPrompt
+                                                  ? `${questionPrompt} @[${name}](student:${name}) `
+                                                  : `@[${name}](student:${name}) `
                                               )
-                                                return
-                                              insightsProps.onSendQuestion({
-                                                taskId: currentInsightsId,
-                                                prompt: questionPrompt,
-                                              })
-                                              setQuestionPrompt('')
-                                            }}
-                                          >
-                                            <Send className="h-4 w-4" />
-                                          </Button>
-                                        </div>
-                                      </div>
+                                            }
+                                          />
+                                          <div className="rounded-2xl border border-blue-100 bg-white/40 p-2 shadow-xl backdrop-blur-md">
+                                            <div className="relative">
+                                              <MentionTextarea
+                                                mentionItems={mentionItems}
+                                                className="min-h-[110px] w-full border-0 bg-transparent py-3 pl-3 pr-24 text-sm shadow-none focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                                                placeholder="Ask your AI coach or share a reflection..."
+                                                disableAutoResize
+                                                value={questionPrompt}
+                                                onChange={event =>
+                                                  setQuestionPrompt(event.target.value)
+                                                }
+                                              />
+                                              <div className="absolute bottom-2 right-2 flex items-center gap-1">
+                                                <Button
+                                                  size="icon"
+                                                  variant="ghost"
+                                                  className={cn(
+                                                    'h-8 w-8 rounded-xl hover:bg-blue-100 hover:text-blue-700 disabled:opacity-30',
+                                                    showAIQuestion
+                                                      ? 'bg-blue-100 text-blue-700'
+                                                      : 'text-blue-600'
+                                                  )}
+                                                  title="Generate with Socratic AI"
+                                                  onClick={() => setShowAIQuestion(!showAIQuestion)}
+                                                  disabled={!activeInsightsTaskId}
+                                                >
+                                                  <Sparkles className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                  size="icon"
+                                                  className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
+                                                  disabled={
+                                                    !activeInsightsTaskId ||
+                                                    !activeInsightsTask ||
+                                                    !insightsProps.sessionId ||
+                                                    !questionPrompt.trim()
+                                                  }
+                                                  onClick={() => {
+                                                    if (
+                                                      !activeInsightsTaskId ||
+                                                      !activeInsightsTask ||
+                                                      !insightsProps.sessionId
+                                                    )
+                                                      return
+                                                    insightsProps.onSendQuestion({
+                                                      taskId: currentInsightsId,
+                                                      prompt: questionPrompt,
+                                                    })
+                                                    setQuestionPrompt('')
+                                                  }}
+                                                >
+                                                  <Send className="h-4 w-4" />
+                                                </Button>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </TabsContent>
+                                      </Tabs>
                                     </div>
-                                  </TabsContent>
-                                </Tabs>
+                                  ) : (
+                                    <div className="flex h-full items-center justify-center rounded-lg border bg-white p-4 text-sm text-slate-500">
+                                      Insights unavailable without an active session.
+                                    </div>
+                                  )}
+                                </div>
                               </div>
-                            ) : (
-                              <div className="flex h-full items-center justify-center rounded-lg border bg-white p-4 text-sm text-slate-500">
-                                Insights unavailable without an active session.
-                              </div>
-                            )}
+                            </Card>
                           </div>
                         </div>
-                      </Card>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )
-            ) : (
-              <SubmissionsPanel
+                      )}
+                    </>
+                  )
+                ) : (
+                  <SubmissionsPanel
                     courseId={courseId || ''}
                     width={rightPanelWidth}
                     hidden={rightPanelHidden}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -285,9 +285,7 @@ export function SubmissionsPanel({
   return (
     <div className="relative z-40 flex min-h-0 shrink-0 flex-col" style={{ width }}>
       <div className="flex h-full min-h-0 flex-col">
-        <div
-          className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]"
-        >
+        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]">
           <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
             Desk
           </div>


### PR DESCRIPTION
## **User description**
- Remove all hover nudge/scale/translate animations from cards and buttons
- Remove subtitle text and card descriptions (keep titles only)
- Apply Controls panel design: translucent dark bg, rounded-2xl, white/10 border, backdrop blur
- Change Student icon to GraduationCap, Tutor icon to Presentation
- Button hover: white background with original button color text


___

## **CodeAnt-AI Description**
**Simplify the role selection page with a cleaner dark card layout**

### What Changed
- Removed role descriptions and the extra intro line so the page shows only the account choices
- Updated the Student and Tutor icons to match their roles more clearly
- Switched the role cards to a translucent dark style with borders and blur to match the controls panel
- Removed motion-heavy hover effects and changed the Register button hover state to a white background with role-colored text

### Impact
`✅ Clearer role selection`
`✅ More consistent sign-up screens`
`✅ Less distracting card and button interactions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
