### PR TITLE
fix(ai): cross-provider fallback + truthful errors (fixes PCI outage)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -11,6 +11,8 @@ import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { adkPciMasterChat } from '@/lib/adk-client'
 import { generateWithFallback } from '@/lib/agents'
 import { generateWithKimiVision } from '@/lib/ai/kimi'
+import { generateWithGeminiVision } from '@/lib/ai/gemini'
+import { isGeminiActive } from '@/lib/ai/provider'
 import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
 import {
   guardrailSystemPrompt,
@@ -217,11 +219,38 @@ export async function POST(request: NextRequest) {
         { type: 'text', text: `${activeSystemPrompt}\n\n${userPrompt}` },
         ...pdfPages.map(url => ({ type: 'image_url' as const, image_url: { url } })),
       ]
-      const visionText = await generateWithKimiVision(promptItems, {
-        temperature: activeTemperature,
-        maxTokens: 4096,
-        timeoutMs: 60000,
-      })
+      const visionOpts = { temperature: activeTemperature, maxTokens: 4096, timeoutMs: 60000 }
+      // Provider-aware vision with fallback: try the active provider first, then
+      // the other configured one, so a single provider's quota/outage (e.g. a
+      // Gemini 429) doesn't break document attachments.
+      const visionOrder: Array<'gemini' | 'kimi'> = isGeminiActive()
+        ? ['gemini', 'kimi']
+        : ['kimi', 'gemini']
+      let visionText: string | null = null
+      let lastVisionError: unknown = null
+      for (const p of visionOrder) {
+        const hasKey = p === 'gemini' ? !!process.env.GEMINI_API_KEY : !!process.env.KIMI_API_KEY
+        if (!hasKey) continue
+        try {
+          visionText =
+            p === 'gemini'
+              ? await generateWithGeminiVision(promptItems, visionOpts)
+              : await generateWithKimiVision(promptItems, visionOpts)
+          lastVisionError = null
+          break
+        } catch (err) {
+          lastVisionError = err
+          console.warn(
+            `[pci-master] ${p} vision failed${p !== visionOrder[visionOrder.length - 1] ? ', trying fallback' : ''}:`,
+            err instanceof Error ? err.message : err
+          )
+        }
+      }
+      if (visionText == null) {
+        throw lastVisionError instanceof Error
+          ? lastVisionError
+          : new Error('All vision providers failed')
+      }
       response = toCleanResponse(visionText)
     } else if (adkBaseUrl) {
       try {

--- a/tutorme-app/src/lib/agents/orchestrator-llm.ts
+++ b/tutorme-app/src/lib/agents/orchestrator-llm.ts
@@ -19,6 +19,32 @@ function activeProviderLabel(): AIProvider {
   return isGeminiActive() ? 'gemini' : 'kimi'
 }
 
+/**
+ * Configured providers in fallback order: the active provider first, then the
+ * other one if its key is set. Lets us fall back (e.g. Gemini → Kimi) when the
+ * active provider errors — most importantly on rate-limit/quota (429) or a
+ * transient 503 — instead of failing the whole request.
+ */
+function configuredProviders(): AIProvider[] {
+  const primary: AIProvider = isGeminiActive() ? 'gemini' : 'kimi'
+  const order: AIProvider[] = []
+  for (const p of [primary, primary === 'gemini' ? 'kimi' : 'gemini'] as AIProvider[]) {
+    const hasKey = p === 'gemini' ? !!process.env.GEMINI_API_KEY : !!process.env.KIMI_API_KEY
+    if (hasKey && !order.includes(p)) order.push(p)
+  }
+  return order
+}
+
+function allProvidersFailedError(providers: AIProvider[], lastError: unknown): Error {
+  if (providers.length === 0) {
+    return new Error('No AI providers configured. Please set GEMINI_API_KEY or KIMI_API_KEY.')
+  }
+  // Surface the REAL upstream reason (e.g. the 429 quota message) instead of a
+  // misleading "not configured" — so this is diagnosable.
+  const detail = lastError instanceof Error ? lastError.message : String(lastError)
+  return new Error(`All AI providers failed (${providers.join(', ')}). Last error: ${detail}`)
+}
+
 interface AIOptions {
   temperature?: number
   maxTokens?: number
@@ -95,24 +121,24 @@ export async function generateWithFallback(
     }
   }
 
-  // Direct provider (Gemini when active, otherwise Kimi). generateWithKimi delegates
-  // to Gemini internally when GEMINI_API_KEY is configured.
-  if (isGeminiActive() || process.env.KIMI_API_KEY) {
+  // Direct providers with cross-provider fallback (active first, then the other).
+  const providers = configuredProviders()
+  let lastError: unknown = null
+  for (const provider of providers) {
     try {
-      const content = await generateWithKimi(prompt, { ...options })
-
-      const result = {
-        content,
-        provider: activeProviderLabel(),
-        latencyMs: Date.now() - startTime,
-      }
+      const content = await generateWithKimi(prompt, { ...options, forceProvider: provider })
+      const result = { content, provider, latencyMs: Date.now() - startTime }
       if (!options.skipCache) await cache.set(cacheKeyForPrompt(prompt), result, AI_CACHE_TTL)
       return result
     } catch (error) {
-      console.log('Direct provider failed:', error)
+      lastError = error
+      console.warn(
+        `[ai] generate via "${provider}" failed${provider !== providers[providers.length - 1] ? ', trying fallback' : ''}:`,
+        error instanceof Error ? error.message : error
+      )
     }
   }
-  throw new Error('No AI providers configured. Please set GEMINI_API_KEY or KIMI_API_KEY.')
+  throw allProvidersFailedError(providers, lastError)
 }
 
 /**
@@ -156,23 +182,24 @@ export async function chatWithFallback(
     }
   }
 
-  // Direct provider (Gemini when active, otherwise Kimi).
-  if (isGeminiActive() || process.env.KIMI_API_KEY) {
+  // Direct providers with cross-provider fallback (active first, then the other).
+  const providers = configuredProviders()
+  let lastError: unknown = null
+  for (const provider of providers) {
     try {
-      const content = await chatWithKimi(messages, { ...options })
-
-      const result = {
-        content,
-        provider: activeProviderLabel(),
-        latencyMs: Date.now() - startTime,
-      }
+      const content = await chatWithKimi(messages, { ...options, forceProvider: provider })
+      const result = { content, provider, latencyMs: Date.now() - startTime }
       if (!options.skipCache) await cache.set(cacheKeyForChat(messages), result, AI_CACHE_TTL)
       return result
     } catch (error) {
-      console.log('Direct provider failed:', error)
+      lastError = error
+      console.warn(
+        `[ai] chat via "${provider}" failed${provider !== providers[providers.length - 1] ? ', trying fallback' : ''}:`,
+        error instanceof Error ? error.message : error
+      )
     }
   }
-  throw new Error('No AI providers configured. Please set GEMINI_API_KEY or KIMI_API_KEY.')
+  throw allProvidersFailedError(providers, lastError)
 }
 
 /**

--- a/tutorme-app/src/lib/ai/kimi.ts
+++ b/tutorme-app/src/lib/ai/kimi.ts
@@ -55,9 +55,12 @@ export async function generateWithKimi(
     timeoutMs?: number
     retries?: number
     usageContext?: UsageContext
+    /** Force a specific provider, bypassing the AI_PROVIDER default (used for fallback). */
+    forceProvider?: 'kimi' | 'gemini'
   } = {}
 ): Promise<string> {
-  if (isGeminiActive()) {
+  const useGemini = options.forceProvider ? options.forceProvider === 'gemini' : isGeminiActive()
+  if (useGemini) {
     return generateWithGemini(prompt, options)
   }
 
@@ -127,9 +130,12 @@ export async function chatWithKimi(
     timeoutMs?: number
     retries?: number
     usageContext?: UsageContext
+    /** Force a specific provider, bypassing the AI_PROVIDER default (used for fallback). */
+    forceProvider?: 'kimi' | 'gemini'
   } = {}
 ): Promise<string> {
-  if (isGeminiActive()) {
+  const useGemini = options.forceProvider ? options.forceProvider === 'gemini' : isGeminiActive()
+  if (useGemini) {
     return chatWithGemini(messages, options)
   }
 

--- a/tutorme-app/src/lib/ai/orchestrator-fallback.test.ts
+++ b/tutorme-app/src/lib/ai/orchestrator-fallback.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock the provider layer so we can simulate one provider failing (e.g. a Gemini
+// 429 quota error) and assert the orchestrator falls back to the other.
+const generateWithKimi = vi.fn()
+const chatWithKimi = vi.fn()
+const isGeminiActive = vi.fn(() => true)
+
+vi.mock('@/lib/ai/kimi', () => ({
+  generateWithKimi: (...args: unknown[]) => generateWithKimi(...args),
+  chatWithKimi: (...args: unknown[]) => chatWithKimi(...args),
+}))
+vi.mock('@/lib/ai/provider', () => ({ isGeminiActive: () => isGeminiActive() }))
+vi.mock('@/lib/adk-client', () => ({ adkGenerate: vi.fn(), adkChat: vi.fn() }))
+vi.mock('@/lib/db', () => ({ cache: { get: vi.fn(async () => null), set: vi.fn(async () => {}) } }))
+
+import { generateWithFallback, chatWithFallback } from '@/lib/agents'
+
+describe('orchestrator cross-provider fallback', () => {
+  const env = { ...process.env }
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isGeminiActive.mockReturnValue(true)
+    process.env.GEMINI_API_KEY = 'g-key'
+    process.env.KIMI_API_KEY = 'k-key'
+    delete process.env.ADK_BASE_URL
+    delete process.env.MOCK_AI
+  })
+  afterEach(() => {
+    process.env = { ...env }
+  })
+
+  it('falls back to Kimi when the active provider (Gemini) hits a 429', async () => {
+    generateWithKimi.mockImplementation(async (_p: string, opts: { forceProvider?: string }) => {
+      if (opts.forceProvider === 'gemini') throw new Error('Gemini API error: 429 - quota exceeded')
+      return 'kimi-says-hi'
+    })
+
+    const result = await generateWithFallback('summarize this', { skipCache: true })
+    expect(result.content).toBe('kimi-says-hi')
+    expect(result.provider).toBe('kimi')
+    // Tried Gemini first, then Kimi.
+    expect(generateWithKimi).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws a truthful error (with the real upstream reason) when all providers fail', async () => {
+    generateWithKimi.mockRejectedValue(new Error('Gemini API error: 429 - quota exceeded'))
+    await expect(generateWithFallback('x', { skipCache: true })).rejects.toThrow(/429|quota/)
+    // Not the misleading "No AI providers configured".
+    await expect(generateWithFallback('x', { skipCache: true })).rejects.not.toThrow(
+      /No AI providers configured/
+    )
+  })
+
+  it('chat path falls back too', async () => {
+    chatWithKimi.mockImplementation(async (_m: unknown, opts: { forceProvider?: string }) => {
+      if (opts.forceProvider === 'gemini') throw new Error('503 unavailable')
+      return 'kimi-chat'
+    })
+    const result = await chatWithFallback([{ role: 'user', content: 'hi' }], { skipCache: true })
+    expect(result.content).toBe('kimi-chat')
+    expect(result.provider).toBe('kimi')
+  })
+
+  it('only uses providers whose key is configured', async () => {
+    delete process.env.KIMI_API_KEY // only Gemini configured
+    generateWithKimi.mockResolvedValue('gemini-only')
+    const result = await generateWithFallback('x', { skipCache: true })
+    expect(result.provider).toBe('gemini')
+    expect(generateWithKimi).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## **User description**
## Root cause (from prod logs)
The PCI assistant failed with "Failed to get PCI Master response". The real, swallowed error:
```
Gemini API error: 429 — "Quota exceeded for metric:
generativelanguage.googleapis.com/generate_content_free_tier_requests,
limit: 20, model: gemini-2.5-flash"
```
Prod runs `AI_PROVIDER=gemini` on a **free-tier** Gemini key (~20 req limit) which was exhausted. The orchestrator **caught the 429 and re-threw a misleading "No AI providers configured"**, and there was **no fallback** to the configured **Kimi** key.

## Fix
- **Orchestrator** (`generateWithFallback` / `chatWithFallback`): try the active provider first, then **fall back to the other configured provider** (e.g. Gemini → Kimi) when it errors — especially 429/503. If all fail, throw a **truthful** error including the real upstream reason instead of "not configured".
- **Kimi helpers**: add a `forceProvider` option so the orchestrator can target a specific provider for fallback (they otherwise auto-delegate based on `AI_PROVIDER`).
- **PCI vision path**: provider-aware with the same fallback, so an attached document doesn't break when one provider is rate-limited.

When the primary provider succeeds, behaviour is identical to before — fallback only kicks in on failure.

## Testing
- New unit tests (mocked providers): Gemini 429 → falls back to Kimi; all-fail → truthful error (contains "429/quota", not "No AI providers configured"); chat path falls back; only configured providers are tried. **4/4.**
- Existing orchestrator + pci-master tests: **9/9** still pass. typecheck / lint / build green.

## Companion config change (yours)
The immediate prod fix is also a one-line env change you'll apply:
`gcloud run services update tutorme-app --region asia-southeast1 --update-env-vars AI_PROVIDER=kimi` (point at the paid Kimi key), or upgrade the Gemini key to paid. This PR makes the system resilient regardless of which provider is primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**AI requests now fall back to the other configured provider when the primary one fails, and errors show the real upstream cause.**

### What Changed
- If the active AI provider hits a rate limit or temporary outage, requests now try the other configured provider before failing.
- When every provider fails, the error now includes the real reason returned by the upstream service instead of reporting that no providers are configured.
- PCI document handling now uses the same fallback behavior, so attached files keep working when one vision provider is down.
- Added tests that cover provider fallback, truthful error messages, and using only the providers that are actually configured.

### Impact
`✅ Fewer AI request failures during quota spikes`
`✅ Clearer AI error messages`
`✅ More reliable PCI document processing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
