### PR TITLE
feat(grading): persist DMI answer key on deploy so live submissions auto-grade

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2252,6 +2252,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 hotspotImageUrl: i.hotspotImageUrl,
                 regions: i.regions,
               })) || [],
+            // Answer key + marks for server-side grading (never sent to students).
+            answerKey:
+              homeworkItem.dmiItems?.map(i => ({
+                id: i.id,
+                answer: i.answer,
+                marks: i.marks,
+              })) || [],
             deployedAt: Date.now(),
             polls: [],
             questions: [],
@@ -3036,6 +3043,13 @@ FEEDBACK: [your explanation]`
           pairs: item.pairs,
           hotspotImageUrl: item.hotspotImageUrl,
           regions: item.regions,
+        })),
+        // Answer key + marks for server-side auto-grading. Sent to the server
+        // only — never broadcast to students.
+        answerKey: assessmentDmiItems.map(item => ({
+          id: item.id,
+          answer: item.answer,
+          marks: item.marks,
         })),
         deployedAt: Date.now(),
         polls: [],
@@ -9187,6 +9201,15 @@ FEEDBACK: [your explanation]`
                                                         pairs: item.pairs,
                                                         hotspotImageUrl: item.hotspotImageUrl,
                                                         regions: item.regions,
+                                                      })) || [],
+                                                    // Answer key + marks for
+                                                    // server-side grading (never
+                                                    // sent to students).
+                                                    answerKey:
+                                                      task.dmiItems?.map(item => ({
+                                                        id: item.id,
+                                                        answer: item.answer,
+                                                        marks: item.marks,
                                                       })) || [],
                                                     deployedAt: Date.now(),
                                                     polls: [],

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -141,6 +141,10 @@ export interface LiveTask {
   instructions?: string
   source: 'task' | 'assessment' | 'homework'
   dmiItems?: LiveTaskDmiItem[]
+  /** Per-question answer key + marks. Sent tutor→server on deploy ONLY and
+   *  persisted server-side for auto-grading; NEVER copied into the student
+   *  broadcast (normalizedTask) or stored in deployedMaterial. */
+  answerKey?: Array<{ id: string; answer?: string; marks?: number }>
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]
@@ -1256,6 +1260,38 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   updatedAt: now,
                 })
                 .onConflictDoNothing({ target: builderTask.taskId })
+
+              // Persist the answer key + marks server-side so live submissions
+              // auto-grade against it. Carried on the deploy payload's
+              // `answerKey` (never in the student broadcast). One row per task,
+              // refreshed on each deploy; the grader reads the latest by taskId.
+              const answerKey = Array.isArray(task.answerKey) ? task.answerKey : []
+              const gradableKey = answerKey.filter(
+                k => k && typeof k.id === 'string' && (k.answer ?? '').toString().trim().length > 0
+              )
+              if (gradableKey.length > 0) {
+                try {
+                  await drizzleDb
+                    .insert(builderTaskDmi)
+                    .values({
+                      dmiId: `dmi-${normalizedTask.id}`,
+                      taskId: normalizedTask.id,
+                      type: normalizedTask.source === 'assessment' ? 'assessment' : 'task',
+                      items: gradableKey,
+                      createdAt: now,
+                      updatedAt: now,
+                    })
+                    .onConflictDoUpdate({
+                      target: builderTaskDmi.dmiId,
+                      set: { items: gradableKey, updatedAt: now },
+                    })
+                } catch (dmiErr) {
+                  console.warn(
+                    '[task:deploy] BuilderTaskDmi answer-key persist failed (non-critical):',
+                    dmiErr
+                  )
+                }
+              }
             }
           } catch (btErr) {
             console.warn('[task:deploy] BuilderTask auto-create failed (non-critical):', btErr)

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -88,6 +88,9 @@ export interface LiveTask {
   instructions?: string
   source: 'task' | 'assessment' | 'homework'
   dmiItems?: LiveTaskDmiItem[]
+  /** Per-question answer key + marks. Sent tutor→server on deploy ONLY for
+   *  server-side auto-grading; NEVER broadcast to students. */
+  answerKey?: Array<{ id: string; answer?: string; marks?: number }>
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]


### PR DESCRIPTION
Closes the missing link from the DMI marks/answers work: the live auto-grader reads answer keys from `BuilderTaskDmi`, which had **no production write path** — so live submissions never auto-graded against the tutor's vetted answers.

## How
- The tutor **deploy payload** now carries an `answerKey` (per-question `id` + `answer` + `marks`) alongside the student-safe `dmiItems`. It is sent to the server **only** — never copied into the student broadcast (`normalizedTask`) or `deployedMaterial`, so students still never receive answers.
- The `task:deploy` handler (already tutor-gated) **upserts `BuilderTaskDmi`** — one row per task, deterministic `dmiId`, refreshed on each deploy — right after the existing `BuilderTask` auto-create, so the FK is satisfied. Only questions with a non-empty answer are persisted, so question papers (no fabricated key) write nothing and stay manually graded.
- The grader already reads `BuilderTaskDmi.items` and weights by `marks` (earlier PR), so live submissions now produce a **marks-weighted score against the vetted answer key**.

`answerKey` added to both `LiveTask` interfaces (socket-types + socket server). Applied to assessment, task, and homework deploy paths.

## Security
The answer key only originates from a tutor-role socket on deploy and is never broadcast; the student-facing `dmiItems` continue to omit `answer`/`rubric`.

## Verification
- `npm run typecheck` — clean
- `npm run build` — succeeds (verified pre-cherry-pick)
- End-to-end (live session → submit → auto-grade) is socket+DB+AI-driven; must be confirmed on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)