### PR TITLE
feat(assess): tutor-chosen answer-reveal policy (instant / after-submit / hidden)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -43,6 +43,7 @@ interface TaskQuestion {
   type: string
   question: string
   options?: string[]
+  correctAnswer?: string
   points: number
   rubric?: string[]
   hints?: string[]
@@ -65,6 +66,7 @@ export default function StudentAssignmentsPage() {
     id: string
     title: string
     questions: TaskQuestion[]
+    answerReveal?: 'instant' | 'after_submit' | 'hidden'
   } | null>(null)
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -125,6 +127,7 @@ export default function StudentAssignmentsPage() {
         id: taskId,
         title: data.task.title,
         questions: data.task.questions,
+        answerReveal: data.task.answerReveal,
       })
       setStartTime(Date.now())
       setTakingQuiz(true)
@@ -156,11 +159,10 @@ export default function StudentAssignmentsPage() {
           ...(csrf && { 'X-CSRF-Token': csrf }),
         },
         credentials: 'include',
+        // Score is computed server-side; only the answers/time are sent.
         body: JSON.stringify({
           answers: results.answers,
           timeSpent: timeSpentSec,
-          score: results.score,
-          questionResults: results.questionResults,
         }),
       })
 
@@ -172,6 +174,14 @@ export default function StudentAssignmentsPage() {
             ? `Submitted! Score: ${Math.round(submittedScore)}%`
             : 'Submitted! Awaiting grading.'
         )
+        loadAssignments() // refresh list (modal closes via its Continue button)
+        // Hand the authoritative server grade back so the results screen can
+        // show the real score + (when allowed) the correct answers.
+        return {
+          score: data?.submission?.score ?? null,
+          questionResults: data?.questionResults,
+          correctAnswers: data?.correctAnswers,
+        }
       } else if (submitRes.status === 409) {
         toast.info('Already submitted')
       } else {
@@ -181,9 +191,6 @@ export default function StudentAssignmentsPage() {
       toast.error('Failed to submit')
     } finally {
       setSubmitting(false)
-      setTakingQuiz(false)
-      setActiveTask(null)
-      loadAssignments() // refresh list
     }
   }
 
@@ -247,6 +254,7 @@ export default function StudentAssignmentsPage() {
         : 'short_answer') as 'multiple_choice' | 'short_answer',
       question: q.question,
       options: q.options,
+      correctAnswer: q.correctAnswer,
       rubric: q.rubric?.join('; '),
     }))
 
@@ -255,6 +263,7 @@ export default function StudentAssignmentsPage() {
         questions={quizQuestions}
         onComplete={handleQuizComplete}
         onClose={handleCloseQuiz}
+        answerReveal={activeTask.answerReveal}
       />
     )
   }

--- a/tutorme-app/src/app/[locale]/student/work/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/work/page.tsx
@@ -56,6 +56,7 @@ interface TaskQuestion {
   type: string
   question: string
   options?: string[]
+  correctAnswer?: string
   points: number
   rubric?: string[]
   hints?: string[]
@@ -102,6 +103,7 @@ function AssignmentsTab() {
     id: string
     title: string
     questions: TaskQuestion[]
+    answerReveal?: 'instant' | 'after_submit' | 'hidden'
   } | null>(null)
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -136,6 +138,7 @@ function AssignmentsTab() {
         id: taskId,
         title: data.task.title,
         questions: data.task.questions,
+        answerReveal: data.task.answerReveal,
       })
       setStartTime(Date.now())
       setTakingQuiz(true)
