### PR TITLE
fix(tutor): panel scroll-into-view on expand

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -501,90 +501,90 @@ function MyCoursesSection() {
           onClick={() => setIsExpanded(prev => !prev)}
           className={cn(charcoalHeaderClass, 'panel-header-hover cursor-pointer justify-between')}
         >
-        <div className="flex items-center gap-3">
-          <BookOpen className="h-5 w-5" />
-          <span className="text-base font-semibold">My Courses</span>
-        </div>
-        {isExpanded ? (
-          <ChevronUp className="h-5 w-5 text-white/70" />
-        ) : (
-          <ChevronDown className="h-5 w-5 text-white/70" />
-        )}
-      </div>
-      <CardContent spacing="none" className="space-y-4 px-5 pb-5">
-        {/* Tabs */}
-        <div className="flex gap-2 border-b border-[#E2E8F0] bg-white">
-          {(['active', 'pending', 'unpublished', 'catalogued'] as const).map(tab => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`relative px-4 py-2 text-sm font-medium transition ${
-                activeTab === tab ? 'text-[#1D4ED8]' : 'text-[#64748B] hover:text-[#1F2933]'
-              }`}
-            >
-              <span className="capitalize">{tab}</span>
-              <span className="ml-1.5 rounded-full bg-[#F1F5F9] px-2 py-0.5 text-xs text-[#64748B]">
-                {courseCounts[tab]}
-              </span>
-              {activeTab === tab && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#1D4ED8]" />
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* Course List - Scrollable Container */}
-        <div
-          ref={coursesPanelRef}
-          className={cn(
-            'pr-2 transition-all duration-300 ease-in-out',
-            isExpanded ? 'overflow-y-auto' : 'h-0 overflow-hidden'
-          )}
-          style={isExpanded ? { height: measuredMaxHeight } : undefined}
-        >
-          {loading ? (
-            <div className="flex h-full items-center justify-center">
-              <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#1D4ED8] border-t-transparent" />
-            </div>
-          ) : filteredCourses.length === 0 ? (
-            <div className="flex h-full flex-col items-center justify-center text-center">
-              <BookOpen className="h-12 w-12 text-[#CBD5E1]" />
-              <p className="mt-2 text-sm text-[#64748B]">
-                {activeTab === 'active'
-                  ? 'No active courses yet'
-                  : activeTab === 'pending'
-                    ? 'No pending courses'
-                    : activeTab === 'unpublished'
-                      ? 'No unpublished courses'
-                      : 'No catalogued courses'}
-              </p>
-            </div>
+          <div className="flex items-center gap-3">
+            <BookOpen className="h-5 w-5" />
+            <span className="text-base font-semibold">My Courses</span>
+          </div>
+          {isExpanded ? (
+            <ChevronUp className="h-5 w-5 text-white/70" />
           ) : (
-            <div className="space-y-3">
-              {filteredCourses.slice(0, 10).map(course => renderCourseRow(course, activeTab))}
-            </div>
+            <ChevronDown className="h-5 w-5 text-white/70" />
           )}
         </div>
-
-        {/* Hidden measurement lists to keep panel height stable across tabs */}
-        <div
-          className="pointer-events-none absolute left-0 top-0 -z-10 opacity-0"
-          aria-hidden="true"
-        >
-          <div className="px-5 pb-5">
+        <CardContent spacing="none" className="space-y-4 px-5 pb-5">
+          {/* Tabs */}
+          <div className="flex gap-2 border-b border-[#E2E8F0] bg-white">
             {(['active', 'pending', 'unpublished', 'catalogued'] as const).map(tab => (
-              <div key={tab} ref={measureRefs[tab]} className="space-y-3 pr-2">
-                {categorizeCourses[tab].slice(0, 10).map(course => renderCourseRow(course, tab))}
-              </div>
+              <button
+                key={tab}
+                onClick={() => setActiveTab(tab)}
+                className={`relative px-4 py-2 text-sm font-medium transition ${
+                  activeTab === tab ? 'text-[#1D4ED8]' : 'text-[#64748B] hover:text-[#1F2933]'
+                }`}
+              >
+                <span className="capitalize">{tab}</span>
+                <span className="ml-1.5 rounded-full bg-[#F1F5F9] px-2 py-0.5 text-xs text-[#64748B]">
+                  {courseCounts[tab]}
+                </span>
+                {activeTab === tab && (
+                  <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#1D4ED8]" />
+                )}
+              </button>
             ))}
           </div>
-        </div>
-      </CardContent>
-      <ScheduleViewModal
-        courseId={scheduleCourse?.id ?? null}
-        courseName={scheduleCourse?.name}
-        onClose={() => setScheduleCourse(null)}
-      />
+
+          {/* Course List - Scrollable Container */}
+          <div
+            ref={coursesPanelRef}
+            className={cn(
+              'pr-2 transition-all duration-300 ease-in-out',
+              isExpanded ? 'overflow-y-auto' : 'h-0 overflow-hidden'
+            )}
+            style={isExpanded ? { height: measuredMaxHeight } : undefined}
+          >
+            {loading ? (
+              <div className="flex h-full items-center justify-center">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#1D4ED8] border-t-transparent" />
+              </div>
+            ) : filteredCourses.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center text-center">
+                <BookOpen className="h-12 w-12 text-[#CBD5E1]" />
+                <p className="mt-2 text-sm text-[#64748B]">
+                  {activeTab === 'active'
+                    ? 'No active courses yet'
+                    : activeTab === 'pending'
+                      ? 'No pending courses'
+                      : activeTab === 'unpublished'
+                        ? 'No unpublished courses'
+                        : 'No catalogued courses'}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {filteredCourses.slice(0, 10).map(course => renderCourseRow(course, activeTab))}
+              </div>
+            )}
+          </div>
+
+          {/* Hidden measurement lists to keep panel height stable across tabs */}
+          <div
+            className="pointer-events-none absolute left-0 top-0 -z-10 opacity-0"
+            aria-hidden="true"
+          >
+            <div className="px-5 pb-5">
+              {(['active', 'pending', 'unpublished', 'catalogued'] as const).map(tab => (
+                <div key={tab} ref={measureRefs[tab]} className="space-y-3 pr-2">
+                  {categorizeCourses[tab].slice(0, 10).map(course => renderCourseRow(course, tab))}
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+        <ScheduleViewModal
+          courseId={scheduleCourse?.id ?? null}
+          courseName={scheduleCourse?.name}
+          onClose={() => setScheduleCourse(null)}
+        />
       </Card>
     </div>
   )
@@ -652,7 +652,10 @@ export default function TutorMyPage() {
     kakaoTalk: '',
   })
   const [profileSettingsOpen, setProfileSettingsOpen] = useState(true)
-  const profileScrollRef = useAutoScrollOnExpand(profileSettingsOpen, { delay: 350, block: 'nearest' })
+  const profileScrollRef = useAutoScrollOnExpand(profileSettingsOpen, {
+    delay: 350,
+    block: 'nearest',
+  })
 
   // Category selection state (3-level: Region → Country → Category)
   const [selectedRegions, setSelectedRegions] = useState<string[]>([])
@@ -1844,169 +1847,169 @@ export default function TutorMyPage() {
               )}
               onClick={() => setProfileSettingsOpen(prev => !prev)}
             >
-            <div className="flex items-center gap-3">
-              <Settings className="h-5 w-5" />
-              <span className="text-base font-semibold">Profile Settings</span>
+              <div className="flex items-center gap-3">
+                <Settings className="h-5 w-5" />
+                <span className="text-base font-semibold">Profile Settings</span>
+              </div>
+              {profileSettingsOpen ? (
+                <ChevronUp className="h-4 w-4 text-white/70" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-white/70" />
+              )}
             </div>
-            {profileSettingsOpen ? (
-              <ChevronUp className="h-4 w-4 text-white/70" />
-            ) : (
-              <ChevronDown className="h-4 w-4 text-white/70" />
-            )}
-          </div>
-          {profileSettingsOpen && (
-            <CardContent spacing="none" className="space-y-4 bg-white px-6 py-4">
-              <div className="grid gap-3 lg:grid-cols-2 lg:items-stretch">
-                <div className="flex min-h-[380px] flex-col gap-2 lg:min-h-0">
-                  <Label className="text-sm text-[#1F2933]">Bio</Label>
-                  <Textarea
-                    value={bio}
-                    onChange={e => {
-                      const val = e.target.value
-                      if (val.length <= 800) {
-                        setBio(val)
+            {profileSettingsOpen && (
+              <CardContent spacing="none" className="space-y-4 bg-white px-6 py-4">
+                <div className="grid gap-3 lg:grid-cols-2 lg:items-stretch">
+                  <div className="flex min-h-[380px] flex-col gap-2 lg:min-h-0">
+                    <Label className="text-sm text-[#1F2933]">Bio</Label>
+                    <Textarea
+                      value={bio}
+                      onChange={e => {
+                        const val = e.target.value
+                        if (val.length <= 800) {
+                          setBio(val)
+                        }
+                      }}
+                      disabled={loading || saving}
+                      placeholder="Short bio for your public page..."
+                      maxLength={800}
+                      className="min-h-[280px] flex-1 resize-none border-[#E2E8F0] focus-visible:ring-[#1D4ED8]"
+                    />
+                    <span
+                      className={
+                        bio.length > 800
+                          ? 'text-xs font-medium text-red-500'
+                          : 'text-xs text-slate-400'
                       }
-                    }}
-                    disabled={loading || saving}
-                    placeholder="Short bio for your public page..."
-                    maxLength={800}
-                    className="min-h-[280px] flex-1 resize-none border-[#E2E8F0] focus-visible:ring-[#1D4ED8]"
-                  />
-                  <span
-                    className={
-                      bio.length > 800
-                        ? 'text-xs font-medium text-red-500'
-                        : 'text-xs text-slate-400'
-                    }
-                  >
-                    {bio.length}/800
-                  </span>
-                </div>
+                    >
+                      {bio.length}/800
+                    </span>
+                  </div>
 
-                <div className="flex min-h-[250px] flex-col gap-2 lg:min-h-0">
-                  <Label className="text-sm text-[#1F2933]">Edit Social Media</Label>
-                  <div className="grid gap-2.5 md:grid-cols-2">
-                    <div className="flex items-center gap-2">
-                      <TikTokIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
-                        <Input
-                          placeholder="username"
-                          value={socialAccounts.tiktok.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              tiktok: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                  <div className="flex min-h-[250px] flex-col gap-2 lg:min-h-0">
+                    <Label className="text-sm text-[#1F2933]">Edit Social Media</Label>
+                    <div className="grid gap-2.5 md:grid-cols-2">
+                      <div className="flex items-center gap-2">
+                        <TikTokIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
+                          <Input
+                            placeholder="username"
+                            value={socialAccounts.tiktok.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                tiktok: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex items-center gap-2">
-                      <Youtube className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
-                        <Input
-                          placeholder="username"
-                          value={socialAccounts.youtube.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              youtube: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                      <div className="flex items-center gap-2">
+                        <Youtube className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
+                          <Input
+                            placeholder="username"
+                            value={socialAccounts.youtube.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                youtube: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex items-center gap-2">
-                      <Instagram className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
-                        <Input
-                          placeholder="username"
-                          value={socialAccounts.instagram.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              instagram: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                      <div className="flex items-center gap-2">
+                        <Instagram className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
+                          <Input
+                            placeholder="username"
+                            value={socialAccounts.instagram.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                instagram: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex items-center gap-2">
-                      <Facebook className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-xs text-[#64748B]">
-                          https://
-                        </span>
-                        <Input
-                          placeholder="username"
-                          value={socialAccounts.facebook.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              facebook: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                      <div className="flex items-center gap-2">
+                        <Facebook className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-xs text-[#64748B]">
+                            https://
+                          </span>
+                          <Input
+                            placeholder="username"
+                            value={socialAccounts.facebook.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                facebook: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex items-center gap-2">
-                      <XBrandIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
-                        <Input
-                          placeholder="username"
-                          value={socialAccounts.x.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              x: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                      <div className="flex items-center gap-2">
+                        <XBrandIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-[#64748B]">@</span>
+                          <Input
+                            placeholder="username"
+                            value={socialAccounts.x.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                x: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="flex items-center gap-2">
-                      <KakaoTalkIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
-                      <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
-                        <span className="inline-flex items-center pl-3 text-xs text-[#64748B]">
-                          https://
-                        </span>
-                        <Input
-                          value={socialAccounts.kakaoTalk.replace(/^@+/, '')}
-                          onChange={e =>
-                            setSocialAccounts(prev => ({
-                              ...prev,
-                              kakaoTalk: e.target.value.replace(/^@+/, ''),
-                            }))
-                          }
-                          disabled={loading || saving}
-                          className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                        />
+                      <div className="flex items-center gap-2">
+                        <KakaoTalkIcon className="h-9 w-9 shrink-0 text-[#64748B]" />
+                        <div className="flex flex-1 rounded-md border border-[#E2E8F0] focus-within:outline-none focus-within:ring-0">
+                          <span className="inline-flex items-center pl-3 text-xs text-[#64748B]">
+                            https://
+                          </span>
+                          <Input
+                            value={socialAccounts.kakaoTalk.replace(/^@+/, '')}
+                            onChange={e =>
+                              setSocialAccounts(prev => ({
+                                ...prev,
+                                kakaoTalk: e.target.value.replace(/^@+/, ''),
+                              }))
+                            }
+                            disabled={loading || saving}
+                            className="border-0 pl-0 !outline-none !ring-0 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </CardContent>
-          )}
+              </CardContent>
+            )}
           </Card>
         </div>
 

--- a/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/my-page/page.tsx
@@ -185,7 +185,8 @@ function MyCoursesSection() {
     'active'
   )
   const [isExpanded, setIsExpanded] = useState(true)
-  const coursesPanelRef = useAutoScrollOnExpand(isExpanded, { delay: 350 })
+  const coursesPanelRef = useRef<HTMLDivElement>(null)
+  const coursesScrollRef = useAutoScrollOnExpand(isExpanded, { delay: 350, block: 'nearest' })
   const [measuredMaxHeight, setMeasuredMaxHeight] = useState(400)
   const measureRefs = {
     active: useRef<HTMLDivElement>(null),
@@ -494,11 +495,12 @@ function MyCoursesSection() {
   }
 
   return (
-    <Card className="relative border border-[#E2E8F0] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]">
-      <div
-        onClick={() => setIsExpanded(prev => !prev)}
-        className={cn(charcoalHeaderClass, 'panel-header-hover cursor-pointer justify-between')}
-      >
+    <div ref={coursesScrollRef}>
+      <Card className="relative border border-[#E2E8F0] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]">
+        <div
+          onClick={() => setIsExpanded(prev => !prev)}
+          className={cn(charcoalHeaderClass, 'panel-header-hover cursor-pointer justify-between')}
+        >
         <div className="flex items-center gap-3">
           <BookOpen className="h-5 w-5" />
           <span className="text-base font-semibold">My Courses</span>
@@ -583,7 +585,8 @@ function MyCoursesSection() {
         courseName={scheduleCourse?.name}
         onClose={() => setScheduleCourse(null)}
       />
-    </Card>
+      </Card>
+    </div>
   )
 }
 
@@ -649,6 +652,7 @@ export default function TutorMyPage() {
     kakaoTalk: '',
   })
   const [profileSettingsOpen, setProfileSettingsOpen] = useState(true)
+  const profileScrollRef = useAutoScrollOnExpand(profileSettingsOpen, { delay: 350, block: 'nearest' })
 
   // Category selection state (3-level: Region → Country → Category)
   const [selectedRegions, setSelectedRegions] = useState<string[]>([])
@@ -1831,14 +1835,15 @@ export default function TutorMyPage() {
           </DialogContent>
         </Dialog>
 
-        <Card className="border border-[#E2E8F0] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]">
-          <div
-            className={cn(
-              charcoalHeaderClass,
-              'panel-header-hover cursor-pointer select-none justify-between'
-            )}
-            onClick={() => setProfileSettingsOpen(prev => !prev)}
-          >
+        <div ref={profileScrollRef}>
+          <Card className="border border-[#E2E8F0] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]">
+            <div
+              className={cn(
+                charcoalHeaderClass,
+                'panel-header-hover cursor-pointer select-none justify-between'
+              )}
+              onClick={() => setProfileSettingsOpen(prev => !prev)}
+            >
             <div className="flex items-center gap-3">
               <Settings className="h-5 w-5" />
               <span className="text-base font-semibold">Profile Settings</span>
@@ -2002,7 +2007,8 @@ export default function TutorMyPage() {
               </div>
             </CardContent>
           )}
-        </Card>
+          </Card>
+        </div>
 
         {/* My Courses Section */}
         <MyCoursesSection />

--- a/tutorme-app/src/lib/scroll-into-view.ts
+++ b/tutorme-app/src/lib/scroll-into-view.ts
@@ -46,6 +46,26 @@ function isStuckAtTop(el: Element, scroller: Element | Window): boolean {
   return false
 }
 
+function isTopBlockingElement(el: Element): boolean {
+  const style = window.getComputedStyle(el)
+  const rect = el.getBoundingClientRect()
+
+  // Exclude elements that are clearly sidebars (tall and narrow, positioned at left/right)
+  // A top-blocking element should:
+  // 1. Be relatively wide (span most of the viewport width)
+  // 2. Not be extremely tall relative to its width (not a sidebar)
+  const viewportWidth = window.innerWidth
+  const widthRatio = rect.width / viewportWidth
+
+  // If the element spans less than 40% of the viewport width, it's likely a sidebar
+  if (widthRatio < 0.4) return false
+
+  // If the element is taller than it is wide by a large margin, it's likely a sidebar
+  if (rect.height > rect.width * 2) return false
+
+  return true
+}
+
 export function getStickyTopOffset(scroller: Element | Window): number {
   if (typeof document === 'undefined') return 0
 
@@ -61,6 +81,9 @@ export function getStickyTopOffset(scroller: Element | Window): number {
 
     const rect = el.getBoundingClientRect()
     if (rect.height <= 0) continue
+
+    // Skip sidebars and other non-top-blocking elements
+    if (!isTopBlockingElement(el)) continue
 
     offset += rect.height
     counted.add(el)
@@ -112,8 +135,11 @@ export function scrollElementIntoView(el: Element, options: ScrollIntoViewOption
   const scroller = getScrollableAncestor(el)
   const stickyOffset = getStickyTopOffset(scroller)
 
-  const viewportHeight =
-    scroller === window ? window.innerHeight : (scroller as HTMLElement).clientHeight
+  const isWindowScroller = scroller === window
+  const scrollerEl = isWindowScroller ? null : (scroller as HTMLElement)
+  const scrollerRect = scrollerEl?.getBoundingClientRect()
+  const scrollerTop = scrollerRect ? scrollerRect.top : 0
+  const viewportHeight = isWindowScroller ? window.innerHeight : scrollerEl!.clientHeight
 
   const rect = el.getBoundingClientRect()
   const panelHeight = rect.height
@@ -123,23 +149,23 @@ export function scrollElementIntoView(el: Element, options: ScrollIntoViewOption
 
   if (block === 'nearest') {
     // Minimal scroll to bring the element into view
-    const isAbove = rect.top < stickyOffset + margin
-    const isBelow = rect.bottom > viewportHeight - margin
+    const isAbove = rect.top < scrollerTop + stickyOffset + margin
+    const isBelow = rect.bottom > scrollerTop + viewportHeight - margin
 
     if (isAbove && isBelow) {
       // Element spans the viewport — scroll to show top
-      delta = rect.top - (stickyOffset + margin)
+      delta = rect.top - (scrollerTop + stickyOffset + margin)
     } else if (isAbove) {
       // Element is above the visible area — scroll down to show top
-      delta = rect.top - (stickyOffset + margin)
+      delta = rect.top - (scrollerTop + stickyOffset + margin)
     } else if (isBelow) {
       // Element is below the visible area — scroll up to show bottom
-      delta = rect.bottom - (viewportHeight - margin)
+      delta = rect.bottom - (scrollerTop + viewportHeight - margin)
     }
     // If neither isAbove nor isBelow, element is fully visible — no scroll needed
   } else if (block === 'start') {
     // Scroll so the top of the element is just below the sticky offset
-    const desiredTop = stickyOffset + margin
+    const desiredTop = scrollerTop + stickyOffset + margin
     if (rect.top > desiredTop + 1 || rect.top < desiredTop - 1) {
       delta = rect.top - desiredTop
     }
@@ -148,12 +174,12 @@ export function scrollElementIntoView(el: Element, options: ScrollIntoViewOption
     // If the panel is taller than the available viewport, scroll its top into view
     // just below the sticky offset. Otherwise scroll so the full panel is visible.
     if (panelHeight > availableHeight) {
-      const desiredTop = stickyOffset + margin
+      const desiredTop = scrollerTop + stickyOffset + margin
       if (rect.top > desiredTop + 1 || rect.top < desiredTop - 1) {
         delta = rect.top - desiredTop
       }
     } else {
-      const desiredBottom = viewportHeight - margin
+      const desiredBottom = scrollerTop + viewportHeight - margin
       if (rect.bottom > desiredBottom + 1) {
         delta = rect.bottom - desiredBottom
       }


### PR DESCRIPTION
## Summary

Fixes collapsible panel scroll behavior on tutor pages so that expanding panels smoothly scroll into full view when partially off-screen.

## Changes

### `tutorme-app/src/app/[locale]/tutor/my-page/page.tsx`
- **My Courses panel**: Changed `useAutoScrollOnExpand` from `block: 'end'` (default) to `block: 'nearest'`. Wrapped the entire `<Card>` in a scroll-target `<div>` so the whole panel scrolls into view, not just the inner scrollable content area.
- **Profile Settings panel**: Added `useAutoScrollOnExpand` with `block: 'nearest'` — this panel previously had no scroll-into-view behavior on expand.

### `tutorme-app/src/lib/scroll-into-view.ts`
Fixed two bugs in `scrollElementIntoView` that caused panels to be hidden below the viewport after expansion:

1. **Nested scroller position not accounted for**: When the scrollable ancestor was a nested element (not `window`), `rect` values (relative to viewport) were compared against `viewportHeight` (scroller's `clientHeight`) without adjusting for the scroller's position in the viewport. Added `scrollerTop` to all threshold calculations.

2. **Left sidebar incorrectly counted in sticky offset**: `getStickyTopOffset` counted ALL fixed/sticky elements with `top <= 0`, including the tutor's left sidebar (`position: fixed`, `top: 0`, `height: 100vh`). This inflated `stickyOffset` by the full viewport height. Added `isTopBlockingElement()` filter to exclude sidebars (elements spanning < 40% viewport width or > 2x taller than wide).

## Behavior
- Only scrolls when the panel is partially off-screen — no scroll jump when already fully visible
- Smooth scrolling via `scroll-behavior: smooth`
- Accounts for sticky/fixed headers and nested scrollable containers
- `delay: 350` allows CSS expand animation (300ms) to complete before scrolling

## Testing
1. Collapse panels, click to expand — panel should smoothly scroll into full view
2. When a panel is already fully visible, clicking to expand should NOT scroll
3. On tutor settings page (Account), expanding panels in the controls/billing tabs should correctly scroll within the nested scrollable container
4. The tutor left sidebar should no longer interfere with scroll calculations
