### PR TITLE
fix(live): course:sync no longer strips DMI question types to plain inputs

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1399,13 +1399,30 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 : assessments.includes(item)
                   ? 'assessment'
                   : 'homework',
+              // Carry the FULL student-facing fields (input type + options/pairs/
+              // hotspot + marks) so a course:sync doesn't overwrite a deployed
+              // DMI with bare text fields — that was turning every question into
+              // a plain input after a sync. answer/rubric are deliberately NOT
+              // included (they must never reach students).
               dmiItems: Array.isArray(raw.dmiItems)
-                ? (raw.dmiItems as Array<Record<string, unknown>>).map(d => ({
-                    id: (d.id as string) || '',
-                    questionNumber: (d.questionNumber as number) || 0,
-                    questionText: (d.questionText as string) || '',
-                    ...(typeof d.marks === 'number' ? { marks: d.marks } : {}),
-                  }))
+                ? (raw.dmiItems as Array<Record<string, unknown>>).map(
+                    (d): LiveTaskDmiItem => ({
+                      id: (d.id as string) || '',
+                      questionNumber: (d.questionNumber as number) || 0,
+                      questionText: (d.questionText as string) || '',
+                      marks: typeof d.marks === 'number' ? (d.marks as number) : undefined,
+                      questionType: d.questionType as LiveTaskDmiItem['questionType'],
+                      options: Array.isArray(d.options) ? (d.options as string[]) : undefined,
+                      pairs: Array.isArray(d.pairs)
+                        ? (d.pairs as LiveTaskDmiItem['pairs'])
+                        : undefined,
+                      hotspotImageUrl:
+                        typeof d.hotspotImageUrl === 'string' ? d.hotspotImageUrl : undefined,
+                      regions: Array.isArray(d.regions)
+                        ? (d.regions as LiveTaskDmiItem['regions'])
+                        : undefined,
+                    })
+                  )
                 : undefined,
               deployedAt: Date.now(),
               polls: [],


### PR DESCRIPTION
**Bug:** a deployed assessment's DMI rendered with correct per-type controls (mcq chips, etc.), then **"after a while" every question turned into a plain input**.

**Cause:** the `course:sync` socket handler rebuilt each task's `dmiItems` with only `{ id, questionNumber, questionText, marks }` and merged it over the deployed task (`{ ...existing, ...liveTask }`) — **overwriting** the rich `questionType`/`options`/`pairs`/`hotspot`/`regions`. The auto-sync (on entering the session + the silent background sync) thus downgraded every field to a textarea on the student side.

**Fix:** carry the full **student-facing** fields through the sync map (`questionType`, `options`, `pairs`, `hotspotImageUrl`, `regions`, `marks`) so a sync preserves the control type. `answer`/`rubric` are deliberately excluded (never sent to students).

typecheck + build clean. Live socket flow → confirm on prod (deploy an assessment with mcq/etc., wait for/trigger a sync, verify the controls persist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)