### PR TITLE
style: change Classroom and Monitor display viewport border to orange-500

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8148,9 +8148,9 @@ FEEDBACK: [your explanation]`
                     className={cn(
                       'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl bg-white shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
                       mainTab === 'live'
-                        ? 'border border-orange-200'
+                        ? 'border border-orange-500'
                         : mainTab === 'test-pci'
-                          ? 'border border-purple-200'
+                          ? 'border border-orange-500'
                           : 'border border-[#E5E7EB]'
                     )}
                   >


### PR DESCRIPTION
## Summary
Change the display viewport border color in Classroom view mode from light gray/purple to orange-500 (matching the Classroom header bar).

## Changes
- **File:** 
- **Line 8151:** Live mode outer Card border:  → 
- **Line 8153:** Test-PCI mode outer Card border:  → 

## Effect
Both the **Classroom** tab and **Monitor** tab display viewports now have an orange-500 border that matches the Classroom header bar color. The border is applied at the shared Card wrapper level, so all tabs within the live mode (Classroom, Whiteboards, Monitor) inherit the same orange border.

## Testing
- Prettier formatting applied (file unchanged after format)
- Minimal 2-line change