### PR TITLE
feat(dmi): deploy generated questions to Classroom (2b) + ordering renderer (Phase 3)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -39,6 +39,7 @@ import {
   FileText,
   ChevronRight,
   ChevronDown,
+  ChevronUp,
   Folder,
   Video,
   Plus,
@@ -406,7 +407,65 @@ function DmiAnswerField({
     )
   }
 
-  // Long answer + interactive types pending dedicated renderers → free-text.
+  // Ordering / ranking — reorder the provided items with up/down controls.
+  // The answer is stored as a JSON array of the items in the chosen order.
+  if (type === 'ordering' && options.length > 0) {
+    let saved: string[] = []
+    try {
+      const parsed = value ? JSON.parse(value) : []
+      if (Array.isArray(parsed)) saved = parsed.filter((v): v is string => typeof v === 'string')
+    } catch {
+      saved = []
+    }
+    // Start from any saved order, then append any options not yet placed so the
+    // list always shows every item exactly once even if options changed.
+    const current = saved.filter(o => options.includes(o))
+    for (const o of options) if (!current.includes(o)) current.push(o)
+    const move = (i: number, dir: -1 | 1) => {
+      const j = i + dir
+      if (j < 0 || j >= current.length) return
+      onInteract()
+      const next = [...current]
+      ;[next[i], next[j]] = [next[j], next[i]]
+      onValueChange(JSON.stringify(next))
+    }
+    return (
+      <ol className="space-y-1.5">
+        {current.map((opt, i) => (
+          <li
+            key={opt}
+            className="flex items-center gap-2 rounded-md border border-gray-200 p-2 text-sm text-gray-800"
+          >
+            <span className="w-5 shrink-0 text-center text-xs font-semibold text-gray-400">
+              {i + 1}
+            </span>
+            <span className="flex-1">{opt}</span>
+            <button
+              type="button"
+              aria-label="Move up"
+              onClick={() => move(i, -1)}
+              disabled={i === 0}
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 disabled:opacity-30"
+            >
+              <ChevronUp className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Move down"
+              onClick={() => move(i, 1)}
+              disabled={i === current.length - 1}
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 disabled:opacity-30"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </button>
+          </li>
+        ))}
+      </ol>
+    )
+  }
+
+  // Long answer + the remaining interactive types (matching / hotspot /
+  // drag_drop) that still need richer data + dedicated renderers → free-text.
   return (
     <textarea
       value={value}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2808,6 +2808,36 @@ FEEDBACK: [your explanation]`
           setTestPciViewMode(`dmi_${newVersion.id}`)
         }
 
+        // Study material: the students must see the GENERATED questions in the
+        // Classroom tab, not the original notes. Replace the deployed content with
+        // the numbered questions and drop the source document so only the
+        // questions (Classroom) + the DMI input fields (Assessment) go out.
+        const isStudyMaterial =
+          data.documentKind === 'study_material' || (questionSpec?.length ?? 0) > 0
+        if (isStudyMaterial) {
+          const generatedClassroomContent = items
+            .map(q => `${q.questionNumber}. ${q.questionText}`)
+            .join('\n\n')
+          if (isTask) {
+            setTaskBuilder(prev => ({
+              ...prev,
+              taskContent: generatedClassroomContent,
+              sourceDocument: undefined,
+            }))
+            setTaskSourceDocument(undefined)
+          } else {
+            setAssessmentBuilder(prev => ({
+              ...prev,
+              taskContent: generatedClassroomContent,
+              sourceDocument: undefined,
+            }))
+            setAssessmentSourceDocument(undefined)
+          }
+          toast.info(
+            'Generated questions set as the Classroom content; the original material will not be deployed.'
+          )
+        }
+
         toast.success(`DMI form v${nextVersionNumber} created with ${items.length} questions`)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to generate DMI'


### PR DESCRIPTION
## Phase 2b — generated questions go to the Classroom tab (study material)

After generating a DMI from **study material** (`documentKind=study_material`, or a `questionSpec` was used), the builder now replaces the deployed content with the **numbered generated questions** and drops the source document. Result: students see the generated questions in the **Classroom** tab and the answer input fields in the **Assessment** tab — the original notes are not deployed. Question papers are unaffected (their original document still deploys).

## Phase 3 — ordering / ranking renderer

`ordering` now has a real student control: the provided options render as a **reorderable list** (up/down), with the answer stored as a JSON array in the chosen order (self-healing if the options change). 

`matching` / `hotspot` / `drag_drop` still fall back to free-text — they need richer data (pairs / image regions / drop targets) emitted by the agent plus a tutor editor, which is a per-type follow-up rather than a render-only change.

## Verification

- `typecheck` + `build` clean.
- Ordering reorder/init logic **unit-checked**: init = options order, swap, boundary no-op, restore-from-saved, append-newly-added.
- The study-material deploy branch needs the LLM to classify a source as study material (no AI key on the local stack), so it's verified by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)