### PR TITLE
ci: advisory e2e job for the insights tab-loop regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,97 @@ jobs:
 
       - name: Run integration tests
         run: npm run test:integration
+
+  # Advisory (non-blocking) e2e smoke for the insights builder. Boots the built
+  # app against an ephemeral Postgres, seeds a tutor, and runs the tab-loop
+  # regression spec (guards the React #185 loop fixed in #262/#264/#280). Marked
+  # continue-on-error and intentionally NOT a required check while it proves out
+  # — promote it to required once it has a stable green history.
+  e2e-insights:
+    name: E2E insights (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: tutorme
+          POSTGRES_PASSWORD: tutorme_password
+          POSTGRES_DB: tutorme_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      DATABASE_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
+      DIRECT_URL: postgresql://tutorme:tutorme_password@localhost:5432/tutorme_test
+      NEXTAUTH_SECRET: e2e-ci-secret-insecure-but-long-enough-32chars
+      NEXTAUTH_URL: http://localhost:3003
+      PLAYWRIGHT_BASE_URL: http://localhost:3003
+      E2E_TUTOR_EMAIL: tutor@example.com
+      E2E_TUTOR_PASSWORD: Password1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tutorme-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Linux native bindings (Next.js build on ubuntu-latest)
+        run: npm install --no-save --legacy-peer-deps @parcel/watcher-linux-x64-glibc @swc/core-linux-x64-gnu @next/swc-linux-x64-gnu
+
+      - name: Generate Drizzle Types
+        run: npx drizzle-kit generate
+
+      - name: Build
+        run: npm run build
+
+      - name: Push schema to test database
+        run: npx drizzle-kit push --force
+
+      - name: Seed e2e tutor
+        run: npx tsx src/scripts/seed-e2e-tutor.ts
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start app
+        # server.ts is the canonical entrypoint (custom server + Socket.io); it
+        # binds :3003 and serves the production .next build.
+        run: |
+          NODE_ENV=production npx tsx server.ts > /tmp/app.log 2>&1 &
+          echo $! > /tmp/app.pid
+
+      - name: Wait for app to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3003/login >/dev/null; then echo "app is up"; exit 0; fi
+            sleep 2
+          done
+          echo "app did not become ready in time"; cat /tmp/app.log; exit 1
+
+      - name: Run insights tab-loop spec
+        run: npx playwright test e2e/insights-tab-loop.spec.ts --project=chromium
+
+      - name: App logs (on failure)
+        if: failure()
+        run: cat /tmp/app.log || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-insights
+          path: tutorme-app/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/tutorme-app/src/scripts/seed-e2e-tutor.ts
+++ b/tutorme-app/src/scripts/seed-e2e-tutor.ts
@@ -22,11 +22,7 @@ export async function seedE2ETutor(): Promise<void> {
   // Same cost factor used by the app's hashPassword; authorize() compares with bcrypt.
   const hashedPassword = await bcrypt.hash(password, 12)
 
-  const [existingUser] = await drizzleDb
-    .select()
-    .from(user)
-    .where(eq(user.email, email))
-    .limit(1)
+  const [existingUser] = await drizzleDb.select().from(user).where(eq(user.email, email)).limit(1)
 
   let userId = existingUser?.userId
   if (userId) {

--- a/tutorme-app/src/scripts/seed-e2e-tutor.ts
+++ b/tutorme-app/src/scripts/seed-e2e-tutor.ts
@@ -1,0 +1,81 @@
+/**
+ * Seeds a deterministic TUTOR account for e2e tests (used by the CI e2e job).
+ * Idempotent — safe to run repeatedly.
+ *
+ * Credentials come from E2E_TUTOR_EMAIL / E2E_TUTOR_PASSWORD; the defaults match
+ * the Playwright specs (tutor@example.com / Password1). The profile is created
+ * onboarded + TOS-accepted so the post-login redirect lands on /tutor/dashboard
+ * rather than the onboarding flow.
+ *
+ * Run with: npx tsx src/scripts/seed-e2e-tutor.ts
+ */
+
+import crypto from 'crypto'
+import bcrypt from 'bcryptjs'
+import { eq } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, profile } from '@/lib/db/schema'
+
+export async function seedE2ETutor(): Promise<void> {
+  const email = (process.env.E2E_TUTOR_EMAIL ?? 'tutor@example.com').trim().toLowerCase()
+  const password = process.env.E2E_TUTOR_PASSWORD ?? 'Password1'
+  // Same cost factor used by the app's hashPassword; authorize() compares with bcrypt.
+  const hashedPassword = await bcrypt.hash(password, 12)
+
+  const [existingUser] = await drizzleDb
+    .select()
+    .from(user)
+    .where(eq(user.email, email))
+    .limit(1)
+
+  let userId = existingUser?.userId
+  if (userId) {
+    await drizzleDb
+      .update(user)
+      .set({ password: hashedPassword, role: 'TUTOR', status: 'active' })
+      .where(eq(user.userId, userId))
+  } else {
+    userId = crypto.randomUUID()
+    await drizzleDb.insert(user).values({
+      userId,
+      email,
+      password: hashedPassword,
+      role: 'TUTOR',
+      status: 'active',
+      emailVerified: new Date(),
+    })
+  }
+
+  const [existingProfile] = await drizzleDb
+    .select()
+    .from(profile)
+    .where(eq(profile.userId, userId))
+    .limit(1)
+
+  if (existingProfile) {
+    await drizzleDb
+      .update(profile)
+      .set({ isOnboarded: true, tosAccepted: true, tosAcceptedAt: new Date() })
+      .where(eq(profile.userId, userId))
+  } else {
+    await drizzleDb.insert(profile).values({
+      profileId: crypto.randomUUID(),
+      userId,
+      name: 'E2E Tutor',
+      isOnboarded: true,
+      tosAccepted: true,
+      tosAcceptedAt: new Date(),
+    })
+  }
+
+  console.log(`✓ Seeded e2e tutor: ${email} (role TUTOR, onboarded)`)
+}
+
+if (require.main === module) {
+  seedE2ETutor()
+    .then(() => process.exit(0))
+    .catch(err => {
+      console.error('e2e tutor seed failed:', err)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
## Why

`e2e/insights-tab-loop.spec.ts` (added in #279, guarding the React #185 tab loop fixed in #262/#264/#280) **never ran in CI** — `ci.yml` only runs unit + integration tests, nothing in `e2e/`. The regression guard was effectively manual. This makes it run automatically.

## What

- **`src/scripts/seed-e2e-tutor.ts`** — idempotent seed of a deterministic `TUTOR` account (`E2E_TUTOR_EMAIL`/`E2E_TUTOR_PASSWORD`, defaults `tutor@example.com`/`Password1`) with an onboarded, TOS-accepted profile so the post-login redirect lands on `/tutor/dashboard`.
- **`E2E insights (advisory)` CI job** — ephemeral Postgres → `drizzle-kit push` → seed → build → boot the canonical `server.ts` on `:3003` → run the tab-loop spec under chromium. Uploads the Playwright report as an artifact.

## Advisory by design

The job is `continue-on-error: true` and is **not** added to the branch-protection required checks, so it won't block merges while it stabilizes. Promote it to a required check once it has a consistent green history.

## Verification

Ran the whole path locally: seed creates the default-cred tutor → the spec logs in with the defaults → reaches the insights builder → cycles Build/Test/Classroom with **zero #185 errors**. Typecheck + workflow YAML both valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)