### PR TITLE
fix(insights): stop React #185 from course Select with unmatched value

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -767,7 +767,12 @@ function CourseBuilderInsightsRouteInner({
                   )}
                   {activeMainTab !== 'live' && insightsProps.onCourseChange && (
                     <Select
-                      value={courseId ?? ''}
+                      // Only feed a value that has a matching <SelectItem>. courseId can
+                      // be an id absent from courses/draftCourses (template vs published
+                      // id split), and a controlled Radix Select value with no matching
+                      // item loops its value-sync forever → React #185 ("Maximum update
+                      // depth exceeded"). currentCourse is the in-list match or undefined.
+                      value={currentCourse?.id ?? ''}
                       onValueChange={v => insightsProps.onCourseChange?.(v)}
                       disabled={hasNoCourses}
                     >


### PR DESCRIPTION
## **User description**
## Root cause (decoded from the production component stack)

The DMI-load **React #185** ("Maximum update depth exceeded") loop is the **course-selector `<Select>`** in the insights route header.

I captured the component stack via the diagnostic boundary (#258) and decoded it against the byte-identical local build:
- chunk `76439` = Radix **Select** (`SelectTrigger`, `SelectBubbleInput`, …)
- chunk `94841` = Radix **Popper**, chunk `25127` = Radix **Collection**
- the 3 wrapper `div`s match the course-selector's header nesting exactly

A controlled Radix `<Select>` whose `value` has **no matching `<SelectItem>`** loops its internal value-sync forever. The course Select used `value={courseId ?? ''}`, but `courseId` can be an id that isn't in `courses`/`draftCourses` — those use **template** ids while `courseId` may be a **published-variant** id (the known template-vs-published id split). No matching item → infinite loop → the full-page "Application error" dark screen, surfacing when loading a DMI (the first action that re-renders the route shell).

## Fix

Feed the Select `value={currentCourse?.id ?? ''}`. `currentCourse` is the in-list course matching `courseId`, so the value is **always** a real item id or `''` (no selection) — never an unmatched value, so the loop can't start. Display is unchanged (`SelectValue` already renders `currentCourse`).

The error boundaries + `error.tsx` from #258 stay as defense-in-depth.

## Verification
- `npm run typecheck` — clean
- `npm run build` — succeeds (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Keep the course selector from crashing the insights page

### What Changed
- The course selector now uses the selected course’s in-list ID, so it always matches a visible option
- This prevents the page from entering an update loop when the current course ID exists outside the selector list
- The displayed course name stays the same

### Impact
`✅ Fewer insights page crashes`
`✅ No more blank error screen when loading a DMI`
`✅ Stable course switching in the insights header`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
