### PR TITLE
feat(answers): LaTeX rendering + convert handwriting to typed text/math

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { DrawingPad } from '@/components/answer/DrawingPad'
+import { MathText, hasMath } from '@/components/answer/MathText'
 import {
   Select,
   SelectContent,
@@ -366,10 +367,38 @@ function WrittenAnswer({
 }) {
   const { text, drawing } = parseWrittenAnswer(value)
   const [showDraw, setShowDraw] = useState(!!drawing)
+  const [converting, setConverting] = useState(false)
   const update = (nextText: string, nextDrawing: string) => {
     onInteract()
     onValueChange(serializeWrittenAnswer(nextText, nextDrawing))
   }
+
+  // Convert the handwriting to typed text + LaTeX, appended to the text box.
+  const convertHandwriting = async () => {
+    if (!drawing || converting) return
+    setConverting(true)
+    try {
+      const res = await fetch('/api/ai/handwriting-to-text', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ image: drawing }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data?.text) {
+        toast.error(data?.error || 'Could not read the handwriting. Try writing more clearly.')
+        return
+      }
+      const converted = String(data.text).trim()
+      update(text ? `${text}\n${converted}` : converted, drawing)
+      toast.success('Handwriting converted to text. Review and edit if needed.')
+    } catch {
+      toast.error('Failed to convert handwriting')
+    } finally {
+      setConverting(false)
+    }
+  }
+
   return (
     <div className="space-y-1.5">
       {multiline ? (
@@ -390,12 +419,34 @@ function WrittenAnswer({
           className={baseField}
         />
       )}
+      {/* Live math preview — render $…$ / $$…$$ LaTeX as the student types. */}
+      {hasMath(text) && (
+        <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+          <span className="mb-1 block text-[10px] font-medium uppercase tracking-wide text-gray-400">
+            Preview
+          </span>
+          <MathText text={text} className="text-sm text-gray-800" />
+        </div>
+      )}
       {showDraw ? (
-        <DrawingPad
-          value={drawing || undefined}
-          onChange={d => update(text, d)}
-          onInteract={onInteract}
-        />
+        <div className="space-y-1.5">
+          <DrawingPad
+            value={drawing || undefined}
+            onChange={d => update(text, d)}
+            onInteract={onInteract}
+          />
+          {drawing && (
+            <button
+              type="button"
+              onClick={convertHandwriting}
+              disabled={converting}
+              className="inline-flex items-center gap-1 rounded-full border border-[#F17623] bg-[#FFF4EC] px-3 py-1 text-xs font-semibold text-[#9a4a12] transition-colors hover:bg-[#ffe9d8] disabled:opacity-60"
+            >
+              {converting ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+              {converting ? 'Converting…' : 'Convert handwriting → text'}
+            </button>
+          )}
+        </div>
       ) : (
         <button
           type="button"

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
+import { MathText, hasMath } from '@/components/answer/MathText'
 import { cn } from '@/lib/utils'
 
 interface Submission {
@@ -405,10 +406,14 @@ function SubmissionRow({
                         return (
                           <div className="mt-1">
                             {text && (
-                              <p className="text-gray-800">
+                              <div className="text-gray-800">
                                 <span className="text-gray-400">Answer: </span>
-                                {text}
-                              </p>
+                                {hasMath(text) ? (
+                                  <MathText text={text} className="mt-0.5 text-gray-800" />
+                                ) : (
+                                  <span className="whitespace-pre-wrap">{text}</span>
+                                )}
+                              </div>
                             )}
                             {drawing && (
                               <div className="mt-1">

--- a/tutorme-app/src/app/api/ai/handwriting-to-text/route.ts
+++ b/tutorme-app/src/app/api/ai/handwriting-to-text/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/ai/handwriting-to-text
+ *
+ * Transcribes a student's handwritten answer (a PNG data URL from the drawing
+ * pad) into clean typed text, with mathematical expressions written as LaTeX so
+ * they render nicely. Returns the transcription; the client puts it in the
+ * answer's text box. Authenticated + rate-limited; nothing is persisted.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
+import { generateWithKimiVision } from '@/lib/ai/kimi'
+import { z } from 'zod'
+
+const RequestSchema = z.object({
+  // A data URL (image/png or image/jpeg). ~7MB cap on the base64 string.
+  image: z.string().min(32).max(9_000_000),
+})
+
+const SYSTEM_PROMPT = `You convert a photo/scan of a student's HANDWRITTEN answer into clean typed text.
+Rules:
+- Transcribe exactly what is written — do NOT solve, correct, complete, or add to the answer.
+- Write every mathematical expression as LaTeX: inline as $...$, and a standalone/displayed equation as $$...$$.
+- Preserve line breaks, ordering, and structure (numbered steps, fractions, exponents, roots, matrices, etc.).
+- For a diagram, sketch, graph, or figure, give a short description in square brackets, e.g. [diagram: right triangle labelled a, b, c].
+- Output ONLY the transcription text. No preamble, no explanation, no code fences.`
+
+export async function POST(request: NextRequest) {
+  try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const parsed = RequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    const { image } = parsed.data
+    if (!image.startsWith('data:image/')) {
+      return NextResponse.json({ error: 'Image must be a data URL' }, { status: 400 })
+    }
+
+    let text: string
+    try {
+      text = await generateWithKimiVision(
+        [
+          { type: 'text', text: 'Transcribe this handwritten answer.' },
+          { type: 'image_url', image_url: { url: image } },
+        ],
+        {
+          systemPrompt: SYSTEM_PROMPT,
+          temperature: 0.1,
+          maxTokens: 1500,
+          timeoutMs: 45000,
+        }
+      )
+    } catch (aiErr) {
+      console.warn('[handwriting-to-text] Kimi vision failed:', aiErr)
+      return NextResponse.json(
+        { error: 'Handwriting conversion is unavailable right now.' },
+        { status: 503 }
+      )
+    }
+
+    // Strip any accidental code fences/preamble the model may add.
+    const cleaned = text
+      .replace(/^```[a-z]*\s*/i, '')
+      .replace(/\s*```$/i, '')
+      .trim()
+
+    return NextResponse.json({ text: cleaned })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to convert handwriting',
+      'api/ai/handwriting-to-text/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/components/answer/MathText.tsx
+++ b/tutorme-app/src/components/answer/MathText.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+// Rendered-SVG cache shared across all MathText instances, keyed by latex source.
+const svgCache = new Map<string, string>()
+
+interface Token {
+  type: 'text' | 'math'
+  content: string
+  display: boolean
+}
+
+/**
+ * Split text into prose + LaTeX segments. Supports $...$ / $$...$$ and
+ * \(...\) / \[...\] delimiters.
+ */
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = []
+  const re = /\$\$([\s\S]+?)\$\$|\$([^$\n]+?)\$|\\\[([\s\S]+?)\\\]|\\\(([\s\S]+?)\\\)/g
+  let lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > lastIndex) {
+      tokens.push({ type: 'text', content: text.slice(lastIndex, m.index), display: false })
+    }
+    const display = m[1] != null || m[3] != null
+    const latex = (m[1] ?? m[2] ?? m[3] ?? m[4] ?? '').trim()
+    tokens.push({ type: 'math', content: latex, display })
+    lastIndex = re.lastIndex
+  }
+  if (lastIndex < text.length) {
+    tokens.push({ type: 'text', content: text.slice(lastIndex), display: false })
+  }
+  return tokens
+}
+
+/** True if the text contains any LaTeX worth rendering. */
+export function hasMath(text: string): boolean {
+  return /\$[^$]+\$|\\\(|\\\[/.test(text)
+}
+
+/**
+ * Renders text with inline/display LaTeX. Math segments are rendered to SVG by
+ * the shared /api/whiteboard/render-formula endpoint (MathJax) and cached.
+ */
+export function MathText({ text, className = '' }: { text: string; className?: string }) {
+  const [, force] = useState(0)
+  const tokens = tokenize(text)
+
+  useEffect(() => {
+    let cancelled = false
+    const missing = Array.from(
+      new Set(tokens.filter(t => t.type === 'math' && !svgCache.has(t.content)).map(t => t.content))
+    )
+    if (missing.length === 0) return
+    Promise.all(
+      missing.map(async latex => {
+        try {
+          const res = await fetch('/api/whiteboard/render-formula', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ latex, display: false }),
+          })
+          if (res.ok) {
+            const d = await res.json()
+            if (d?.svg) svgCache.set(latex, d.svg as string)
+          }
+        } catch {
+          // leave uncached — shown as raw source below
+        }
+      })
+    ).then(() => {
+      if (!cancelled) force(x => x + 1)
+    })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text])
+
+  return (
+    <div className={className}>
+      {tokens.map((t, i) => {
+        if (t.type === 'text') {
+          return (
+            <span key={i} className="whitespace-pre-wrap">
+              {t.content}
+            </span>
+          )
+        }
+        const svg = svgCache.get(t.content)
+        if (svg) {
+          return (
+            <span
+              key={i}
+              className={t.display ? 'mx-auto my-1 block text-center' : 'inline-block align-middle'}
+              // SVG comes from our own MathJax endpoint (not user HTML).
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          )
+        }
+        // Still loading (or render failed) → show the LaTeX source.
+        return (
+          <span key={i} className="rounded bg-gray-100 px-1 font-mono text-xs text-gray-700">
+            {t.content}
+          </span>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
Two composable additions to free-response answers (build on the type/draw feature):

1. **LaTeX/math rendering** — a live **Preview** under the answer box renders `$…$` / `$$…$$` (and `\(…\)` / `\[…\]`) as proper math, via the existing MathJax `render-formula` endpoint (cached). The **tutor grading view** renders the same. New reusable `MathText` component.
2. **Handwriting → text** — after drawing, **"Convert handwriting → text"** sends the drawing to a new vision endpoint that transcribes it to clean typed text, writing maths as **LaTeX** (and noting diagrams), appended to the text box for the student to review/edit. Since the box renders LaTeX, the converted maths shows nicely. Transcribe-only — it never solves or adds to the answer.

- New `POST /api/ai/handwriting-to-text` (Kimi vision; authed + rate-limited).
- New `src/components/answer/MathText.tsx`.

typecheck + build clean. AI/render paths → confirm on prod (type `$x^2$`, and convert a handwritten equation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)