### PR TITLE
fix(student-live): paginated PDF viewer in classroom so all pages of a paper show

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -60,6 +60,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
+import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
 import type {
@@ -1775,9 +1776,6 @@ function StudentFeedbackContent() {
                               doc.mimeType === 'application/pdf' ||
                               (!doc.mimeType && /\.pdf($|\?|#)/i.test(doc.fileName || rawUrl))
                             const isImage = doc.mimeType?.startsWith('image/')
-                            const pdfSrc = url.includes('#')
-                              ? `${url}&toolbar=0&navpanes=0`
-                              : `${url}#toolbar=0&navpanes=0`
                             return (
                               <div className="mb-4 h-[55vh] w-full">
                                 {!loadable ? (
@@ -1788,11 +1786,11 @@ function StudentFeedbackContent() {
                                     </p>
                                   </div>
                                 ) : isPdf ? (
-                                  <iframe
-                                    src={pdfSrc}
-                                    title="Document"
-                                    className="h-full w-full rounded-lg border"
-                                  />
+                                  // Paginated viewer (Page X of Y + Prev/Next, or
+                                  // scroll for <=20 pages) so students can see EVERY
+                                  // page of a multi-page paper — the bare iframe with
+                                  // toolbar/navpanes hidden gave no page navigation.
+                                  <PDFViewer fileUrl={url} className="h-full w-full" />
                                 ) : isImage ? (
                                   <div className="flex h-full items-center justify-center">
                                     {/* eslint-disable-next-line @next/next/no-img-element */}


### PR DESCRIPTION
## Issue

In the student classroom, the deployed document rendered in a bare `<iframe src=…#toolbar=0&navpanes=0>`. Those params **strip all page navigation**, so on a multi-page question paper the student saw page 1 with no page controls and no sign there were more pages — i.e. the "Page 1 of 1 / only the cover" symptom.

(Note: the tutor's Test-mode preview already uses the paginated `PDFViewer`; the student classroom did not.)

## Fix

Swap the iframe for the existing **`PDFViewer`** component (already used tutor-side): it fetches the whole PDF through the proxy in one buffer and shows **Page X of Y + Prev/Next** (or scrolls all pages for ≤20), so students can read every page of the paper. Image / other-file branches are unchanged.

## Verification

- `typecheck` + `build` clean.
- Smoke-tested: the student feedback page loads with the new viewer import — no crash, no console/page errors.
- `PDFViewer` is the same proven component used in the tutor builder. Full multi-page rendering with a live deployed PDF is best confirmed on prod (needs a deployed assessment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)