### PR TITLE
feat(assess): student self-study choice (practice vs test) for post-class quizzes

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -66,8 +66,11 @@ export default function StudentAssignmentsPage() {
     id: string
     title: string
     questions: TaskQuestion[]
-    answerReveal?: 'instant' | 'after_submit' | 'hidden'
+    answerReveal?: 'instant' | 'after_submit' | 'hidden' | 'student_choice'
   } | null>(null)
+  // For 'student_choice' tasks: the student's self-study selection (null until
+  // they pick). 'practice' reveals answers as they go; 'test' hides until submit.
+  const [studyMode, setStudyMode] = useState<'practice' | 'test' | null>(null)
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [startTime, setStartTime] = useState<number>(0)
@@ -129,6 +132,7 @@ export default function StudentAssignmentsPage() {
         questions: data.task.questions,
         answerReveal: data.task.answerReveal,
       })
+      setStudyMode(null)
       setStartTime(Date.now())
       setTakingQuiz(true)
     } catch {
@@ -197,6 +201,7 @@ export default function StudentAssignmentsPage() {
   const handleCloseQuiz = () => {
     setTakingQuiz(false)
     setActiveTask(null)
+    setStudyMode(null)
   }
 
   const parseDocumentSource = (raw?: string | null): ParsedDocumentSource | null => {
@@ -247,6 +252,53 @@ export default function StudentAssignmentsPage() {
 
   // Quiz-taking overlay
   if (takingQuiz && activeTask) {
+    // Self-study tasks: let the student pick practice vs test before starting.
+    if (activeTask.answerReveal === 'student_choice' && studyMode === null) {
+      return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <h2 className="text-center text-lg font-bold text-gray-900">{activeTask.title}</h2>
+            <p className="mt-1 text-center text-sm text-gray-500">How do you want to study?</p>
+            <div className="mt-5 space-y-3">
+              <button
+                onClick={() => setStudyMode('practice')}
+                className="w-full rounded-xl border border-[#F17623] bg-[#FFF4EC] p-4 text-left transition-colors hover:bg-[#ffe9d8]"
+              >
+                <p className="font-semibold text-[#9a4a12]">Practice</p>
+                <p className="text-sm text-gray-600">
+                  See the correct answer as you go — great for learning.
+                </p>
+              </button>
+              <button
+                onClick={() => setStudyMode('test')}
+                className="w-full rounded-xl border border-gray-300 bg-gray-50 p-4 text-left transition-colors hover:bg-gray-100"
+              >
+                <p className="font-semibold text-gray-800">Test yourself</p>
+                <p className="text-sm text-gray-600">
+                  Answers stay hidden until you submit — check what you really know.
+                </p>
+              </button>
+            </div>
+            <Button variant="ghost" className="mt-4 w-full" onClick={handleCloseQuiz}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    // Resolve the student's choice to a concrete reveal mode for the quiz.
+    const effectiveReveal: 'instant' | 'after_submit' | 'hidden' =
+      activeTask.answerReveal === 'student_choice'
+        ? studyMode === 'practice'
+          ? 'instant'
+          : 'after_submit'
+        : activeTask.answerReveal === 'after_submit'
+          ? 'after_submit'
+          : activeTask.answerReveal === 'hidden'
+            ? 'hidden'
+            : 'instant'
+
     const quizQuestions = activeTask.questions.map(q => ({
       id: q.id,
       type: (q.type === 'mcq' || q.type === 'multiple_choice'
@@ -263,7 +315,7 @@ export default function StudentAssignmentsPage() {
         questions={quizQuestions}
         onComplete={handleQuizComplete}
         onClose={handleCloseQuiz}
-        answerReveal={activeTask.answerReveal}
+        answerReveal={effectiveReveal}
       />
     )
   }

--- a/tutorme-app/src/app/[locale]/student/work/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/work/page.tsx
@@ -103,8 +103,9 @@ function AssignmentsTab() {
     id: string
     title: string
     questions: TaskQuestion[]
-    answerReveal?: 'instant' | 'after_submit' | 'hidden'
+    answerReveal?: 'instant' | 'after_submit' | 'hidden' | 'student_choice'
   } | null>(null)
+  const [studyMode, setStudyMode] = useState<'practice' | 'test' | null>(null)
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [startTime, setStartTime] = useState<number>(0)
@@ -140,6 +141,7 @@ function AssignmentsTab() {
         questions: data.task.questions,
         answerReveal: data.task.answerReveal,
       })
+      setStudyMode(null)
       setStartTime(Date.now())
       setTakingQuiz(true)
     } catch {
@@ -200,6 +202,7 @@ function AssignmentsTab() {
   const handleCloseQuiz = () => {
     setTakingQuiz(false)
     setActiveTask(null)
+    setStudyMode(null)
   }
 
   const parseDocumentSource = (raw?: string | null) => {
@@ -249,6 +252,51 @@ function AssignmentsTab() {
     activeTab === 'all' ? assignments : assignments.filter(a => a.status === activeTab)
 
   if (takingQuiz && activeTask) {
+    if (activeTask.answerReveal === 'student_choice' && studyMode === null) {
+      return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <h2 className="text-center text-lg font-bold text-gray-900">{activeTask.title}</h2>
+            <p className="mt-1 text-center text-sm text-gray-500">How do you want to study?</p>
+            <div className="mt-5 space-y-3">
+              <button
+                onClick={() => setStudyMode('practice')}
+                className="w-full rounded-xl border border-[#F17623] bg-[#FFF4EC] p-4 text-left transition-colors hover:bg-[#ffe9d8]"
+              >
+                <p className="font-semibold text-[#9a4a12]">Practice</p>
+                <p className="text-sm text-gray-600">
+                  See the correct answer as you go — great for learning.
+                </p>
+              </button>
+              <button
+                onClick={() => setStudyMode('test')}
+                className="w-full rounded-xl border border-gray-300 bg-gray-50 p-4 text-left transition-colors hover:bg-gray-100"
+              >
+                <p className="font-semibold text-gray-800">Test yourself</p>
+                <p className="text-sm text-gray-600">
+                  Answers stay hidden until you submit — check what you really know.
+                </p>
+              </button>
+            </div>
+            <Button variant="ghost" className="mt-4 w-full" onClick={handleCloseQuiz}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    const effectiveReveal: 'instant' | 'after_submit' | 'hidden' =
+      activeTask.answerReveal === 'student_choice'
+        ? studyMode === 'practice'
+          ? 'instant'
+          : 'after_submit'
+        : activeTask.answerReveal === 'after_submit'
+          ? 'after_submit'
+          : activeTask.answerReveal === 'hidden'
+            ? 'hidden'
+            : 'instant'
+
     const quizQuestions = activeTask.questions.map(q => ({
       id: q.id,
       type: (q.type === 'mcq' || q.type === 'multiple_choice'
@@ -264,7 +312,7 @@ function AssignmentsTab() {
         questions={quizQuestions}
         onComplete={handleQuizComplete}
         onClose={handleCloseQuiz}
-        answerReveal={activeTask.answerReveal}
+        answerReveal={effectiveReveal}
       />
     )
   }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1005,7 +1005,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // correct answers. Default 'instant' preserves the existing live-feedback
     // behaviour; the tutor can switch to reveal-after-submit or hidden.
     const [deployAnswerReveal, setDeployAnswerReveal] = useState<
-      'instant' | 'after_submit' | 'hidden'
+      'instant' | 'after_submit' | 'hidden' | 'student_choice'
     >('instant')
 
     // Active tab tracking for Enter button
@@ -10261,6 +10261,7 @@ FEEDBACK: [your explanation]`
                                                         | 'instant'
                                                         | 'after_submit'
                                                         | 'hidden'
+                                                        | 'student_choice'
                                                     )
                                                   }
                                                   title="When students may see the correct answers"
@@ -10273,6 +10274,9 @@ FEEDBACK: [your explanation]`
                                                     Answers: after submit
                                                   </option>
                                                   <option value="hidden">Answers: hidden</option>
+                                                  <option value="student_choice">
+                                                    Answers: student chooses (self-study)
+                                                  </option>
                                                 </select>
                                               </>
                                             )}

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -122,9 +122,20 @@ export async function GET(
     // can't peek (the score is computed server-side on submit).
     const rawReveal = (task.metadata as { answerReveal?: string } | null)?.answerReveal
     const answerReveal =
-      rawReveal === 'after_submit' ? 'after_submit' : rawReveal === 'hidden' ? 'hidden' : 'instant'
-    const safeQuestions =
-      answerReveal === 'instant' ? questions : questions.map(({ correctAnswer: _c, ...q }) => q)
+      rawReveal === 'after_submit'
+        ? 'after_submit'
+        : rawReveal === 'hidden'
+          ? 'hidden'
+          : rawReveal === 'student_choice'
+            ? 'student_choice'
+            : 'instant'
+    // correctAnswer is exposed for 'instant' and 'student_choice' (the student
+    // may opt into practice mode); stripped for after_submit/hidden so it can't
+    // be peeked before submitting.
+    const exposeAnswers = answerReveal === 'instant' || answerReveal === 'student_choice'
+    const safeQuestions = exposeAnswers
+      ? questions
+      : questions.map(({ correctAnswer: _c, ...q }) => q)
 
     return NextResponse.json({
       alreadySubmitted: existing != null,

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -176,13 +176,13 @@ export async function POST(
       console.warn('[submit] AI feedback generation failed (non-critical):', feedbackError)
     }
 
-    // Reveal correct answers in the response ONLY when the tutor chose
-    // 'after_submit' — now that the student has submitted, it's safe to show
+    // Reveal correct answers in the response when the tutor chose 'after_submit'
+    // or 'student_choice' — now that the student has submitted it's safe to show
     // them on the results screen. 'hidden'/'instant' get no post-submit key
     // ('instant' already had them client-side; 'hidden' never reveals).
     const rawReveal = (task.metadata as { answerReveal?: string } | null)?.answerReveal
     const correctAnswers =
-      rawReveal === 'after_submit'
+      rawReveal === 'after_submit' || rawReveal === 'student_choice'
         ? answerKey.reduce<Record<string, string>>((acc, k) => {
             if (k.answer != null && k.answer !== '') acc[k.id] = k.answer
             return acc

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -145,8 +145,8 @@ export interface LiveTask {
    *  persisted server-side for auto-grading; NEVER copied into the student
    *  broadcast (normalizedTask) or stored in deployedMaterial. */
   answerKey?: Array<{ id: string; answer?: string; marks?: number }>
-  /** Tutor's answer-reveal policy: 'instant' | 'after_submit' | 'hidden'. */
-  answerReveal?: 'instant' | 'after_submit' | 'hidden'
+  /** Tutor's answer-reveal policy: 'instant' | 'after_submit' | 'hidden' | 'student_choice'. */
+  answerReveal?: 'instant' | 'after_submit' | 'hidden' | 'student_choice'
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]
@@ -1299,7 +1299,12 @@ export async function initEnhancedSocketServer(server: NetServer) {
               // so the async assignment GET/submit routes honor it. Merged into
               // existing metadata so other keys are preserved.
               const reveal = task.answerReveal
-              if (reveal === 'instant' || reveal === 'after_submit' || reveal === 'hidden') {
+              if (
+                reveal === 'instant' ||
+                reveal === 'after_submit' ||
+                reveal === 'hidden' ||
+                reveal === 'student_choice'
+              ) {
                 try {
                   const { sql } = await import('drizzle-orm')
                   await drizzleDb

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -82,12 +82,14 @@ export interface LiveTaskSourceDocument {
 
 /**
  * When students may see the correct answers for a deployed task/assessment:
- * - 'instant'      — graded live as they answer (answers sent to the browser).
- * - 'after_submit' — correct answers revealed only on the results screen.
- * - 'hidden'       — never reveal answers; show the score only.
+ * - 'instant'        — graded live as they answer (answers sent to the browser).
+ * - 'after_submit'   — correct answers revealed only on the results screen.
+ * - 'hidden'         — never reveal answers; show the score only.
+ * - 'student_choice' — post-class self-study: the student picks practice (see
+ *                      answers as they go) or test (hide until submit).
  * Chosen by the tutor at deploy time.
  */
-export type AnswerReveal = 'instant' | 'after_submit' | 'hidden'
+export type AnswerReveal = 'instant' | 'after_submit' | 'hidden' | 'student_choice'
 
 export interface LiveTask {
   id: string


### PR DESCRIPTION
Completes the answer-reveal direction with the student-side half. Adds a 4th tutor deploy mode **`student_choice`** for material students revisit after a live class.

- **Tutor**: new "Answers: student chooses (self-study)" option; persisted on `BuilderTask.metadata`.
- **GET route**: exposes `correctAnswer` for `student_choice` (so practice can reveal as they go) + returns the mode.
- **Student page**: a pre-quiz prompt offers **Practice** (reveal as you go → `instant`) or **Test yourself** (hide until submit → `after_submit`). Resolves to a concrete mode for QuizModal; scoring stays server-side.
- **Submit route**: returns correct answers for `student_choice` so the test-mode results screen can reveal them.

typecheck + build clean. Live/async flow is DB-driven → needs prod verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)