### PR TITLE
feat(dmi): edit marks & answers for task DMIs (from the View-DMI modal)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -11277,6 +11277,23 @@ FEEDBACK: [your explanation]`
                       })}
                     </div>
                     <DialogFooter>
+                      {/* Edit marks & answers for the loaded DMI — works for both
+                          task and assessment DMIs, the entry point tasks lacked.
+                          Only when there's editable builder state to write back. */}
+                      {canEdit &&
+                        (assessmentDmiItems.length > 0 || taskDmiItems.length > 0) && (
+                          <Button
+                            variant="modal-secondary-dark"
+                            onClick={() => {
+                              setShowLiveDmiModal(false)
+                              setDmiEditor({
+                                source: assessmentDmiItems.length > 0 ? 'assessment' : 'task',
+                              })
+                            }}
+                          >
+                            Edit marks &amp; answers
+                          </Button>
+                        )}
                       <Button
                         variant="modal-secondary-dark"
                         onClick={() => setShowLiveDmiModal(false)}


### PR DESCRIPTION
Task DMIs had no edit entry point — the editor button lived only on the assessment pill. Adds an **Edit marks & answers** button to the live View-DMI modal footer (which already shows task *or* assessment DMIs), opening the existing editor with the matching source. Per-question marks/answers/rubric are now editable for task DMIs too. Shown only when there's editable builder state. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)