### PR TITLE
fix(course-builder): stop React #185 loop when loading a DMI with items

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1595,7 +1595,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           console.error('Error saving tutor assets:', error)
         }
       },
-      [insightsProps]
+      // No reactive deps: the callback only reads its `assets` argument and the
+      // module-level fetchWithCsrf. A stale `[insightsProps]` here re-created the
+      // callback every render and needlessly re-armed the debounced save timer.
+      []
     )
 
     // Debounced assets save
@@ -1625,33 +1628,55 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       if (!loadedTaskId) return
 
       const timeoutId = setTimeout(() => {
-        setCourseBuilderNodes(prev =>
-          prev.map(mod => ({
+        // Equality-guarded write: if nothing about the loaded task actually
+        // changed, return `prev` unchanged so `nodes` keeps its identity. A new
+        // identity would trip the live-session edit detector (setHasUnsyncedChanges
+        // -> onUnsyncedChangesChange -> parent re-render -> new insightsProps ->
+        // re-render -> re-arm), which with DMI items present never converges and
+        // throws React #185 (max update depth).
+        setCourseBuilderNodes(prev => {
+          let changed = false
+          const next = prev.map(mod => ({
             ...mod,
             lessons: mod.lessons.map(lesson => ({
               ...lesson,
-              tasks: lesson.tasks.map(task =>
-                task.id === loadedTaskId
-                  ? {
-                      ...task,
-                      title: taskBuilder.title,
-                      shortDescription: taskBuilder.details,
-                      description: taskBuilder.taskContent,
-                      instructions: taskBuilder.taskPci,
-                      extensions: taskBuilder.extensions,
-                      dmiItems: taskDmiItems,
-                      dmiVersions: taskDmiVersions,
-                      activeDmiVersionId:
-                        testPciSource === 'task' && testPciViewMode.startsWith('dmi_')
-                          ? testPciViewMode.replace('dmi_', '')
-                          : task.activeDmiVersionId,
-                      sourceDocument: taskBuilder.sourceDocument,
-                    }
-                  : task
-              ),
+              tasks: lesson.tasks.map(task => {
+                if (task.id !== loadedTaskId) return task
+                const nextActiveDmiVersionId =
+                  testPciSource === 'task' && testPciViewMode.startsWith('dmi_')
+                    ? testPciViewMode.replace('dmi_', '')
+                    : task.activeDmiVersionId
+                if (
+                  task.title === taskBuilder.title &&
+                  task.shortDescription === taskBuilder.details &&
+                  task.description === taskBuilder.taskContent &&
+                  task.instructions === taskBuilder.taskPci &&
+                  task.extensions === taskBuilder.extensions &&
+                  task.dmiItems === taskDmiItems &&
+                  task.dmiVersions === taskDmiVersions &&
+                  task.activeDmiVersionId === nextActiveDmiVersionId &&
+                  task.sourceDocument === taskBuilder.sourceDocument
+                ) {
+                  return task
+                }
+                changed = true
+                return {
+                  ...task,
+                  title: taskBuilder.title,
+                  shortDescription: taskBuilder.details,
+                  description: taskBuilder.taskContent,
+                  instructions: taskBuilder.taskPci,
+                  extensions: taskBuilder.extensions,
+                  dmiItems: taskDmiItems,
+                  dmiVersions: taskDmiVersions,
+                  activeDmiVersionId: nextActiveDmiVersionId,
+                  sourceDocument: taskBuilder.sourceDocument,
+                }
+              }),
             })),
           }))
-        )
+          return changed ? next : prev
+        })
       }, 1000) // Auto-save after 1 second of inactivity
 
       return () => clearTimeout(timeoutId)
@@ -1675,31 +1700,49 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       if (!loadedAssessmentId) return
 
       const timeoutId = setTimeout(() => {
-        setCourseBuilderNodes(prev =>
-          prev.map(mod => ({
+        // Equality-guarded write — see the task auto-save above. Returning `prev`
+        // when the assessment is unchanged keeps `nodes` identity stable and
+        // prevents the live-session unsynced-changes feedback loop (React #185)
+        // that fires once a loaded DMI has items.
+        setCourseBuilderNodes(prev => {
+          let changed = false
+          const next = prev.map(mod => ({
             ...mod,
             lessons: mod.lessons.map(lesson => ({
               ...lesson,
-              homework: lesson.homework.map(hw =>
-                hw.id === loadedAssessmentId
-                  ? {
-                      ...hw,
-                      title: assessmentBuilder.title,
-                      description: assessmentBuilder.taskContent,
-                      instructions: assessmentBuilder.taskPci,
-                      dmiItems: assessmentDmiItems,
-                      dmiVersions: assessmentDmiVersions,
-                      activeDmiVersionId:
-                        testPciSource === 'assessment' && testPciViewMode.startsWith('dmi_')
-                          ? testPciViewMode.replace('dmi_', '')
-                          : hw.activeDmiVersionId,
-                      sourceDocument: assessmentBuilder.sourceDocument,
-                    }
-                  : hw
-              ),
+              homework: lesson.homework.map(hw => {
+                if (hw.id !== loadedAssessmentId) return hw
+                const nextActiveDmiVersionId =
+                  testPciSource === 'assessment' && testPciViewMode.startsWith('dmi_')
+                    ? testPciViewMode.replace('dmi_', '')
+                    : hw.activeDmiVersionId
+                if (
+                  hw.title === assessmentBuilder.title &&
+                  hw.description === assessmentBuilder.taskContent &&
+                  hw.instructions === assessmentBuilder.taskPci &&
+                  hw.dmiItems === assessmentDmiItems &&
+                  hw.dmiVersions === assessmentDmiVersions &&
+                  hw.activeDmiVersionId === nextActiveDmiVersionId &&
+                  hw.sourceDocument === assessmentBuilder.sourceDocument
+                ) {
+                  return hw
+                }
+                changed = true
+                return {
+                  ...hw,
+                  title: assessmentBuilder.title,
+                  description: assessmentBuilder.taskContent,
+                  instructions: assessmentBuilder.taskPci,
+                  dmiItems: assessmentDmiItems,
+                  dmiVersions: assessmentDmiVersions,
+                  activeDmiVersionId: nextActiveDmiVersionId,
+                  sourceDocument: assessmentBuilder.sourceDocument,
+                }
+              }),
             })),
           }))
-        )
+          return changed ? next : prev
+        })
       }, 1000) // Auto-save after 1 second of inactivity
 
       return () => clearTimeout(timeoutId)


### PR DESCRIPTION
## **User description**
## Problem

Now that the AI provider works again and DMI generation returns real items, loading a generated DMI in the course builder crashed with a full dark screen: **"Application error: a client-side exception has occurred."** The browser console showed **React error #185 — "Maximum update depth exceeded"** (an infinite render loop), with the same recursive-render stack signature as the earlier DMI crashes.

## Root cause

The debounced task/assessment **auto-save effects** call `setCourseBuilderNodes(prev => prev.map(...))`, which **unconditionally rebuilds** `builderNodes` — fresh arrays and objects — so `nodes` (a `useMemo` over `builderNodes`) gets a **new identity every run even when nothing actually changed**.

In a live session (which `insights?mode=edit` is), that new identity trips the edit detector:

```
auto-save writes nodes  →  nodes identity flips
  →  edit detector (setHasUnsyncedChanges)
  →  onUnsyncedChangesChange  →  parent route re-renders
  →  new inline insightsProps object  →  CourseBuilder re-renders
  →  auto-save re-arms  →  …
```

While DMIs were empty there was no payload to churn; once a loaded DMI has **items**, real data flows through this cycle every pass and it never converges → #185.

## Fix (surgical)

- **Equality-guard both auto-save updaters**: return `prev` unchanged when the loaded task/assessment is structurally identical, so `nodes` keeps its identity and the feedback loop can't start. Genuine edits still detect a change and persist normally.
- Drop the stale `[insightsProps]` dependency on `saveAssetsToApi` (the callback reads neither `insightsProps` nor any other reactive value) — it was re-creating the callback and re-arming the assets-save timer every render.

No behavior change for real edits; only no-op writes are now skipped.

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds (0 errors)
- `eslint` on the file — 0 errors (only pre-existing `any`/unused warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop the course builder from crashing when loading a DMI with items**

### What Changed
- Loading a generated DMI with items no longer triggers a full-screen client error in the course builder.
- Auto-save now skips writes when a loaded task or assessment has not actually changed, which keeps the page from re-rendering in a loop.
- Asset saving no longer re-starts on every render, reducing repeated save timer resets.

### Impact
`✅ Fewer course builder crashes`
`✅ Stable DMI loading in edit mode`
`✅ Fewer repeated auto-save cycles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
