### PR TITLE
fix(course-builder): contain builder crashes + capture the failing component

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -49,6 +49,7 @@ import { cn } from '@/lib/utils'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CourseBuilder } from '../../dashboard/components/CourseBuilder'
+import { PanelErrorBoundary } from '@/components/ui/panel-error-boundary'
 import { GoLiveDialog } from '../../dashboard/components/GoLiveDialog'
 import { toast } from 'sonner'
 import type { CourseBuilderInsightsProps } from './course-builder-types'
@@ -1016,31 +1017,33 @@ function CourseBuilderInsightsRouteInner({
             <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
           </div>
         ) : (
-          <CourseBuilder
-            ref={model.courseBuilderRef}
-            courseId={courseId ?? ''}
-            courseName={courseName || model.course?.name}
-            courseDescription={model.course?.description ?? undefined}
-            initialLessons={model.loadedLessons ?? undefined}
-            hideDirectorySearch
-            directoryMenusAlwaysVisible
-            onSave={onSaveCourse}
-            insightsProps={{
-              ...insightsProps,
-              onEndSession: insightsProps.sessionId ? handleEndSession : undefined,
-              onStartSession: handleStartSessionClick,
-              endingSession,
-            }}
-            onMainTabChange={handleMainTabChange}
-            initialMainTab={isClassroomMode ? 'live' : (tabFromUrl ?? 'builder')}
-            mainTab={activeMainTab}
-            leftPanelHidden={leftPanelHidden}
-            onLeftPanelHiddenChange={setLeftPanelHidden}
-            saveMode={saveMode}
-            onSaveModeChange={onSaveModeChange}
-            onSyncToLiveSession={onSyncToLiveSession}
-            onUnsyncedChangesChange={setHasUnsyncedChanges}
-          />
+          <PanelErrorBoundary label="the course builder" resetKeys={[courseId, activeMainTab]}>
+            <CourseBuilder
+              ref={model.courseBuilderRef}
+              courseId={courseId ?? ''}
+              courseName={courseName || model.course?.name}
+              courseDescription={model.course?.description ?? undefined}
+              initialLessons={model.loadedLessons ?? undefined}
+              hideDirectorySearch
+              directoryMenusAlwaysVisible
+              onSave={onSaveCourse}
+              insightsProps={{
+                ...insightsProps,
+                onEndSession: insightsProps.sessionId ? handleEndSession : undefined,
+                onStartSession: handleStartSessionClick,
+                endingSession,
+              }}
+              onMainTabChange={handleMainTabChange}
+              initialMainTab={isClassroomMode ? 'live' : (tabFromUrl ?? 'builder')}
+              mainTab={activeMainTab}
+              leftPanelHidden={leftPanelHidden}
+              onLeftPanelHiddenChange={setLeftPanelHidden}
+              saveMode={saveMode}
+              onSaveModeChange={onSaveModeChange}
+              onSyncToLiveSession={onSyncToLiveSession}
+              onUnsyncedChangesChange={setHasUnsyncedChanges}
+            />
+          </PanelErrorBoundary>
         )}
 
         {!model.loading && courseId && (


### PR DESCRIPTION
## **User description**
## Why

Loading a generated DMI still triggers **React #185 ("Maximum update depth exceeded")** — a full dark screen. I decoded the minified prod stack against the byte-identical local build:

- `ry` → the `if (50 < nestedUpdates) throw Error(185)` guard
- `ow`/`ok` → `dispatchSetState` (a `useState` setter firing)
- `i` (chunk `25127`) → Radix `setRef` via `composeRefs`, mapping over composed refs

So the loop is **a ref callback dispatching a `useState` update on every attach**, inside Radix's ref-composition / `Collection` / `useControllableState` machinery. The exact *app* component that feeds it is a runtime fact the minified stack can't name, and no static grep matches the pattern in app code.

The throw escapes the per-panel `PanelErrorBoundary` (which only wraps the test-pci IIFE) and crashes the whole app into the blank "Application error" page.

## What this does

Wrap `<CourseBuilder>` at the insights route in `PanelErrorBoundary`:

1. **Stops the full-page dark screen** — the error is contained to a recoverable panel; the rest of the insights page (nav, controls) stays usable, with a "Try again" button. `resetKeys=[courseId, activeMainTab]` auto-clears on tab/course change.
2. **Captures the culprit** — `componentDidCatch` logs the React **component stack**, which names the exact looping component so the root-cause fix can be made surgically next.

This is containment + instrumentation, not the final root-cause fix — that lands once the component stack identifies the component.

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep course builder errors from crashing the whole insights page**

### What Changed
- The course builder is now wrapped in an error boundary on the insights route, so a builder crash stays inside the panel instead of showing a full-page application error
- When the error happens, the page can still keep the surrounding controls and navigation usable, with a retry option for the builder area
- The error state clears when the course or main tab changes, so users do not stay stuck on a failed view after switching context

### Impact
`✅ Fewer full-page course builder crashes`
`✅ Keep insights page controls usable after an error`
`✅ Faster recovery after switching courses or tabs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
