### PR TITLE
feat(ai): make Kimi vision model env-configurable (KIMI_VISION_MODEL)

### DIFF
--- a/tutorme-app/src/lib/ai/kimi.ts
+++ b/tutorme-app/src/lib/ai/kimi.ts
@@ -42,6 +42,10 @@ const KIMI_BASE_URL = (process.env.KIMI_BASE_URL || 'https://api.moonshot.cn/v1'
   ''
 )
 const DEFAULT_MODEL = process.env.KIMI_MODEL || 'kimi-k2.5'
+// Image (vision) calls need a vision-capable model, which Moonshot exposes as
+// separate *-vision-preview models. Configurable so a different platform/region
+// can use its own vision model name; defaults to the standard Moonshot one.
+const VISION_MODEL = process.env.KIMI_VISION_MODEL || 'moonshot-v1-8k-vision-preview'
 
 /**
  * Generate text using Kimi K2.5
@@ -309,7 +313,7 @@ export async function generateWithKimiVision(
           Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          model: options.model || 'moonshot-v1-8k-vision-preview',
+          model: options.model || VISION_MODEL,
           messages,
           temperature: options.temperature ?? 0.7,
           max_tokens: options.maxTokens ?? 2048,


### PR DESCRIPTION
## **User description**
## Summary
The PCI **vision** path — used when a tutor attaches a document and asks the assistant to summarize its diagrams/images (the exact flow that started this whole AI thread) — sent a **hardcoded** vision model `moonshot-v1-8k-vision-preview`. On a platform/region whose vision model is named differently, document attachments would **404**, even though text generation works fine.

## Change
Add **`KIMI_VISION_MODEL`** env var (default unchanged: `moonshot-v1-8k-vision-preview`) and use it for the vision request. This lets the vision/document path target the correct vision model independently of the text `KIMI_MODEL`.

## Companion config (yours, after merge/deploy)
Set it to whatever your `platform.kimi.ai` console lists as the vision-capable model, e.g.:
```
gcloud run services update tutorme-app --region asia-southeast1 \
  --project project-29e0fd29-a707-458c-bd1 \
  --update-env-vars KIMI_VISION_MODEL=<vision-model-from-console>
```

## Testing
`npm run typecheck`, `eslint` (no errors), `prettier`, `npm run build` — all pass. Default behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use the correct Kimi vision model for document image requests**

### What Changed
- Vision requests now use a separate configurable model name instead of a fixed one
- Teams can point document/image summaries at the vision model available in their Moonshot region
- Text generation keeps using its existing model setting

### Impact
`✅ Fewer document attachment failures`
`✅ Fewer vision-model 404 errors`
`✅ Clearer regional deployment setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