@@ -170,7 +173,18 @@ function AssignmentsTab() {
 
       if (submitRes.ok) {
         const data = await submitRes.json()
-        toast.success(`Submitted! Score: ${Math.round(data.submission.score)}%`)
+        const submittedScore = data?.submission?.score
+        toast.success(
+          typeof submittedScore === 'number'
+            ? `Submitted! Score: ${Math.round(submittedScore)}%`
+            : 'Submitted! Awaiting grading.'
+        )
+        loadAssignments() // modal closes via its Continue button
+        return {
+          score: submittedScore ?? null,
+          questionResults: data?.questionResults,
+          correctAnswers: data?.correctAnswers,
+        }
       } else if (submitRes.status === 409) {
         toast.info('Already submitted')
       } else {
@@ -180,9 +194,6 @@ function AssignmentsTab() {
       toast.error('Failed to submit')
     } finally {
       setSubmitting(false)
-      setTakingQuiz(false)
-      setActiveTask(null)
-      loadAssignments()
     }
   }
 
@@ -245,6 +256,7 @@ function AssignmentsTab() {
         : 'short_answer') as 'multiple_choice' | 'short_answer',
       question: q.question,
       options: q.options,
+      correctAnswer: q.correctAnswer,
       rubric: q.rubric?.join('; '),
     }))
     return (
@@ -252,6 +264,7 @@ function AssignmentsTab() {
         questions={quizQuestions}
         onComplete={handleQuizComplete}
         onClose={handleCloseQuiz}
+        answerReveal={activeTask.answerReveal}
       />
     )
   }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1001,6 +1001,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // "Edit marks & answers" review modal — lets the tutor set per-question marks
     // and vet/approve the AI-generated answers before deploying.
     const [dmiEditor, setDmiEditor] = useState<{ source: 'task' | 'assessment' } | null>(null)
+    // Tutor's answer-reveal policy applied to deploys: when students may see the
+    // correct answers. Default 'instant' preserves the existing live-feedback
+    // behaviour; the tutor can switch to reveal-after-submit or hidden.
+    const [deployAnswerReveal, setDeployAnswerReveal] = useState<
+      'instant' | 'after_submit' | 'hidden'
+    >('instant')
 
     // Active tab tracking for Enter button
     const [taskBuilderActiveTab, setTaskBuilderActiveTab] = useState<'content' | 'pci'>('content')
@@ -2259,6 +2265,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 answer: i.answer,
                 marks: i.marks,
               })) || [],
+            answerReveal: deployAnswerReveal,
             deployedAt: Date.now(),
             polls: [],
             questions: [],
@@ -3051,6 +3058,7 @@ FEEDBACK: [your explanation]`
           answer: item.answer,
           marks: item.marks,
         })),
+        answerReveal: deployAnswerReveal,
         deployedAt: Date.now(),
         polls: [],
         questions: [],
@@ -3067,7 +3075,13 @@ FEEDBACK: [your explanation]`
       // Success is confirmed by the server's task:deployed broadcast (handled in
       // insights/page.tsx), not optimistically here.
       insightsProps.onDeployTask?.(task)
