### PR TITLE
feat(course-builder): fixed middle panel width + pink Assessment Builder theme + WifiSignal updates

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -988,7 +988,6 @@ function CourseBuilderInsightsRouteInner({
             </div>
 
             <div className="flex items-center gap-2">
-              {showWifiSignal && <WifiSignal connected={!!insightsProps.sessionId} error={false} />}
               {(activeMainTab === 'builder' || activeMainTab === 'live') &&
                 onSaveModeChange &&
                 !modeLocked && (
@@ -1021,6 +1020,7 @@ function CourseBuilderInsightsRouteInner({
                   Editing
                 </div>
               )}
+              <WifiSignal connected={!!insightsProps.sessionId} error={!insightsProps.sessionId} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR includes several UI improvements for the Course Builder and related components:

### Changes

1. **Fixed middle panel width** (800px) — center panel no longer shifts when side panels collapse/expand
2. **Pink theme for Assessment Builder** — distinct pink header gradient and pink Assessment/PCI tab buttons (Task Builder stays blue)
3. **WifiSignal updates** — now shows in all modes (Build/Test/Classroom), red when no session, green when connected, positioned at far right of header
4. **Dynamic countdown** — landing page countdown shows 39 days from current date instead of hardcoded past date

### Commits
- ecce8f1ba Fix middle panel width to stay constant when side panels collapse
- 511678d04 Fix countdown to show 39 days from current date
- 58f030cb2 Add pink theme for Assessment Builder: header gradient and Assessment/PCI buttons
- 18ec7aef2 Update WifiSignal: show in all modes, red when no session, green when connected, move to far right