### PR TITLE
diag(insights): render-trace to pinpoint the #185 loop driver

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -50,6 +50,7 @@ import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CourseBuilder } from '../../dashboard/components/CourseBuilder'
 import { PanelErrorBoundary } from '@/components/ui/panel-error-boundary'
+import { recordDiag } from '@/lib/insights-diag'
 import { GoLiveDialog } from '../../dashboard/components/GoLiveDialog'
 import { toast } from 'sonner'
 import type { CourseBuilderInsightsProps } from './course-builder-types'
@@ -658,6 +659,18 @@ function CourseBuilderInsightsRouteInner({
   const isCoursePublished = currentCourse?.isPublished === true
   const isCourseVariant = currentCourse?.isVariant === true
   const originalSchedule = currentCourse?.schedule || []
+
+  // TEMP diagnostic: trace each route render's key state to find the #185 driver.
+  recordDiag({
+    src: 'route',
+    activeMainTab,
+    controlsMode,
+    saveMode,
+    courseId,
+    matched: currentCourse?.id ?? null,
+    sid: insightsProps?.sessionId ?? null,
+    unsynced: hasUnsyncedChanges,
+  })
 
   // Reschedule handlers
   const openRescheduleDialog = useCallback(() => {

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { CourseBuilderInsightsRoute } from '../courses/components/CourseBuilderInsightsRoute'
 import { PanelErrorBoundary } from '@/components/ui/panel-error-boundary'
+import { recordDiag } from '@/lib/insights-diag'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import {
@@ -1220,6 +1221,16 @@ function TutorInsightsPageInner() {
   }
 
   const dataMode = saveMode === 'draft' && !sessionId ? 'detached' : 'default'
+
+  // TEMP diagnostic: trace each page render to find the #185 driver.
+  recordDiag({
+    src: 'page',
+    courseId,
+    saveMode,
+    sessionId,
+    nCourses: courses.length,
+    nDraft: draftCourses.length,
+  })
 
   return (
     <div className="flex min-h-screen w-full flex-col items-stretch bg-gray-50">

--- a/tutorme-app/src/components/ui/panel-error-boundary.tsx
+++ b/tutorme-app/src/components/ui/panel-error-boundary.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { getDiag } from '@/lib/insights-diag'
 
 interface PanelErrorBoundaryProps {
   children: ReactNode
@@ -80,6 +81,18 @@ export class PanelErrorBoundary extends Component<
               </summary>
               <pre className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap rounded bg-slate-50 p-2 text-[10px] leading-tight text-slate-700">
                 {this.state.componentStack}
+              </pre>
+            </details>
+          )}
+          {this.props.showStack && getDiag().length > 0 && (
+            <details className="mt-2 max-w-xl text-left">
+              <summary className="cursor-pointer text-xs font-medium text-slate-600">
+                Diagnostic details (render trace)
+              </summary>
+              <pre className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap rounded bg-slate-50 p-2 text-[10px] leading-tight text-slate-700">
+                {getDiag()
+                  .map(e => JSON.stringify(e))
+                  .join('\n')}
               </pre>
             </details>
           )}

--- a/tutorme-app/src/lib/insights-diag.ts
+++ b/tutorme-app/src/lib/insights-diag.ts
@@ -1,0 +1,24 @@
+/**
+ * TEMPORARY render-trace for diagnosing the insights-route React #185 loop.
+ * Records the last N render snapshots into a window-global ring buffer so the
+ * error boundary can display them on-screen. Remove once the loop is fixed.
+ */
+
+interface DiagWindow {
+  __diagSeq?: number
+  __INSIGHTS_DIAG__?: Array<Record<string, unknown>>
+}
+
+export function recordDiag(entry: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return
+  const w = window as unknown as DiagWindow
+  w.__diagSeq = (w.__diagSeq ?? 0) + 1
+  if (!w.__INSIGHTS_DIAG__) w.__INSIGHTS_DIAG__ = []
+  w.__INSIGHTS_DIAG__.push({ seq: w.__diagSeq, ...entry })
+  if (w.__INSIGHTS_DIAG__.length > 60) w.__INSIGHTS_DIAG__.shift()
+}
+
+export function getDiag(): Array<Record<string, unknown>> {
+  if (typeof window === 'undefined') return []
+  return (window as unknown as DiagWindow).__INSIGHTS_DIAG__ ?? []
+}


### PR DESCRIPTION
## **User description**
Temporary diagnostic. The course-Select value fix (#259) didn't stop the loop (identical stack), so the driver is a re-render storm. This records each page/route render's key state into a ring buffer and shows it on the error panel as 'Diagnostic details (render trace)'. Reveals which state oscillates / whether route vs page drives it. Will be reverted once root-caused.

- typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add on-screen render trace to diagnose the insights loop**

### What Changed
- The insights error panel can now show a render trace alongside the component stack when an error occurs
- The page and route now record key state on each render so repeated state changes can be seen in the trace
- The trace keeps only the latest entries to avoid overwhelming the error panel

### Impact
`✅ Faster loop diagnosis`
`✅ Clearer insights error reports`
`✅ Easier identification of re-render storms`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
