### PR TITLE
feat(student-live): double-click an assessment to open the Assessment tab

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1686,6 +1686,15 @@ function StudentFeedbackContent() {
                       key={task.id}
                       type="button"
                       onClick={() => handleSelectTask(task.id)}
+                      onDoubleClick={() => {
+                        handleSelectTask(task.id)
+                        // Double-clicking an assessment (or any task that carries
+                        // DMI questions) jumps straight to its answer inputs in
+                        // the Assessment tab.
+                        if (task.source === 'assessment' || (task.dmiItems?.length ?? 0) > 0) {
+                          setRightPanelTab('dmi')
+                        }
+                      }}
                       className={`flex w-full flex-col gap-1 rounded-lg border px-3 py-2 text-left transition-colors ${
                         activeTaskId === task.id
                           ? 'border-blue-200 bg-blue-50'


### PR DESCRIPTION
In the student classroom (`/student/feedback`), **double-clicking** a task in the Lessons panel now also opens the right-hand **Assessment** tab when the task is an assessment (or carries DMI questions) — taking the student straight to the answer inputs. A single click still just selects/opens the task in the center viewer as before.

Verified: typecheck + lint clean; the Lessons button keeps its single-click select and gains a double-click that calls `setRightPanelTab('dmi')` for assessments / tasks with `dmiItems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)