### PR TITLE
fix(course-builder): stop dark-screen crash when loading an assessment DMI

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1424,7 +1424,16 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           activeExtensionId,
         })
         setTaskDmiItems(task.dmiItems || [])
-        setTaskDmiVersions(task.dmiVersions || [])
+        // Normalize persisted versions so `items` is always an array — a legacy /
+        // partially-saved version with a missing items array would otherwise crash
+        // the DMI version-list / preview dialogs (rendered at the root, outside the
+        // panel error boundary, so it dark-screens the whole app).
+        setTaskDmiVersions(
+          (task.dmiVersions || []).map(v => ({
+            ...v,
+            items: Array.isArray(v.items) ? v.items : [],
+          }))
+        )
         setTestPciSource('task')
         if (task.activeDmiVersionId) {
           setTestPciViewMode(`dmi_${task.activeDmiVersionId}`)
@@ -1470,7 +1479,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         activeExtensionId: null,
       })
       setAssessmentDmiItems(assessment.dmiItems || [])
-      setAssessmentDmiVersions(assessment.dmiVersions || [])
+      // Normalize so every version's `items` is an array (see task note above).
+      setAssessmentDmiVersions(
+        (assessment.dmiVersions || []).map(v => ({
+          ...v,
+          items: Array.isArray(v.items) ? v.items : [],
+        }))
+      )
       setTestPciSource('assessment')
       if (assessment.activeDmiVersionId) {
         setTestPciViewMode(`dmi_${assessment.activeDmiVersionId}`)
@@ -2699,9 +2714,9 @@ FEEDBACK: [your explanation]`
     // Load a specific DMI version
     const handleLoadDmiVersion = (version: DMIVersion, type: 'task' | 'assessment') => {
       if (type === 'task') {
-        setTaskDmiItems(version.items)
+        setTaskDmiItems(version.items || [])
       } else {
-        setAssessmentDmiItems(version.items)
+        setAssessmentDmiItems(version.items || [])
       }
       setShowDmiVersionList(false)
 
@@ -8716,7 +8731,7 @@ FEEDBACK: [your explanation]`
                                                   >
                                                     <div className="ml-1 h-full w-full overflow-y-auto rounded-md border bg-white p-4">
                                                       <div className="space-y-4">
-                                                        {version?.items.map(item => (
+                                                        {(version?.items ?? []).map(item => (
                                                           <div
                                                             key={item.id}
                                                             className="rounded-lg border bg-gray-50 p-3"
@@ -10450,7 +10465,8 @@ FEEDBACK: [your explanation]`
                               </span>
                             </div>
                             <div className="text-muted-foreground text-xs">
-                              {version.items.length} question{version.items.length !== 1 ? 's' : ''}
+                              {version.items?.length ?? 0} question
+                              {(version.items?.length ?? 0) !== 1 ? 's' : ''}
                             </div>
                           </div>
                           <div className="flex gap-1">
@@ -10511,8 +10527,8 @@ FEEDBACK: [your explanation]`
             <DialogHeader>
               <DialogTitle>DMI Preview — Version {previewDmiVersion?.versionNumber}</DialogTitle>
               <DialogDescription>
-                {previewDmiVersion?.items.length} question
-                {previewDmiVersion?.items.length !== 1 ? 's' : ''} ·{' '}
+                {previewDmiVersion?.items?.length ?? 0} question
+                {(previewDmiVersion?.items?.length ?? 0) !== 1 ? 's' : ''} ·{' '}
                 {previewDmiVersion
                   ? new Date(previewDmiVersion.createdAt).toLocaleDateString()
                   : ''}
@@ -10520,13 +10536,13 @@ FEEDBACK: [your explanation]`
             </DialogHeader>
             <div className="pt-4">
               <div className="max-h-[500px] overflow-y-auto rounded-[14px] border border-[rgba(226,232,240,0.9)] bg-white p-4 text-[#1F2933] shadow-[0_10px_24px_rgba(15,23,42,0.16)]">
-                {!previewDmiVersion || previewDmiVersion.items.length === 0 ? (
+                {!previewDmiVersion || (previewDmiVersion.items?.length ?? 0) === 0 ? (
                   <div className="text-muted-foreground py-6 text-center text-sm">
                     No questions in this version.
                   </div>
                 ) : (
                   <div className="space-y-4">
-                    {previewDmiVersion.items.map((item, idx) => (
+                    {(previewDmiVersion.items ?? []).map((item, idx) => (
                       <div key={item.id} className="rounded-lg border bg-slate-50 p-4">
                         <div className="mb-2 text-sm font-semibold text-slate-700">
                           Question {item.questionNumber}


### PR DESCRIPTION
## **User description**
## Issue 2 (surgical)
After generating a DMI in an **assessment** and clicking to load it, the screen went dark with "Application error: a client-side exception has occurred."

**Root cause:** the DMI **version-list** and **preview** dialogs render at the component **root — outside** the `PanelErrorBoundary` — and dereferenced `version.items.length` / `previewDmiVersion.items.map(...)` **without** guarding `items` being `undefined`. A persisted/legacy assessment DMI version whose `items` array is missing therefore threw during render, and since it's outside the boundary it dark-screened the whole app instead of showing the contained fallback. (`DMIVersion.items` is typed as required but nothing normalized it on load.)

**Surgical fix:**
- **Durable root fix** — normalize on load: every persisted DMI version's `items` is coerced to an array (both task and assessment paths).
- **Guards** on the out-of-boundary dialog renders (version-list count, preview count / empty-check / map) and `handleLoadDmiVersion`'s `setDmiItems`, plus the in-boundary version map for parity — so a missing `items` array can never throw again.

Freshly-generated DMIs always have `items`, which is why the bug only surfaced for assessments with persisted versions that lost/omitted `items`.

## Testing
`npm run typecheck`, `eslint` (no new errors), `prettier --check`, `npm run build` — all pass. Verified no unguarded `.items` access remains in the DMI dialogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop DMI loading from crashing on saved versions with missing questions**

### What Changed
- Saved DMI versions now load with an empty questions list when that data is missing, for both tasks and assessments
- Opening the version list or preview now shows `0 questions` or an empty state instead of crashing
- Loading a selected version now safely handles missing questions data

### Impact
`✅ Fewer dark-screen crashes when opening saved DMIs`
`✅ Clearer empty-state handling for broken versions`
`✅ Safer loading of legacy assessment and task versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
