### PR TITLE
fix(classroom): pin Desk insights input to bottom & equalize student live tabs

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1997,7 +1997,7 @@ function StudentFeedbackContent() {
             )}
 
             <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-              <div className="flex w-full items-center gap-2 rounded-lg bg-gray-100 p-1">
+              <div className="grid w-full grid-cols-4 items-center gap-2 rounded-lg bg-gray-100 p-1">
                 <Button
                   variant="ghost"
                   size="sm"

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7965,8 +7965,8 @@ FEEDBACK: [your explanation]`
                               <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
                                 Desk
                               </div>
-                              <div className="min-h-0 flex-1 overflow-hidden">
-                                <div className="px-2 pt-4">
+                              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                                <div className="shrink-0 px-2 pt-4">
                                   <Tabs
                                     value={liveRightPanelTab}
                                     onValueChange={value => {
@@ -8001,7 +8001,7 @@ FEEDBACK: [your explanation]`
                                         }
                                         className="flex h-full min-h-0 flex-col"
                                       >
-                                        <TabsList className="mb-2 grid w-full grid-cols-3 gap-2 rounded-lg bg-white p-1 shadow-none">
+                                        <TabsList className="mb-2 grid w-full shrink-0 grid-cols-3 gap-2 rounded-lg bg-white p-1 shadow-none">
                                           <TabsTrigger
                                             value="analytics"
                                             className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
@@ -8046,7 +8046,7 @@ FEEDBACK: [your explanation]`
                                               }
                                             />
                                           </div>
-                                          <div className="mt-2 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
+                                          <div className="mt-2 shrink-0 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
                                             <div className="relative">
                                               <MentionTextarea
                                                 mentionItems={mentionItems}
@@ -8120,7 +8120,7 @@ FEEDBACK: [your explanation]`
                                               }
                                             />
                                           </div>
-                                          <div className="mt-2 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
+                                          <div className="mt-2 shrink-0 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
                                             <div className="relative">
                                               <MentionTextarea
                                                 mentionItems={mentionItems}


### PR DESCRIPTION
## Summary

Two classroom layout fixes.

### Task 1 — Tutor Desk panel (Insights tab)
On the Classroom tab → Desk panel → **Insights** (Analytics / Poll / Question), the chat area collapsed to content height and the input floated up beneath it instead of sitting at the bottom of the Desk panel.

Root cause: the Desk **content region** was `min-h-0 flex-1 overflow-hidden` but **not** a flex column, so the `flex-1`/`h-full` heights below it never resolved.

Fix:
- Make the Desk content region `flex flex-col` so height propagates down.
- Mark the Submissions/Insights tab bar and the Analytics/Poll/Question sub-tab list `shrink-0`.
- Mark the Poll & Question input wrappers `shrink-0`.

Result: chat area grows to fill, input pinned to bottom of the Desk panel.

### Task 2 — Student live classroom tabs
**Lessons** / **Interact** / **Assessment** / **My Board** were unequal widths — a flex row of `whitespace-nowrap` buttons whose longer labels expanded past their `flex-1` basis. Switch the container to `grid grid-cols-4` (`minmax(0,1fr)` columns) so all four tabs are exactly equal width.

## Testing
- `npm run typecheck` passes.
- prettier clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)