### PR TITLE
feat(answers): students can type OR draw free-response answers (maths, diagrams)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -14,6 +14,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { DrawingPad } from '@/components/answer/DrawingPad'
 import {
   Select,
   SelectContent,
@@ -315,6 +316,78 @@ function ClassroomControlsPanel({
  * drag_drop/hotspot store JSON). hotspot falls back to free-text when its item
  * has no image; long answer is always free-text.
  */
+/**
+ * A free-response answer the student can either TYPE or DRAW (pen/mouse/finger) —
+ * crucial for maths and other work that doesn't fit a keyboard. A drawn answer is
+ * stored as a PNG data URL; a typed answer as plain text. The mode is inferred
+ * from the current value so it survives re-renders.
+ */
+function WrittenAnswer({
+  value,
+  onValueChange,
+  onInteract,
+  multiline,
+  placeholder,
+  baseField,
+}: {
+  value: string
+  onValueChange: (next: string) => void
+  onInteract: () => void
+  multiline: boolean
+  placeholder: string
+  baseField: string
+}) {
+  const isDrawn = typeof value === 'string' && value.startsWith('data:image')
+  const [mode, setMode] = useState<'type' | 'draw'>(isDrawn ? 'draw' : 'type')
+  // Don't show a data-URL blob as text when typing; keep typed text out of draw.
+  const textValue = isDrawn ? '' : value
+  const tabBtn = (active: boolean) =>
+    cn(
+      'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+      active ? 'bg-[#F17623] text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+    )
+  return (
+    <div>
+      <div className="mb-1.5 inline-flex gap-1 rounded-lg bg-gray-50 p-0.5">
+        <button type="button" className={tabBtn(mode === 'type')} onClick={() => setMode('type')}>
+          Type
+        </button>
+        <button type="button" className={tabBtn(mode === 'draw')} onClick={() => setMode('draw')}>
+          Draw
+        </button>
+      </div>
+      {mode === 'type' ? (
+        multiline ? (
+          <textarea
+            value={textValue}
+            onFocus={onInteract}
+            onChange={e => {
+              onInteract()
+              onValueChange(e.target.value)
+            }}
+            placeholder={placeholder}
+            className={`min-h-[64px] resize-y ${baseField}`}
+          />
+        ) : (
+          <input
+            type="text"
+            value={textValue}
+            onFocus={onInteract}
+            onChange={e => {
+              onInteract()
+              onValueChange(e.target.value)
+            }}
+            placeholder={placeholder}
+            className={baseField}
+          />
+        )
+      ) : (
+        <DrawingPad value={isDrawn ? value : undefined} onChange={onValueChange} onInteract={onInteract} />
+      )}
+    </div>
+  )
+}
+
 function DmiAnswerField({
   item,
   value,
@@ -425,7 +498,22 @@ function DmiAnswerField({
 
   // Short answer & fill-in-the-blank — single-line input. Choice types with no
   // options provided fall back here so the student is never stuck.
-  if (type === 'short' || type === 'fill_blank' || type === 'mcq' || type === 'multiple_response') {
+  // Short / fill-in answers — type OR draw (maths working, symbols, diagrams).
+  if (type === 'short' || type === 'fill_blank') {
+    return (
+      <WrittenAnswer
+        value={value}
+        onValueChange={onValueChange}
+        onInteract={onInteract}
+        multiline={false}
+        placeholder={type === 'fill_blank' ? 'Fill in the blank…' : 'Type your answer…'}
+        baseField={baseField}
+      />
+    )
+  }
+
+  // mcq / multiple_response that arrived without options → plain text input.
+  if (type === 'mcq' || type === 'multiple_response') {
     return (
       <input
         type="text"
@@ -435,7 +523,7 @@ function DmiAnswerField({
           onInteract()
           onValueChange(e.target.value)
         }}
-        placeholder={type === 'fill_blank' ? 'Fill in the blank…' : 'Type your answer…'}
+        placeholder="Type your answer…"
         className={baseField}
       />
     )
@@ -697,17 +785,15 @@ function DmiAnswerField({
   }
 
   // Long answer + hotspot (still needs image+regions) and any interactive type
-  // that arrives without its data → free-text.
+  // that arrives without its data → free-response (type OR draw).
   return (
-    <textarea
+    <WrittenAnswer
       value={value}
-      onFocus={onInteract}
-      onChange={e => {
-        onInteract()
-        onValueChange(e.target.value)
-      }}
+      onValueChange={onValueChange}
+      onInteract={onInteract}
+      multiline
       placeholder="Type your answer…"
-      className={`min-h-[64px] resize-y ${baseField}`}
+      baseField={baseField}
     />
   )
 }

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -381,10 +381,22 @@ function SubmissionRow({
                           </span>
                         )}
                       </div>
-                      <p className="mt-1 text-gray-800">
-                        <span className="text-gray-400">Answer: </span>
-                        {typeof ans === 'string' ? ans : JSON.stringify(ans)}
-                      </p>
+                      {typeof ans === 'string' && ans.startsWith('data:image') ? (
+                        <div className="mt-1">
+                          <span className="text-xs text-gray-400">Answer (drawn):</span>
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={ans}
+                            alt="Student's drawn answer"
+                            className="mt-1 max-h-64 w-full rounded-md border border-gray-200 bg-white object-contain"
+                          />
+                        </div>
+                      ) : (
+                        <p className="mt-1 text-gray-800">
+                          <span className="text-gray-400">Answer: </span>
+                          {typeof ans === 'string' ? ans : JSON.stringify(ans)}
+                        </p>
+                      )}
                       {meta?.modelAnswer && (
                         <p className="mt-1 rounded bg-emerald-50 px-2 py-1 text-xs text-emerald-800">
                           <span className="font-semibold">Model answer:</span> {meta.modelAnswer}

--- a/tutorme-app/src/components/answer/DrawingPad.tsx
+++ b/tutorme-app/src/components/answer/DrawingPad.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+interface DrawingPadProps {
+  /** Existing PNG data URL to restore (when the student already drew something). */
+  value?: string
+  /** Called with the PNG data URL after each stroke (empty string when cleared). */
+  onChange: (dataUrl: string) => void
+  onInteract?: () => void
+  className?: string
+}
+
+/**
+ * A lightweight pen/mouse/touch drawing surface for written answers (e.g. maths
+ * working). Emits a PNG data URL so the answer can be submitted and graded like
+ * any other answer value.
+ */
+export function DrawingPad({ value, onChange, onInteract, className = '' }: DrawingPadProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const drawing = useRef(false)
+  const last = useRef<{ x: number; y: number } | null>(null)
+
+  // Size the canvas to its rendered box (device-pixel aware) and restore any
+  // existing drawing. Runs once on mount.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const rect = canvas.getBoundingClientRect()
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.max(1, Math.round(rect.width * dpr))
+    canvas.height = Math.max(1, Math.round(rect.height * dpr))
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.scale(dpr, dpr)
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    ctx.lineWidth = 2.2
+    ctx.strokeStyle = '#1F2933'
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, rect.width, rect.height)
+    if (value && value.startsWith('data:image')) {
+      const img = new Image()
+      img.onload = () => ctx.drawImage(img, 0, 0, rect.width, rect.height)
+      img.src = value
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const pointFromEvent = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const rect = canvasRef.current!.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  const handleDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault()
+    canvasRef.current?.setPointerCapture(e.pointerId)
+    drawing.current = true
+    last.current = pointFromEvent(e)
+    onInteract?.()
+  }
+
+  const handleMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawing.current) return
+    const ctx = canvasRef.current?.getContext('2d')
+    if (!ctx || !last.current) return
+    const p = pointFromEvent(e)
+    ctx.beginPath()
+    ctx.moveTo(last.current.x, last.current.y)
+    ctx.lineTo(p.x, p.y)
+    ctx.stroke()
+    last.current = p
+  }
+
+  const handleUp = () => {
+    if (!drawing.current) return
+    drawing.current = false
+    last.current = null
+    const url = canvasRef.current?.toDataURL('image/png')
+    if (url) onChange(url)
+  }
+
+  const handleClear = () => {
+    const canvas = canvasRef.current
+    const ctx = canvas?.getContext('2d')
+    if (!canvas || !ctx) return
+    const rect = canvas.getBoundingClientRect()
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, rect.width, rect.height)
+    onChange('')
+  }
+
+  return (
+    <div className={className}>
+      <canvas
+        ref={canvasRef}
+        className="h-44 w-full touch-none rounded-md border border-gray-300 bg-white"
+        onPointerDown={handleDown}
+        onPointerMove={handleMove}
+        onPointerUp={handleUp}
+        onPointerLeave={handleUp}
+      />
+      <div className="mt-1 flex items-center justify-between">
+        <span className="text-[10px] text-gray-400">Write or draw with a pen, mouse, or finger.</span>
+        <button
+          type="button"
+          onClick={handleClear}
+          className="text-xs font-medium text-gray-500 hover:text-gray-700"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/lib/grading/auto-grade.test.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.test.ts
@@ -74,6 +74,16 @@ describe('autoGradeDmi', () => {
     expect(r.needsReview).toBe(0)
   })
 
+  it('flags a drawn (image) answer for review instead of marking it wrong', () => {
+    // A short-key item answered with a drawing (PNG data URL) can't be matched.
+    const r = autoGradeDmi([{ id: 'q1', answer: 'Paris' }], {
+      q1: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+    })
+    expect(r.needsReview).toBe(1)
+    const q1 = r.questionResults?.find(x => x.questionId === 'q1')
+    expect(q1).toMatchObject({ correct: false, pointsMax: 0, needsReview: true })
+  })
+
   it('scores short items and excludes open-ended ones from the same task', () => {
     const mixed = [
       { id: 'q1', answer: 'Paris' }, // short, correct

--- a/tutorme-app/src/lib/grading/auto-grade.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.ts
@@ -110,9 +110,13 @@ export function autoGradeDmi(
     const g = normalize(rawGiven)
     const expected = normalize(item.answer)
     const matched = g.length > 0 && (g === expected || ` ${g} `.includes(` ${expected} `))
+    // A drawn answer (PNG data URL) is an image, not text — it can never be
+    // auto-matched, so always send it to the tutor for review instead of marking
+    // it wrong.
+    const isDrawn = String(rawGiven).startsWith('data:image')
     // Open-ended (long-key) items that weren't reproduced can't be auto-judged —
     // exclude and flag rather than penalize a possible paraphrase.
-    const review = !matched && wordCount(expected) > SHORT_ANSWER_MAX_WORDS
+    const review = !matched && (isDrawn || wordCount(expected) > SHORT_ANSWER_MAX_WORDS)
     const marks = itemMarks(item)
 
     if (matched) correct += 1


### PR DESCRIPTION
Some answers — maths working, symbols, diagrams — can't be typed. Free-response DMI questions (`long`, `short`, `fill_blank`) now have a **Type / Draw** toggle: type with the keyboard, or **write/draw with a pen, mouse, or finger** on a canvas.

- New `DrawingPad` (pointer-based canvas: pen/mouse/touch, Clear, restores an existing drawing). A drawn answer is a PNG data URL, submitted like any other value.
- `WrittenAnswer` wrapper renders the toggle + textarea/input or the pad; mode inferred from the value.
- **Grading:** a drawn answer (`data:image`) is flagged **needs-review** (never auto-marked wrong — an image can't match a text key), and the tutor grading view renders it **as an image**.

typecheck + build clean; grader unit tests 12/12 (incl. a new drawn-answer case). Touch/pen UX → confirm on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)