### PR TITLE
fix(pci): retarget task guardrails at the finalized rubric (post-envelope)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -307,6 +307,7 @@ export async function POST(request: NextRequest) {
       guardrailWarnings = runTaskGuardrails(response.response, {
         sourceContent: context?.content,
         finalizing,
+        finalizedPci: pciDraft,
       }).violations
       if (guardrailWarnings.length > 0) {
         console.warn(

--- a/tutorme-app/src/lib/ai/guardrails/guardrails.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/guardrails.test.ts
@@ -30,10 +30,32 @@ describe('task PCI validator (warn-only)', () => {
     expect(v.some(x => x.ruleId === 'TASK-10')).toBe(true)
   })
 
-  it('flags missing PCI Summary / Final PCI Specification on a finalizing turn', () => {
-    const v = validateTaskPciOutput('Here is some guidance.', { finalizing: true })
-    expect(v.some(x => x.ruleId === 'TASK-4')).toBe(true)
+  it('flags a finalizing turn that produced no finalized rubric (empty pci)', () => {
+    const v = validateTaskPciOutput('Okay, finalized!', { finalizing: true, finalizedPci: '' })
     expect(v.some(x => x.ruleId === 'TASK-15')).toBe(true)
+  })
+
+  it('does not flag a finalizing turn that produced a rubric', () => {
+    const v = validateTaskPciOutput('Done — applied your rubric.', {
+      finalizing: true,
+      finalizedPci: 'Correct: identifies all roles. Retry: unspecified.',
+    })
+    expect(v.some(x => x.ruleId === 'TASK-15')).toBe(false)
+  })
+
+  it('flags a chat reply that leaks raw JSON/spec instead of staying conversational', () => {
+    const v = validateTaskPciOutput('{"reply":"hi","pci":"..."}', {})
+    expect(v.some(x => x.ruleId === 'TASK-15')).toBe(true)
+  })
+
+  it('scans the finalized rubric (not just the chat reply) for fabricated policy', () => {
+    const v = validateTaskPciOutput('Sounds good!', {
+      finalizing: true,
+      finalizedPci: 'Students get 3 retries before the answer is revealed.',
+    })
+    // a fabricated retry policy in the rubric is caught even though the chat
+    // reply itself is clean
+    expect(v.length).toBeGreaterThan(0)
   })
 })
 

--- a/tutorme-app/src/lib/ai/guardrails/validate.ts
+++ b/tutorme-app/src/lib/ai/guardrails/validate.ts
@@ -53,6 +53,12 @@ export interface TaskValidationContext {
   sourceContent?: string
   /** Whether this turn is meant to finalize the PCI (vs. summarize/confirm). */
   finalizing?: boolean
+  /**
+   * The finalized rubric the assistant produced this turn (the `pci` from the
+   * {reply,pci} envelope), if any. Fabrication checks run against this too — it's
+   * the binding artifact, not just the conversational chat reply.
+   */
+  finalizedPci?: string
 }
 
 /**
@@ -64,7 +70,11 @@ export function validateTaskPciOutput(
   ctx: TaskValidationContext = {}
 ): GuardrailViolation[] {
   const violations: GuardrailViolation[] = []
-  const text = responseText || ''
+  const reply = responseText || ''
+  // Fabrication/certainty checks run over the conversational reply AND the
+  // finalized rubric (the binding artifact lives in `finalizedPci` now, not in
+  // the chat reply), so an invented policy is caught wherever it appears.
+  const text = [reply, ctx.finalizedPci || ''].filter(Boolean).join('\n')
   const source = (ctx.sourceContent || '').toLowerCase()
 
   // TASK-3/11/13: fabricated evaluation policy not grounded in tutor source.
@@ -94,26 +104,25 @@ export function validateTaskPciOutput(
     }
   }
 
-  // TASK-15: when finalizing, the stable sections should be present.
-  if (ctx.finalizing) {
-    const hasSummary = /pci summary/i.test(text)
-    const hasSpec = /final pci specification|pci specification/i.test(text)
-    if (!hasSummary) {
-      violations.push({
-        ruleId: 'TASK-4',
-        severity: 'warning',
-        message:
-          'No "PCI Summary" section detected before finalization (Transparency/Output Structure).',
-      })
-    }
-    if (!hasSpec) {
-      violations.push({
-        ruleId: 'TASK-15',
-        severity: 'warning',
-        message:
-          'No "Final PCI Specification" section detected in a finalizing turn (Output Structure).',
-      })
-    }
+  // TASK-15 (Output Structure): the chat reply must stay conversational — the
+  // machine spec belongs in the `pci` field, never dumped into the chat.
+  if (/```|"task_title"|"final_pci"|^\s*\{\s*"reply"/im.test(reply)) {
+    violations.push({
+      ruleId: 'TASK-15',
+      severity: 'warning',
+      message:
+        'Chat reply contains raw JSON/spec content; it should be conversational only (the finalized rubric belongs in the PCI field).',
+    })
+  }
+
+  // TASK-15: a finalizing turn should actually produce a finalized rubric.
+  if (ctx.finalizing && !(ctx.finalizedPci || '').trim()) {
+    violations.push({
+      ruleId: 'TASK-15',
+      severity: 'warning',
+      message:
+        'Finalizing turn produced no finalized rubric (pci was empty) — confirm whether the tutor intended to finalize.',
+    })
   }
 
   return violations


### PR DESCRIPTION
## **User description**
Follow-up #3 from the PCI review. After the `{reply,pci}` envelope change, the warn-only `runTaskGuardrails` was validating the **conversational chat reply** — but the binding rubric now lives in `pci`/`pciDraft`. Two consequences:
- **Missed violations:** fabricated policies (invented retries/grading/reveal timing) in the *actual finalized rubric* were no longer scanned.
- **Spurious warnings:** every finalizing turn warned *"No Final PCI Specification section detected"* — that section no longer exists in the new format.

## Fix
- `validate.ts`: fabrication + false-certainty checks now scan **reply + `finalizedPci`** (catches invented policy wherever it appears). Replaced the obsolete "stable sections present" check with two contract-aligned ones:
  1. the chat reply must stay conversational → warn if it leaks raw JSON/spec content;
  2. a finalizing turn should actually produce a non-empty rubric.
- `route.ts`: pass `finalizedPci: pciDraft` into `runTaskGuardrails`.

## Tests
Replaced the stale finalizing-section test with: empty-pci finalize warns, clean finalize doesn't, reply-leaks-JSON warns, and a fabricated retry policy **in the rubric** is caught even when the chat reply is clean. **22 pass** (guardrails + pci-master).

Verified: typecheck clean; targeted vitest green. (Branch protection now requires Build + Typecheck + Unit tests, strict/up-to-date — this PR satisfies all.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Check the finalized PCI rubric and keep chat replies conversational**

### What Changed
- Final review now checks the produced PCI rubric itself, so invented retry rules or certainty claims are caught even when the chat reply looks clean
- Finalizing turns warn only when no rubric was produced, instead of looking for an old section name that no longer exists
- Chat replies that include raw JSON, code blocks, or spec content now trigger a warning

### Impact
`✅ Caught fabricated rubric rules`
`✅ Fewer false finalization warnings`
`✅ Clearer chat replies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