-    }, [assessmentBuilder, assessmentDmiItems, insightsProps, loadedAssessmentId])
+    }, [
+      assessmentBuilder,
+      assessmentDmiItems,
+      insightsProps,
+      loadedAssessmentId,
+      deployAnswerReveal,
+    ])
 
     useEffect(() => {
       return () => {
@@ -9211,6 +9225,7 @@ FEEDBACK: [your explanation]`
                                                         answer: item.answer,
                                                         marks: item.marks,
                                                       })) || [],
+                                                    answerReveal: deployAnswerReveal,
                                                     deployedAt: Date.now(),
                                                     polls: [],
                                                     questions: [],
@@ -10236,6 +10251,29 @@ FEEDBACK: [your explanation]`
                                                 >
                                                   Edit marks & answers
                                                 </Button>
+                                                <div className="h-3 w-px bg-gray-300" />
+                                                <select
+                                                  value={deployAnswerReveal}
+                                                  disabled={!canEdit}
+                                                  onChange={e =>
+                                                    setDeployAnswerReveal(
+                                                      e.target.value as
+                                                        | 'instant'
+                                                        | 'after_submit'
+                                                        | 'hidden'
+                                                    )
+                                                  }
+                                                  title="When students may see the correct answers"
+                                                  className="h-6 rounded border border-gray-200 bg-white px-1 text-xs font-medium text-gray-600"
+                                                >
+                                                  <option value="instant">
+                                                    Answers: instant feedback
+                                                  </option>
+                                                  <option value="after_submit">
+                                                    Answers: after submit
+                                                  </option>
+                                                  <option value="hidden">Answers: hidden</option>
+                                                </select>
                                               </>
                                             )}
 

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -117,6 +117,15 @@ export async function GET(
 
     const questions = mapQuestions(dmi?.items, task.metadata)
 
+    // Honor the tutor's answer-reveal policy. Only 'instant' may expose correct
+    // answers to the browser before submitting; otherwise strip them so students
+    // can't peek (the score is computed server-side on submit).
+    const rawReveal = (task.metadata as { answerReveal?: string } | null)?.answerReveal
+    const answerReveal =
+      rawReveal === 'after_submit' ? 'after_submit' : rawReveal === 'hidden' ? 'hidden' : 'instant'
+    const safeQuestions =
+      answerReveal === 'instant' ? questions : questions.map(({ correctAnswer: _c, ...q }) => q)
+
     return NextResponse.json({
       alreadySubmitted: existing != null,
       existingScore: existing?.score ?? null,
@@ -124,7 +133,8 @@ export async function GET(
         id: task.taskId,
         title: task.title,
         type: task.type,
-        questions,
+        answerReveal,
+        questions: safeQuestions,
       },
     })
   } catch (error) {

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -176,8 +176,23 @@ export async function POST(
       console.warn('[submit] AI feedback generation failed (non-critical):', feedbackError)
     }
 
+    // Reveal correct answers in the response ONLY when the tutor chose
+    // 'after_submit' — now that the student has submitted, it's safe to show
+    // them on the results screen. 'hidden'/'instant' get no post-submit key
+    // ('instant' already had them client-side; 'hidden' never reveals).
+    const rawReveal = (task.metadata as { answerReveal?: string } | null)?.answerReveal
+    const correctAnswers =
+      rawReveal === 'after_submit'
+        ? answerKey.reduce<Record<string, string>>((acc, k) => {
+            if (k.answer != null && k.answer !== '') acc[k.id] = k.answer
+            return acc
+          }, {})
+        : undefined
+
     return NextResponse.json({
       submission: { submissionId, score: score ?? 0, status: 'submitted' },
+      questionResults,
+      correctAnswers,
     })
   } catch (error) {
     return handleApiError(

--- a/tutorme-app/src/components/quiz/quiz-modal.tsx
+++ b/tutorme-app/src/components/quiz/quiz-modal.tsx
@@ -26,21 +26,39 @@ export interface QuestionResultItem {
   timeSpentSec?: number
 }
 
+/** What the parent's submit returns so the modal can show the authoritative
+ *  server grade (used by the non-'instant' reveal modes). */
+export interface QuizServerResult {
+  score?: number | null
+  questionResults?: QuestionResultItem[]
+  correctAnswers?: Record<string, string>
+}
+
 interface QuizModalProps {
   questions: Question[]
   onComplete: (results: {
     score: number
     answers: Record<string, any>
     questionResults?: QuestionResultItem[]
-  }) => void
+  }) => void | Promise<QuizServerResult | void>
   onClose: () => void
   studentId?: string // Optional student ID for personalized feedback
+  /** Tutor's answer-reveal policy. 'instant' keeps the legacy client-graded
+   *  results; 'after_submit'/'hidden' use the server's authoritative grade. */
+  answerReveal?: 'instant' | 'after_submit' | 'hidden'
 }
 
-export function QuizModal({ questions, onComplete, onClose, studentId }: QuizModalProps) {
+export function QuizModal({
+  questions,
+  onComplete,
+  onClose,
+  studentId,
+  answerReveal = 'instant',
+}: QuizModalProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [answers, setAnswers] = useState<Record<string, any>>({})
   const [showResults, setShowResults] = useState(false)
+  const [serverScore, setServerScore] = useState<number | null>(null)
   const [gradedAnswers, setGradedAnswers] = useState<
     Record<
       string,
@@ -72,6 +90,35 @@ export function QuizModal({ questions, onComplete, onClose, studentId }: QuizMod
   }
 
   const gradeQuiz = async () => {
+    // Non-'instant' modes: the browser has no answer key, so submit first and
+    // render the server's authoritative grade. Correct answers are revealed only
+    // for 'after_submit'.
+    if (answerReveal !== 'instant') {
+      const server = (await onComplete({ answers, score: 0, questionResults: [] })) || {}
+      const byId: Record<string, QuestionResultItem> = {}
+      ;(server.questionResults || []).forEach(r => {
+        byId[r.questionId] = r
+      })
+      const gradedFromServer: typeof gradedAnswers = {}
+      for (const q of questions) {
+        const r = byId[q.id]
+        const reveal = answerReveal === 'after_submit' ? server.correctAnswers?.[q.id] : undefined
+        gradedFromServer[q.id] = {
+          correct: r?.correct ?? false,
+          score: r?.pointsMax
+            ? Math.round(((r.pointsEarned ?? 0) / r.pointsMax) * 100)
+            : r?.correct
+              ? 100
+              : 0,
+          explanation: reveal ? `Correct answer: ${reveal}` : undefined,
+        }
+      }
+      setServerScore(typeof server.score === 'number' ? server.score : null)
+      setGradedAnswers(gradedFromServer)
+      setShowResults(true)
+      return
+    }
+
     const graded: Record<
       string,
       {
@@ -147,9 +194,12 @@ export function QuizModal({ questions, onComplete, onClose, studentId }: QuizMod
   }
 
   if (showResults) {
-    const score = Math.round(
-      (Object.values(gradedAnswers).filter(g => g.correct).length / questions.length) * 100
-    )
+    const score =
+      serverScore != null
+        ? serverScore
+        : Math.round(
+            (Object.values(gradedAnswers).filter(g => g.correct).length / questions.length) * 100
+          )
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -145,6 +145,8 @@ export interface LiveTask {
    *  persisted server-side for auto-grading; NEVER copied into the student
    *  broadcast (normalizedTask) or stored in deployedMaterial. */
   answerKey?: Array<{ id: string; answer?: string; marks?: number }>
+  /** Tutor's answer-reveal policy: 'instant' | 'after_submit' | 'hidden'. */
+  answerReveal?: 'instant' | 'after_submit' | 'hidden'
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]
@@ -1289,6 +1291,29 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   console.warn(
                     '[task:deploy] BuilderTaskDmi answer-key persist failed (non-critical):',
                     dmiErr
+                  )
+                }
+              }
+
+              // Persist the tutor's answer-reveal policy onto the task metadata
+              // so the async assignment GET/submit routes honor it. Merged into
+              // existing metadata so other keys are preserved.
+              const reveal = task.answerReveal
+              if (reveal === 'instant' || reveal === 'after_submit' || reveal === 'hidden') {
+                try {
+                  const { sql } = await import('drizzle-orm')
+                  await drizzleDb
+                    .update(builderTask)
+                    .set({
+                      metadata: sql`COALESCE(${builderTask.metadata}, '{}'::jsonb) || ${JSON.stringify(
+                        { answerReveal: reveal }
+                      )}::jsonb`,
+                    })
+                    .where(eq(builderTask.taskId, normalizedTask.id))
+                } catch (revealErr) {
+                  console.warn(
+                    '[task:deploy] answerReveal persist failed (non-critical):',
+                    revealErr
                   )
                 }
               }

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -80,6 +80,15 @@ export interface LiveTaskSourceDocument {
   mimeType: string
 }
 
+/**
+ * When students may see the correct answers for a deployed task/assessment:
+ * - 'instant'      — graded live as they answer (answers sent to the browser).
+ * - 'after_submit' — correct answers revealed only on the results screen.
+ * - 'hidden'       — never reveal answers; show the score only.
+ * Chosen by the tutor at deploy time.
+ */
+export type AnswerReveal = 'instant' | 'after_submit' | 'hidden'
+
 export interface LiveTask {
   id: string
   title: string
@@ -91,6 +100,8 @@ export interface LiveTask {
   /** Per-question answer key + marks. Sent tutor→server on deploy ONLY for
    *  server-side auto-grading; NEVER broadcast to students. */
   answerKey?: Array<{ id: string; answer?: string; marks?: number }>
+  /** Tutor's answer-reveal policy for this deploy (default 'instant'). */
+  answerReveal?: AnswerReveal
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]


### PR DESCRIPTION
Implements your direction: instead of hardcoding answer visibility, the **tutor chooses at deploy** when students may see correct answers.

## Modes (default `instant` = current behavior, zero regression)
- **instant** — graded live, answers available client-side (unchanged).
- **after_submit** — answers stripped from the GET payload; correct answers returned by the *submit* endpoint and shown on the results screen afterward.
- **hidden** — answers never revealed; score only.

## Flow
- DMI pill gains an **Answers** selector; the mode rides the deploy payload (assessment/task/homework) → persisted on `BuilderTask.metadata`.
- GET route strips `correctAnswer` unless `instant`; returns the mode. Submit route returns correct answers only for `after_submit`. **Scoring is fully server-side** (builds on #370 — no client-trusted score).
- `QuizModal` honors the mode: `instant` keeps the legacy path; the others render the server's authoritative grade. Results screen now stays until the student closes it (was auto-dismissed).

## Notes
- Default `instant` ⇒ no behavior change until a tutor opts in.
- **Student self-study reveal choice (post-class) is a planned follow-up.**
- typecheck + build clean. Live quiz flow is socket/DB-driven → **needs prod verification**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)