### PR TITLE
fix(storage): make upload cleanup reference-aware (stop deleting shared docs)

### DIFF
--- a/tutorme-app/src/__tests__/integration/cleanup-reference-aware.test.ts
+++ b/tutorme-app/src/__tests__/integration/cleanup-reference-aware.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration test: the upload-cleanup endpoint is reference-aware.
+ *
+ * Guards the data-loss bug where deleting a task/lesson deleted a document's GCS
+ * object even though the same document was still referenced by the tutor's asset
+ * library (or another lesson) — later failing with "Document not found in
+ * storage" until re-uploaded. collectReferencedKeys must surface every key still
+ * in use so the route skips deleting them.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, course, courseLesson, tutorAsset } from '@/lib/db/schema'
+import { collectReferencedKeys } from '@/lib/storage/referenced-keys'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const otherTutorId = crypto.randomUUID()
+const courseId = `c_clean_${stamp}`
+const lessonId = `l_clean_${stamp}`
+
+const assetKey = `documents/${tutorId}/library-doc.pdf`
+const lessonKey = `documents/${tutorId}/lesson-page-1.pdf`
+const otherTutorKey = `documents/${otherTutorId}/their-doc.pdf`
+
+describe('cleanup reference-awareness', () => {
+  beforeAll(async () => {
+    const now = new Date()
+    await drizzleDb.insert(user).values([
+      {
+        userId: tutorId,
+        email: `claude-clean-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        userId: otherTutorId,
+        email: `claude-clean-other-${stamp}@example.com`,
+        role: 'TUTOR',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+    await drizzleDb.insert(course).values({ courseId, name: 'Clean Course', creatorId: tutorId })
+    // A lesson whose builderData references a doc via a nested sourceDocument.fileKey.
+    await drizzleDb.insert(courseLesson).values({
+      lessonId,
+      courseId,
+      title: 'Lesson',
+      order: 0,
+      builderData: {
+        tasks: [{ id: 't1', sourceDocument: { fileKey: lessonKey } }],
+      },
+    })
+    // Asset library entry referencing another doc by fileKey.
+    await drizzleDb.insert(tutorAsset).values({
+      assetId: `a_${stamp}`,
+      tutorId,
+      name: 'Library Doc',
+      fileKey: assetKey,
+    })
+  })
+
+  afterAll(async () => {
+    const t = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn()
+      } catch {}
+    }
+    await t(() => drizzleDb.delete(tutorAsset).where(eq(tutorAsset.tutorId, tutorId)))
+    await t(() => drizzleDb.delete(courseLesson).where(eq(courseLesson.courseId, courseId)))
+    await t(() => drizzleDb.delete(course).where(eq(course.courseId, courseId)))
+    await t(() => drizzleDb.delete(user).where(inArray(user.userId, [tutorId, otherTutorId])))
+  })
+
+  it('surfaces keys referenced by the asset library and by lesson builderData', async () => {
+    const referenced = await collectReferencedKeys(tutorId)
+    // Both the asset-library doc and the lesson-referenced doc are protected.
+    expect(referenced.has(assetKey)).toBe(true)
+    expect(referenced.has(lessonKey)).toBe(true)
+    // A truly-orphaned key is NOT protected (so it can still be cleaned up).
+    expect(referenced.has(`documents/${tutorId}/orphan.pdf`)).toBe(false)
+    // Another tutor's referenced key does not leak into this tutor's set.
+    expect(referenced.has(otherTutorKey)).toBe(false)
+  })
+})

--- a/tutorme-app/src/app/api/uploads/cleanup/route.ts
+++ b/tutorme-app/src/app/api/uploads/cleanup/route.ts
@@ -1,18 +1,28 @@
 /**
  * POST /api/uploads/cleanup
  *
- * Deletes GCS/local files by their storage keys.
- * Used by the Course Builder to clean up orphaned documents
- * when tutors replace or remove sourceDocuments.
+ * Deletes GCS/local files by their storage keys. Used by the Course Builder to
+ * clean up orphaned documents when tutors replace or remove sourceDocuments,
+ * or delete a task/lesson/node.
+ *
+ * IMPORTANT: deletion is REFERENCE-AWARE. A document uploaded once is often
+ * shared — it lives in the tutor's asset library AND may be referenced by one or
+ * more tasks/lessons. Deleting one task must NOT destroy a file that's still in
+ * the asset library or another lesson, otherwise the file vanishes from storage
+ * while the reference remains, and re-loading it later fails with
+ * "Document not found in storage" (the user only recovers by re-uploading). So
+ * before removing a key we skip it if it's still referenced anywhere by this
+ * tutor (see collectReferencedKeys).
  *
  * Body: { keys: string[] }
- * Response: { deleted: number, errors: string[] }
+ * Response: { deleted: number, skipped: number, errors: string[] }
  */
 
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf, handleApiError } from '@/lib/api/middleware'
 import { removeFile } from '@/lib/storage/service'
 import { canDeleteUploadKey } from '@/lib/security/upload-access'
+import { collectReferencedKeys } from '@/lib/storage/referenced-keys'
 
 export const POST = withCsrf(
   withAuth(async (req: NextRequest, session) => {
@@ -21,16 +31,24 @@ export const POST = withCsrf(
       const keys = Array.isArray(body.keys) ? (body.keys as string[]) : []
 
       if (keys.length === 0) {
-        return NextResponse.json({ deleted: 0, errors: [] })
+        return NextResponse.json({ deleted: 0, skipped: 0, errors: [] })
       }
+
+      const referenced = await collectReferencedKeys(session.user.id)
 
       const errors: string[] = []
       let deleted = 0
+      let skipped = 0
 
       for (const key of keys) {
         if (!key || typeof key !== 'string') continue
         if (!canDeleteUploadKey(session, key)) {
           errors.push(`${key}: access denied`)
+          continue
+        }
+        // Still referenced elsewhere (asset library / another lesson) — keep it.
+        if (referenced.has(key)) {
+          skipped++
           continue
         }
         try {
@@ -41,7 +59,7 @@ export const POST = withCsrf(
         }
       }
 
-      return NextResponse.json({ deleted, errors })
+      return NextResponse.json({ deleted, skipped, errors })
     } catch (err: any) {
       return handleApiError(err, 'Cleanup failed', 'api/uploads/cleanup/route.ts')
     }

--- a/tutorme-app/src/lib/storage/referenced-keys.ts
+++ b/tutorme-app/src/lib/storage/referenced-keys.ts
@@ -1,0 +1,47 @@
+/**
+ * Reference-aware storage cleanup helper.
+ *
+ * A document uploaded once is often shared — it lives in the tutor's asset
+ * library AND may be referenced by one or more tasks/lessons. Before deleting a
+ * storage object (e.g. when a task/lesson is removed) we must confirm it isn't
+ * still referenced somewhere, otherwise the file vanishes while the reference
+ * remains and re-loading it later fails with "Document not found in storage".
+ */
+
+import { eq } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { tutorAsset, course, courseLesson } from '@/lib/db/schema'
+import { extractGcsKeyFromPublicUrl } from '@/lib/storage/gcs'
+import { collectFileKeys } from '@/lib/services/course-builder.service'
+
+/**
+ * Collect every storage key still referenced by this tutor — their asset library
+ * and the builder data of all their courses' lessons. A key in this set must not
+ * be deleted, even if a single task that also used it is being removed.
+ */
+export async function collectReferencedKeys(tutorId: string): Promise<Set<string>> {
+  const referenced = new Set<string>()
+
+  // 1) Asset library (the case behind the reported bug).
+  const assets = await drizzleDb
+    .select({ fileKey: tutorAsset.fileKey, url: tutorAsset.url })
+    .from(tutorAsset)
+    .where(eq(tutorAsset.tutorId, tutorId))
+  for (const a of assets) {
+    if (a.fileKey) referenced.add(a.fileKey)
+    if (a.url) {
+      const k = extractGcsKeyFromPublicUrl(a.url)
+      if (k) referenced.add(k)
+    }
+  }
+
+  // 2) Every fileKey persisted in this tutor's course lessons.
+  const lessons = await drizzleDb
+    .select({ builderData: courseLesson.builderData })
+    .from(courseLesson)
+    .innerJoin(course, eq(courseLesson.courseId, course.courseId))
+    .where(eq(course.creatorId, tutorId))
+  for (const k of collectFileKeys(lessons.map(l => l.builderData))) referenced.add(k)
+
+  return referenced
+}


### PR DESCRIPTION
## **User description**
## Issue 1
A document loaded fine, then a day or two later failed with **"Could not split '<doc>' into page tasks: Document not found in storage"** — and deleting + re-uploading fixed it.

**Root cause (verified, not what it first looked like):** The storage *key* is correct and stable, and **no GCS bucket has a lifecycle rule** (I checked all three: `solocorn-uploads`, `solocorn-videos`, cloudbuild — all `lifecycle: none`). The file is **actively deleted by the app**: deleting a task / lesson / node calls `POST /api/uploads/cleanup`, which removed that item's `fileKey`s from GCS **without checking whether they were still referenced elsewhere**. A document that's also in the **asset library** (or another lesson) thus had its bytes deleted while the asset row survived — so re-loading it later 404s, and only re-uploading restores it. (The bucket's 7-day soft-delete just means the bytes were recoverable, not that they weren't deleted.)

**Fix:** make cleanup **reference-aware**. Before removing a key, collect every key still referenced by this tutor — their **asset library** (`tutorAsset.fileKey`/`url`) and the **builderData of all their courses' lessons** — and **skip** deleting any referenced key. Truly orphaned keys are still cleaned up. The response now reports `skipped`.

`collectReferencedKeys` lives in `src/lib/storage/referenced-keys.ts` (a Next route file can't export non-handlers).

## Testing
Integration test (throwaway Postgres): seeds an asset-library doc and a lesson-referenced doc; `collectReferencedKeys` surfaces **both** (protected) and excludes a truly-orphaned key and another tutor's key. **Passed.** typecheck / lint / prettier / build all pass.

## Related (not in this PR)
`PUT /api/tutor/assets` does a destructive "replace-all" that also deletes GCS objects for any asset missing from the payload — same non-reference-aware pattern, a possible follow-up to harden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop cleanup from deleting documents that are still in use**

### What Changed
- Upload cleanup now skips files that are still referenced in the tutor’s asset library or in other lessons, so shared documents are not removed by mistake
- The cleanup response now includes how many files were skipped in addition to how many were deleted
- Added coverage to verify referenced files are protected while orphaned files can still be cleaned up

### Impact
`✅ Fewer missing-document errors after deleting lessons`
`✅ Safer document cleanup for shared files`
`✅ Fewer re-uploads after accidental file deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
