### PR TITLE
fix: match classroom display viewer border to input field style

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8515,7 +8515,7 @@ FEEDBACK: [your explanation]`
                                       className={cn(
                                         'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden bg-white p-0',
                                         mainTab === 'live' &&
-                                          'rounded-md border-2 border-orange-500',
+                                          'rounded-md border border-orange-300',
                                         mainTab === 'test-pci' &&
                                           'rounded-md border border-purple-300'
                                       )}


### PR DESCRIPTION
Change display viewer border from `border-2 border-orange-500` (thicker, darker reddish-orange) to `border border-orange-300` (thinner, lighter tangerine) to match the input field outline style.

This removes the reddish darker inner line appearance in the classroom display viewer, making both the viewer and input field have consistent orange/tangerine borders.

**Before:**
- Display viewer: thick dark orange border (border-2 border-orange-500)
- Input field: thin light tangerine border (border border-orange-300)

**After:**
- Display viewer: thin light tangerine border (border border-orange-300)
- Input field: thin light tangerine border (border border-orange-300)