### PR TITLE
feat: apply floating card shadow design to Account Settings

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -72,7 +72,8 @@ const LANGUAGES = [
   { code: 'ja', name: '日本語 (Japanese)' },
 ]
 
-const SECTION_CARD_CLASS = 'overflow-hidden bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]'
+const SECTION_CARD_CLASS =
+  'overflow-hidden bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)] border-[rgba(0,0,0,0.05)]'
 
 interface PaymentMethod {
   id: string
@@ -171,7 +172,7 @@ function OneOnOneSettingsCard() {
     >
       <div className="space-y-6 p-6">
         {/* Enable/Disable Toggle */}
-        <div className="flex items-center justify-between rounded-lg border p-4">
+        <div className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm">
           <div>
             <p className="font-medium">Enable 1-on-1 Booking</p>
             <p className="text-sm text-gray-500">
@@ -976,7 +977,7 @@ export default function TutorSettings() {
                   {paymentMethods.map(method => (
                     <div
                       key={method.id}
-                      className="flex items-center justify-between rounded-lg border p-4"
+                      className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
                     >
                       <div className="flex items-center gap-3">
                         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50">
@@ -1133,7 +1134,7 @@ export default function TutorSettings() {
                   {billingHistory.map(invoice => (
                     <div
                       key={invoice.id}
-                      className="flex items-center justify-between rounded-lg border p-4"
+                      className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
                     >
                       <div>
                         <p className="font-medium">{invoice.description}</p>
@@ -1383,7 +1384,7 @@ export default function TutorSettings() {
                       {connectedDevices.map(device => (
                         <div
                           key={device.id}
-                          className="flex items-center justify-between rounded-lg border p-3"
+                          className="flex items-center justify-between rounded-[12px] border p-3 transition-all hover:bg-slate-50 hover:shadow-sm"
                         >
                           <div className="flex items-center gap-3">
                             <Smartphone className="h-5 w-5 text-gray-400" />


### PR DESCRIPTION
Applies the Analytics page's floating card shadow design to the Account Settings page:

- Add nearly invisible border `border-[rgba(0,0,0,0.05)]` to SECTION_CARD_CLASS
- Change inner item border-radius from `rounded-lg` to `rounded-[12px]`
- Add `hover:bg-slate-50 hover:shadow-sm transition-all` to card items (1-on-1 toggle, payment methods, billing history, connected devices)