### PR TITLE
feat(dmi): typed answer-input fields — Phase 1 (model + agent + student rendering)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -61,7 +61,14 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/componen
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
-import type { LiveTask, LiveTaskPoll, LiveTaskQuestion, ChatMessage } from '@/lib/socket'
+import type {
+  LiveTask,
+  LiveTaskPoll,
+  LiveTaskQuestion,
+  LiveTaskDmiItem,
+  ChatMessage,
+} from '@/lib/socket'
+import { normalizeDmiQuestionType, DMI_QUESTION_TYPE_LABELS } from '@/lib/assessment/question-types'
 
 type WhiteboardPages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
 type WhiteboardPage = WhiteboardPages[number]
@@ -297,6 +304,120 @@ function ClassroomControlsPanel({
         </motion.div>
       </div>
     </div>
+  )
+}
+
+/**
+ * Renders the answer input for a single DMI item according to its questionType.
+ * Answers are stored as plain strings in `taskAnswers` (multiple_response stores
+ * a JSON array string). Interactive types without a dedicated renderer yet
+ * (matching/ordering/hotspot/drag_drop) fall back to a free-text field.
+ */
+function DmiAnswerField({
+  item,
+  value,
+  onValueChange,
+  onInteract,
+}: {
+  item: LiveTaskDmiItem
+  value: string
+  onValueChange: (next: string) => void
+  onInteract: () => void
+}) {
+  const type = normalizeDmiQuestionType(item.questionType)
+  const options =
+    item.options && item.options.length > 0
+      ? item.options
+      : type === 'true_false'
+        ? ['True', 'False']
+        : []
+  const baseField =
+    'w-full rounded-md border border-gray-200 p-2 text-sm focus:border-[#F17623] focus:outline-none'
+
+  // Single-select choice (mcq / true_false) — render radios when we have options.
+  if ((type === 'mcq' || type === 'true_false') && options.length > 0) {
+    return (
+      <div className="space-y-1.5">
+        {options.map(opt => (
+          <label key={opt} className="flex items-center gap-2 text-sm text-gray-800">
+            <input
+              type="radio"
+              name={`dmi-${item.id}`}
+              checked={value === opt}
+              onChange={() => {
+                onInteract()
+                onValueChange(opt)
+              }}
+              className="h-4 w-4 accent-[#F17623]"
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    )
+  }
+
+  // Multi-select choice — checkboxes; answer stored as a JSON array string.
+  if (type === 'multiple_response' && options.length > 0) {
+    let selected: string[] = []
+    try {
+      const parsed = value ? JSON.parse(value) : []
+      if (Array.isArray(parsed)) selected = parsed.filter((v): v is string => typeof v === 'string')
+    } catch {
+      selected = []
+    }
+    const toggle = (opt: string) => {
+      onInteract()
+      const next = selected.includes(opt) ? selected.filter(o => o !== opt) : [...selected, opt]
+      onValueChange(JSON.stringify(next))
+    }
+    return (
+      <div className="space-y-1.5">
+        {options.map(opt => (
+          <label key={opt} className="flex items-center gap-2 text-sm text-gray-800">
+            <input
+              type="checkbox"
+              checked={selected.includes(opt)}
+              onChange={() => toggle(opt)}
+              className="h-4 w-4 accent-[#F17623]"
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    )
+  }
+
+  // Short answer & fill-in-the-blank — single-line input. Choice types with no
+  // options provided fall back here so the student is never stuck.
+  if (type === 'short' || type === 'fill_blank' || type === 'mcq' || type === 'multiple_response') {
+    return (
+      <input
+        type="text"
+        value={value}
+        onFocus={onInteract}
+        onChange={e => {
+          onInteract()
+          onValueChange(e.target.value)
+        }}
+        placeholder={type === 'fill_blank' ? 'Fill in the blank…' : 'Type your answer…'}
+        className={baseField}
+      />
+    )
+  }
+
+  // Long answer + interactive types pending dedicated renderers → free-text.
+  return (
+    <textarea
+      value={value}
+      onFocus={onInteract}
+      onChange={e => {
+        onInteract()
+        onValueChange(e.target.value)
+      }}
+      placeholder="Type your answer…"
+      className={`min-h-[64px] resize-y ${baseField}`}
+    />
   )
 }
 
@@ -1722,33 +1843,38 @@ function StudentFeedbackContent() {
                       <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
                         Questions
                       </p>
-                      {activeTask.dmiItems.map(item => (
-                        <div
-                          key={item.id}
-                          className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-                        >
-                          <p className="mb-2 text-sm font-medium text-gray-800">
-                            {item.questionNumber ? `${item.questionNumber}. ` : ''}
-                            {item.questionText}
-                          </p>
-                          <textarea
-                            value={taskAnswers[item.id] ?? ''}
-                            // Once the student starts working on a task/assessment,
-                            // stop auto-following the tutor so their navigation can't
-                            // yank the student away from what they're answering.
-                            onFocus={() => setFollowTutor(false)}
-                            onChange={e => {
-                              setFollowTutor(false)
-                              setTaskAnswers(prev => ({
-                                ...prev,
-                                [item.id]: e.target.value,
-                              }))
-                            }}
-                            placeholder="Type your answer…"
-                            className="min-h-[64px] w-full resize-y rounded-md border border-gray-200 p-2 text-sm focus:border-[#F17623] focus:outline-none"
-                          />
-                        </div>
-                      ))}
+                      {activeTask.dmiItems.map(item => {
+                        const qType = normalizeDmiQuestionType(item.questionType)
+                        return (
+                          <div
+                            key={item.id}
+                            className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                          >
+                            <div className="mb-2 flex items-start justify-between gap-2">
+                              <p className="text-sm font-medium text-gray-800">
+                                {item.questionNumber ? `${item.questionNumber}. ` : ''}
+                                {item.questionText}
+                              </p>
+                              {qType !== 'long' && (
+                                <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+                                  {DMI_QUESTION_TYPE_LABELS[qType]}
+                                </span>
+                              )}
+                            </div>
+                            <DmiAnswerField
+                              item={item}
+                              value={taskAnswers[item.id] ?? ''}
+                              // Once the student starts working, stop auto-following
+                              // the tutor so their navigation can't yank the student
+                              // away from what they're answering.
+                              onInteract={() => setFollowTutor(false)}
+                              onValueChange={next =>
+                                setTaskAnswers(prev => ({ ...prev, [item.id]: next }))
+                              }
+                            />
+                          </div>
+                        )
+                      })}
                     </div>
                   ) : (
                     <p className="text-sm text-gray-500">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2224,6 +2224,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 id: i.id,
                 questionNumber: i.questionNumber,
                 questionText: i.questionText,
+                questionType: i.questionType,
+                options: i.options,
               })) || [],
             deployedAt: Date.now(),
             polls: [],
@@ -2748,6 +2750,10 @@ FEEDBACK: [your explanation]`
           questionNumber: q.questionNumber || 1,
           questionText: q.questionText || 'Question',
           answer: q.answer || '',
+          // Carry the answer-input type + choice options through to the deployed
+          // DMI so the student sees the right control (short/mcq/etc.).
+          questionType: q.questionType,
+          options: Array.isArray(q.options) ? q.options : undefined,
         }))
 
         // Calculate version number

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -63,6 +63,10 @@ export interface DMIQuestion {
   questionNumber: number
   questionText: string
   answer: string
+  /** Which answer-input control the student sees (defaults to long answer). */
+  questionType?: import('@/lib/assessment/question-types').DmiQuestionType
+  /** Options for choice types (mcq / true_false / multiple_response). */
+  options?: string[]
 }
 
 export interface DMIVersion {

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -11,6 +11,12 @@ import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { generateWithKimi, generateWithKimiVision } from '@/lib/ai/kimi'
 import { stripCodeFences } from '@/lib/ai/llm-response'
 import {
+  DMI_QUESTION_TYPES,
+  DMI_QUESTION_TYPE_LABELS,
+  normalizeDmiQuestionType,
+  type DmiQuestionType,
+} from '@/lib/assessment/question-types'
+import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
   type GuardrailViolation,
@@ -24,63 +30,112 @@ const GenerateDmiRequestSchema = z.object({
   title: z.string().max(200).optional(),
   content: z.string().max(50000).optional(),
   pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
+  /**
+   * For study material: the question types + counts the tutor wants generated.
+   * Ignored for a question paper (its questions are mirrored as-is).
+   */
+  questionSpec: z
+    .array(z.object({ type: z.enum(DMI_QUESTION_TYPES), count: z.number().int().min(1).max(50) }))
+    .max(10)
+    .optional(),
 })
 
-const SYSTEM_PROMPT = `You are an expert educational assessment designer.
+const SYSTEM_PROMPT = `You are an expert educational assessment designer building a DMI (Digital Marking Interface).
 
-Analyze the provided content and generate structured assessment questions.
+A DMI is a set of ANSWER INPUT FIELDS that a student fills in. The student reads the actual
+questions from the deployed document — your job is to produce, for each question, a well-numbered
+answer field of the RIGHT INPUT TYPE. Do not rewrite or invent questions for a question paper;
+mirror its questions one-to-one as typed input fields.
 
-For each question, output exactly in this format:
-Q[number]: [question text]
+First, classify the source and output it as the very first line:
+KIND: question_paper   (the document already contains questions / exam tasks)
+KIND: study_material   (notes / material with no explicit questions)
+
+Then, for each question, output exactly in this format:
+Q[number] [type]: [question text — copied EXACTLY from the source for a question paper]
+OPTIONS[number]: option 1 | option 2 | option 3      (ONLY for mcq / true_false / multiple_response)
 A[number]: [suggested answer or key points]
 
-Generate 5-10 questions that cover the main concepts, ranging from comprehension to application level.
-Be concise and clear. Do not include any other text outside the Q/A pairs.
+[type] must be exactly one of:
+  short              one-line factual answer
+  long               paragraph / essay answer
+  mcq                multiple choice, exactly one correct option
+  true_false         true / false
+  multiple_response  multiple choice, one or more correct options
+  fill_blank         fill in the blank / cloze
+  matching           match items across two columns
+  ordering           order or rank items
+  hotspot            click a region of an image
+  drag_drop          drag items into targets
+Pick the type that best matches how the question expects to be answered.
 
-Assessment guardrails (follow exactly):
-- This is a tutor-facing Draft DMI. The A[number] answers are for tutor verification ONLY and must never be shown to a student.
-- When the source is an existing exam document, preserve question wording EXACTLY — do not paraphrase or rewrite questions.
-- Do not invent content, mark allocations, or evaluation criteria. If something in the source is unclear, say so in the answer line rather than guessing.
-- Treat suggested answers as examples/key points for the tutor to confirm, not as the only acceptable response.`
+Rules:
+- For a question_paper, preserve question wording EXACTLY — do not paraphrase. If the source has
+  no explicit questions (study_material), generate 5-10 questions covering the main concepts.
+- The A[number] answers are for tutor verification ONLY and must never be shown to a student.
+- Do not invent mark allocations or evaluation criteria. If something is unclear, say so in the A
+  line rather than guessing.
+- Output ONLY the KIND line and the Q / OPTIONS / A lines — no other text.`
 
-function parseDmiResponse(
-  text: string
-): Array<{ questionNumber: number; questionText: string; answer: string }> {
-  const questions: Array<{ questionNumber: number; questionText: string; answer: string }> = []
+interface ParsedDmiQuestion {
+  questionNumber: number
+  questionText: string
+  answer: string
+  questionType: DmiQuestionType
+  options?: string[]
+}
+
+interface ParsedDmiResponse {
+  documentKind: 'question_paper' | 'study_material' | null
+  questions: ParsedDmiQuestion[]
+}
+
+function parseDmiResponse(text: string): ParsedDmiResponse {
+  const questions: ParsedDmiQuestion[] = []
   const lines = text.split('\n')
-  let currentQ: { questionNumber: number; questionText: string; answer: string } | null = null
+  let currentQ: ParsedDmiQuestion | null = null
+  let documentKind: ParsedDmiResponse['documentKind'] = null
 
   for (const rawLine of lines) {
     const line = rawLine.trim()
-    const qMatch = line.match(/^Q(\d+)[:.\)]\s*(.+)$/i)
-    const aMatch = line.match(/^A(\d+)[:.\)]\s*(.+)$/i)
+    if (!line) continue
+
+    const kindMatch = line.match(/^KIND[:.\)]\s*(question_paper|study_material)/i)
+    if (kindMatch && !documentKind) {
+      documentKind = kindMatch[1].toLowerCase() as ParsedDmiResponse['documentKind']
+      continue
+    }
+
+    // Q[n] [type]: text  — the type tag in []/() is optional (back-compat).
+    const qMatch = line.match(/^Q\s*(\d+)\s*(?:[[(]\s*([a-z_]+)\s*[\])])?\s*[:.\)]\s*(.+)$/i)
+    const optMatch = line.match(/^OPTIONS\s*(\d+)\s*[:.\)]\s*(.+)$/i)
+    const aMatch = line.match(/^A\s*(\d+)\s*[:.\)]\s*(.+)$/i)
 
     if (qMatch) {
-      if (currentQ) {
-        questions.push(currentQ)
-      }
+      if (currentQ) questions.push(currentQ)
       currentQ = {
         questionNumber: parseInt(qMatch[1], 10),
-        questionText: qMatch[2].trim(),
+        questionText: qMatch[3].trim(),
         answer: '',
+        questionType: normalizeDmiQuestionType(qMatch[2]?.toLowerCase()),
       }
+    } else if (optMatch && currentQ) {
+      currentQ.options = optMatch[2]
+        .split('|')
+        .map(o => o.trim())
+        .filter(Boolean)
     } else if (aMatch && currentQ) {
       currentQ.answer = aMatch[2].trim()
-    } else if (currentQ && line.length > 0) {
-      // Append to current question text or answer
-      if (currentQ.answer) {
-        currentQ.answer += ' ' + line
-      } else {
-        currentQ.questionText += ' ' + line
-      }
+    } else if (currentQ) {
+      // Continuation line — append to the answer if started, else the question.
+      if (currentQ.answer) currentQ.answer += ' ' + line
+      else currentQ.questionText += ' ' + line
     }
   }
 
-  if (currentQ) {
-    questions.push(currentQ)
-  }
+  if (currentQ) questions.push(currentQ)
 
-  return questions
+  return { documentKind, questions }
 }
 
 export async function POST(request: NextRequest) {
@@ -100,11 +155,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
 
-    const { type, title, content, pdfPages } = parsed.data
+    const { type, title, content, pdfPages, questionSpec } = parsed.data
 
     if (!content?.trim() && (!pdfPages || pdfPages.length === 0)) {
       return NextResponse.json({ error: 'No content or PDF pages provided' }, { status: 400 })
     }
+
+    // When the tutor has specified question types + counts (study material path),
+    // tell the model to generate exactly that mix.
+    const specInstruction =
+      questionSpec && questionSpec.length > 0
+        ? `\n\nThis source is study material. Generate exactly: ${questionSpec
+            .map(s => `${s.count} ${DMI_QUESTION_TYPE_LABELS[s.type]} (${s.type})`)
+            .join(', ')}. Use those exact types and counts.`
+        : ''
 
     let aiResponse: string
 
@@ -114,7 +178,7 @@ export async function POST(request: NextRequest) {
       > = [
         {
           type: 'text',
-          text: `Generate assessment questions from the following ${type}${title ? ` titled "${title}"` : ''}.`,
+          text: `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}.${specInstruction}`,
         },
         ...pdfPages.map(page => ({
           type: 'image_url' as const,
@@ -129,7 +193,7 @@ export async function POST(request: NextRequest) {
         timeoutMs: 60000,
       })
     } else {
-      const prompt = `Generate assessment questions from the following ${type}${title ? ` titled "${title}"` : ''}:\n\n${content}`
+      const prompt = `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}:${specInstruction}\n\n${content}`
       aiResponse = await generateWithKimi(prompt, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
@@ -147,7 +211,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const questions = parseDmiResponse(stripCodeFences(aiResponse))
+    const { documentKind, questions } = parseDmiResponse(stripCodeFences(aiResponse))
 
     // Warn-only assessment guardrails. Checks wording fidelity against the
     // source (ASMT-4) and other structural rules where data is available.
@@ -168,6 +232,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       response: aiResponse,
+      // null when the model didn't classify; the tutor UI treats null as
+      // "question paper" (the common case) and only prompts for types/counts
+      // when it's explicitly study_material with no questionSpec supplied.
+      documentKind,
+      // True when the source is study material and the tutor hasn't yet chosen
+      // the question types/counts — the builder should prompt before deploying.
+      needsQuestionSpec: documentKind === 'study_material' && !questionSpec,
       questions,
       guardrailWarnings,
     })

--- a/tutorme-app/src/lib/assessment/question-types.ts
+++ b/tutorme-app/src/lib/assessment/question-types.ts
@@ -1,0 +1,71 @@
+/**
+ * DMI (Digital Marking Interface) question/answer-field taxonomy.
+ *
+ * A DMI item is an *answer input field* the student fills in — the question
+ * itself is read from the deployed document (a question paper) or from the
+ * generated questions (when the source was study material). `questionType`
+ * decides which input control the student sees and how their answer is stored.
+ *
+ * Phase 1 renders the text/choice types natively; the richer interactive types
+ * (matching, ordering, hotspot, drag_drop) are part of the model now but render
+ * as a labelled free-text field until their dedicated components land.
+ */
+
+export const DMI_QUESTION_TYPES = [
+  'short', // single-line short answer
+  'long', // multi-line / essay
+  'mcq', // multiple choice — exactly one option
+  'true_false', // true / false
+  'multiple_response', // multiple choice — one or more options
+  'fill_blank', // fill in the blank / cloze
+  'matching', // match items in two columns
+  'ordering', // order / rank items
+  'hotspot', // click a region on an image
+  'drag_drop', // drag items into targets
+] as const
+
+export type DmiQuestionType = (typeof DMI_QUESTION_TYPES)[number]
+
+/** The default when an item has no explicit type (back-compat with old DMIs). */
+export const DEFAULT_DMI_QUESTION_TYPE: DmiQuestionType = 'long'
+
+/** Human-readable labels for tutor UI / prompts. */
+export const DMI_QUESTION_TYPE_LABELS: Record<DmiQuestionType, string> = {
+  short: 'Short answer',
+  long: 'Long answer',
+  mcq: 'Multiple choice',
+  true_false: 'True / False',
+  multiple_response: 'Multiple response',
+  fill_blank: 'Fill in the blank',
+  matching: 'Matching',
+  ordering: 'Ordering / Ranking',
+  hotspot: 'Hotspot',
+  drag_drop: 'Drag and drop',
+}
+
+/** Choice types carry an `options` list the student picks from. */
+export const CHOICE_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([
+  'mcq',
+  'true_false',
+  'multiple_response',
+])
+
+/**
+ * Interactive types that don't yet have a dedicated student renderer; they fall
+ * back to a labelled free-text input in Phase 1.
+ */
+export const FALLBACK_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([
+  'matching',
+  'ordering',
+  'hotspot',
+  'drag_drop',
+])
+
+export function isDmiQuestionType(value: unknown): value is DmiQuestionType {
+  return typeof value === 'string' && (DMI_QUESTION_TYPES as readonly string[]).includes(value)
+}
+
+/** Normalize an arbitrary value to a known type, defaulting safely. */
+export function normalizeDmiQuestionType(value: unknown): DmiQuestionType {
+  return isDmiQuestionType(value) ? value : DEFAULT_DMI_QUESTION_TYPE
+}

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -112,6 +112,10 @@ export interface LiveTaskDmiItem {
   id: string
   questionNumber: number
   questionText: string
+  /** Which answer-input control the student sees (defaults to long answer). */
+  questionType?: import('./assessment/question-types').DmiQuestionType
+  /** Options for choice types (mcq / true_false / multiple_response). */
+  options?: string[]
 }
 
 export interface LiveTaskSourceDocument {

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -59,6 +59,10 @@ export interface LiveTaskDmiItem {
   id: string
   questionNumber: number
   questionText: string
+  /** Which answer-input control the student sees (defaults to long answer). */
+  questionType?: import('../assessment/question-types').DmiQuestionType
+  /** Options for choice types (mcq / true_false / multiple_response). */
+  options?: string[]
 }
 
 export interface LiveTaskSourceDocument {


### PR DESCRIPTION
Phase 1 of reframing the DMI as **typed answer-input fields** (per the request: the agent should create well-numbered/labelled input fields per question type, students answer in the Assessment tab while reading the questions from the deployed document).

## What's in Phase 1

- **Taxonomy** (`src/lib/assessment/question-types.ts`): the 10 agreed types — short, long, mcq, true_false, multiple_response, fill_blank, matching, ordering, hotspot, drag_drop — with normalize/label/choice helpers.
- **Data model**: optional `questionType` + `options` on the DMI item types (`LiveTaskDmiItem` ×2, `DMIQuestion`), carried through the CourseBuilder generate→deploy mapping. Fully backward-compatible (missing type ⇒ long answer).
- **Agent** (`generate-dmi`): classifies the source as `question_paper` vs `study_material`, emits a `[type]` tag + `OPTIONS` per question, and accepts an optional `questionSpec` (types+counts) for study material. Returns `documentKind` + `needsQuestionSpec`. Parser extended and back-compat with untagged `Q/A` lines.
- **Student Assessment tab**: new `DmiAnswerField` renders the correct control per type (text input, radios, checkboxes, textarea) with a small type badge. The 4 interactive types fall back to free-text until Phase 3.

## Not in this PR (next phases)

- **Phase 2**: the study-material dialog in the Assessment Builder (tutor picks types + counts) + deploying the *generated questions* to the Classroom tab.
- **Phase 3**: dedicated interactive renderers for matching / ordering / hotspot / drag-and-drop.

## Verification

- `typecheck` + `build` clean; lint 0 errors.
- DMI **parser unit-checked** on a representative model output — KIND, `[type]` tags, `OPTIONS`, and legacy untagged `Q/A` lines all parse correctly (untagged ⇒ `long`).
- **Caveat:** the live LLM call needs an AI key (absent on the local stack), so the agent's *emitted* format is verified by review, not a live run. The student typed rendering is verified by typecheck/review (driving it needs a live session with a deployed DMI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)