### PR TITLE
feat(answers): mixed type+draw in one answer + expandable drawing pad

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -317,10 +317,37 @@ function ClassroomControlsPanel({
  * has no image; long answer is always free-text.
  */
 /**
- * A free-response answer the student can either TYPE or DRAW (pen/mouse/finger) —
- * crucial for maths and other work that doesn't fit a keyboard. A drawn answer is
- * stored as a PNG data URL; a typed answer as plain text. The mode is inferred
- * from the current value so it survives re-renders.
+ * Split a stored answer into its typed + drawn parts. Backward compatible:
+ * - plain text            -> { text, drawing: '' }
+ * - a bare PNG data URL   -> { text: '', drawing }   (legacy drawn-only answer)
+ * - {"text","drawing"}    -> mixed answer
+ */
+function parseWrittenAnswer(value: string): { text: string; drawing: string } {
+  if (!value) return { text: '', drawing: '' }
+  if (value.startsWith('data:image')) return { text: '', drawing: value }
+  if (value.startsWith('{')) {
+    try {
+      const o = JSON.parse(value) as { text?: unknown; drawing?: unknown }
+      if (o && (typeof o.text === 'string' || typeof o.drawing === 'string')) {
+        return { text: String(o.text ?? ''), drawing: String(o.drawing ?? '') }
+      }
+    } catch {
+      // not JSON — treat as plain text below
+    }
+  }
+  return { text: value, drawing: '' }
+}
+
+/** Pure text stays a plain string (so it auto-grades); a drawing makes it JSON. */
+function serializeWrittenAnswer(text: string, drawing: string): string {
+  if (drawing) return JSON.stringify({ text, drawing })
+  return text
+}
+
+/**
+ * A free-response answer the student can TYPE and/or DRAW (pen/mouse/finger) —
+ * crucial where maths/diagrams and writing mix. Both the text box and the
+ * drawing pad are expandable, and a single answer can contain both.
  */
 function WrittenAnswer({
   value,
@@ -337,52 +364,46 @@ function WrittenAnswer({
   placeholder: string
   baseField: string
 }) {
-  const isDrawn = typeof value === 'string' && value.startsWith('data:image')
-  const [mode, setMode] = useState<'type' | 'draw'>(isDrawn ? 'draw' : 'type')
-  // Don't show a data-URL blob as text when typing; keep typed text out of draw.
-  const textValue = isDrawn ? '' : value
-  const tabBtn = (active: boolean) =>
-    cn(
-      'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
-      active ? 'bg-[#F17623] text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-    )
+  const { text, drawing } = parseWrittenAnswer(value)
+  const [showDraw, setShowDraw] = useState(!!drawing)
+  const update = (nextText: string, nextDrawing: string) => {
+    onInteract()
+    onValueChange(serializeWrittenAnswer(nextText, nextDrawing))
+  }
   return (
-    <div>
-      <div className="mb-1.5 inline-flex gap-1 rounded-lg bg-gray-50 p-0.5">
-        <button type="button" className={tabBtn(mode === 'type')} onClick={() => setMode('type')}>
-          Type
-        </button>
-        <button type="button" className={tabBtn(mode === 'draw')} onClick={() => setMode('draw')}>
-          Draw
-        </button>
-      </div>
-      {mode === 'type' ? (
-        multiline ? (
-          <textarea
-            value={textValue}
-            onFocus={onInteract}
-            onChange={e => {
-              onInteract()
-              onValueChange(e.target.value)
-            }}
-            placeholder={placeholder}
-            className={`min-h-[64px] resize-y ${baseField}`}
-          />
-        ) : (
-          <input
-            type="text"
-            value={textValue}
-            onFocus={onInteract}
-            onChange={e => {
-              onInteract()
-              onValueChange(e.target.value)
-            }}
-            placeholder={placeholder}
-            className={baseField}
-          />
-        )
+    <div className="space-y-1.5">
+      {multiline ? (
+        <textarea
+          value={text}
+          onFocus={onInteract}
+          onChange={e => update(e.target.value, drawing)}
+          placeholder={placeholder}
+          className={`min-h-[96px] resize-y ${baseField}`}
+        />
       ) : (
-        <DrawingPad value={isDrawn ? value : undefined} onChange={onValueChange} onInteract={onInteract} />
+        <input
+          type="text"
+          value={text}
+          onFocus={onInteract}
+          onChange={e => update(e.target.value, drawing)}
+          placeholder={placeholder}
+          className={baseField}
+        />
+      )}
+      {showDraw ? (
+        <DrawingPad
+          value={drawing || undefined}
+          onChange={d => update(text, d)}
+          onInteract={onInteract}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setShowDraw(true)}
+          className="inline-flex items-center gap-1 rounded-full border border-[#F17623] bg-[#FFF4EC] px-3 py-1 text-xs font-semibold text-[#9a4a12] transition-colors hover:bg-[#ffe9d8]"
+        >
+          + Add a drawing
+        </button>
       )}
     </div>
   )

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -381,22 +381,52 @@ function SubmissionRow({
                           </span>
                         )}
                       </div>
-                      {typeof ans === 'string' && ans.startsWith('data:image') ? (
-                        <div className="mt-1">
-                          <span className="text-xs text-gray-400">Answer (drawn):</span>
-                          {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img
-                            src={ans}
-                            alt="Student's drawn answer"
-                            className="mt-1 max-h-64 w-full rounded-md border border-gray-200 bg-white object-contain"
-                          />
-                        </div>
-                      ) : (
-                        <p className="mt-1 text-gray-800">
-                          <span className="text-gray-400">Answer: </span>
-                          {typeof ans === 'string' ? ans : JSON.stringify(ans)}
-                        </p>
-                      )}
+                      {(() => {
+                        // An answer may be plain text, a drawing (PNG data URL),
+                        // or a mixed { text, drawing } — render whichever parts
+                        // are present.
+                        const raw = typeof ans === 'string' ? ans : JSON.stringify(ans)
+                        let text = raw
+                        let drawing = ''
+                        if (raw.startsWith('data:image')) {
+                          text = ''
+                          drawing = raw
+                        } else if (raw.startsWith('{')) {
+                          try {
+                            const o = JSON.parse(raw) as { text?: string; drawing?: string }
+                            if (o && (typeof o.text === 'string' || typeof o.drawing === 'string')) {
+                              text = String(o.text ?? '')
+                              drawing = String(o.drawing ?? '')
+                            }
+                          } catch {
+                            /* keep raw as text */
+                          }
+                        }
+                        return (
+                          <div className="mt-1">
+                            {text && (
+                              <p className="text-gray-800">
+                                <span className="text-gray-400">Answer: </span>
+                                {text}
+                              </p>
+                            )}
+                            {drawing && (
+                              <div className="mt-1">
+                                <span className="text-xs text-gray-400">Drawn:</span>
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={drawing}
+                                  alt="Student's drawn answer"
+                                  className="mt-1 max-h-72 w-full rounded-md border border-gray-200 bg-white object-contain"
+                                />
+                              </div>
+                            )}
+                            {!text && !drawing && (
+                              <p className="text-gray-400">No answer recorded.</p>
+                            )}
+                          </div>
+                        )
+                      })()}
                       {meta?.modelAnswer && (
                         <p className="mt-1 rounded bg-emerald-50 px-2 py-1 text-xs text-emerald-800">
                           <span className="font-semibold">Model answer:</span> {meta.modelAnswer}

--- a/tutorme-app/src/components/answer/DrawingPad.tsx
+++ b/tutorme-app/src/components/answer/DrawingPad.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 interface DrawingPadProps {
   /** Existing PNG data URL to restore (when the student already drew something). */
@@ -13,39 +13,53 @@ interface DrawingPadProps {
 
 /**
  * A lightweight pen/mouse/touch drawing surface for written answers (e.g. maths
- * working). Emits a PNG data URL so the answer can be submitted and graded like
- * any other answer value.
+ * working). The pad is EXPANDABLE — drag the bottom edge to make it taller; the
+ * existing drawing is preserved (more space is added, content isn't scaled).
+ * Emits a PNG data URL so the answer can be submitted/graded like any value.
  */
 export function DrawingPad({ value, onChange, onInteract, className = '' }: DrawingPadProps) {
+  const wrapRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const drawing = useRef(false)
   const last = useRef<{ x: number; y: number } | null>(null)
+  // Latest drawing, kept so a resize can redraw without losing content.
+  const dataRef = useRef<string>(value && value.startsWith('data:image') ? value : '')
 
-  // Size the canvas to its rendered box (device-pixel aware) and restore any
-  // existing drawing. Runs once on mount.
-  useEffect(() => {
+  // Size the canvas backing store to the wrapper and redraw the saved drawing at
+  // its natural size (top-left) so expanding adds blank space without distorting.
+  const initCanvas = useCallback(() => {
     const canvas = canvasRef.current
-    if (!canvas) return
-    const rect = canvas.getBoundingClientRect()
-    const dpr = window.devicePixelRatio || 1
-    canvas.width = Math.max(1, Math.round(rect.width * dpr))
-    canvas.height = Math.max(1, Math.round(rect.height * dpr))
+    const wrap = wrapRef.current
+    if (!canvas || !wrap) return
+    const rect = wrap.getBoundingClientRect()
+    const w = Math.max(1, Math.round(rect.width))
+    const h = Math.max(1, Math.round(rect.height))
+    if (canvas.width === w && canvas.height === h) return
+    canvas.width = w
+    canvas.height = h
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    ctx.scale(dpr, dpr)
     ctx.lineCap = 'round'
     ctx.lineJoin = 'round'
     ctx.lineWidth = 2.2
     ctx.strokeStyle = '#1F2933'
     ctx.fillStyle = '#ffffff'
-    ctx.fillRect(0, 0, rect.width, rect.height)
-    if (value && value.startsWith('data:image')) {
+    ctx.fillRect(0, 0, w, h)
+    if (dataRef.current.startsWith('data:image')) {
       const img = new Image()
-      img.onload = () => ctx.drawImage(img, 0, 0, rect.width, rect.height)
-      img.src = value
+      img.onload = () => ctx.drawImage(img, 0, 0)
+      img.src = dataRef.current
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    initCanvas()
+    const wrap = wrapRef.current
+    if (!wrap || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => initCanvas())
+    ro.observe(wrap)
+    return () => ro.disconnect()
+  }, [initCanvas])
 
   const pointFromEvent = (e: React.PointerEvent<HTMLCanvasElement>) => {
     const rect = canvasRef.current!.getBoundingClientRect()
@@ -77,31 +91,41 @@ export function DrawingPad({ value, onChange, onInteract, className = '' }: Draw
     drawing.current = false
     last.current = null
     const url = canvasRef.current?.toDataURL('image/png')
-    if (url) onChange(url)
+    if (url) {
+      dataRef.current = url
+      onChange(url)
+    }
   }
 
   const handleClear = () => {
     const canvas = canvasRef.current
     const ctx = canvas?.getContext('2d')
     if (!canvas || !ctx) return
-    const rect = canvas.getBoundingClientRect()
     ctx.fillStyle = '#ffffff'
-    ctx.fillRect(0, 0, rect.width, rect.height)
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    dataRef.current = ''
     onChange('')
   }
 
   return (
     <div className={className}>
-      <canvas
-        ref={canvasRef}
-        className="h-44 w-full touch-none rounded-md border border-gray-300 bg-white"
-        onPointerDown={handleDown}
-        onPointerMove={handleMove}
-        onPointerUp={handleUp}
-        onPointerLeave={handleUp}
-      />
+      <div
+        ref={wrapRef}
+        className="relative h-44 min-h-[120px] w-full resize-y overflow-hidden rounded-md border border-gray-300 bg-white"
+      >
+        <canvas
+          ref={canvasRef}
+          className="absolute inset-0 h-full w-full touch-none"
+          onPointerDown={handleDown}
+          onPointerMove={handleMove}
+          onPointerUp={handleUp}
+          onPointerLeave={handleUp}
+        />
+      </div>
       <div className="mt-1 flex items-center justify-between">
-        <span className="text-[10px] text-gray-400">Write or draw with a pen, mouse, or finger.</span>
+        <span className="text-[10px] text-gray-400">
+          Pen, mouse, or finger · drag the bottom edge to enlarge.
+        </span>
         <button
           type="button"
           onClick={handleClear}

--- a/tutorme-app/src/lib/grading/auto-grade.test.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.test.ts
@@ -84,6 +84,15 @@ describe('autoGradeDmi', () => {
     expect(q1).toMatchObject({ correct: false, pointsMax: 0, needsReview: true })
   })
 
+  it('flags a mixed text+drawing answer for review', () => {
+    const r = autoGradeDmi([{ id: 'q1', answer: 'Paris' }], {
+      q1: JSON.stringify({ text: 'see my working', drawing: 'data:image/png;base64,iVBOR==' }),
+    })
+    expect(r.needsReview).toBe(1)
+    const q1 = r.questionResults?.find(x => x.questionId === 'q1')
+    expect(q1).toMatchObject({ correct: false, needsReview: true })
+  })
+
   it('scores short items and excludes open-ended ones from the same task', () => {
     const mixed = [
       { id: 'q1', answer: 'Paris' }, // short, correct

--- a/tutorme-app/src/lib/grading/auto-grade.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.ts
@@ -110,10 +110,12 @@ export function autoGradeDmi(
     const g = normalize(rawGiven)
     const expected = normalize(item.answer)
     const matched = g.length > 0 && (g === expected || ` ${g} `.includes(` ${expected} `))
-    // A drawn answer (PNG data URL) is an image, not text — it can never be
-    // auto-matched, so always send it to the tutor for review instead of marking
-    // it wrong.
-    const isDrawn = String(rawGiven).startsWith('data:image')
+    // A drawn answer (a bare PNG data URL, or a mixed {text,drawing} answer that
+    // contains one) is an image — it can never be auto-matched, so always send it
+    // to the tutor for review instead of marking it wrong.
+    const rawGivenStr = String(rawGiven)
+    const isDrawn =
+      rawGivenStr.startsWith('data:image') || rawGivenStr.includes('"drawing":"data:image')
     // Open-ended (long-key) items that weren't reproduced can't be auto-judged —
     // exclude and flag rather than penalize a possible paraphrase.
     const review = !matched && (isDrawn || wordCount(expected) > SHORT_ANSWER_MAX_WORDS)


### PR DESCRIPTION
Enhances the type/draw answer feature per request:

1. **Mixed type + draw** — a single answer can contain **both typed text and a drawing** (no more either/or). The text box is always shown; **"+ Add a drawing"** reveals the pad, both saved together. Ideal where maths/diagrams and writing mix. Stored as `{text,drawing}` JSON; pure text stays a plain string (still auto-grades), and legacy text/data-URL answers still parse.
2. **Expandable** — drag the drawing pad's bottom edge to enlarge it; a `ResizeObserver` re-sizes the canvas and **redraws existing strokes at their natural position** (adds space, no distortion). The text box is resizable with a taller default.

End-to-end: `auto-grade` flags any answer containing a drawing as **needs-review**; the tutor grading view renders the **text and the drawing image together**.

typecheck + build clean; grader tests **13/13** (added a mixed-answer case). Touch/pen/resize UX → confirm on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)