### PR TITLE
feat(dmi): upload a marking scheme to auto-fill answers (AI-matched, nuance-aware)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1001,6 +1001,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // "Edit marks & answers" review modal — lets the tutor set per-question marks
     // and vet/approve the AI-generated answers before deploying.
     const [dmiEditor, setDmiEditor] = useState<{ source: 'task' | 'assessment' } | null>(null)
+    // "Upload marking scheme": parse an uploaded scheme and fill each question's
+    // answer/rubric by matching question numbers.
+    const [markingSchemeLoading, setMarkingSchemeLoading] = useState(false)
+    const markingSchemeInputRef = useRef<HTMLInputElement | null>(null)
     // Tutor's answer-reveal policy applied to deploys: when students may see the
     // correct answers. Default 'instant' preserves the existing live-feedback
     // behaviour; the tutor can switch to reveal-after-submit or hidden.
@@ -2830,6 +2834,99 @@ FEEDBACK: [your explanation]`
       } else {
         setAssessmentDmiItems(editItems)
         setAssessmentDmiVersions(editVersions)
+      }
+    }
+
+    // Read text from an uploaded marking scheme (PDF via pdfjs, or plain text).
+    const extractMarkingSchemeText = async (file: File): Promise<string> => {
+      const isPdf =
+        file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')
+      if (!isPdf) {
+        try {
+          return await file.text()
+        } catch {
+          return ''
+        }
+      }
+      try {
+        const arrayBuffer = await file.arrayBuffer()
+        const pdfjs = await import('pdfjs-dist')
+        if (typeof window !== 'undefined') {
+          const opts = (pdfjs as { GlobalWorkerOptions?: { workerSrc?: string } })
+            .GlobalWorkerOptions
+          if (opts && !opts.workerSrc) opts.workerSrc = '/pdf.worker.min.mjs'
+        }
+        const doc = await pdfjs.getDocument({ data: arrayBuffer }).promise
+        const parts: string[] = []
+        for (let i = 1; i <= Math.min(40, doc.numPages); i++) {
+          const page = await doc.getPage(i)
+          const tc = await page.getTextContent()
+          const pageText = (tc.items as Array<{ str?: string }>)
+            .map(it => it.str ?? '')
+            .join(' ')
+            .replace(/[ \t]+/g, ' ')
+            .trim()
+          if (pageText) parts.push(pageText)
+        }
+        return parts.join('\n\n')
+      } catch (e) {
+        console.error('Marking scheme PDF extraction failed:', e)
+        return ''
+      }
+    }
+
+    // Parse an uploaded marking scheme and fill each question's answer/rubric by
+    // matching question numbers. Edits apply via applyDmiEdit so they persist.
+    const handleMarkingSchemeFile = async (file: File, source: 'task' | 'assessment') => {
+      const items = source === 'task' ? taskDmiItems : assessmentDmiItems
+      if (items.length === 0) return
+      setMarkingSchemeLoading(true)
+      try {
+        toast.info('Reading the marking scheme…')
+        const content = (await extractMarkingSchemeText(file)).slice(0, 80000)
+        if (content.trim().length < 20) {
+          toast.error('Could not read the marking scheme. Upload a text-based PDF or a .txt file.')
+          return
+        }
+        const questions = items.map(it => ({ number: it.questionNumber, label: it.questionText }))
+        const res = await fetch('/api/ai/parse-marking-scheme', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content, questions }),
+        })
+        if (!res.ok) {
+          const e = await res.json().catch(() => ({}))
+          toast.error(e?.error || 'Failed to parse the marking scheme')
+          return
+        }
+        const data = await res.json()
+        const matches: Array<{ number: number; answer: string; rubric?: string }> = Array.isArray(
+          data?.matches
+        )
+          ? data.matches
+          : []
+        if (matches.length === 0) {
+          toast.error('No answers could be matched from that marking scheme.')
+          return
+        }
+        let applied = 0
+        for (const m of matches) {
+          const item = items.find(it => it.questionNumber === m.number)
+          if (!item) continue
+          applyDmiEdit(source, item.id, {
+            answer: m.answer,
+            ...(m.rubric ? { rubric: m.rubric } : {}),
+          })
+          applied += 1
+        }
+        toast.success(
+          `Filled ${applied} of ${questions.length} answers from the marking scheme.`
+        )
+      } catch (err) {
+        console.error('Marking scheme parse failed:', err)
+        toast.error('Failed to read the marking scheme')
+      } finally {
+        setMarkingSchemeLoading(false)
       }
     }
 
@@ -11000,6 +11097,36 @@ FEEDBACK: [your explanation]`
                         {totalMarks} mark{totalMarks === 1 ? '' : 's'}.
                       </DialogDescription>
                     </DialogHeader>
