### PR TITLE
fix(dmi): JSON-constrained generation + restore work reverted by a383f1c0c; scroll all PDF pages

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -60,6 +60,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
+import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
 import type {
@@ -1775,9 +1776,6 @@ function StudentFeedbackContent() {
                               doc.mimeType === 'application/pdf' ||
                               (!doc.mimeType && /\.pdf($|\?|#)/i.test(doc.fileName || rawUrl))
                             const isImage = doc.mimeType?.startsWith('image/')
-                            const pdfSrc = url.includes('#')
-                              ? `${url}&toolbar=0&navpanes=0`
-                              : `${url}#toolbar=0&navpanes=0`
                             return (
                               <div className="mb-4 h-[55vh] w-full">
                                 {!loadable ? (
@@ -1788,11 +1786,10 @@ function StudentFeedbackContent() {
                                     </p>
                                   </div>
                                 ) : isPdf ? (
-                                  <iframe
-                                    src={pdfSrc}
-                                    title="Document"
-                                    className="h-full w-full rounded-lg border"
-                                  />
+                                  // Paginated/continuous-scroll viewer so students can
+                                  // see EVERY page of a multi-page paper (the bare iframe
+                                  // with toolbar/navpanes hidden gave no page navigation).
+                                  <PDFViewer fileUrl={url} className="h-full w-full" />
                                 ) : isImage ? (
                                   <div className="flex h-full items-center justify-center">
                                     {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -2108,8 +2105,11 @@ function StudentFeedbackContent() {
                           >
                             <div className="mb-2 flex items-start justify-between gap-2">
                               <p className="text-sm font-medium text-gray-800">
-                                {item.questionNumber ? `${item.questionNumber}. ` : ''}
-                                {item.questionText}
+                                {/* The label is usually self-numbered ("Question 1(a)"); only
+                                    prepend the counter for older free-text questions. */}
+                                {/^\s*(?:question\b|\d)/i.test(item.questionText)
+                                  ? item.questionText
+                                  : `${item.questionNumber ? `${item.questionNumber}. ` : ''}${item.questionText}`}
                               </p>
                               {qType !== 'long' && (
                                 <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2690,6 +2690,44 @@ FEEDBACK: [your explanation]`
       }
     }
 
+    // Extract the selectable text of EVERY page of a PDF. Used in preference to
+    // page-images for digital papers so a long multi-page question paper is fully
+    // captured (image analysis is capped at a few pages). Returns '' if the PDF
+    // has no extractable text (e.g. a scan) so the caller can fall back to images.
+    const extractPdfText = async (pdfUrl: string, maxPages = 30): Promise<string> => {
+      try {
+        const fetchUrl =
+          pdfUrl.startsWith('http://') || pdfUrl.startsWith('https://')
+            ? `/api/proxy-file?url=${encodeURIComponent(pdfUrl)}`
+            : pdfUrl
+        const response = await fetch(fetchUrl)
+        if (!response.ok) throw new Error('Failed to fetch PDF')
+        const arrayBuffer = await response.arrayBuffer()
+        const pdfjs = await import('pdfjs-dist')
+        if (typeof window !== 'undefined') {
+          const opts = (pdfjs as { GlobalWorkerOptions?: { workerSrc?: string } })
+            .GlobalWorkerOptions
+          if (opts && !opts.workerSrc) opts.workerSrc = '/pdf.worker.min.mjs'
+        }
+        const doc = await pdfjs.getDocument({ data: arrayBuffer }).promise
+        const parts: string[] = []
+        for (let i = 1; i <= Math.min(maxPages, doc.numPages); i++) {
+          const page = await doc.getPage(i)
+          const tc = await page.getTextContent()
+          const pageText = (tc.items as Array<{ str?: string }>)
+            .map(it => it.str ?? '')
+            .join(' ')
+            .replace(/[ \t]+/g, ' ')
+            .trim()
+          if (pageText) parts.push(`--- Page ${i} ---\n${pageText}`)
+        }
+        return parts.join('\n\n')
+      } catch (error) {
+        console.error('PDF text extraction error:', error)
+        return ''
+      }
+    }
+
     // Generate DMI using AI from content or PDF images with versioning.
     // `questionSpec` is supplied (via the spec dialog) when the source is study
     // material and the tutor has chosen which question types/counts to generate.
@@ -2719,10 +2757,18 @@ FEEDBACK: [your explanation]`
       setDmiGenerating(true)
       try {
         let pdfPages: string[] | undefined
+        let pdfText: string | undefined
         if (hasPdf) {
           toast.info('Analyzing PDF with AI...')
-          // Analyze up to 5 pages (the generate-dmi API cap) instead of silently 3.
-          pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 5)
+          // Prefer full-text extraction so EVERY page of a multi-page paper is
+          // captured (image analysis is capped at a few pages and would miss
+          // later questions). Fall back to page images for scanned PDFs.
+          const extracted = await extractPdfText(sourceDoc.fileUrl, 30)
+          if (extracted.trim().length > 200) {
+            pdfText = extracted.slice(0, 50000)
+          } else {
+            pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8)
+          }
         }
 
         const response = await fetch('/api/ai/generate-dmi', {
@@ -2731,7 +2777,7 @@ FEEDBACK: [your explanation]`
           body: JSON.stringify({
             type,
             title: builder.title,
-            content: !hasPdf && hasContent ? content : undefined,
+            content: pdfText ?? (!hasPdf && hasContent ? content : undefined),
             pdfPages,
             questionSpec,
           }),

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -30,7 +30,7 @@ const GenerateDmiRequestSchema = z.object({
   type: z.enum(['task', 'assessment']),
   title: z.string().max(200).optional(),
   content: z.string().max(50000).optional(),
-  pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
+  pdfPages: z.array(z.string().max(5_000_000)).max(8).optional(),
   /**
    * For study material: the question types + counts the tutor wants generated.
    * Ignored for a question paper (its questions are mirrored as-is).
@@ -41,48 +41,46 @@ const GenerateDmiRequestSchema = z.object({
     .optional(),
 })
 
-const SYSTEM_PROMPT = `You are an expert educational assessment designer building a DMI (Digital Marking Interface).
+const SYSTEM_PROMPT = `You build a DMI: a list of ANSWER INPUT FIELDS for a question paper. The student
+reads the real questions from the deployed document, so for a question paper you must NOT reproduce
+the question wording or any answers — you only output a short reference LABEL per answerable part.
 
-A DMI is a set of ANSWER INPUT FIELDS that a student fills in. The student reads the actual
-questions from the deployed document — your job is to produce, for each question, a well-numbered
-answer field of the RIGHT INPUT TYPE. Do not rewrite or invent questions for a question paper;
-mirror its questions one-to-one as typed input fields.
-
-First, classify the source and output it as the very first line:
-KIND: question_paper   (the document already contains questions / exam tasks)
-KIND: study_material   (notes / material with no explicit questions)
-
-Then, for each question, output exactly in this format:
-Q[number] [type]: [question text — copied EXACTLY from the source for a question paper]
-OPTIONS[number]: option 1 | option 2 | option 3      (ONLY for mcq / true_false / multiple_response)
-PAIRS[number]: left A :: right 1 | left B :: right 2 | left C :: right 3   (ONLY for matching / drag_drop)
-A[number]: [suggested answer or key points]
-
-[type] must be exactly one of:
-  short              one-line factual answer
-  long               paragraph / essay answer
-  mcq                multiple choice, exactly one correct option
-  true_false         true / false
-  multiple_response  multiple choice, one or more correct options
-  fill_blank         fill in the blank / cloze
-  matching           match items across two columns
-  ordering           order or rank items
-  hotspot            click a region of an image
-  drag_drop          drag items into targets
-Pick the type that best matches how the question expects to be answered. Write the [type] tag
-as the exact lowercase token above (e.g. [mcq], [true_false]) — not a human-readable label.
+Return ONLY a JSON object (no prose, no markdown, no code fences) with EXACTLY this shape:
+{
+  "documentKind": "question_paper" | "study_material",
+  "fields": [
+    { "label": "Question 1(a)", "type": "short" },
+    { "label": "Question 2", "type": "mcq", "options": ["A", "B", "C", "D", "E"] }
+  ]
+}
 
 Rules:
-- For a question_paper, preserve question wording EXACTLY — do not paraphrase. If the source has
-  no explicit questions (study_material), generate 5-10 questions covering the main concepts.
-- The A[number] answers are for tutor verification ONLY and must never be shown to a student.
-- For a matching question, the PAIRS line gives the CORRECT left::right correspondences (the
-  answer key); the student will see the left items and pick from the shuffled right values.
-- For a drag_drop question, the PAIRS line gives each draggable item and the target it belongs
-  in as item :: target (the answer key); targets may repeat across items.
-- Do not invent mark allocations or evaluation criteria. If something is unclear, say so in the A
-  line rather than guessing.
-- Output ONLY the KIND line and the Q / OPTIONS / PAIRS / A lines — no other text.`
+- documentKind: "question_paper" if the document already contains questions/exam tasks; otherwise
+  "study_material" (notes with no explicit questions).
+- For a question_paper: output ONE field per answerable part — every question AND every sub-part
+  (a),(b),(c) and sub-sub-part (i),(ii). "label" is the part's reference EXACTLY as printed, e.g.
+  "Question 1(a)", "Question 1(b)(i)", "Question 3(a)(ii)". The label MUST be only the reference —
+  never the question wording, instructions, marks, or answers. Enumerate EVERY part across ALL
+  pages, in order, exactly once: do not skip, merge, summarise, repeat, or stop early. A 6-question
+  paper with sub-parts typically yields 15-30 fields.
+- For study_material: generate 5-10 questions; here "label" is the full question text.
+- "type" is exactly one of: short, long, mcq, true_false, multiple_response, fill_blank, matching,
+  ordering, hotspot, drag_drop. Choose by how the part is meant to be answered (multiple-choice
+  item -> "mcq" with "options"; short response -> "short"; extended/essay -> "long"). Default to
+  "short" if unsure.
+- "options" array ONLY for mcq / true_false / multiple_response.
+- "pairs" (array of {"left","right"}) ONLY for matching / drag_drop.
+
+EXAMPLE — Question 1 has parts (a),(b)(i),(b)(ii),(c); Question 2 has (a),(b). Correct JSON:
+{"documentKind":"question_paper","fields":[
+{"label":"Question 1(a)","type":"short"},
+{"label":"Question 1(b)(i)","type":"short"},
+{"label":"Question 1(b)(ii)","type":"short"},
+{"label":"Question 1(c)","type":"long"},
+{"label":"Question 2(a)","type":"short"},
+{"label":"Question 2(b)","type":"long"}
+]}
+Output the JSON object and nothing else.`
 
 interface ParsedDmiQuestion {
   questionNumber: number
@@ -96,6 +94,63 @@ interface ParsedDmiQuestion {
 interface ParsedDmiResponse {
   documentKind: 'question_paper' | 'study_material' | null
   questions: ParsedDmiQuestion[]
+}
+
+/**
+ * Primary parser: the model returns a strict JSON object of {label, type} fields.
+ * Because the schema has no slot for question wording or answers, the model
+ * cannot leak them into the student-visible label. Returns null if the response
+ * isn't usable JSON so the caller can fall back to the legacy line parser.
+ */
+function parseDmiJson(raw: string): ParsedDmiResponse | null {
+  try {
+    const text = stripCodeFences(raw).trim()
+    const start = text.indexOf('{')
+    const end = text.lastIndexOf('}')
+    if (start === -1 || end === -1 || end <= start) return null
+    const obj = JSON.parse(text.slice(start, end + 1)) as {
+      documentKind?: unknown
+      fields?: Array<{ label?: unknown; type?: unknown; options?: unknown; pairs?: unknown }>
+    }
+    if (!Array.isArray(obj.fields) || obj.fields.length === 0) return null
+
+    const documentKind =
+      obj.documentKind === 'study_material'
+        ? 'study_material'
+        : obj.documentKind === 'question_paper'
+          ? 'question_paper'
+          : null
+
+    const questions: ParsedDmiQuestion[] = obj.fields
+      .map((f, i) => {
+        const label = String(f.label ?? '').trim()
+        const options = Array.isArray(f.options)
+          ? f.options.map(o => String(o).trim()).filter(Boolean)
+          : undefined
+        const pairs = Array.isArray(f.pairs)
+          ? f.pairs
+              .map((p: { left?: unknown; right?: unknown }) => ({
+                left: String(p?.left ?? '').trim(),
+                right: String(p?.right ?? '').trim(),
+              }))
+              .filter(p => p.left && p.right)
+          : undefined
+        return {
+          questionNumber: i + 1,
+          questionText: label,
+          answer: '',
+          questionType: normalizeTypeToken(typeof f.type === 'string' ? f.type : undefined),
+          options: options && options.length > 0 ? options : undefined,
+          pairs: pairs && pairs.length > 0 ? pairs : undefined,
+        }
+      })
+      .filter(q => q.questionText)
+
+    if (questions.length === 0) return null
+    return { documentKind, questions }
+  } catch {
+    return null
+  }
 }
 
 // Map a free-form type tag — a snake_case token OR a human label like
@@ -180,7 +235,9 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
     )
     const optMatch = line.match(/^OPTIONS\s*(\d+)?\s*[:.)]\s*(.+)$/i)
     const pairsMatch = line.match(/^PAIRS\s*(\d+)?\s*[:.)]\s*(.+)$/i)
-    const aMatch = line.match(/^A\s*(\d+)?\s*[:.)]\s*(.+)$/i)
+    // Accept "A1:", "A:", "Answer:", "Ans:" — so a model answer is captured as
+    // the (tutor-only) answer and never leaks into the student-visible label.
+    const aMatch = line.match(/^(?:Answer|Ans|A)\s*(\d+)?\s*[:.)]\s*(.+)$/i)
 
     if (qMatch) {
       if (currentQ) questions.push(currentQ)
@@ -213,6 +270,17 @@ function parseDmiResponse(text: string): ParsedDmiResponse {
   }
 
   if (currentQ) questions.push(currentQ)
+
+  // For a question paper the label must be ONLY the reference (e.g. "Question
+  // 1(a)"). Defensively strip any leaked answer/explanation the model crammed
+  // onto the Q line so question text or model answers never reach the student.
+  if (documentKind === 'question_paper') {
+    for (const q of questions) {
+      q.questionText = q.questionText
+        .replace(/\s*(?:answer|ans|explanation|solution)\s*[:.)].*$/i, '')
+        .trim()
+    }
+  }
 
   // Fallback: the model ignored the Q[n] format entirely (e.g. a plain numbered
   // list of questions). Extract numbered lines so we never return an empty DMI
@@ -286,7 +354,7 @@ export async function POST(request: NextRequest) {
       aiResponse = await generateWithKimiVision(promptItems, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
-        maxTokens: 4096,
+        maxTokens: 6000,
         timeoutMs: 60000,
       })
     } else {
@@ -294,7 +362,7 @@ export async function POST(request: NextRequest) {
       aiResponse = await generateWithKimi(prompt, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
-        maxTokens: 4096,
+        maxTokens: 6000,
         timeoutMs: 60000,
       })
     }
@@ -308,7 +376,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { documentKind, questions } = parseDmiResponse(stripCodeFences(aiResponse))
+    // Prefer the strict-JSON output; fall back to the legacy line parser if the
+    // model didn't return usable JSON.
+    const { documentKind, questions } =
+      parseDmiJson(aiResponse) ?? parseDmiResponse(stripCodeFences(aiResponse))
 
     // Warn-only assessment guardrails. Checks wording fidelity against the
     // source (ASMT-4) and other structural rules where data is available.

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -15,9 +15,6 @@ interface PDFViewerProps {
   onHidePreview?: () => void
 }
 
-/** Maximum pages to render in scroll-all mode before switching to single-page pagination. */
-const MAX_SCROLL_PAGES = 20
-
 function getProxiedPdfUrl(fileUrl: string): string {
   // Use the proxy for external URLs so the server can refresh expired GCS signatures
   if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
@@ -91,7 +88,8 @@ export function PDFViewer({
     }
   }, [fileUrl, isBlobUrl])
 
-  const isScrollMode = numPages > 0 && numPages <= MAX_SCROLL_PAGES
+  // Always render every page in a continuous scroll view, regardless of length.
+  const isScrollMode = numPages > 0
 
   const onDocumentLoadSuccess = useCallback(({ numPages: total }: { numPages: number }) => {
     setNumPages(total)
@@ -105,13 +103,6 @@ export function PDFViewer({
     setError(err.message || 'Failed to load PDF')
     setLoading(false)
   }, [])
-
-  const changePage = useCallback(
-    (delta: number) => {
-      setPageNumber(prev => Math.max(1, Math.min(numPages, prev + delta)))
-    },
-    [numPages]
-  )
 
   const changeScale = useCallback((delta: number) => {
     setScale(prev => {
@@ -180,25 +171,9 @@ export function PDFViewer({
         <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#E5E7EB] bg-white px-2">
           <div className="flex items-center gap-1.5">
             {!hidePageNavigation && (
-              <>
-                <button
-                  onClick={() => changePage(-1)}
-                  disabled={pageNumber <= 1}
-                  className="rounded px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 disabled:text-gray-400"
-                >
-                  ← Prev
-                </button>
-                <span className="min-w-[80px] text-center text-xs text-gray-600">
-                  Page {pageNumber} of {numPages}
-                </span>
-                <button
-                  onClick={() => changePage(1)}
-                  disabled={pageNumber >= numPages}
-                  className="rounded px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 disabled:text-gray-400"
-                >
-                  Next →
-                </button>
-              </>
+              <span className="text-xs text-gray-600">
+                {numPages} {numPages === 1 ? 'page' : 'pages'} · scroll to view all
+              </span>
             )}
           </div>
 
@@ -294,13 +269,6 @@ export function PDFViewer({
               </div>
             )}
           </Document>
-
-          {/* Warning for large documents forced into pagination mode */}
-          {!isScrollMode && numPages > MAX_SCROLL_PAGES && (
-            <div className="py-3 text-center text-xs text-amber-700">
-              Large document ({numPages} pages). Use the Prev/Next buttons above to navigate pages.
-            </div>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Addresses both reported issues — and fixes a **regression** found along the way.

## 🔴 Regression: a383f1c0c silently reverted my shipped DMI work
The commit **`a383f1c0c`** ("feat(tutor/settings): remove bio photo…") was based on a stale main and, as a side effect, **reverted #318 / #323 / #324**: the label-only DMI prompt, the full-page PDF text extraction, and the classroom paginated viewer. That's exactly why the DMI went back to producing **full question text + leaked answers** (the undesirable output in `dmi/`). All three are **restored** here.

## 2 — DMI generation: AI, now constrained to JSON
You asked whether it's AI or code — it's **AI** (Kimi). The free-text format let the model reproduce question text/answers no matter the prompt. Now it must return **strict JSON**: `{ "documentKind", "fields": [{ "label", "type", "options?" }] }`. There's **no field for question wording or answers**, so it structurally can't leak them — it has to emit one label-only field per answerable sub-part (`Question 1(a)`, `Question 1(b)(i)`, …). `parseDmiJson` is primary; the line parser stays as a fallback. `extractPdfText` (every page of a digital PDF; image fallback for scans) is restored so all questions are seen.

## 1 — PDF: scroll all pages
`PDFViewer` now renders **every page in one continuous scroll** (removed the 20-page cap that forced the "Large document — use Prev/Next" message). The toolbar shows a page count instead.

## Verification
- `typecheck` + `build` clean.
- `parseDmiJson` unit-checked (clean JSON; fenced + surrounding prose; garbage → fallback).
- The LLM + PDF paths need an AI key (absent on the local stack) → verified by review + deterministic parser tests. **Best confirmed by re-running the AP paper on prod after deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)