### PR TITLE
feat(availability): add availability summary with active day ranges and view-all toggle

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -2390,6 +2390,34 @@ function DayView({
   )
 }
 
+function computeRangesForDay(blocks: AvailabilityBlock[]): { start: string; end: string }[] {
+  const available = blocks
+    .filter((b) => b.isAvailable)
+    .sort((a, b) => TIME_SLOTS.indexOf(a.startTime) - TIME_SLOTS.indexOf(b.startTime))
+
+  const ranges: { start: string; end: string }[] = []
+  let current: { start: string; end: string } | null = null
+
+  for (const block of available) {
+    if (!current) {
+      current = { start: block.startTime, end: block.endTime }
+    } else if (current.end === block.startTime) {
+      current.end = block.endTime
+    } else {
+      ranges.push(current)
+      current = { start: block.startTime, end: block.endTime }
+    }
+  }
+  if (current) ranges.push(current)
+  return ranges
+}
+
+function formatRanges(dayName: string, ranges: { start: string; end: string }[]): string {
+  if (ranges.length === 0) return `${dayName}: No slots selected`
+  const rangeStr = ranges.map((r) => `${r.start}–${r.end}`).join(', ')
+  return `${dayName}: ${rangeStr}`
+}
+
 function AvailabilityView({ availability, onToggle, onSave }: any) {
   const days = [
     { label: 'Mon', full: 'Monday', index: 1 },
@@ -2401,12 +2429,28 @@ function AvailabilityView({ availability, onToggle, onSave }: any) {
     { label: 'Sun', full: 'Sunday', index: 0 },
   ]
   const [activeDay, setActiveDay] = useState(days[0].full)
+  const [showAllDays, setShowAllDays] = useState(false)
 
-  const activeDayIndex = days.find(d => d.full === activeDay)?.index ?? 1
+  const activeDayIndex = days.find((d) => d.full === activeDay)?.index ?? 1
   const dayBlocks = availability.filter(
     (block: AvailabilityBlock) => block.dayOfWeek === activeDayIndex
   )
   const selectedCount = dayBlocks.filter((b: AvailabilityBlock) => b.isAvailable).length
+
+  const activeDayRanges = useMemo(() => computeRangesForDay(dayBlocks), [dayBlocks])
+  const activeDaySummary = formatRanges(activeDay, activeDayRanges)
+
+  const allDaysSummary = useMemo(() => {
+    return days
+      .map((day) => {
+        const blocks = availability.filter(
+          (block: AvailabilityBlock) => block.dayOfWeek === day.index
+        )
+        const ranges = computeRangesForDay(blocks)
+        return formatRanges(day.full, ranges)
+      })
+      .join('; ')
+  }, [availability])
 
   return (
     <div className="flex h-full flex-col">
@@ -2453,6 +2497,24 @@ function AvailabilityView({ availability, onToggle, onSave }: any) {
           </TabsContent>
         ))}
       </Tabs>
+
+      <div className="mt-4 border-t pt-4">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-gray-700">
+            {showAllDays ? 'All availability:' : `${activeDay} availability:`}
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowAllDays(!showAllDays)}
+            className="text-xs text-blue-600 hover:text-blue-800"
+          >
+            {showAllDays ? 'Show active day' : 'View all days'}
+          </button>
+        </div>
+        <div className="mt-2 min-h-[3rem] text-sm text-gray-600">
+          {showAllDays ? allDaysSummary : activeDaySummary}
+        </div>
+      </div>
 
       <div className="mt-4 flex justify-end gap-3 border-t pt-4">
         <Button variant="modal-primary" onClick={onSave}>


### PR DESCRIPTION
## Summary

Adds a plain-text summary field below the availability time slot grid and above the Save button. The summary shows the tutor's selected availability as grouped time ranges (e.g., "Monday: 08:00–12:00, 14:00–18:00") instead of individual hour slots.

## Changes

### New Helper Functions
- **** — Groups consecutive available 1-hour slots into contiguous time ranges
- **** — Formats as "Day: HH:MM–HH:MM, HH:MM–HH:MM" or "Day: No slots selected"

### UI Updates in 
- **Active day summary (default)** — Shows the currently selected day's availability ranges. Always fits in 1–2 rows.
- **"View all days" toggle** — Switches to a semicolon-separated list of all 7 days with their ranges
- **"Show active day" toggle** — Returns to the compact single-day view
- **Positioned** between the time slot grid and the Save Availability button

### Edge Cases Handled
- No slots selected → shows "Monday: No slots selected"
- All slots selected → shows "Monday: 00:00–23:00" (single range)
- Scattered slots → multiple comma-separated ranges

## Files Changed
- 

## Testing
- Typecheck passed with no errors
- Active day view tested: fits within 3-row constraint
- All days view tested: wraps naturally for longer schedules