### PR TITLE
fix(grading): grade async assignment submissions server-side (don't trust client score)

### DIFF
--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -11,20 +11,49 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, eq } from 'drizzle-orm'
+import { and, desc, eq } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
 import { handleApiError, requireCsrf } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { builderTask, courseEnrollment, taskSubmission } from '@/lib/db/schema'
+import { builderTask, builderTaskDmi, courseEnrollment, taskSubmission } from '@/lib/db/schema'
 import { generateFeedback, submitFeedbackForReview } from '@/lib/feedback/workflow'
+import { autoGradeDmi, type DmiAnswerItem } from '@/lib/grading/auto-grade'
 
 const MAX_SCORE = 100
 
-function clampScore(value: unknown): number | null {
-  if (typeof value !== 'number' || Number.isNaN(value)) return null
-  return Math.max(0, Math.min(MAX_SCORE, value))
+// (Client-supplied scores are no longer accepted; scoring is server-side.)
+
+/**
+ * Build the server-side answer key for a task. Prefers the DMI answer key
+ * (BuilderTaskDmi.items — the same source the live grader and GET route use),
+ * falling back to questions embedded in the task metadata. The id derivation
+ * MUST mirror the GET route's mapQuestions so submitted answers line up.
+ */
+function buildAnswerKey(dmiItems: unknown, metadata: unknown): DmiAnswerItem[] {
+  const fromItems = Array.isArray(dmiItems) ? dmiItems : []
+  if (fromItems.length > 0) {
+    return fromItems.map((raw, i) => {
+      const item = (raw ?? {}) as Record<string, unknown>
+      return {
+        id: String(item.id ?? item.questionNumber ?? i + 1),
+        answer: item.answer != null ? String(item.answer) : undefined,
+        marks: typeof item.marks === 'number' && item.marks > 0 ? item.marks : undefined,
+      }
+    })
+  }
+  const meta = (metadata ?? {}) as Record<string, unknown>
+  const metaQuestions = Array.isArray(meta.questions) ? meta.questions : []
+  return metaQuestions.map((raw, i) => {
+    const item = (raw ?? {}) as Record<string, unknown>
+    const answer = item.correctAnswer ?? item.answer
+    return {
+      id: String(item.id ?? item.questionNumber ?? i + 1),
+      answer: answer != null ? String(answer) : undefined,
+      marks: typeof item.points === 'number' && item.points > 0 ? item.points : undefined,
+    }
+  })
 }
 
 export async function POST(
@@ -46,19 +75,23 @@ export async function POST(
       return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
     }
 
+    // NOTE: client-supplied `score`/`questionResults` are intentionally ignored —
+    // the score is computed server-side against the answer key below so a student
+    // cannot POST an arbitrary grade.
     const body = (await request.json().catch(() => ({}))) as {
       answers?: Record<string, unknown>
       timeSpent?: number
-      score?: number
-      questionResults?: unknown
     }
     const answers = body.answers ?? {}
     const timeSpent = typeof body.timeSpent === 'number' && body.timeSpent >= 0 ? body.timeSpent : 0
-    const score = clampScore(body.score)
 
     // Task must exist, be published, and not deleted
     const [task] = await drizzleDb
-      .select({ courseId: builderTask.courseId, status: builderTask.status })
+      .select({
+        courseId: builderTask.courseId,
+        status: builderTask.status,
+        metadata: builderTask.metadata,
+      })
       .from(builderTask)
       .where(eq(builderTask.taskId, taskId))
       .limit(1)
@@ -92,10 +125,20 @@ export async function POST(
     }
 
     const submissionId = randomUUID()
-    const questionResults =
-      body.questionResults != null && typeof body.questionResults === 'object'
-        ? body.questionResults
-        : null
+
+    // Grade server-side against the task's answer key (DMI items, else metadata
+    // questions). When there's no key the score is null — pending tutor review —
+    // never a value the client supplied.
+    const [dmi] = await drizzleDb
+      .select({ items: builderTaskDmi.items })
+      .from(builderTaskDmi)
+      .where(eq(builderTaskDmi.taskId, taskId))
+      .orderBy(desc(builderTaskDmi.updatedAt))
+      .limit(1)
+    const answerKey = buildAnswerKey(dmi?.items, task.metadata)
+    const graded = autoGradeDmi(answerKey, answers as Record<string, string>)
+    const score = graded.score
+    const questionResults = graded.questionResults
 
     await drizzleDb.insert(taskSubmission).values({
       submissionId,


### PR DESCRIPTION
Async submit route persisted client-supplied score/questionResults verbatim — a student could POST any grade. Now recomputes score server-side against the task answer key (BuilderTaskDmi.items, else metadata.questions) weighted by marks, ignoring client values. No key → null (pending tutor review). maxScore stays 100, consistent with the live grading path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)