### PR TITLE
feat(grading): surface flagged essays + rubric in the tutor grading view

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -37,6 +37,16 @@ interface Submission {
   timeSpent: number
   submittedAt: string | null
   gradedAt: string | null
+  questionMeta?: Record<
+    string,
+    {
+      questionText?: string
+      rubric?: string
+      modelAnswer?: string
+      marks?: number
+      needsReview?: boolean
+    }
+  >
 }
 
 type StatusFilter = 'all' | 'submitted' | 'graded'
@@ -257,6 +267,8 @@ function SubmissionRow({
 
   const answers = submission.answers ?? {}
   const answerEntries = Object.entries(answers)
+  const questionMeta = submission.questionMeta ?? {}
+  const reviewCount = Object.values(questionMeta).filter(m => m?.needsReview).length
 
   return (
     <Card className="overflow-hidden bg-white shadow-[0_14px_45px_rgba(0,0,0,0.12)]">
@@ -301,19 +313,57 @@ function SubmissionRow({
       {expanded && (
         <CardContent ref={contentRef} className="space-y-4 border-t pt-4">
           <div>
-            <h4 className="mb-2 text-sm font-semibold text-gray-700">Answers</h4>
+            <div className="mb-2 flex items-center gap-2">
+              <h4 className="text-sm font-semibold text-gray-700">Answers</h4>
+              {reviewCount > 0 && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+                  {reviewCount} need{reviewCount === 1 ? 's' : ''} your review
+                </span>
+              )}
+            </div>
             {answerEntries.length === 0 ? (
               <p className="text-sm text-gray-400">No structured answers recorded.</p>
             ) : (
               <ul className="space-y-2">
-                {answerEntries.map(([qid, ans]) => (
-                  <li key={qid} className="rounded-md bg-gray-50 p-2 text-sm">
-                    <span className="font-medium text-gray-500">Q{qid}: </span>
-                    <span className="text-gray-800">
-                      {typeof ans === 'string' ? ans : JSON.stringify(ans)}
-                    </span>
-                  </li>
-                ))}
+                {answerEntries.map(([qid, ans]) => {
+                  const meta = questionMeta[qid]
+                  return (
+                    <li
+                      key={qid}
+                      className={`rounded-md p-2 text-sm ${
+                        meta?.needsReview
+                          ? 'border border-amber-200 bg-amber-50'
+                          : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="font-medium text-gray-600">
+                          {meta?.questionText ?? `Q${qid}`}
+                        </span>
+                        {meta?.needsReview && (
+                          <span className="shrink-0 rounded-full bg-amber-200 px-2 py-0.5 text-[10px] font-semibold text-amber-800">
+                            Needs review
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-gray-800">
+                        <span className="text-gray-400">Answer: </span>
+                        {typeof ans === 'string' ? ans : JSON.stringify(ans)}
+                      </p>
+                      {meta?.modelAnswer && (
+                        <p className="mt-1 rounded bg-emerald-50 px-2 py-1 text-xs text-emerald-800">
+                          <span className="font-semibold">Model answer:</span> {meta.modelAnswer}
+                        </p>
+                      )}
+                      {meta?.rubric && (
+                        <p className="mt-1 rounded bg-sky-50 px-2 py-1 text-xs text-sky-800">
+                          <span className="font-semibold">Marking:</span> {meta.rubric}
+                          {typeof meta.marks === 'number' ? ` · ${meta.marks} marks` : ''}
+                        </p>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             )}
           </div>

--- a/tutorme-app/src/app/api/tutor/submissions/route.ts
+++ b/tutorme-app/src/app/api/tutor/submissions/route.ts
@@ -7,11 +7,21 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray } from 'drizzle-orm'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { handleApiError } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { builderTask, profile, taskSubmission, user } from '@/lib/db/schema'
+import { builderTask, builderTaskDmi, profile, taskSubmission, user } from '@/lib/db/schema'
+
+/** Per-question grading context shown to the tutor (tutor-only — carries the
+ *  answer key / rubric). `needsReview` flags items the auto-grader set aside. */
+interface QuestionMeta {
+  questionText?: string
+  rubric?: string
+  modelAnswer?: string
+  marks?: number
+  needsReview?: boolean
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -58,12 +68,67 @@ export async function GET(request: NextRequest) {
       .orderBy(desc(taskSubmission.submittedAt))
       .limit(200)
 
+    // Fetch the answer key (rubric / model answer / question text) for the tasks
+    // in this batch so the tutor can grade flagged open-ended items with guidance.
+    // Tutor-only endpoint, so exposing the key here is safe.
+    const taskIds = Array.from(new Set(rows.map(r => r.taskId)))
+    const keyByTask = new Map<string, Map<string, Record<string, unknown>>>()
+    if (taskIds.length > 0) {
+      const dmis = await drizzleDb
+        .select({
+          taskId: builderTaskDmi.taskId,
+          items: builderTaskDmi.items,
+          updatedAt: builderTaskDmi.updatedAt,
+        })
+        .from(builderTaskDmi)
+        .where(inArray(builderTaskDmi.taskId, taskIds))
+        .orderBy(desc(builderTaskDmi.updatedAt))
+      for (const d of dmis) {
+        if (keyByTask.has(d.taskId)) continue // keep the latest (first by desc)
+        const byId = new Map<string, Record<string, unknown>>()
+        if (Array.isArray(d.items)) {
+          for (const raw of d.items as Array<Record<string, unknown>>) {
+            const id = String(raw.id ?? raw.questionNumber ?? '')
+            if (id) byId.set(id, raw)
+          }
+        }
+        keyByTask.set(d.taskId, byId)
+      }
+    }
+
+    const buildQuestionMeta = (
+      taskId: string,
+      questionResults: unknown
+    ): Record<string, QuestionMeta> => {
+      const byId = keyByTask.get(taskId)
+      const flagged = new Set<string>()
+      if (Array.isArray(questionResults)) {
+        for (const qr of questionResults as Array<Record<string, unknown>>) {
+          if (qr?.needsReview) flagged.add(String(qr.questionId))
+        }
+      }
+      const meta: Record<string, QuestionMeta> = {}
+      const ids = new Set<string>([...(byId?.keys() ?? []), ...flagged])
+      for (const id of ids) {
+        const item = byId?.get(id)
+        meta[id] = {
+          questionText: item?.questionText ? String(item.questionText) : undefined,
+          rubric: item?.rubric ? String(item.rubric) : undefined,
+          modelAnswer: item?.answer ? String(item.answer) : undefined,
+          marks: typeof item?.marks === 'number' ? (item.marks as number) : undefined,
+          needsReview: flagged.has(id) || undefined,
+        }
+      }
+      return meta
+    }
+
     return NextResponse.json({
       submissions: rows.map(r => ({
         ...r,
         studentName: r.studentName ?? 'Student',
         submittedAt: r.submittedAt?.toISOString() ?? null,
         gradedAt: r.gradedAt?.toISOString() ?? null,
+        questionMeta: buildQuestionMeta(r.taskId, r.questionResults),
       })),
     })
   } catch (error) {


### PR DESCRIPTION
Open-ended answers the auto-grader sets aside (`needsReview`) were invisible to the tutor, who had no rubric/model-answer to grade against. The grading view now shows per submission: a **"N need your review"** badge + per-answer flags, and the **question text**, **model answer**, and **marking rubric** (+marks) inline — from the task's DMI key (tutor-only). Submissions API joins BuilderTaskDmi (one query) → per-question `questionMeta`. Final score still set via the existing grade route. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)