### PR TITLE
fix(insights): make analytics display fill Desk panel height

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AnalyticsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AnalyticsPanel.tsx
@@ -89,34 +89,36 @@ export function AnalyticsPanel({
   }, [liveTasks, totalStudents])
 
   return (
-    <div className="flex flex-1 flex-col space-y-4 px-1 pb-0">
+    <div className="flex h-full flex-col space-y-4 px-1 pb-0">
       {/* Student presence */}
-      <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
+      <div className="flex flex-1 flex-col rounded-xl border bg-white/80 p-3 shadow-sm">
         <p className="mb-2 text-xs font-semibold uppercase text-gray-500">Student Presence</p>
-        {studentStatusData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={160}>
-            <PieChart>
-              <Pie
-                data={studentStatusData}
-                cx="50%"
-                cy="50%"
-                innerRadius={40}
-                outerRadius={60}
-                paddingAngle={3}
-                dataKey="value"
-              >
-                {studentStatusData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
-        ) : (
-          <div className="flex h-[160px] items-center justify-center text-xs text-gray-400">
-            No students have joined yet
-          </div>
-        )}
+        <div className="flex flex-1 flex-col">
+          {studentStatusData.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={studentStatusData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={60}
+                  paddingAngle={3}
+                  dataKey="value"
+                >
+                  {studentStatusData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-xs text-gray-400">
+              No students have joined yet
+            </div>
+          )}
+        </div>
         <div className="mt-1 flex flex-wrap gap-2">
           {studentStatusData.map(d => (
             <div key={d.name} className="flex items-center gap-1 text-[10px] text-gray-600">
@@ -180,11 +182,11 @@ export function AnalyticsPanel({
 
       {/* Student List — name, real presence, and real task-completion badge */}
       {students && students.length > 0 && (
-        <div className="rounded-xl border bg-white/80 p-3 shadow-sm">
+        <div className="flex flex-1 flex-col rounded-xl border bg-white/80 p-3 shadow-sm">
           <p className="mb-2 text-xs font-semibold uppercase text-gray-500">
             Students ({students.length})
           </p>
-          <div className="max-h-[200px] space-y-1 overflow-y-auto">
+          <div className="flex-1 space-y-1 overflow-y-auto">
             {students.map(s => (
               <div
                 key={s.id}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8283,7 +8283,7 @@ FEEDBACK: [your explanation]`
 
                                           <TabsContent
                                             value="analytics"
-                                            className="flex flex-1 flex-col justify-end overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
+                                            className="flex flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                           >
                                             <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
                                               <AnalyticsPanel


### PR DESCRIPTION
- AnalyticsPanel: use h-full and flex-1 instead of fixed 160px heights
- Student List: use flex-1 instead of max-h-[200px]
- CourseBuilder: remove justify-end from TabsContent to let display fill space