### PR TITLE
fix(course-builder): stop mainTab ping-pong loop on DMI load (React #185)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2775,7 +2775,13 @@ FEEDBACK: [your explanation]`
       setTestPciSource(type)
       setTestPciViewMode(`dmi_${version.id}`)
       setTestPciActiveTab('classroom')
+      // Switch to the Test tab. Notify the parent route in the SAME batch as the
+      // local setMainTab so the controlled `mainTab` prop and local state never
+      // desync — otherwise the local→parent (effect 981) and parent→local
+      // (effect 1867) sync effects run with opposite stale values and swap the
+      // tab back and forth forever (React #185 "Maximum update depth exceeded").
       setMainTab('test-pci')
+      onMainTabChange?.('test-pci')
 
       toast.success(`Loaded DMI version ${version.versionNumber}`)
     }


### PR DESCRIPTION
## **User description**
## Root cause — proven by render-trace

The render-trace (#260) caught it: on DMI load, the route's `activeMainTab` **oscillated `builder` ↔ `test-pci`** on every render (seq 10→60) until the update-depth limit threw **React #185**. The course Select's trigger ref was just the thrown 51st `setState` — not the cause.

`handleLoadDmiVersion` switched the tab with a **local-only** `setMainTab('test-pci')`, without notifying the controlled parent. CourseBuilder syncs `mainTab` **both ways**:
- effect 981: local → parent (`onMainTabChange(mainTab)`)
- effect 1867: parent → local (`setMainTab(mainTabProp)`)

The local-only change desynced them, so each commit those two effects ran with **opposite stale values and swapped** the tab back and forth forever.

## Fix

Notify the parent in the **same batch** as the local change — `onMainTabChange?.('test-pci')` right next to `setMainTab('test-pci')`, exactly as the Tabs `onValueChange` already does. Local and parent stay in sync → the sync effects converge → no oscillation. Every other `setMainTab` site is either the parent→local sync (1867) or already notifies the parent (Tabs 5850), so this was the only desync source.

## Verification
- `npm run typecheck` — clean
- `npm run build` — succeeds

Diagnostics from #258/#260 stay in place for one confirmation cycle, then I'll revert them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop the Course Builder from looping when a DMI version is loaded**

### What Changed
- Loading a DMI version now switches to the Test tab without causing the tab state to bounce back and forth.
- The tab change is now sent to the parent route at the same time as the local update, so both stay in sync.
- This prevents the “Maximum update depth exceeded” crash that could happen during DMI loading.

### Impact
`✅ Fewer DMI load crashes`
`✅ Stable tab switching after loading a DMI version`
`✅ No more React update-depth errors from tab sync`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
