### PR TITLE
fix(landing): require Enter for search, fix @username search

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -4632,6 +4632,7 @@ export default function LandingPage() {
   const [theme] = useState<ColorTheme>('emerald')
   const [mode] = useState<ThemeMode>('light')
   const [searchQuery, setSearchQuery] = useState('')
+  const [committedSearchQuery, setCommittedSearchQuery] = useState('')
   const [tutorTotal, setTutorTotal] = useState<number | null>(null)
   const [courseTotal, setCourseTotal] = useState<number | null>(null)
   const [contactModalOpen, setContactModalOpen] = useState(false)
@@ -4924,6 +4925,7 @@ export default function LandingPage() {
                 onSubmit={e => {
                   e.preventDefault()
                   if (!searchQuery.trim()) return
+                  setCommittedSearchQuery(searchQuery.trim())
                   scrollToSearchResults()
                   ;(e.currentTarget.querySelector('input') as HTMLInputElement | null)?.blur()
                 }}
@@ -4934,7 +4936,18 @@ export default function LandingPage() {
                     type="text"
                     placeholder="Search tutors, courses, categories..."
                     value={searchQuery}
-                    onChange={e => setSearchQuery(e.target.value)}
+                    onChange={e => {
+                      setSearchQuery(e.target.value)
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        if (searchQuery.trim()) {
+                          setCommittedSearchQuery(searchQuery.trim())
+                          scrollToSearchResults()
+                        }
+                      }
+                    }}
                     className="ml-4 flex-1 bg-transparent text-sm text-slate-700 outline-none placeholder:text-slate-400 focus:outline-none focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
                   />
                   <button
@@ -5015,7 +5028,13 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <Panel2SearchResults query={searchQuery} onClearAll={() => setSearchQuery('')} />
+        <Panel2SearchResults
+          query={committedSearchQuery}
+          onClearAll={() => {
+            setSearchQuery('')
+            setCommittedSearchQuery('')
+          }}
+        />
 
         <div id="how-it-works" />
 

--- a/tutorme-app/src/app/api/public/courses/route.ts
+++ b/tutorme-app/src/app/api/public/courses/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const searchQuery = searchParams.get('q')?.toLowerCase().trim() || ''
+    const searchQuery = searchParams.get('q')?.toLowerCase().trim().replace(/^@/, '') || ''
     const countryParam = searchParams.get('country')?.trim() || ''
     const countryName =
       countryParam && countryParam !== 'global'

--- a/tutorme-app/src/app/api/public/tutors/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/route.ts
@@ -115,7 +115,7 @@ export async function GET(request: NextRequest) {
       })
     }
 
-    const searchQuery = searchParams.get('q')?.toLowerCase().trim() || ''
+    const searchQuery = searchParams.get('q')?.toLowerCase().trim().replace(/^@/, '') || ''
     const categoryFilter = searchParams.get('subject')?.toLowerCase().trim() || ''
     const combinationFilter = searchParams.get('combination')?.toLowerCase().trim() || ''
     const nationalityFilter = searchParams.get('nationality')?.toLowerCase().trim() || ''
@@ -182,6 +182,7 @@ export async function GET(request: NextRequest) {
           searchPattern
             ? or(
                 ilike(profile.name, searchPattern),
+                ilike(profile.username, searchPattern),
                 ilike(profile.bio, searchPattern),
                 ilike(course.name, searchPattern),
                 ilike(courseVariant.category, searchPattern),


### PR DESCRIPTION
Fixes two issues with the landing page search:

**1. Search triggers on every keystroke**
- Before: Typing immediately showed search results with 200ms debounce
- After: Search only executes when user presses Enter or submits the form

**2. @username search returns no results**
- Before: @soloc sent %@soloc% to SQL which didn't match username soloc
- After: @ prefix is stripped before sending to API, so @soloc searches for soloc
- Also added username search to tutors API (was missing)

**Changes:**
- Added committedSearchQuery state that only updates on Enter/submit
- Typing updates visual input but doesn't trigger API call
- Both APIs now strip leading @ from search query
- Tutors API now includes ilike(profile.username) in search

**Files modified:**
- page.tsx: Enter key handling + committed search state
- courses/route.ts: Strip @ prefix
- tutors/route.ts: Strip @ prefix + add username search