### PR TITLE
fix(course-builder): align Desk tab selector position across all modes

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7710,29 +7710,31 @@ FEEDBACK: [your explanation]`
                       onToggleHidden={setRightPanelHidden}
                       liveSubmissions={insightsProps?.liveSubmissions}
                       headerExtra={
-                        <Tabs
-                          value={liveRightPanelTab}
-                          onValueChange={value => {
-                            if (value === 'insights' && mainTab !== 'live') return
-                            setLiveRightPanelTab(value as 'submissions' | 'insights')
-                          }}
-                        >
-                          <TabsList className="grid w-full grid-cols-2 gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
-                            <TabsTrigger
-                              value="submissions"
-                              className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                            >
-                              Submissions
-                            </TabsTrigger>
-                            <TabsTrigger
-                              value="insights"
-                              disabled={mainTab !== 'live'}
-                              className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                            >
-                              Insights
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
+                        <div className="px-2 pt-4">
+                          <Tabs
+                            value={liveRightPanelTab}
+                            onValueChange={value => {
+                              if (value === 'insights' && mainTab !== 'live') return
+                              setLiveRightPanelTab(value as 'submissions' | 'insights')
+                            }}
+                          >
+                            <TabsList className="grid w-full grid-cols-2 gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
+                              <TabsTrigger
+                                value="submissions"
+                                className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
+                              >
+                                Submissions
+                              </TabsTrigger>
+                              <TabsTrigger
+                                value="insights"
+                                disabled={mainTab !== 'live'}
+                                className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
+                              >
+                                Insights
+                              </TabsTrigger>
+                            </TabsList>
+                          </Tabs>
+                        </div>
                       }
                     />
                   ) : (
@@ -8013,29 +8015,31 @@ FEEDBACK: [your explanation]`
                         onToggleHidden={setRightPanelHidden}
                         liveSubmissions={insightsProps?.liveSubmissions}
                         headerExtra={
-                          <Tabs
-                            value={liveRightPanelTab}
-                            onValueChange={value => {
-                              if (value === 'insights') return
-                              setLiveRightPanelTab(value as 'submissions' | 'insights')
-                            }}
-                          >
-                            <TabsList className="grid w-full grid-cols-2 gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
-                              <TabsTrigger
-                                value="submissions"
-                                className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                              >
-                                Submissions
-                              </TabsTrigger>
-                              <TabsTrigger
-                                value="insights"
-                                disabled
-                                className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                              >
-                                Insights
-                              </TabsTrigger>
-                            </TabsList>
-                          </Tabs>
+                          <div className="px-2 pt-4">
+                            <Tabs
+                              value={liveRightPanelTab}
+                              onValueChange={value => {
+                                if (value === 'insights') return
+                                setLiveRightPanelTab(value as 'submissions' | 'insights')
+                              }}
+                            >
+                              <TabsList className="grid w-full grid-cols-2 gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
+                                <TabsTrigger
+                                  value="submissions"
+                                  className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
+                                >
+                                  Submissions
+                                </TabsTrigger>
+                                <TabsTrigger
+                                  value="insights"
+                                  disabled
+                                  className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
+                                >
+                                  Insights
+                                </TabsTrigger>
+                              </TabsList>
+                            </Tabs>
+                          </div>
                         }
                       />
                     )}


### PR DESCRIPTION
## Summary

This PR bundles four UI/UX fixes that were previously scattered across multiple branches.

## Changes

### 1. CollapsibleCard scroll target (`src/components/collapsible-card.tsx`)
- **Problem**: The `contentRef` from `useAutoScrollOnExpand` was attached to the inner content div, so `scrollElementIntoView` only considered the content area (below the header) when calculating scroll position. This caused the card header to be pushed above the viewport when scrolling expanded panels into view.
- **Fix**: Wrapped the entire `<Card>` in a `<div ref={cardRef}>` so the scroll target includes both the header and the content.

### 2. scroll-into-view nested scroller fixes (`src/lib/scroll-into-view.ts`)
- **Bug 1**: Nested scroller position not accounted for — `rect` values (relative to viewport) were compared against `viewportHeight` (scroller clientHeight) without adjusting for the scroller's position in the viewport.
- **Bug 2**: Left sidebar incorrectly counted in sticky offset — `getStickyTopOffset` counted ALL fixed/sticky elements with `top <= 0`, including the tutor's left sidebar (`position: fixed`, `top: 0`, `height: 100vh`).
- **Fix**: Added `scrollerTop` to all threshold calculations; added `isTopBlockingElement()` filter to exclude sidebars.

### 3. Student course card UI (`src/app/[locale]/student/courses/page.tsx`)
- Session count moved to header right group with `Calendar` icon
- Generic `User` avatar fallback when no tutor image
- Bottom buttons: height `h-9` → `h-8`, text size reduced to `text-xs`
- Button hover styles: Enter Classroom (white bg + green text), Details (white bg + black text), Unregister (white bg + red text)

### 4. Universal focus ring removal (`src/app/globals.css`)
- Replaced narrow `input:focus !important` rule with broad `*:focus, *:focus-visible { outline: none }` inside `@layer base`

### 5. Desk tab selector position (`src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx`)
- **Problem**: The Submissions/Insights tab selector in the Desk panel shifted position depending on mode — flush against header in Build/Test and Live-Submissions, but with padding gap in Live-Insights.
- **Fix**: Wrapped all three tab selectors with consistent `<div className="px-2 pt-4">` padding.

### 6. Disable Insights tab in builder/test-pci modes (`src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx`)
- Insights only works during live sessions. Added `disabled` prop and `onValueChange` guard to prevent selecting Insights in Build and Test PCI modes.
