### PR TITLE
fix(builder): stop infinite render loop when loading a DMI (React #185)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -977,9 +977,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Main builder tab (task vs assessment)
     const [mainBuilderTab, setMainBuilderTab] = useState<'task' | 'assessment'>('task')
 
+    // Notify the parent ONLY of locally-originated tab changes. When the change
+    // came FROM the parent (prop → local via the sync effect below), local
+    // already equals mainTabProp, so we must NOT echo it back up — that echo is
+    // what looped the controlled/uncontrolled tab forever (React #185, seen on
+    // DMI load which drives the tab to 'test-pci' from the parent).
     useEffect(() => {
+      if (mainTabProp !== undefined && mainTab === mainTabProp) return
       onMainTabChange?.(mainTab)
-    }, [mainTab, onMainTabChange])
+    }, [mainTab, mainTabProp, onMainTabChange])
 
     // Reset builder to blank slate whenever the builder tab is clicked
     useEffect(() => {


### PR DESCRIPTION
## **User description**
## Symptom
Loading a DMI crashes the insights builder: *"Couldn't display the insights builder. Minified React error #185"* ("Maximum update depth exceeded"). The render trace shows `activeMainTab` flipping **builder ↔ test-pci** (and `controlsMode` build ↔ test) every render — an infinite setState loop.

## Root cause — controlled/uncontrolled echo
`CourseBuilder` mirrors the parent route's `mainTab` prop into local state (prop→local sync effect), **and** a second effect pushed local `mainTab` back up via `onMainTabChange` on *every* change — including changes that originated from the parent. Loading a DMI drives the tab to `test-pci` from the parent, which echoed straight back up and oscillated. (Earlier fixes batched the action site but left this echo.)

## Fix
The upward-notify effect now fires **only for locally-originated changes** — it skips when local `mainTab` already equals `mainTabProp` (the change came from the parent). Action sites (tab click, DMI load) still call `onMainTabChange` directly, so real changes propagate; prop-driven changes no longer echo. Since the parent derives `controlsMode` from the tab, this also stops the build↔test flip.

## Verification
- `npm run build` ✓ (1170 pages); typecheck clean.
- ⚠️ Couldn't drive the deep DMI-load UI end-to-end on this stack (no easy data path), but the fix targets the exact documented echo and is reasoned through all transition cases. A real DMI-load click in prod is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop the insights builder from crashing when loading a DMI**

### What Changed
- Loading a DMI no longer triggers the builder’s tab state to bounce back and forth, which prevented the “Maximum update depth exceeded” crash.
- Tab changes that come from the parent route are no longer sent back up again, so the builder keeps the selected tab stable instead of looping.
- Manual tab clicks and other direct user actions still update the parent as expected.

### Impact
`✅ DMI loads no longer crash the insights builder`
`✅ Fewer builder freezes from tab switching loops`
`✅ Clearer DMI opening flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
