### PR TITLE
fix(insights): contain route-shell crash + capture the looping component

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/error.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/error.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Segment-level error boundary for /tutor/insights.
+ *
+ * Catches any client render error in this route (including ones thrown above the
+ * in-tree PanelErrorBoundary, e.g. in the page component itself) so a crash
+ * degrades to a recoverable message instead of the blank global "Application
+ * error" screen. Logs the error (message + digest) for diagnosis.
+ */
+export default function InsightsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('[insights/error] route error:', error, 'digest:', error?.digest)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center justify-center gap-4 bg-gray-50 p-6 text-center">
+      <p className="text-base font-semibold text-slate-800">
+        Something went wrong loading the insights builder.
+      </p>
+      <p className="max-w-md text-sm text-slate-500">
+        {error?.message || 'An unexpected error occurred.'}
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={reset}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Try again
+        </button>
+        <button
+          onClick={() => {
+            window.location.href = '/tutor/dashboard'
+          }}
+          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          Back to dashboard
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { useSession } from 'next-auth/react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { CourseBuilderInsightsRoute } from '../courses/components/CourseBuilderInsightsRoute'
+import { PanelErrorBoundary } from '@/components/ui/panel-error-boundary'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import {
@@ -1222,84 +1223,86 @@ function TutorInsightsPageInner() {
 
   return (
     <div className="flex min-h-screen w-full flex-col items-stretch bg-gray-50">
-      <CourseBuilderInsightsRoute
-        courseId={courseId}
-        dataMode={dataMode}
-        detachedStorageKey={
-          dataMode === 'detached' ? `insights-course-builder:${courseId}` : undefined
-        }
-        detachedCourseName={dataMode === 'detached' ? detachedCourseName : undefined}
-        insightsProps={{
-          courseId,
-          courses: courses.map(course => ({
-            id: course.id,
-            name: course.name,
-            categories: course.categories,
-            isPublished: course.isPublished,
-            nationality: course.nationality,
-            variantCategory: course.variantCategory,
-          })),
-          onCourseChange: value => {
-            setCourseId(value)
-            const isDraftCourse = draftCourses.some(course => course.id === value)
-            // Only auto-switch to draft mode for draft courses.
-            // Live courses can be edited in either mode, so keep the current mode.
-            if (!sessionId && isDraftCourse) {
-              setSaveMode('draft')
-            }
+      <PanelErrorBoundary label="the insights builder" showStack resetKeys={[courseId, saveMode]}>
+        <CourseBuilderInsightsRoute
+          courseId={courseId}
+          dataMode={dataMode}
+          detachedStorageKey={
+            dataMode === 'detached' ? `insights-course-builder:${courseId}` : undefined
+          }
+          detachedCourseName={dataMode === 'detached' ? detachedCourseName : undefined}
+          insightsProps={{
+            courseId,
+            courses: courses.map(course => ({
+              id: course.id,
+              name: course.name,
+              categories: course.categories,
+              isPublished: course.isPublished,
+              nationality: course.nationality,
+              variantCategory: course.variantCategory,
+            })),
+            onCourseChange: value => {
+              setCourseId(value)
+              const isDraftCourse = draftCourses.some(course => course.id === value)
+              // Only auto-switch to draft mode for draft courses.
+              // Live courses can be edited in either mode, so keep the current mode.
+              if (!sessionId && isDraftCourse) {
+                setSaveMode('draft')
+              }
 
-            const match = [...courses, ...draftCourses].find(course => course.id === value)
-            if (match) {
-              setDetachedCourseName(match.name)
-            }
-          },
-          sessionId,
-          sessions,
-          onSessionChange: setSessionId,
-          liveTasks,
-          liveSubmissions,
-          // Only expose deploy inside a live session — the deploy buttons gate
-          // on this callback, so hiding it prevents "deploying" from the plain
-          // builder (where the emit would be silently dropped, no session/room).
-          onDeployTask: sessionId ? handleDeployTask : undefined,
-          onSendPoll: handleSendPoll,
-          onSendQuestion: handleSendQuestion,
-          students,
-          metrics,
-          classDuration,
-          isRecording,
-          recordingDuration: recordingDurationSeconds,
-          onToggleRecording: handleToggleRecording,
-          socket,
-          studentBoards,
-          tutorId: session?.user?.id,
-          tutorName: session?.user?.name || 'Tutor',
-        }}
-        sessionCategory={sessionCategory}
-        sessionNationality={sessionNationality}
-        sessionVariantName={sessionVariantName}
-        onSaveCourse={handleSave}
-        onSyncToLiveSession={handleSyncToLiveSession}
-        onCreateCourse={() => setIsCreateDialogOpen(true)}
-        onDeleteCourse={() => setIsDeleteDialogOpen(true)}
-        isCreateDialogOpen={isCreateDialogOpen}
-        setIsCreateDialogOpen={setIsCreateDialogOpen}
-        newCourseName={newCourseName}
-        setNewCourseName={setNewCourseName}
-        onCreateNewCourse={handleCreateNewCourse}
-        isDeleteDialogOpen={isDeleteDialogOpen}
-        setIsDeleteDialogOpen={setIsDeleteDialogOpen}
-        onDeleteCourseConfirm={handleDeleteCourse}
-        courses={courses}
-        draftCourses={draftCourses.filter(
-          draft => !courses.some(live => live.name.startsWith(draft.name + ' —'))
-        )}
-        courseName={courseName}
-        onCourseNameChange={handleCourseNameChange}
-        saveMode={saveMode}
-        onSaveModeChange={handleModeChange}
-        modeLocked={false}
-      />
+              const match = [...courses, ...draftCourses].find(course => course.id === value)
+              if (match) {
+                setDetachedCourseName(match.name)
+              }
+            },
+            sessionId,
+            sessions,
+            onSessionChange: setSessionId,
+            liveTasks,
+            liveSubmissions,
+            // Only expose deploy inside a live session — the deploy buttons gate
+            // on this callback, so hiding it prevents "deploying" from the plain
+            // builder (where the emit would be silently dropped, no session/room).
+            onDeployTask: sessionId ? handleDeployTask : undefined,
+            onSendPoll: handleSendPoll,
+            onSendQuestion: handleSendQuestion,
+            students,
+            metrics,
+            classDuration,
+            isRecording,
+            recordingDuration: recordingDurationSeconds,
+            onToggleRecording: handleToggleRecording,
+            socket,
+            studentBoards,
+            tutorId: session?.user?.id,
+            tutorName: session?.user?.name || 'Tutor',
+          }}
+          sessionCategory={sessionCategory}
+          sessionNationality={sessionNationality}
+          sessionVariantName={sessionVariantName}
+          onSaveCourse={handleSave}
+          onSyncToLiveSession={handleSyncToLiveSession}
+          onCreateCourse={() => setIsCreateDialogOpen(true)}
+          onDeleteCourse={() => setIsDeleteDialogOpen(true)}
+          isCreateDialogOpen={isCreateDialogOpen}
+          setIsCreateDialogOpen={setIsCreateDialogOpen}
+          newCourseName={newCourseName}
+          setNewCourseName={setNewCourseName}
+          onCreateNewCourse={handleCreateNewCourse}
+          isDeleteDialogOpen={isDeleteDialogOpen}
+          setIsDeleteDialogOpen={setIsDeleteDialogOpen}
+          onDeleteCourseConfirm={handleDeleteCourse}
+          courses={courses}
+          draftCourses={draftCourses.filter(
+            draft => !courses.some(live => live.name.startsWith(draft.name + ' —'))
+          )}
+          courseName={courseName}
+          onCourseNameChange={handleCourseNameChange}
+          saveMode={saveMode}
+          onSaveModeChange={handleModeChange}
+          modeLocked={false}
+        />
+      </PanelErrorBoundary>
 
       {/* Create New Course Dialog */}
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>

--- a/tutorme-app/src/components/ui/panel-error-boundary.tsx
+++ b/tutorme-app/src/components/ui/panel-error-boundary.tsx
@@ -8,10 +8,17 @@ interface PanelErrorBoundaryProps {
   resetKeys?: unknown[]
   /** Label shown in the fallback, e.g. "this view" (default) or "the Test panel". */
   label?: string
+  /**
+   * When true, render the React component stack inside the fallback (collapsed)
+   * so it can be read/screenshotted without opening the console. Used to
+   * diagnose a hard-to-reproduce crash; the stack still goes to console too.
+   */
+  showStack?: boolean
 }
 
 interface PanelErrorBoundaryState {
   error: Error | null
+  componentStack: string | null
 }
 
 /**
@@ -28,14 +35,15 @@ export class PanelErrorBoundary extends Component<
   PanelErrorBoundaryProps,
   PanelErrorBoundaryState
 > {
-  state: PanelErrorBoundaryState = { error: null }
+  state: PanelErrorBoundaryState = { error: null, componentStack: null }
 
-  static getDerivedStateFromError(error: Error): PanelErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<PanelErrorBoundaryState> {
     return { error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('[PanelErrorBoundary] render error contained:', error, info.componentStack)
+    this.setState({ componentStack: info.componentStack ?? null })
   }
 
   componentDidUpdate(prevProps: PanelErrorBoundaryProps) {
@@ -43,11 +51,11 @@ export class PanelErrorBoundary extends Component<
     const prev = prevProps.resetKeys ?? []
     const next = this.props.resetKeys ?? []
     if (prev.length !== next.length || prev.some((v, i) => !Object.is(v, next[i]))) {
-      this.setState({ error: null })
+      this.setState({ error: null, componentStack: null })
     }
   }
 
-  private reset = () => this.setState({ error: null })
+  private reset = () => this.setState({ error: null, componentStack: null })
 
   render() {
     if (this.state.error) {
@@ -65,6 +73,16 @@ export class PanelErrorBoundary extends Component<
           >
             Try again
           </button>
+          {this.props.showStack && this.state.componentStack && (
+            <details className="mt-2 max-w-xl text-left">
+              <summary className="cursor-pointer text-xs font-medium text-slate-600">
+                Diagnostic details (component stack)
+              </summary>
+              <pre className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap rounded bg-slate-50 p-2 text-[10px] leading-tight text-slate-700">
+                {this.state.componentStack}
+              </pre>
+            </details>
+          )}
         </div>
       )
     }


### PR DESCRIPTION
## **User description**
## Context

The DMI-load **React #185** infinite loop persists in **Incognito** (so it's not a stale cache — it's real code). The PanelErrorBoundary I added around `<CourseBuilder>` in #257 did **not** catch it → the looping `setState` lives in the insights **route shell, above the builder**.

Decoded from the minified prod stack: a **ref callback** (Radix `composeRefs`/`setRef`) dispatching a `useState` update in a loop, fired when the route enters `test-pci`/`test` mode on DMI load. The exact app component is a runtime fact the minified JS stack can't name — but the **React component stack** can (Radix sets explicit `displayName`s like `SelectTrigger`, `DialogContent`, `Collection.Slot`).

## What this does

- **Wrap `<CourseBuilderInsightsRoute>` in `page.tsx`** with `PanelErrorBoundary` — high enough to catch the route-shell loop. It logs the component stack **and renders it on-screen** (`showStack`, in a collapsible `<details>`) so it can be screenshotted without the console.
- **Add `insights/error.tsx`** segment boundary as a backstop, so anything thrown above the in-tree boundary (the page component's own body) degrades to a recoverable page instead of the blank global "Application error" screen.
- `PanelErrorBoundary`: capture `componentStack` into state; render it when `showStack` is set.

This is containment + instrumentation. Once the component stack names the looping Radix component, the root-cause fix is surgical.

## Verification
- `npm run typecheck` — clean
- `npm run build` — succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep the insights builder usable when it crashes**

### What Changed
- The insights page now catches route-level crashes and shows a recovery screen instead of the blank global error page
- The error screen explains that loading failed, shows the crash message, and offers buttons to try again or return to the dashboard
- The panel error fallback can now show the React component stack on-screen in a collapsed diagnostic section, making hard-to-reproduce crashes easier to inspect

### Impact
`✅ Fewer blank-screen failures in insights`
`✅ Clearer recovery after builder crashes`
`✅ Faster crash diagnosis from the page itself`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
