### PR TITLE
feat(ai): make Kimi base URL + model env-configurable

### DIFF
--- a/tutorme-app/src/lib/ai/kimi.ts
+++ b/tutorme-app/src/lib/ai/kimi.ts
@@ -32,8 +32,16 @@ interface KimiResponse {
   }
 }
 
-const KIMI_BASE_URL = 'https://api.moonshot.cn/v1'
-const DEFAULT_MODEL = 'kimi-k2.5'
+// Moonshot has separate platforms with separate keys/endpoints:
+//   China:  https://api.moonshot.cn/v1   (platform.moonshot.cn)
+//   Global: https://api.moonshot.ai/v1   (platform.moonshot.ai)
+// A key from one platform 401s against the other, so the endpoint (and model)
+// are env-configurable. Defaults preserve the original China endpoint.
+const KIMI_BASE_URL = (process.env.KIMI_BASE_URL || 'https://api.moonshot.cn/v1').replace(
+  /\/+$/,
+  ''
+)
+const DEFAULT_MODEL = process.env.KIMI_MODEL || 'kimi-k2.5'
 
 /**
  * Generate text using Kimi K2.5

--- a/tutorme-app/src/lib/chat/providers.ts
+++ b/tutorme-app/src/lib/chat/providers.ts
@@ -7,8 +7,13 @@ import { SOLOCORN_SYSTEM_PROMPT } from './system-prompt'
 
 // Configuration
 const KIMI_API_KEY = process.env.KIMI_API_KEY
-const KIMI_BASE_URL = 'https://api.moonshot.cn/v1'
-const KIMI_MODEL = 'kimi-k2.5'
+// Endpoint + model are env-configurable so a global (api.moonshot.ai) key works
+// without a code change; defaults preserve the original China endpoint.
+const KIMI_BASE_URL = (process.env.KIMI_BASE_URL || 'https://api.moonshot.cn/v1').replace(
+  /\/+$/,
+  ''
+)
+const KIMI_MODEL = process.env.KIMI_MODEL || 'kimi-k2.5'
 
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant'


### PR DESCRIPTION
## **User description**
## Context
The prod Kimi health check returned **`401 Invalid Authentication`**. The endpoint was hardcoded to Moonshot's **China** platform (`https://api.moonshot.cn/v1`), and a key from the **global** platform (`platform.moonshot.ai` → `api.moonshot.ai`) is rejected there with exactly that 401. With the endpoint hardcoded, a global key couldn't be used at all.

## Change
Make **`KIMI_BASE_URL`** and **`KIMI_MODEL`** env-configurable in `kimi.ts` and `chat/providers.ts`. Defaults are unchanged (`https://api.moonshot.cn/v1`, `kimi-k2.5`), so behaviour is identical unless the env is set. Trailing slashes on the URL are trimmed.

## How to use (yours, once a valid key is in place)
- **Global Moonshot key:** set `KIMI_BASE_URL=https://api.moonshot.ai/v1` (and `KIMI_MODEL` if the global model name differs).
- **China key:** leave defaults; just ensure `KIMI_API_KEY` is a valid `.cn` key.

## Testing
`npm run typecheck`, `eslint` (no errors), `prettier`, `npm run build` — all pass. Default path unchanged (covered by existing AI tests, 17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make Kimi work with both Moonshot key types

### What Changed
- Kimi now uses the API base URL from environment settings, so a Moonshot global key can be used without changing code
- The default China endpoint and default model stay the same when no environment values are set
- Any trailing slash in the base URL is removed so the service uses a clean endpoint

### Impact
`✅ Global Moonshot keys can be used`
`✅ Fewer authentication errors for Kimi requests`
`✅ No change for existing China-based setups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
