### PR TITLE
fix(dmi): few-shot label example + never leak answers into the field label

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -91,7 +91,25 @@ Rules:
   in as item :: target (the answer key); targets may repeat across items.
 - Do not invent mark allocations or evaluation criteria. If something is unclear, say so in the A
   line rather than guessing.
-- Output ONLY the KIND line and the Q / OPTIONS / PAIRS / A lines — no other text.`
+- Output ONLY the KIND line and the Q / OPTIONS / PAIRS / A lines — no other text.
+
+EXAMPLE — a question paper whose Question 1 has parts (a), (b)(i), (b)(ii), (c) and Question 2 has
+parts (a), (b). The CORRECT output is one field per sub-part, label only, no question text:
+KIND: question_paper
+Q1 [short]: Question 1(a)
+A1: ...
+Q2 [short]: Question 1(b)(i)
+A2: ...
+Q3 [short]: Question 1(b)(ii)
+A3: ...
+Q4 [long]: Question 1(c)
+A4: ...
+Q5 [short]: Question 2(a)
+A5: ...
+Q6 [long]: Question 2(b)
+A6: ...
+(Every sub-part is its own field; the label is ONLY the reference; the question wording never
+appears in a Q line — the student reads it from the document.)`
 
 interface ParsedDmiQuestion {
   questionNumber: number
@@ -189,7 +207,9 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
     )
     const optMatch = line.match(/^OPTIONS\s*(\d+)?\s*[:.)]\s*(.+)$/i)
     const pairsMatch = line.match(/^PAIRS\s*(\d+)?\s*[:.)]\s*(.+)$/i)
-    const aMatch = line.match(/^A\s*(\d+)?\s*[:.)]\s*(.+)$/i)
+    // Accept "A1:", "A:", "Answer:", "Ans:" — so a model answer is captured as
+    // the (tutor-only) answer and never leaks into the student-visible label.
+    const aMatch = line.match(/^(?:Answer|Ans|A)\s*(\d+)?\s*[:.)]\s*(.+)$/i)
 
     if (qMatch) {
       if (currentQ) questions.push(currentQ)
@@ -222,6 +242,17 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
   }
 
   if (currentQ) questions.push(currentQ)
+
+  // For a question paper the label must be ONLY the reference (e.g. "Question
+  // 1(a)"). Defensively strip any leaked answer/explanation the model crammed
+  // onto the Q line so question text or model answers never reach the student.
+  if (documentKind === 'question_paper') {
+    for (const q of questions) {
+      q.questionText = q.questionText
+        .replace(/\s*(?:answer|ans|explanation|solution)\s*[:.)].*$/i, '')
+        .trim()
+    }
+  }
 
   // Fallback: the model ignored the Q[n] format entirely (e.g. a plain numbered
   // list of questions). Extract numbered lines so we never return an empty DMI


### PR DESCRIPTION
Follow-up so the DMI matches the **desired** output you supplied in `dmi/` — one label-only field per sub-part (`Question 1(a)`, `Question 1(b)(i)`, … `Question 6(d)`), no question text, **no model answers shown to students**.

## What the produced (undesirable) DMI showed
~4 fields containing **full question text + leaked "Answer: …"** model answers — vs the desired ~22 label-only fields.

## Changes (`generate-dmi`)

- **Prompt:** added a concrete worked **example** (Question 1 with parts (a),(b)(i),(b)(ii),(c); Question 2 with (a),(b)) showing the exact label-only output — the strongest lever for getting the model to emit one field per sub-part with no question text.
- **Parser hardening:** recognize `Answer:` / `Ans:` lines (not only `A1:`) so a model answer is captured as the **tutor-only** answer instead of leaking into the student-visible label; and for a `question_paper`, defensively strip any answer/explanation crammed onto the `Q` line.

(This stacks on #318, which already added full-page text extraction + the labels-only prompt — now deployed.)

## Verification

- `typecheck` + `build` clean.
- Parser **unit-checked**: answer on its own line stays hidden; inline-leaked answer stripped; the full AP enumeration yields **22 clean `Question N(..)` fields** (`Question 1(a)` … `Question 6(d)`) — matching the desired DMI.
- Live LLM + PDF paths need an AI key (absent locally) → verified by review + deterministic parser tests; best confirmed by re-running the AP paper on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)