### PR TITLE
fix(analytics): make AI Assistant panel fill full Desk panel height

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
@@ -21,7 +21,7 @@ export function AiAssistantPanel({ sessionId }: AiAssistantPanelProps) {
   }
 
   return (
-    <div className="flex h-full flex-col gap-3 px-1 pb-0">
+    <div className="flex h-full flex-1 flex-col gap-3 px-1 pb-0">
       {/* Chat display */}
       <div className="flex-1 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
         {messages.length === 0 ? (

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8028,9 +8028,9 @@ FEEDBACK: [your explanation]`
                                         </TabsList>
                                         <TabsContent
                                           value="analytics"
-                                          className="flex flex-1 flex-col justify-end overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
+                                          className="flex flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                         >
-                                          <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
+                                          <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
                                             <AiAssistantPanel sessionId={insightsProps.sessionId} />
                                           </div>
                                         </TabsContent>
@@ -8376,9 +8376,9 @@ FEEDBACK: [your explanation]`
 
                                           <TabsContent
                                             value="analytics"
-                                            className="flex flex-1 flex-col justify-end overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
+                                            className="flex flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                           >
-                                            <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
+                                            <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
                                               <AiAssistantPanel
                                                 sessionId={insightsProps.sessionId}
                                               />


### PR DESCRIPTION
Fixes the AI Assistant panel in the Analytics tab not filling the full height of the Desk panel.

**Root causes identified:**
1. `AiAssistantPanel.tsx` outer div had `h-full` but was missing `flex-1`, so it wouldn't grow to fill parent flex containers when the parent used `overflow-auto`
2. `CourseBuilder.tsx` analytics tab wrapper had `justify-end` (wrong for top-filling content) and `overflow-auto` on the wrapper div (breaks flex height propagation)

**Changes:**
- `AiAssistantPanel.tsx`: Added `flex-1` to the outer div
- `CourseBuilder.tsx` (both Desk and center panel instances): 
  - Removed `justify-end` from `TabsContent`
  - Changed wrapper div from `flex-1 overflow-auto` to `flex h-full flex-col overflow-hidden`

This matches the pattern used by the Poll and Question tabs which correctly fill their containers.