### PR TITLE
fix(dmi): study-material questions on Classroom + MCQ letter selection (a–e)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -338,8 +338,39 @@ function DmiAnswerField({
   // Tap-to-place selection for drag_drop (touch fallback for native drag).
   const [dragSelected, setDragSelected] = useState<string | null>(null)
 
-  // Single-select choice (mcq / true_false) — render radios when we have options.
-  if ((type === 'mcq' || type === 'true_false') && options.length > 0) {
+  // Multiple choice — clickable LETTER chips (a–e). The full option text is read
+  // on the Classroom side; the student just selects the letter, which is stored.
+  if (type === 'mcq' && options.length > 0) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {options.map((_opt, i) => {
+          const letter = String.fromCharCode(65 + i) // A, B, C, …
+          const selected = value === letter
+          return (
+            <button
+              key={letter}
+              type="button"
+              onClick={() => {
+                onInteract()
+                onValueChange(letter)
+              }}
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold transition-colors',
+                selected
+                  ? 'border-[#F17623] bg-[#F17623] text-white'
+                  : 'border-gray-300 text-gray-700 hover:border-[#F17623] hover:text-[#F17623]'
+              )}
+            >
+              {letter}
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  // True / False — radios.
+  if (type === 'true_false' && options.length > 0) {
     return (
       <div className="space-y-1.5">
         {options.map(opt => (

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2838,42 +2838,29 @@ FEEDBACK: [your explanation]`
           regions: Array.isArray(q.regions) ? q.regions : undefined,
         }))
 
-        // Calculate version number
-        const existingVersions = isTask ? taskDmiVersions : assessmentDmiVersions
-        const nextVersionNumber = existingVersions.length + 1
-
-        // Create new version
-        const newVersion: DMIVersion = {
-          id: `dmi-version-${Date.now()}`,
-          versionNumber: nextVersionNumber,
-          items: items,
-          createdAt: Date.now(),
-          taskId: isTask ? loadedTaskId || undefined : undefined,
-          assessmentId: !isTask ? loadedAssessmentId || undefined : undefined,
-        }
-
-        if (isTask) {
-          setTaskDmiItems(items)
-          setTaskDmiVersions(prev => [...prev, newVersion])
-          setTestPciSource('task')
-          setTestPciViewMode(`dmi_${newVersion.id}`)
-        } else {
-          setAssessmentDmiItems(items)
-          setAssessmentDmiVersions(prev => [...prev, newVersion])
-          setTestPciSource('assessment')
-          setTestPciViewMode(`dmi_${newVersion.id}`)
-        }
-
-        // Study material: the students must see the GENERATED questions in the
-        // Classroom tab, not the original notes. Replace the deployed content with
-        // the numbered questions and drop the source document so only the
-        // questions (Classroom) + the DMI input fields (Assessment) go out.
+        // Study material: students see the GENERATED questions (with options) on
+        // the Classroom side; the DMI on the right keeps ONLY a short "Question N"
+        // label + its input control. A question paper keeps the DMI label as-is
+        // (it already references the deployed paper).
         const isStudyMaterial =
           data.documentKind === 'study_material' || (questionSpec?.length ?? 0) > 0
+
+        let dmiItems = items
         if (isStudyMaterial) {
           const generatedClassroomContent = items
-            .map(q => `${q.questionNumber}. ${q.questionText}`)
+            .map(q => {
+              let block = `${q.questionNumber}. ${q.questionText}`
+              // Choice questions: list options as a) b) c) … under the stem.
+              if (Array.isArray(q.options) && q.options.length > 0) {
+                block +=
+                  '\n' +
+                  q.options.map((o, i) => `   ${String.fromCharCode(97 + i)}) ${o}`).join('\n')
+              }
+              return block
+            })
             .join('\n\n')
+          // The DMI shows only the reference; the full question lives in Classroom.
+          dmiItems = items.map(q => ({ ...q, questionText: `Question ${q.questionNumber}` }))
           if (isTask) {
             setTaskBuilder(prev => ({
               ...prev,
@@ -2894,7 +2881,30 @@ FEEDBACK: [your explanation]`
           )
         }
 
-        toast.success(`DMI form v${nextVersionNumber} created with ${items.length} questions`)
+        const existingVersions = isTask ? taskDmiVersions : assessmentDmiVersions
+        const nextVersionNumber = existingVersions.length + 1
+        const newVersion: DMIVersion = {
+          id: `dmi-version-${Date.now()}`,
+          versionNumber: nextVersionNumber,
+          items: dmiItems,
+          createdAt: Date.now(),
+          taskId: isTask ? loadedTaskId || undefined : undefined,
+          assessmentId: !isTask ? loadedAssessmentId || undefined : undefined,
+        }
+
+        if (isTask) {
+          setTaskDmiItems(dmiItems)
+          setTaskDmiVersions(prev => [...prev, newVersion])
+          setTestPciSource('task')
+          setTestPciViewMode(`dmi_${newVersion.id}`)
+        } else {
+          setAssessmentDmiItems(dmiItems)
+          setAssessmentDmiVersions(prev => [...prev, newVersion])
+          setTestPciSource('assessment')
+          setTestPciViewMode(`dmi_${newVersion.id}`)
+        }
+
+        toast.success(`DMI form v${nextVersionNumber} created with ${dmiItems.length} questions`)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to generate DMI'
         toast.error(message)
@@ -2972,6 +2982,13 @@ FEEDBACK: [your explanation]`
           id: item.id,
           questionNumber: item.questionNumber,
           questionText: item.questionText,
+          // Carry the answer-input type + options/pairs so the student gets the
+          // right control (e.g. mcq letter choices), not a plain textarea.
+          questionType: item.questionType,
+          options: item.options,
+          pairs: item.pairs,
+          hotspotImageUrl: item.hotspotImageUrl,
+          regions: item.regions,
         })),
         deployedAt: Date.now(),
         polls: [],

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -70,7 +70,8 @@ Rules:
   ordering, hotspot, drag_drop. Choose by how the part is meant to be answered (multiple-choice
   item -> "mcq" with "options"; short response -> "short"; extended/essay -> "long"). Default to
   "short" if unsure.
-- "options" array ONLY for mcq / true_false / multiple_response.
+- "options" array ONLY for mcq / true_false / multiple_response. For "mcq", ALWAYS provide
+  EXACTLY 5 options (these become choices a–e); make them plausible and distinct.
 - "pairs" (array of {"left","right"}) ONLY for matching / drag_drop.
 
 EXAMPLE — Question 1 has parts (a),(b)(i),(b)(ii),(c); Question 2 has (a),(b). Correct JSON:


### PR DESCRIPTION
Two refinements to the study-material → DMI flow.

## 1 — Generated questions on the Classroom (left); DMI shows only the label
- The full generated questions (with `a) b) c) …` options) now deploy as the **Classroom** content (left), so it's no longer empty.
- The **DMI** on the right keeps **only a short "Question N" label** + its input control (the full question lives on the left).
- **Bug fixed:** `handleDeployAssessmentDmi` was deploying DMI items as only `{id, number, text}` — it **dropped `questionType`/`options`/`pairs`**, so the student DMI lost its controls (everything became a textarea). Now carried through.

## 2 — Multiple choice: options a–e, click the letter
- The agent is instructed to always produce **exactly 5 options** for `mcq` (a–e); the Classroom lists them under the stem.
- The student DMI renders clickable **letter chips A–E** — the student selects the **letter** (stored as the answer), not the full option text.

## Verification
typecheck + build clean; insights-builder tab-loop e2e passes (no #185 crash). The AI generation/classification needs a live run (no AI key locally) — best confirmed on prod by generating from a book and checking the Classroom shows the full MCQs and the DMI shows A–E chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)