### PR TITLE
feat(curriculum): redesign + Lesson button with outline style

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6053,7 +6053,7 @@ FEEDBACK: [your explanation]`
                         <Button
                           size="sm"
                           onClick={addCourseBuilderNode}
-                          className="mb-4 h-8 w-full gap-1 text-xs"
+                          className="mb-4 h-8 w-full gap-1 border border-blue-600 bg-white text-xs text-blue-600 transition-colors hover:bg-blue-600 hover:text-white"
                         >
                           <Plus className="h-3 w-3" />
                           Lesson


### PR DESCRIPTION
Redesigns the "+ Lesson" button in the Curriculum panel.

**Changes:**
- Default state: blue outline (), white background (), blue text ()
- Hover state: blue background (), white text ()
- Added  for smooth hover animation