### PR TITLE
fix(handwriting): incremental convert (skip already-converted) + single-line tolerance

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -368,12 +368,16 @@ function WrittenAnswer({
   const { text, drawing } = parseWrittenAnswer(value)
   const [showDraw, setShowDraw] = useState(!!drawing)
   const [converting, setConverting] = useState(false)
+  // What we've already transcribed from this handwriting, so a re-convert only
+  // adds the NEW strokes and never re-appends (or disturbs) earlier text.
+  const convertedRef = useRef('')
   const update = (nextText: string, nextDrawing: string) => {
     onInteract()
     onValueChange(serializeWrittenAnswer(nextText, nextDrawing))
   }
 
-  // Convert the handwriting to typed text + LaTeX, appended to the text box.
+  // Convert the handwriting to typed text + LaTeX, APPENDED to the answer. The
+  // student's typed text is never modified — only new handwriting is added.
   const convertHandwriting = async () => {
     if (!drawing || converting) return
     setConverting(true)
@@ -382,16 +386,28 @@ function WrittenAnswer({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ image: drawing }),
+        body: JSON.stringify({
+          image: drawing,
+          // Tell the model what's already been transcribed so it skips it.
+          previousText: convertedRef.current || undefined,
+        }),
       })
       const data = await res.json().catch(() => ({}))
-      if (!res.ok || !data?.text) {
+      if (!res.ok) {
         toast.error(data?.error || 'Could not read the handwriting. Try writing more clearly.')
         return
       }
-      const converted = String(data.text).trim()
+      const converted = String(data?.text ?? '').trim()
+      if (!converted) {
+        toast.info('No new handwriting to convert.')
+        return
+      }
+      // Append only the new transcription to whatever is already in the box.
       update(text ? `${text}\n${converted}` : converted, drawing)
-      toast.success('Handwriting converted to text. Review and edit if needed.')
+      convertedRef.current = convertedRef.current
+        ? `${convertedRef.current}\n${converted}`
+        : converted
+      toast.success('Handwriting converted. Review and edit if needed.')
     } catch {
       toast.error('Failed to convert handwriting')
     } finally {

--- a/tutorme-app/src/app/api/ai/handwriting-to-text/route.ts
+++ b/tutorme-app/src/app/api/ai/handwriting-to-text/route.ts
@@ -16,13 +16,20 @@ import { z } from 'zod'
 const RequestSchema = z.object({
   // A data URL (image/png or image/jpeg). ~7MB cap on the base64 string.
   image: z.string().min(32).max(9_000_000),
+  // Handwriting already transcribed in a previous pass — skip it, return only new.
+  previousText: z.string().max(8000).optional(),
 })
 
 const SYSTEM_PROMPT = `You convert a photo/scan of a student's HANDWRITTEN answer into clean typed text.
 Rules:
 - Transcribe exactly what is written — do NOT solve, correct, complete, or add to the answer.
 - Write every mathematical expression as LaTeX: inline as $...$, and a standalone/displayed equation as $$...$$.
-- Preserve line breaks, ordering, and structure (numbered steps, fractions, exponents, roots, matrices, etc.).
+- LINE GROUPING: handwriting is rarely perfectly horizontal. Treat symbols that sit ROUGHLY on the same
+  horizontal line — including natural slant, small vertical offsets, and the normal raising/lowering of
+  superscripts, subscripts, fraction bars, roots, and operators — as ONE line / one expression. Only start
+  a NEW line when the writing clearly drops to a new row (a deliberate line break). When unsure, keep an
+  equation on a single line. Never split one equation across multiple lines because of slight wobble.
+- Preserve ordering and genuine structure (numbered steps, separate lines, matrices, etc.).
 - For a diagram, sketch, graph, or figure, give a short description in square brackets, e.g. [diagram: right triangle labelled a, b, c].
 - Output ONLY the transcription text. No preamble, no explanation, no code fences.`
 
@@ -41,16 +48,20 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
-    const { image } = parsed.data
+    const { image, previousText } = parsed.data
     if (!image.startsWith('data:image/')) {
       return NextResponse.json({ error: 'Image must be a data URL' }, { status: 400 })
     }
+
+    const instruction = previousText?.trim()
+      ? `Transcribe this handwritten answer. Part of the handwriting has ALREADY been transcribed as:\n"""\n${previousText.trim()}\n"""\nTranscribe ONLY the handwriting that is NOT already covered by that text (newly added strokes). If nothing new has been added, output an empty response.`
+      : 'Transcribe this handwritten answer.'
 
     let text: string
     try {
       text = await generateWithKimiVision(
         [
-          { type: 'text', text: 'Transcribe this handwritten answer.' },
+          { type: 'text', text: instruction },
           { type: 'image_url', image_url: { url: image } },
         ],
         {


### PR DESCRIPTION
Three refinements to handwriting→text:

1. **Typed text untouched** — converting only **appends** the new transcription; it never modifies what the student typed.
2. **Single-line tolerance** — the prompt now treats handwriting that sits roughly on one horizontal line (natural slant, small vertical offsets, super/subscripts, fraction bars) as **one line**, so a slightly uneven equation isn't split into two.
3. **Incremental re-convert** — converting again without clearing the pad transcribes **only the new strokes**: the client tracks what was already converted (`previousText`) and the endpoint is instructed to skip handwriting already covered by it (returns nothing when there's nothing new).

typecheck + build clean. AI behavior → confirm on prod (write an uneven equation; convert, add more, convert again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)