### PR TITLE
feat(dmi): matching question type — full pipeline

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -407,6 +407,49 @@ function DmiAnswerField({
     )
   }
 
+  // Matching — show each left prompt with a dropdown of the (sorted) right
+  // values. The answer is stored as a JSON map of left -> chosen right.
+  if (type === 'matching' && item.pairs && item.pairs.length > 0) {
+    const pairs = item.pairs
+    const rightBank = Array.from(new Set(pairs.map(p => p.right))).sort((a, b) =>
+      a.localeCompare(b)
+    )
+    let answerMap: Record<string, string> = {}
+    try {
+      const parsed = value ? JSON.parse(value) : {}
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) answerMap = parsed
+    } catch {
+      answerMap = {}
+    }
+    const setMatch = (left: string, right: string) => {
+      onInteract()
+      onValueChange(JSON.stringify({ ...answerMap, [left]: right }))
+    }
+    return (
+      <div className="space-y-2">
+        {pairs.map(p => (
+          <div key={p.left} className="flex items-center gap-2 text-sm">
+            <span className="flex-1 text-gray-800">{p.left}</span>
+            <span className="shrink-0 text-gray-300">→</span>
+            <select
+              value={answerMap[p.left] ?? ''}
+              onFocus={onInteract}
+              onChange={e => setMatch(p.left, e.target.value)}
+              className={`w-44 shrink-0 ${baseField}`}
+            >
+              <option value="">Choose…</option>
+              {rightBank.map(r => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
   // Ordering / ranking — reorder the provided items with up/down controls.
   // The answer is stored as a JSON array of the items in the chosen order.
   if (type === 'ordering' && options.length > 0) {
@@ -464,8 +507,8 @@ function DmiAnswerField({
     )
   }
 
-  // Long answer + the remaining interactive types (matching / hotspot /
-  // drag_drop) that still need richer data + dedicated renderers → free-text.
+  // Long answer + the remaining interactive types (hotspot / drag_drop, and
+  // matching/ordering when they arrive without their data) → free-text.
   return (
     <textarea
       value={value}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2237,6 +2237,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 questionText: i.questionText,
                 questionType: i.questionType,
                 options: i.options,
+                pairs: i.pairs,
               })) || [],
             deployedAt: Date.now(),
             polls: [],
@@ -2780,6 +2781,7 @@ FEEDBACK: [your explanation]`
           // DMI so the student sees the right control (short/mcq/etc.).
           questionType: q.questionType,
           options: Array.isArray(q.options) ? q.options : undefined,
+          pairs: Array.isArray(q.pairs) ? q.pairs : undefined,
         }))
 
         // Calculate version number

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -67,6 +67,8 @@ export interface DMIQuestion {
   questionType?: import('@/lib/assessment/question-types').DmiQuestionType
   /** Options for choice types (mcq / true_false / multiple_response). */
   options?: string[]
+  /** Correct left↔right pairs for `matching` (the right values form the bank). */
+  pairs?: import('@/lib/assessment/question-types').DmiMatchPair[]
 }
 
 export interface DMIVersion {

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -54,6 +54,7 @@ KIND: study_material   (notes / material with no explicit questions)
 Then, for each question, output exactly in this format:
 Q[number] [type]: [question text — copied EXACTLY from the source for a question paper]
 OPTIONS[number]: option 1 | option 2 | option 3      (ONLY for mcq / true_false / multiple_response)
+PAIRS[number]: left A :: right 1 | left B :: right 2 | left C :: right 3   (ONLY for matching)
 A[number]: [suggested answer or key points]
 
 [type] must be exactly one of:
@@ -73,9 +74,11 @@ Rules:
 - For a question_paper, preserve question wording EXACTLY — do not paraphrase. If the source has
   no explicit questions (study_material), generate 5-10 questions covering the main concepts.
 - The A[number] answers are for tutor verification ONLY and must never be shown to a student.
+- For a matching question, the PAIRS line gives the CORRECT left::right correspondences (the
+  answer key); the student will see the left items and pick from the shuffled right values.
 - Do not invent mark allocations or evaluation criteria. If something is unclear, say so in the A
   line rather than guessing.
-- Output ONLY the KIND line and the Q / OPTIONS / A lines — no other text.`
+- Output ONLY the KIND line and the Q / OPTIONS / PAIRS / A lines — no other text.`
 
 interface ParsedDmiQuestion {
   questionNumber: number
@@ -83,6 +86,7 @@ interface ParsedDmiQuestion {
   answer: string
   questionType: DmiQuestionType
   options?: string[]
+  pairs?: { left: string; right: string }[]
 }
 
 interface ParsedDmiResponse {
@@ -109,6 +113,7 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
     // Q[n] [type]: text  — the type tag in []/() is optional (back-compat).
     const qMatch = line.match(/^Q\s*(\d+)\s*(?:[[(]\s*([a-z_]+)\s*[\])])?\s*[:.\)]\s*(.+)$/i)
     const optMatch = line.match(/^OPTIONS\s*(\d+)\s*[:.\)]\s*(.+)$/i)
+    const pairsMatch = line.match(/^PAIRS\s*(\d+)\s*[:.\)]\s*(.+)$/i)
     const aMatch = line.match(/^A\s*(\d+)\s*[:.\)]\s*(.+)$/i)
 
     if (qMatch) {
@@ -124,6 +129,14 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
         .split('|')
         .map(o => o.trim())
         .filter(Boolean)
+    } else if (pairsMatch && currentQ) {
+      currentQ.pairs = pairsMatch[2]
+        .split('|')
+        .map(seg => {
+          const [left, right] = seg.split('::').map(s => s.trim())
+          return { left: left ?? '', right: right ?? '' }
+        })
+        .filter(p => p.left && p.right)
     } else if (aMatch && currentQ) {
       currentQ.answer = aMatch[2].trim()
     } else if (currentQ) {

--- a/tutorme-app/src/lib/assessment/question-types.ts
+++ b/tutorme-app/src/lib/assessment/question-types.ts
@@ -26,6 +26,16 @@ export const DMI_QUESTION_TYPES = [
 
 export type DmiQuestionType = (typeof DMI_QUESTION_TYPES)[number]
 
+/**
+ * A correct left↔right correspondence for a `matching` item. `left` items are
+ * shown to the student as prompts; the `right` values form the (shuffled) bank
+ * the student picks from. The pairing itself is the answer key.
+ */
+export interface DmiMatchPair {
+  left: string
+  right: string
+}
+
 /** The default when an item has no explicit type (back-compat with old DMIs). */
 export const DEFAULT_DMI_QUESTION_TYPE: DmiQuestionType = 'long'
 
@@ -52,14 +62,10 @@ export const CHOICE_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([
 
 /**
  * Interactive types that don't yet have a dedicated student renderer; they fall
- * back to a labelled free-text input in Phase 1.
+ * back to a labelled free-text input. (matching + ordering are implemented;
+ * hotspot + drag_drop still need richer data + renderers.)
  */
-export const FALLBACK_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([
-  'matching',
-  'ordering',
-  'hotspot',
-  'drag_drop',
-])
+export const FALLBACK_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set(['hotspot', 'drag_drop'])
 
 export function isDmiQuestionType(value: unknown): value is DmiQuestionType {
   return typeof value === 'string' && (DMI_QUESTION_TYPES as readonly string[]).includes(value)

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -116,6 +116,8 @@ export interface LiveTaskDmiItem {
   questionType?: import('./assessment/question-types').DmiQuestionType
   /** Options for choice types (mcq / true_false / multiple_response). */
   options?: string[]
+  /** Correct left↔right pairs for `matching` (the right values form the bank). */
+  pairs?: import('./assessment/question-types').DmiMatchPair[]
 }
 
 export interface LiveTaskSourceDocument {

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -63,6 +63,8 @@ export interface LiveTaskDmiItem {
   questionType?: import('../assessment/question-types').DmiQuestionType
   /** Options for choice types (mcq / true_false / multiple_response). */
   options?: string[]
+  /** Correct left↔right pairs for `matching` (the right values form the bank). */
+  pairs?: import('../assessment/question-types').DmiMatchPair[]
 }
 
 export interface LiveTaskSourceDocument {


### PR DESCRIPTION
Implements the **matching** input type end to end (data model → agent → tutor carry-through → student renderer).

## Changes

- **Data model**: optional `pairs` (`DmiMatchPair { left, right }`) on the DMI item types (`LiveTaskDmiItem` ×2, `DMIQuestion`), threaded through the CourseBuilder generate→deploy mapping.
- **Agent** (`generate-dmi`): emits a `PAIRS[n]: left :: right | left :: right` line for matching items (the correct correspondences / answer key); the parser extracts them into `pairs`.
- **Student Assessment tab**: each left prompt renders with a dropdown of the right values — de-duped and alphabetically sorted so the bank doesn't reveal the pair order. The answer is stored as a JSON map of `left -> chosen right`.

## Status of the 10 types

Implemented renderers: short, long, mcq, true_false, multiple_response, fill_blank, **ordering**, **matching**. Remaining on free-text fallback: **hotspot**, **drag_drop** (need image-region / drop-target data + tutor editors).

## Verification

- `typecheck` + `build` clean.
- PAIRS parser + matching answer logic **unit-checked**: pair parsing, sorted right-bank (hides answer order), answer-map updates, malformed-JSON tolerance.
- The agent emit path needs an AI key (absent on the local stack) → verified by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)