### PR TITLE
test(integration): fix recurring live-test flake (shared Date.now() id collision)

### DIFF
--- a/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
+++ b/tutorme-app/src/__tests__/integration/live-auto-grading.test.ts
@@ -32,7 +32,7 @@ import {
 } from '@/lib/db/schema'
 import { autoGradeDmi } from '@/lib/grading/auto-grade'
 
-const stamp = Date.now()
+const stamp = `${Date.now()}_${crypto.randomUUID().slice(0, 8)}`
 const tutorEmail = `claude-grade-tutor-${stamp}@example.com`
 const studentEmail = `claude-grade-student-${stamp}@example.com`
 

--- a/tutorme-app/src/__tests__/integration/live-submission-persistence.test.ts
+++ b/tutorme-app/src/__tests__/integration/live-submission-persistence.test.ts
@@ -31,7 +31,7 @@ import {
 } from '@/lib/db/schema'
 import { GET as getSubmissions } from '@/app/api/tutor/submissions/route'
 
-const stamp = Date.now()
+const stamp = `${Date.now()}_${crypto.randomUUID().slice(0, 8)}`
 const tutorEmail = `claude-subm-tutor-${stamp}@example.com`
 const studentEmail = `claude-subm-student-${stamp}@example.com`
 


### PR DESCRIPTION
## The flake
`live-auto-grading.test.ts` and `live-submission-persistence.test.ts` both build their entity ids from `const stamp = Date.now()` (`c_${stamp}`, `task_${stamp}`, …). When the two files evaluate in the **same millisecond** (vitest loads them together), they get the **same `stamp`** →
- duplicate `Course_pkey` (`c_<stamp>` inserted twice), and
- a `TaskSubmission → BuilderTask` FK violation (the colliding course insert had thrown, so the task never got created).

This is the intermittent integration failure that's been red across many PRs (it's a non-required CI check, so it didn't block merges/deploys — but it's noise).

## Fix
Append a random uuid slice to `stamp` so ids are unique **per file and per run**:
```
const stamp = `${Date.now()}_${crypto.randomUUID().slice(0, 8)}`
```

## Verification
Ran **both** files together against a freshly `drizzle-kit push`'d schema → all pass; ran `live-submission-persistence` a **second** time on the same DB → still passes (no cross-run collision either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)