### PR TITLE
feat(dmi): explicit "From study material" generation + stronger detection

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10077,6 +10077,33 @@ FEEDBACK: [your explanation]`
                                               variant="ghost"
                                               size="sm"
                                               className="h-6 px-2 text-xs font-medium text-gray-600 hover:text-gray-900"
+                                              disabled={dmiGenerating || !canEdit}
+                                              title="Document is study material (notes/book): pick question types & counts to generate questions + DMI"
+                                              onClick={() => {
+                                                if (!canEdit) return
+                                                const content = assessmentBuilder.taskContent
+                                                const hasPdf =
+                                                  currentAssessmentDocument?.mimeType ===
+                                                  'application/pdf'
+                                                if (!content.trim() && !hasPdf) {
+                                                  toast.error(
+                                                    'Please add content to the Assessment tab or load a document first'
+                                                  )
+                                                  return
+                                                }
+                                                setDmiSpecRows([{ type: 'short', count: 3 }])
+                                                setDmiSpecDialog({ type: 'assessment' })
+                                              }}
+                                            >
+                                              From study material
+                                            </Button>
+
+                                            <div className="h-3 w-px bg-gray-300" />
+
+                                            <Button
+                                              variant="ghost"
+                                              size="sm"
+                                              className="h-6 px-2 text-xs font-medium text-gray-600 hover:text-gray-900"
                                               onClick={() => setShowDmiVersionList(true)}
                                               title="View DMI Versions"
                                             >

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -55,8 +55,10 @@ Return ONLY a JSON object (no prose, no markdown, no code fences) with EXACTLY t
 }
 
 Rules:
-- documentKind: "question_paper" if the document already contains questions/exam tasks; otherwise
-  "study_material" (notes with no explicit questions).
+- documentKind (ALWAYS include it): "question_paper" if the document already contains explicit,
+  numbered questions / exam tasks the student is meant to answer; "study_material" if it is a
+  textbook, lecture notes, article, summary, or any prose WITHOUT explicit exam questions. When in
+  doubt and the document is mostly explanatory prose, choose "study_material".
 - For a question_paper: output ONE field per answerable part — every question AND every sub-part
   (a),(b),(c) and sub-sub-part (i),(ii). "label" is the part's reference EXACTLY as printed, e.g.
   "Question 1(a)", "Question 1(b)(i)", "Question 3(a)(ii)". The label MUST be only the reference —


### PR DESCRIPTION
Makes the **study-material → generated-questions → DMI** flow reliable.

## What already existed
The full pipeline is in place: when a source is study material, a dialog asks **which question types + counts**, the model generates the questions, a DMI is built, and on deploy the **generated questions go to the Classroom tab** while the **DMI goes to the Assessment tab** — and the original document is dropped so students don't see it.

## The gap
It only triggered when the model **auto-classified** the document as `study_material`, which is unreliable for a textbook/notes (the model often treats it as a question paper, so the dialog never appeared).

## Changes
- **Explicit "From study material" button** next to *Generate DMI*: opens the type/count dialog directly — deterministic, no dependence on model classification — then runs the existing generate-with-spec → deploy-to-Classroom path. So the tutor can always invoke this flow for a book/notes.
- **Stronger `documentKind` prompt**: always classify, and default mostly-prose docs to `study_material` so the automatic path also works.

## Persistence / original document
Generated questions persist as the auto-saved assessment content (and are what deploy to the Classroom); the original document is dropped. Cross-tab persistence is preserved by the earlier blank-slate-once fix.

## Verification
typecheck + build clean; insights-builder tab-loop e2e passes (no #185 crash). The AI classification/generation itself needs a live run (no AI key locally) — best confirmed by loading a book as an assessment and using **From study material** on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)