### PR TITLE
fix(dmi): reach the questions in front-matter-heavy past papers (MCQ exams)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2758,6 +2758,23 @@ FEEDBACK: [your explanation]`
       }
     }
 
+    // Past papers often open with cover pages, a table of contents, and exam
+    // instructions before any questions (e.g. an AP practice exam's questions
+    // start ~page 23 of 110). Drop that leading front matter so the real
+    // questions reach the model instead of being crowded out of the token
+    // budget — and so the classifier isn't biased toward "study material" by
+    // pages of administrative prose. Anchored on the first TRUE multiple-choice
+    // item (a number followed by lettered options); a table-of-contents listing
+    // won't match this, so it's safe.
+    const focusOnQuestions = (raw: string): string => {
+      if (raw.length < 6000) return raw
+      const firstMcq = raw.search(
+        /(?:^|\n)\s*\d{1,3}\.\s[\s\S]{0,600}?\(A\)[\s\S]{0,500}?\(B\)[\s\S]{0,500}?\(C\)/
+      )
+      // Only trim when there's substantial front matter before the questions.
+      return firstMcq > 1500 ? raw.slice(firstMcq) : raw
+    }
+
     // Apply a per-question edit (marks / answer / rubric) to the loaded DMI.
     // Updates BOTH the live items state (used by deploy + the View-DMI modal)
     // and the matching version (persisted with the course on save) so edits
@@ -2820,10 +2837,13 @@ FEEDBACK: [your explanation]`
           toast.info('Analyzing PDF with AI...')
           // Prefer full-text extraction so EVERY page of a multi-page paper is
           // captured (image analysis is capped at a few pages and would miss
-          // later questions). Fall back to page images for scanned PDFs.
-          const extracted = await extractPdfText(sourceDoc.fileUrl, 30)
+          // later questions). Read enough pages to clear any front matter and
+          // reach the questions, then drop the leading cover/instructions so the
+          // budget is spent on the actual questions. Fall back to page images
+          // for scanned PDFs.
+          const extracted = await extractPdfText(sourceDoc.fileUrl, 60)
           if (extracted.trim().length > 200) {
-            pdfText = extracted.slice(0, 50000)
+            pdfText = focusOnQuestions(extracted).slice(0, 70000)
           } else {
             pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8)
           }

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -29,7 +29,9 @@ export const maxDuration = 60
 const GenerateDmiRequestSchema = z.object({
   type: z.enum(['task', 'assessment']),
   title: z.string().max(200).optional(),
-  content: z.string().max(50000).optional(),
+  // Up to ~80k chars (~20k tokens) so a full multi-section paper's questions fit
+  // after front matter is trimmed client-side; still well under the model limit.
+  content: z.string().max(80000).optional(),
   pdfPages: z.array(z.string().max(5_000_000)).max(8).optional(),
   /**
    * For study material: the question types + counts the tutor wants generated.


### PR DESCRIPTION
**Bug:** an AP Statistics practice exam produced no MCQ DMI. Root cause (verified against the file): the PDF is **110 pages** and Section I (the 40 MCQ) starts on **page 23** — but the generator extracted only the first **30 pages** and capped at **50k chars**, so the budget was eaten by 22 pages of cover/contents/instructions/proctor notes. The model never saw the questions, and the administrative prose biased classification.

**Fix (client extraction + server cap):**
- Extract up to **60 pages** (was 30); raise the content cap to **80k chars** (was 50k) — still ~20k tokens, well under the model limit.
- New `focusOnQuestions()` drops leading front matter, anchored on the **first true multiple-choice item** (a number followed by `(A)…(B)…(C)`). A table-of-contents listing can't match it; only trims when there's substantial front matter, so study material and front-loaded papers are untouched.

Validated against the actual PDF: the trimmer lands exactly on **"1. Of the following dotplots…"** (page 23), dropping ~33k chars of front matter so all **40 MCQ** questions reach the model → MCQ DMI with clickable letter chips. typecheck + build clean. AI path needs prod verification (re-load the MCQ exam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)