### PR TITLE
fix(student): restore consistent right-panel width across classroom tabs

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1999,8 +1999,9 @@ function StudentFeedbackContent() {
               rightPanelResizing ? 'transition-none' : 'transition-all duration-500 ease-out'
             )}
             style={{
-              // Narrow width for Lessons/Interact (380px), expanded for Assessment/My Board (680px)
-              width: rightPanelWidth + (isExpanded ? EXPANDED_PANEL_BONUS : 0),
+              // Keep the right panel a consistent width across ALL tabs — Lessons
+              // and Interact were shrinking vs Assessment/My Board.
+              width: rightPanelWidth + EXPANDED_PANEL_BONUS,
             }}
           >
             {/* Resize handle */}


### PR DESCRIPTION
**Regression:** a recent commit ("Restore narrow right panel width for Lessons/Interact tabs") re-introduced a tab-dependent width, so **Lessons and Interact shrank** while Assessment/My Board stayed wide. Restored the consistent width (`base + EXPANDED_PANEL_BONUS`) for every tab, matching the earlier behavior — the panel no longer resizes when switching tabs. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)