### PR TITLE
test(insights): e2e guard for builder mode-tab render loop; drop dead error-boundary stack path

### DIFF
--- a/tutorme-app/e2e/insights-tab-loop.spec.ts
+++ b/tutorme-app/e2e/insights-tab-loop.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * E2E regression: the insights builder must survive repeated mode-tab clicks.
+ *
+ * Clicking the Build / Test / Classroom mode tabs used to trigger React error
+ * #185 ("Maximum update depth exceeded") — a render loop from CourseBuilder
+ * mirroring its `mainTab` prop into local state and echoing it back to the
+ * parent one render apart. The PanelErrorBoundary then swapped the builder for
+ * "Couldn't display the insights builder." Fixed by removing the upward-push
+ * effect (PR #264). This guards against any recurrence of that bug class.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Insights builder — mode tabs', () => {
+  test('clicking Build/Test/Classroom repeatedly does not crash the builder', async ({ page }) => {
+    // Surface React #185 / update-depth as a test failure even when the error
+    // boundary contains it (the boundary swallows the throw but logs to console).
+    const loopErrors: string[] = []
+    page.on('pageerror', e => {
+      if (/#185|Maximum update depth/i.test(e.message)) loopErrors.push(`pageerror: ${e.message}`)
+    })
+    page.on('console', m => {
+      const t = m.text()
+      if (/#185|Maximum update depth|insights builder/i.test(t)) loopErrors.push(`console: ${t}`)
+    })
+
+    // Log in as a tutor (same convention as tutor-course-config.spec.ts).
+    await page.goto('/login')
+    await page.locator('#email').fill(process.env.E2E_TUTOR_EMAIL ?? 'tutor@example.com')
+    await page.locator('#password').fill(process.env.E2E_TUTOR_PASSWORD ?? 'Password1')
+    await page.getByRole('button', { name: 'Login' }).click()
+    await expect(page).toHaveURL(/\/tutor\/dashboard/, { timeout: 10000 })
+
+    // Open the standalone insights builder shell.
+    await page.goto('/tutor/insights')
+
+    // The mode tabs are part of the builder shell (TutorControlsPanel). Scope to
+    // that tablist so we don't collide with the panel's own inner tabs (which
+    // also include "Build" / "Classroom" labels).
+    const modeTabs = page.getByTestId('builder-mode-tabs')
+    await expect(modeTabs.getByRole('tab', { name: 'Build', exact: true })).toBeVisible({
+      timeout: 15000,
+    })
+
+    const crashText = page.getByText(
+      /Couldn.t display the insights builder|Maximum update depth|Minified React error #185/i
+    )
+    await expect(crashText).toHaveCount(0)
+
+    // Cycle through the mode tabs several times — this is the exact gesture that
+    // used to crash on the first click.
+    const sequence = ['Test', 'Build', 'Classroom', 'Build', 'Test', 'Classroom']
+    for (const label of sequence) {
+      await modeTabs.getByRole('tab', { name: label, exact: true }).click()
+      // Give any (now-removed) render loop a chance to blow the stack.
+      await page.waitForTimeout(500)
+      await expect(
+        crashText,
+        `builder crashed after clicking "${label}"`
+      ).toHaveCount(0)
+    }
+
+    expect(loopErrors, `unexpected render-loop errors:\n${loopErrors.join('\n')}`).toEqual([])
+  })
+})

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -214,7 +214,10 @@ function TutorControlsPanel({
                   onValueChange={v => onModeChange(v as ControlsMode)}
                   className="mt-2 w-full"
                 >
-                  <TabsList className="grid h-9 w-full grid-cols-3 gap-1 rounded-lg bg-white/10 p-1">
+                  <TabsList
+                    data-testid="builder-mode-tabs"
+                    className="grid h-9 w-full grid-cols-3 gap-1 rounded-lg bg-white/10 p-1"
+                  >
                     <TabsTrigger
                       value="build"
                       className={cn(

--- a/tutorme-app/src/components/ui/panel-error-boundary.tsx
+++ b/tutorme-app/src/components/ui/panel-error-boundary.tsx
@@ -8,17 +8,10 @@ interface PanelErrorBoundaryProps {
   resetKeys?: unknown[]
   /** Label shown in the fallback, e.g. "this view" (default) or "the Test panel". */
   label?: string
-  /**
-   * When true, render the React component stack inside the fallback (collapsed)
-   * so it can be read/screenshotted without opening the console. Used to
-   * diagnose a hard-to-reproduce crash; the stack still goes to console too.
-   */
-  showStack?: boolean
 }
 
 interface PanelErrorBoundaryState {
   error: Error | null
-  componentStack: string | null
 }
 
 /**
@@ -35,7 +28,7 @@ export class PanelErrorBoundary extends Component<
   PanelErrorBoundaryProps,
   PanelErrorBoundaryState
 > {
-  state: PanelErrorBoundaryState = { error: null, componentStack: null }
+  state: PanelErrorBoundaryState = { error: null }
 
   static getDerivedStateFromError(error: Error): Partial<PanelErrorBoundaryState> {
     return { error }
@@ -43,7 +36,6 @@ export class PanelErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('[PanelErrorBoundary] render error contained:', error, info.componentStack)
-    this.setState({ componentStack: info.componentStack ?? null })
   }
 
   componentDidUpdate(prevProps: PanelErrorBoundaryProps) {
@@ -51,11 +43,11 @@ export class PanelErrorBoundary extends Component<
     const prev = prevProps.resetKeys ?? []
     const next = this.props.resetKeys ?? []
     if (prev.length !== next.length || prev.some((v, i) => !Object.is(v, next[i]))) {
-      this.setState({ error: null, componentStack: null })
+      this.setState({ error: null })
     }
   }
 
-  private reset = () => this.setState({ error: null, componentStack: null })
+  private reset = () => this.setState({ error: null })
 
   render() {
     if (this.state.error) {
@@ -73,16 +65,6 @@ export class PanelErrorBoundary extends Component<
           >
             Try again
           </button>
-          {this.props.showStack && this.state.componentStack && (
-            <details className="mt-2 max-w-xl text-left">
-              <summary className="cursor-pointer text-xs font-medium text-slate-600">
-                Diagnostic details (component stack)
-              </summary>
-              <pre className="mt-1 max-h-64 overflow-auto whitespace-pre-wrap rounded bg-slate-50 p-2 text-[10px] leading-tight text-slate-700">
-                {this.state.componentStack}
-              </pre>
-            </details>
-          )}
         </div>
       )
     }


### PR DESCRIPTION
## What

1. **Regression test (#1).** `e2e/insights-tab-loop.spec.ts` logs in as a tutor, opens `/tutor/insights`, and cycles the **Build / Test / Classroom** mode tabs. It asserts the builder never shows "Couldn't display the insights builder" and that no React #185 "Maximum update depth" error reaches the console/page — guarding the loop fixed in #264. Scoped to a new `data-testid="builder-mode-tabs"` on the mode tablist so it doesn't collide with the panel's inner Build/Classroom tabs.
2. **Dead-code removal (#2).** Drops the now-unused `showStack` prop and the component-stack `<details>` render path from `PanelErrorBoundary` (no caller passed `showStack` after #265).

## Verification

- Ran the new spec against a local dev server — **passes** (cycles all 6 tab clicks, no crash, no #185). Uses the exact gesture that crashed pre-#264.
- `npm run typecheck` + `npm run build` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)