### PR TITLE
fix(dmi): enumerate every question/sub-part as labelled input fields; read all pages

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -2106,8 +2106,11 @@ function StudentFeedbackContent() {
                           >
                             <div className="mb-2 flex items-start justify-between gap-2">
                               <p className="text-sm font-medium text-gray-800">
-                                {item.questionNumber ? `${item.questionNumber}. ` : ''}
-                                {item.questionText}
+                                {/* The label is usually self-numbered ("Question 1(a)"); only
+                                    prepend the counter for older free-text questions. */}
+                                {/^\s*(?:question\b|\d)/i.test(item.questionText)
+                                  ? item.questionText
+                                  : `${item.questionNumber ? `${item.questionNumber}. ` : ''}${item.questionText}`}
                               </p>
                               {qType !== 'long' && (
                                 <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2695,6 +2695,44 @@ FEEDBACK: [your explanation]`
       }
     }
 
+    // Extract the selectable text of EVERY page of a PDF. Used in preference to
+    // page-images for digital papers so a long multi-page question paper is fully
+    // captured (image analysis is capped at a few pages). Returns '' if the PDF
+    // has no extractable text (e.g. a scan) so the caller can fall back to images.
+    const extractPdfText = async (pdfUrl: string, maxPages = 30): Promise<string> => {
+      try {
+        const fetchUrl =
+          pdfUrl.startsWith('http://') || pdfUrl.startsWith('https://')
+            ? `/api/proxy-file?url=${encodeURIComponent(pdfUrl)}`
+            : pdfUrl
+        const response = await fetch(fetchUrl)
+        if (!response.ok) throw new Error('Failed to fetch PDF')
+        const arrayBuffer = await response.arrayBuffer()
+        const pdfjs = await import('pdfjs-dist')
+        if (typeof window !== 'undefined') {
+          const opts = (pdfjs as { GlobalWorkerOptions?: { workerSrc?: string } })
+            .GlobalWorkerOptions
+          if (opts && !opts.workerSrc) opts.workerSrc = '/pdf.worker.min.mjs'
+        }
+        const doc = await pdfjs.getDocument({ data: arrayBuffer }).promise
+        const parts: string[] = []
+        for (let i = 1; i <= Math.min(maxPages, doc.numPages); i++) {
+          const page = await doc.getPage(i)
+          const tc = await page.getTextContent()
+          const pageText = (tc.items as Array<{ str?: string }>)
+            .map(it => it.str ?? '')
+            .join(' ')
+            .replace(/[ \t]+/g, ' ')
+            .trim()
+          if (pageText) parts.push(`--- Page ${i} ---\n${pageText}`)
+        }
+        return parts.join('\n\n')
+      } catch (error) {
+        console.error('PDF text extraction error:', error)
+        return ''
+      }
+    }
+
     // Generate DMI using AI from content or PDF images with versioning.
     // `questionSpec` is supplied (via the spec dialog) when the source is study
     // material and the tutor has chosen which question types/counts to generate.
@@ -2724,10 +2762,18 @@ FEEDBACK: [your explanation]`
       setDmiGenerating(true)
       try {
         let pdfPages: string[] | undefined
+        let pdfText: string | undefined
         if (hasPdf) {
           toast.info('Analyzing PDF with AI...')
-          // Analyze up to 5 pages (the generate-dmi API cap) instead of silently 3.
-          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 5)
+          // Prefer full-text extraction so EVERY page of a multi-page paper is
+          // captured (image analysis is capped at a few pages and would miss
+          // later questions). Fall back to page images for scanned PDFs.
+          const extracted = await extractPdfText(sourceDoc.fileUrl, 30)
+          if (extracted.trim().length > 200) {
+            pdfText = extracted.slice(0, 50000)
+          } else {
+            pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8)
+          }
         }
 
         const response = await fetch('/api/ai/generate-dmi', {
@@ -2736,7 +2782,7 @@ FEEDBACK: [your explanation]`
           body: JSON.stringify({
             type,
             title: builder.title,
-            content: !hasPdf && hasContent ? content : undefined,
+            content: pdfText ?? (!hasPdf && hasContent ? content : undefined),
             pdfPages,
             questionSpec,
           }),

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -30,7 +30,7 @@ const GenerateDmiRequestSchema = z.object({
   type: z.enum(['task', 'assessment']),
   title: z.string().max(200).optional(),
   content: z.string().max(50000).optional(),
-  pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
+  pdfPages: z.array(z.string().max(5_000_000)).max(8).optional(),
   /**
    * For study material: the question types + counts the tutor wants generated.
    * Ignored for a question paper (its questions are mirrored as-is).
@@ -44,19 +44,24 @@ const GenerateDmiRequestSchema = z.object({
 const SYSTEM_PROMPT = `You are an expert educational assessment designer building a DMI (Digital Marking Interface).
 
 A DMI is a set of ANSWER INPUT FIELDS that a student fills in. The student reads the actual
-questions from the deployed document — your job is to produce, for each question, a well-numbered
-answer field of the RIGHT INPUT TYPE. Do not rewrite or invent questions for a question paper;
-mirror its questions one-to-one as typed input fields.
+questions from the deployed document — so for a question paper you do NOT reproduce the question
+text. Instead you produce one numbered input field per answerable part, labelled by its number.
 
 First, classify the source and output it as the very first line:
 KIND: question_paper   (the document already contains questions / exam tasks)
 KIND: study_material   (notes / material with no explicit questions)
 
-Then, for each question, output exactly in this format:
-Q[number] [type]: [question text — copied EXACTLY from the source for a question paper]
+Then output one line per input field in this format:
+Q[number] [type]: [field label]
 OPTIONS[number]: option 1 | option 2 | option 3      (ONLY for mcq / true_false / multiple_response)
 PAIRS[number]: left A :: right 1 | left B :: right 2 | left C :: right 3   (ONLY for matching / drag_drop)
 A[number]: [suggested answer or key points]
+
+[number] is a SEQUENTIAL counter (1, 2, 3, …) for the output lines. [field label] is:
+- question_paper: the question's reference EXACTLY as printed — every question AND every
+  sub-question / sub-part as its own field, e.g. "Question 1(a)", "Question 1(b)", "Question 2",
+  "Question 3(a)(i)". Do NOT include the question text — only the reference label.
+- study_material: the full generated question text (there is no paper for the student to read).
 
 [type] must be exactly one of:
   short              one-line factual answer
@@ -73,8 +78,12 @@ Pick the type that best matches how the question expects to be answered. Write t
 as the exact lowercase token above (e.g. [mcq], [true_false]) — not a human-readable label.
 
 Rules:
-- For a question_paper, preserve question wording EXACTLY — do not paraphrase. If the source has
-  no explicit questions (study_material), generate 5-10 questions covering the main concepts.
+- For a question_paper: enumerate EVERY question and EVERY sub-part across ALL pages, in order,
+  exactly once each — do not skip, merge, summarise, or repeat any part, and do not stop early.
+  A question with parts (a),(b),(c) becomes three separate fields. Use the reference label exactly
+  as printed; pick the [type] from how that part is meant to be answered (a multiple-choice item
+  -> mcq with OPTIONS, a short response -> short, an extended/essay response -> long, etc.).
+- For study_material (no explicit questions): generate 5-10 questions covering the main concepts.
 - The A[number] answers are for tutor verification ONLY and must never be shown to a student.
 - For a matching question, the PAIRS line gives the CORRECT left::right correspondences (the
   answer key); the student will see the left items and pick from the shuffled right values.
@@ -286,7 +295,7 @@ export async function POST(request: NextRequest) {
       aiResponse = await generateWithKimiVision(promptItems, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
-        maxTokens: 4096,
+        maxTokens: 6000,
         timeoutMs: 60000,
       })
     } else {
@@ -294,7 +303,7 @@ export async function POST(request: NextRequest) {
       aiResponse = await generateWithKimi(prompt, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
-        maxTokens: 4096,
+        maxTokens: 6000,
         timeoutMs: 60000,
       })
     }


### PR DESCRIPTION
Fixes the AP-Statistics DMI result: a multi-page paper with 6 questions + sub-questions produced only a repeated couple of full-text questions, instead of a numbered input field per part.

## Two root causes

1. **Only the first ~5 pages reached the model.** PDFs were sent as **5 page-images**, so later questions of a multi-page paper were never seen → it collapsed to a couple.
2. **Fields reproduced question text** and didn't enumerate sub-parts.

## Fix

**Capture all pages (`CourseBuilder.tsx`)**
- Extract the **selectable text of every page** (up to 30) and send it as `content` — covers the whole paper cheaply. Falls back to page-images (now up to **8**) for scanned/image-only PDFs.
- Image cap 5→8; `maxTokens` 4096→6000 to fit many sub-part fields.

**Labelled fields, not repeated questions (`generate-dmi` prompt)**
- For a `question_paper`: emit **one input field per answerable part** — every question *and* every sub-part `(a)/(b)/(i)` — labelled by its reference (e.g. `Question 1(a)`) with **no** question text, enumerating **all** parts in order, exactly once (no skip/merge/repeat/stop-early).
- `study_material` still generates full question text (that text is deployed to the Classroom tab).
- Student Assessment tab drops the redundant numeric prefix when the label is self-numbered.

**Result:** students see the original paper in **Classroom** and a numbered field per question/sub-question in **Assessment** — exactly the requested behavior.

## Verification

- `typecheck` + `build` clean.
- Parser **unit-checked** on simulated AP-style label output → 7 fields including `Question 6(a)…`, `Question 7(a)(i)`, MC items typed `mcq` with options, no repeats.
- The live LLM + PDF-text paths need an AI key (absent on the local stack), so those are verified by review + the deterministic parser test. Best validated by re-running your AP paper on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)