+                    {/* Upload marking scheme: AI matches each question number to
+                        its answer (capturing the scheme's acceptable variations). */}
+                    <div className="flex items-center gap-2 rounded-lg border border-sky-200 bg-sky-50 px-3 py-2">
+                      <FileText className="h-4 w-4 shrink-0 text-sky-700" />
+                      <span className="text-xs text-sky-800">
+                        Have a marking scheme? Auto-fill every answer from it.
+                      </span>
+                      <input
+                        ref={markingSchemeInputRef}
+                        type="file"
+                        accept="application/pdf,.pdf,text/plain,.txt"
+                        className="hidden"
+                        onChange={e => {
+                          const file = e.target.files?.[0]
+                          e.target.value = ''
+                          if (file && dmiEditor) void handleMarkingSchemeFile(file, dmiEditor.source)
+                        }}
+                      />
+                      <button
+                        type="button"
+                        disabled={!canEdit || markingSchemeLoading}
+                        onClick={() => markingSchemeInputRef.current?.click()}
+                        className="ml-auto inline-flex items-center gap-1 rounded-full border border-sky-300 bg-white px-3 py-1 text-xs font-semibold text-sky-700 transition-colors hover:bg-sky-100 disabled:opacity-60"
+                      >
+                        {markingSchemeLoading ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : null}
+                        Upload marking scheme
+                      </button>
+                    </div>
                     <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-1">
                       {editItems.map(item => {
                         const marksVal =

--- a/tutorme-app/src/app/api/ai/parse-marking-scheme/route.ts
+++ b/tutorme-app/src/app/api/ai/parse-marking-scheme/route.ts
@@ -1,0 +1,149 @@
+/**
+ * POST /api/ai/parse-marking-scheme
+ *
+ * Parses an uploaded marking scheme and matches each DMI question to its answer.
+ * The tutor uploads a marking scheme (text or PDF page images) plus the list of
+ * question references already in the DMI; the model cuts through page noise and
+ * returns, per question number, the expected answer and a rubric capturing the
+ * scheme's nuances (acceptable variations, phrasings, tolerances). Tutor-only;
+ * nothing is persisted — the client applies the matches to the DMI for review.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, getSessionForRealm, authOptions } from '@/lib/auth'
+import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
+import { AISecurityManager } from '@/lib/security/ai-sanitization'
+import { generateWithKimi, generateWithKimiVision } from '@/lib/ai/kimi'
+import { stripCodeFences } from '@/lib/ai/llm-response'
+import { GUARDRAILED_TEMPERATURE } from '@/lib/ai/guardrails'
+import { z } from 'zod'
+
+const RequestSchema = z.object({
+  content: z.string().max(80000).optional(),
+  pdfPages: z.array(z.string().max(5_000_000)).max(8).optional(),
+  questions: z
+    .array(z.object({ number: z.number().int(), label: z.string().max(400) }))
+    .min(1)
+    .max(200),
+})
+
+const SYSTEM_PROMPT = `You are given a MARKING SCHEME and a list of QUESTION REFERENCES from an exam/assessment.
+For each reference, find its correct answer in the marking scheme and return it.
+
+Return ONLY a JSON object (no prose, no markdown, no code fences):
+{ "matches": [ { "number": <integer>, "answer": "<expected answer>", "rubric": "<acceptable variations + marking notes>" } ] }
+
+Rules:
+- Match by question / part number (e.g. "Question 1(a)", "Q3", "12"). Cut through page headers, footers,
+  mark totals, watermarks, "GO ON TO THE NEXT PAGE", and formatting noise to find the right answer.
+- "number" is the integer from the reference you were given (the leading #N), NOT a number you invent.
+- "answer": the canonical correct answer. For a multiple-choice item give the correct OPTION LETTER (A, B, C, …).
+  For a short item give the key expected answer. For a worked/extended item give a concise model answer.
+- "rubric": capture the NUANCES the scheme allows — alternative acceptable answers, accepted phrasings /
+  spellings / synonyms, numeric tolerances and units, and any "allow / accept / do not accept / condone"
+  notes. This lets a grader fairly judge differently-worded answers. Keep it concise but faithful.
+- Only include a reference whose answer you can actually find in the scheme. OMIT the rest. NEVER invent
+  an answer that is not in the marking scheme.`
+
+interface SchemeMatch {
+  number: number
+  answer: string
+  rubric?: string
+}
+
+function parseMatches(raw: string, validNumbers: Set<number>): SchemeMatch[] {
+  try {
+    const text = stripCodeFences(raw).trim()
+    const start = text.indexOf('{')
+    const end = text.lastIndexOf('}')
+    if (start === -1 || end <= start) return []
+    const obj = JSON.parse(text.slice(start, end + 1)) as {
+      matches?: Array<{ number?: unknown; answer?: unknown; rubric?: unknown }>
+    }
+    if (!Array.isArray(obj.matches)) return []
+    const out: SchemeMatch[] = []
+    for (const m of obj.matches) {
+      const n = Number(m?.number)
+      const answer = String(m?.answer ?? '').trim()
+      if (!Number.isInteger(n) || !validNumbers.has(n) || !answer) continue
+      const rubric = String(m?.rubric ?? '').trim()
+      out.push({ number: n, answer, rubric: rubric || undefined })
+    }
+    return out
+  } catch {
+    return []
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
+    const session =
+      (await getSessionForRealm(request, 'tutor')) ?? (await getServerSession(authOptions, request))
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const parsed = RequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    const { content, pdfPages, questions } = parsed.data
+
+    if (!content?.trim() && (!pdfPages || pdfPages.length === 0)) {
+      return NextResponse.json({ error: 'No marking scheme content provided' }, { status: 400 })
+    }
+
+    const questionList = questions.map(q => `#${q.number}: ${q.label}`).join('\n')
+
+    let aiResponse: string
+    if (pdfPages && pdfPages.length > 0) {
+      const promptItems: Array<
+        { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
+      > = [
+        {
+          type: 'text',
+          text: `Question references to match (use the leading #N as "number"):\n${questionList}\n\nThe marking scheme follows as page images.`,
+        },
+        ...pdfPages.map(page => ({ type: 'image_url' as const, image_url: { url: page } })),
+      ]
+      aiResponse = await generateWithKimiVision(promptItems, {
+        systemPrompt: SYSTEM_PROMPT,
+        temperature: GUARDRAILED_TEMPERATURE,
+        maxTokens: 4096,
+        timeoutMs: 60000,
+      })
+    } else {
+      const prompt = `Question references to match (use the leading #N as "number"):\n${questionList}\n\nMarking scheme:\n${content}`
+      aiResponse = await generateWithKimi(prompt, {
+        systemPrompt: SYSTEM_PROMPT,
+        temperature: GUARDRAILED_TEMPERATURE,
+        maxTokens: 4096,
+        timeoutMs: 60000,
+      })
+    }
+
+    const validation = await AISecurityManager.validateAiResponse(aiResponse)
+    if (!validation.isValid && validation.severity === 'CRITICAL') {
+      return handleApiError(
+        new Error('AI response failed security validation'),
+        'AI response failed security validation',
+        'api/ai/parse-marking-scheme/route.ts'
+      )
+    }
+
+    const validNumbers = new Set(questions.map(q => q.number))
+    const matches = parseMatches(aiResponse, validNumbers)
+
+    return NextResponse.json({ matches, matched: matches.length, total: questions.length })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to parse marking scheme',
+      'api/ai/parse-marking-scheme/route.ts'
+    )
+  }
+}


### PR DESCRIPTION
Adds **Upload marking scheme** to the Edit-marks-&-answers modal. The tutor uploads a marking scheme (PDF/text); the system reads it, sends it with the DMI's question references to a new endpoint, and the model **matches each question number to its answer** — cutting through page headers/footers/mark totals — then fills the **answer** and a **rubric** per question.

The rubric captures the scheme's nuance: alternative acceptable answers, accepted phrasings/spellings/synonyms, numeric tolerances/units, and allow/accept/do-not-accept notes — so a grader can fairly judge differently-worded answers. Matches apply via `applyDmiEdit` (persist + reviewable); only questions actually found are filled, nothing invented.

- New `POST /api/ai/parse-marking-scheme` (Kimi text or vision; tutor-gated + rate-limited; strict-JSON `{matches:[{number,answer,rubric}]}`; validates each number against the supplied references).
- Modal: hidden file input + button; client extracts PDF/text, applies matches with a "Filled X of Y" toast.

typecheck + build clean. AI path → confirm on prod (upload a real marking scheme). Note: scanned image-only schemes need the vision path — text-based PDFs/txt covered client-side now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)