### PR TITLE
fix(builder): remove racy tab-sync echo effect — kills the DMI #185 loop for good

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -977,15 +977,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Main builder tab (task vs assessment)
     const [mainBuilderTab, setMainBuilderTab] = useState<'task' | 'assessment'>('task')
 
-    // Notify the parent ONLY of locally-originated tab changes. When the change
-    // came FROM the parent (prop → local via the sync effect below), local
-    // already equals mainTabProp, so we must NOT echo it back up — that echo is
-    // what looped the controlled/uncontrolled tab forever (React #185, seen on
-    // DMI load which drives the tab to 'test-pci' from the parent).
-    useEffect(() => {
-      if (mainTabProp !== undefined && mainTab === mainTabProp) return
-      onMainTabChange?.(mainTab)
-    }, [mainTab, mainTabProp, onMainTabChange])
+    // NOTE: we deliberately do NOT auto-notify the parent of `mainTab` from an
+    // effect. The parent (route) is the source of truth; it flows `mainTab` down
+    // as a prop and we mirror it locally via the sync effect below. Every genuine
+    // LOCAL change already notifies the parent directly at its action site (the
+    // Tabs onValueChange and the DMI-load handler both call onMainTabChange).
+    // An automatic effect that pushed local→parent raced the parent→local sync
+    // one render apart and ping-ponged the tab forever (React #185 — first
+    // builder↔test-pci, then test-pci↔live). Direct-notify-only breaks the race.
 
     // Reset builder to blank slate whenever the builder tab is clicked
     useEffect(() => {


### PR DESCRIPTION
## **User description**
## Symptom
DMI insights builder still crashes with React #185 — but the new render trace shows it oscillating **test-pci ↔ live** (controlsMode test ↔ classroom), on a **draft course with `sid: null`** (which should never be in classroom mode). #262 fixed the earlier builder↔test-pci flip; this is a second instance of the same structural bug.

## Root cause (structural)
`CourseBuilder` had **two effects syncing the tab in opposite directions**:
- push: auto-call `onMainTabChange(localMainTab)` whenever local changes;
- pull: `setMainTab(mainTabProp)` whenever the parent prop changes.

When the parent changes the tab, these run **one render apart** with opposite stale values and ping-pong forever. My #262 guard (`skip if local === prop`) couldn't fix it because *during the race local and prop are never equal in the same render*.

## Fix
Delete the automatic upward-push effect entirely. The route is the single source of truth (flows `mainTab` down; we mirror it via the existing prop→local sync). Every genuine local change **already notifies the parent directly** at its action site — the Tabs `onValueChange` and the DMI-load handler both call `onMainTabChange` — so nothing is lost.

With no automatic state-pushing effect remaining, `activeMainTab`/`controlsMode` can only change from the one-time `isClassroomMode` effect or real user actions → **the oscillation is structurally impossible**, not just guarded.

## Verification
- `npm run build` ✓ (1170 pages); typecheck clean.
- I audited every `setMainTab`/`onMainTabChange` site: both local action sites notify directly; the only other `setMainTab` is the prop→local sync (correctly silent). No remaining effect pushes tab/mode state.
- ⚠️ Couldn't drive the deep DMI-load UI end-to-end here, but the fix removes the *mechanism* of the loop rather than guarding a symptom. The diagnostic render-trace already in the insights route will catch any recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stop the DMI builder from bouncing between tabs and crashing

### What Changed
- Removed the automatic tab update that echoed local tab changes back to the parent
- The builder now updates the parent only from direct user actions and DMI-load changes
- This removes the tab ping-pong that could trigger a React crash during DMI loading

### Impact
`✅ Fewer builder crashes during DMI loading`
`✅ Stable tab switching between live and test-pci`
`✅ No more tab loop when changing builder state`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
