### PR TITLE
fix: missing edits from PR #239 (course card, focus ring, collapsible scroll)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -1086,8 +1086,17 @@ function CourseCard({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-2">
-            {course.tutorImage && (
+          <div className="flex items-center gap-3">
+            {/* Session count */}
+            <div className="flex items-center gap-1.5 text-xs text-slate-300">
+              <Calendar className="h-3.5 w-3.5 text-slate-400" />
+              <span className="font-medium text-slate-200">
+                {course.sessionCount ?? 0} session{course.sessionCount === 1 ? '' : 's'}
+              </span>
+            </div>
+
+            {/* Avatar */}
+            {course.tutorImage ? (
               <img
                 src={resolvePublicUrl(course.tutorImage) || undefined}
                 alt={course.tutorHandle || 'Tutor'}
@@ -1096,6 +1105,10 @@ function CourseCard({
                   ;(e.target as HTMLImageElement).style.display = 'none'
                 }}
               />
+            ) : (
+              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.1)]">
+                <User className="h-4 w-4 text-slate-300" />
+              </div>
             )}
             <Button
               variant="ghost"
@@ -1116,16 +1129,6 @@ function CourseCard({
           <p className="line-clamp-1 text-xs leading-relaxed text-slate-700">
             {course.description || 'No description available'}
           </p>
-        </div>
-
-        {/* Sessions count */}
-        <div className="mt-2 flex items-center gap-2 text-xs text-slate-300">
-          <div className="flex items-center gap-1 font-medium text-slate-200">
-            <BookOpen className="h-3.5 w-3.5 text-slate-400" />
-            <span>
-              {course.sessionCount ?? 0} session{course.sessionCount === 1 ? '' : 's'}
-            </span>
-          </div>
         </div>
 
         {/* Progress */}
@@ -1178,7 +1181,7 @@ function CourseCard({
       <div className="flex gap-2 border-t border-[rgba(255,255,255,0.1)] p-4">
         {(isOngoing || isPending) && (
           <Button
-            className="h-9 flex-1 border-0 bg-emerald-600 text-white hover:bg-emerald-500"
+            className="h-8 flex-1 border-0 bg-emerald-600 text-xs text-white hover:bg-white hover:text-emerald-600"
             disabled={enteringClass === course.id}
             onClick={e => {
               e.stopPropagation()
@@ -1194,7 +1197,7 @@ function CourseCard({
         )}
         {progress?.isCompleted && (
           <Link href={`/student/feedback`} className="flex-1" onClick={e => e.stopPropagation()}>
-            <Button className="h-9 w-full border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)] text-slate-100 hover:bg-[rgba(255,255,255,0.15)]">
+            <Button className="h-8 w-full border-[rgba(255,255,255,0.2)] bg-[rgba(255,255,255,0.08)] text-xs text-slate-100 hover:bg-[rgba(255,255,255,0.15)]">
               <Trophy className="mr-2 h-4 w-4 text-yellow-400" />
               View Results
             </Button>
@@ -1202,7 +1205,7 @@ function CourseCard({
         )}
         <Button
           variant="outline"
-          className="h-9 flex-1 border-[rgba(255,255,255,0.2)] bg-transparent text-slate-100 hover:bg-[rgba(255,255,255,0.1)]"
+          className="h-8 flex-1 border border-white/60 bg-transparent text-xs text-white hover:bg-white hover:text-black"
           onClick={e => {
             e.stopPropagation()
             onDetails()
@@ -1213,7 +1216,7 @@ function CourseCard({
         {onUnregister && course.enrollment && (
           <Button
             variant="destructive"
-            className="h-9 flex-1"
+            className="h-8 flex-1 text-xs hover:bg-white hover:text-red-600"
             disabled={unregisteringId === course.id}
             onClick={e => {
               e.stopPropagation()

--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -643,6 +643,12 @@
     @apply border-border;
   }
 
+  /* Remove default browser focus rings universally */
+  *:focus,
+  *:focus-visible {
+    outline: none;
+  }
+
   html {
     min-width: 320px;
     -webkit-text-size-adjust: 100%;
@@ -665,7 +671,6 @@
     padding-right: 0 !important;
     margin: 0 !important;
   }
-
 
   body {
     @apply bg-background text-foreground antialiased;
@@ -1345,12 +1350,4 @@
     padding-left: calc(1.5rem * var(--density-scale));
     padding-right: calc(1.5rem * var(--density-scale));
   }
-}
-
-/* Remove focus rings from input elements site-wide */
-input:focus,
-input:focus-visible {
-  outline: none !important;
-  box-shadow: none !important;
-  --tw-ring-shadow: none !important;
 }

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -26,40 +26,40 @@ export function CollapsibleCard({
   children,
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen)
-  const contentRef = useAutoScrollOnExpand(open, { delay: 350, margin: 16, block: 'nearest' })
+  const cardRef = useAutoScrollOnExpand(open, { delay: 350, margin: 16, block: 'nearest' })
 
   return (
-    <Card className={cn('overflow-hidden', className)}>
-      <button
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        className={cn(
-          'panel-header w-full text-left',
-          flush ? 'panel-header-metallic-flush' : 'panel-header-metallic'
-        )}
-      >
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <div className="panel-header-title">{title}</div>
-            {description && <div className="panel-header-subtext">{description}</div>}
+    <div ref={cardRef}>
+      <Card className={cn('overflow-hidden', className)}>
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          className={cn(
+            'panel-header w-full text-left',
+            flush ? 'panel-header-metallic-flush' : 'panel-header-metallic'
+          )}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="panel-header-title">{title}</div>
+              {description && <div className="panel-header-subtext">{description}</div>}
+            </div>
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+              {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+            </div>
           </div>
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
-            {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+        </button>
+        <div
+          className={cn(
+            'grid transition-all duration-300 ease-in-out',
+            open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className={contentClassName}>{children}</div>
           </div>
         </div>
-      </button>
-      <div
-        className={cn(
-          'grid transition-all duration-300 ease-in-out',
-          open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-        )}
-      >
-        <div className="overflow-hidden">
-          <div ref={contentRef} className={contentClassName}>
-            {children}
-          </div>
-        </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   )
 }


### PR DESCRIPTION
## **User description**
## Summary

This PR includes three previously-unmerged edits that were lost when PR #239 was merged before they were fully committed to the branch.

## Changes

### 1. Student Course Card UI (`student/courses/page.tsx`)
- **Session count moved to header**: Now displayed in the right-aligned group with a `Calendar` icon, to the left of the avatar
- **Generic avatar fallback**: When `course.tutorImage` is missing, shows a `User` icon in a rounded container instead of nothing
- **Button height reduced**: All three bottom buttons changed from `h-9` to `h-8` (~11% reduction)
- **Button text size reduced**: Added `text-xs` (12px, down from default ~14px)
- **Button hover styles updated**:
  - Enter Classroom: default green bg + white text; hover white bg + green text
  - Details: default transparent + white outline; hover white bg + black text
  - Unregister: default red bg; hover white bg + red text

### 2. Universal Focus Ring Removal (`globals.css`)
- Replaced the narrow `input:focus` rule (with `!important`) at the bottom of the file
- Added `*:focus, *:focus-visible { outline: none }` inside `@layer base`
- Covers ALL focusable elements universally without specificity wars

### 3. CollapsibleCard Scroll Target (`collapsible-card.tsx`)
- **Root cause of tutor Account page scroll issue**: The `contentRef` was attached to the inner content div, so `scrollElementIntoView` only considered the content area (below the header) when calculating scroll position
- **Fix**: Wrapped the entire `<Card>` in a `<div ref={cardRef}>` so the scroll target includes both the header and the content
- This ensures the whole card remains visible after expansion, not just the content area

## Testing
1. Tutor Settings page → expand panels near bottom of viewport → whole card should scroll into view
2. Student My Courses page → verify session count in header, generic avatar, button sizes/hovers
3. Click any input field → no black focus ring flash


___

## **CodeAnt-AI Description**
**Fix course card details, card scrolling, and browser focus rings**

### What Changed
- Course cards now show the session count beside the tutor avatar, and show a fallback avatar icon when no tutor image is available
- Course action buttons are shorter and use tighter text styling, with updated hover states for Enter Classroom, Details, and Unregister
- Expanding a collapsible card now scrolls the whole card into view, so the header and content stay visible together
- Browser focus rings are removed across the site for a cleaner look on clickable and form elements

### Impact
`✅ Clearer course cards`
`✅ Fewer clipped panel expansions`
`✅ Cleaner form and button focus states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
