### PR TITLE
fix(student-classroom): keep right panel width consistent across tabs

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1978,7 +1978,10 @@ function StudentFeedbackContent() {
               rightPanelResizing ? 'transition-none' : 'transition-all duration-500 ease-out'
             )}
             style={{
-              width: rightPanelWidth + (isExpanded ? EXPANDED_PANEL_BONUS : 0),
+              // Keep the panel a consistent width regardless of which tab is
+              // active — always use the wider (expanded) width that Assessment
+              // and My Board use, so Lessons/Interact don't shrink the panel.
+              width: rightPanelWidth + EXPANDED_PANEL_BONUS,
             }}
           >
             {/* Resize handle */}
@@ -1997,7 +2000,7 @@ function StudentFeedbackContent() {
             )}
 
             <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-              <div className="grid w-full grid-cols-4 items-center gap-2 rounded-lg bg-gray-100 p-1">
+              <div className="flex w-full items-center gap-2 rounded-lg bg-gray-100 p-1">
                 <Button
                   variant="ghost"
                   size="sm"


### PR DESCRIPTION
## Summary

Follow-up to #350, correcting my misread of Task 2.

The actual issue: on the student live classroom, selecting **Lessons** or **Interact** made the **right panel itself narrower** than when **Assessment** or **My Board** were selected — it wasn't about the tab-button widths.

### Root cause
`tutorme-app/src/app/[locale]/student/feedback/page.tsx`:
```ts
const isExpanded = rightPanelTab === 'my-board' || rightPanelTab === 'dmi'
const EXPANDED_PANEL_BONUS = 300
...
width: rightPanelWidth + (isExpanded ? EXPANDED_PANEL_BONUS : 0)
```
`isExpanded` is only true for Assessment (`dmi`) and My Board, so Lessons/Interact lost the `+300` bonus and the panel shrank.

### Fix
- Always add `EXPANDED_PANEL_BONUS` to the panel width, so the panel keeps the wider (Assessment/My Board) width regardless of the active tab.
- Revert the `grid grid-cols-4` tab container introduced in #350 back to the original `flex` layout, since the tab-button widths were not the real problem.

`isExpanded` is still used for the resize-handle visibility, content overflow/padding, and center-column layout — those are intentionally left unchanged; only the panel width is decoupled from the tab.

## Testing
- `npm run typecheck` passes.
- prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)