### PR TITLE
feat(answers): handwriting converts into a separate Preview, not the typed box

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { DrawingPad } from '@/components/answer/DrawingPad'
+import { MathText } from '@/components/answer/MathText'
 import {
   Select,
   SelectContent,
@@ -317,37 +318,48 @@ function ClassroomControlsPanel({
  * has no image; long answer is always free-text.
  */
 /**
- * Split a stored answer into its typed + drawn parts. Backward compatible:
- * - plain text            -> { text, drawing: '' }
- * - a bare PNG data URL   -> { text: '', drawing }   (legacy drawn-only answer)
- * - {"text","drawing"}    -> mixed answer
+ * Split a stored answer into its three independent parts. Backward compatible:
+ * - plain text                       -> { text, converted: '', drawing: '' }
+ * - a bare PNG data URL              -> { drawing }            (legacy drawn-only)
+ * - {"text","converted","drawing"}   -> typed + converted-handwriting + drawing
  */
-function parseWrittenAnswer(value: string): { text: string; drawing: string } {
-  if (!value) return { text: '', drawing: '' }
-  if (value.startsWith('data:image')) return { text: '', drawing: value }
+function parseWrittenAnswer(value: string): { text: string; converted: string; drawing: string } {
+  if (!value) return { text: '', converted: '', drawing: '' }
+  if (value.startsWith('data:image')) return { text: '', converted: '', drawing: value }
   if (value.startsWith('{')) {
     try {
-      const o = JSON.parse(value) as { text?: unknown; drawing?: unknown }
-      if (o && (typeof o.text === 'string' || typeof o.drawing === 'string')) {
-        return { text: String(o.text ?? ''), drawing: String(o.drawing ?? '') }
+      const o = JSON.parse(value) as { text?: unknown; converted?: unknown; drawing?: unknown }
+      if (
+        o &&
+        (typeof o.text === 'string' ||
+          typeof o.drawing === 'string' ||
+          typeof o.converted === 'string')
+      ) {
+        return {
+          text: String(o.text ?? ''),
+          converted: String(o.converted ?? ''),
+          drawing: String(o.drawing ?? ''),
+        }
       }
     } catch {
       // not JSON — treat as plain text below
     }
   }
-  return { text: value, drawing: '' }
+  return { text: value, converted: '', drawing: '' }
 }
 
-/** Pure text stays a plain string (so it auto-grades); a drawing makes it JSON. */
-function serializeWrittenAnswer(text: string, drawing: string): string {
-  if (drawing) return JSON.stringify({ text, drawing })
+/** Pure typed text stays a plain string (so it auto-grades); anything from the
+ *  handwriting (converted text / drawing) makes it JSON. */
+function serializeWrittenAnswer(text: string, converted: string, drawing: string): string {
+  if (converted || drawing) return JSON.stringify({ text, converted, drawing })
   return text
 }
 
 /**
- * A free-response answer the student can TYPE and/or DRAW (pen/mouse/finger) —
- * crucial where maths/diagrams and writing mix. Both the text box and the
- * drawing pad are expandable, and a single answer can contain both.
+ * A free-response answer. The keyboard box is for TYPED text only. Separately,
+ * the student can hand-write on the drawing pad and press "Convert handwriting →
+ * text": the transcription goes to the PREVIEW (rendered), never the keyboard
+ * box. The two are independent.
  */
 function WrittenAnswer({
   value,
@@ -364,19 +376,17 @@ function WrittenAnswer({
   placeholder: string
   baseField: string
 }) {
-  const { text, drawing } = parseWrittenAnswer(value)
-  const [showDraw, setShowDraw] = useState(!!drawing)
+  const { text, converted, drawing } = parseWrittenAnswer(value)
+  const [showDraw, setShowDraw] = useState(!!drawing || !!converted)
   const [converting, setConverting] = useState(false)
-  // What we've already transcribed from this handwriting, so a re-convert only
-  // adds the NEW strokes and never re-appends (or disturbs) earlier text.
-  const convertedRef = useRef('')
-  const update = (nextText: string, nextDrawing: string) => {
+  const update = (nextText: string, nextConverted: string, nextDrawing: string) => {
     onInteract()
-    onValueChange(serializeWrittenAnswer(nextText, nextDrawing))
+    onValueChange(serializeWrittenAnswer(nextText, nextConverted, nextDrawing))
   }
 
-  // Convert the handwriting to typed text + LaTeX, APPENDED to the answer. The
-  // student's typed text is never modified — only new handwriting is added.
+  // Convert the handwriting → text/LaTeX and put it in the PREVIEW (the
+  // `converted` field). The keyboard text box is never touched. A re-convert
+  // only adds NEW strokes (the model is told what's already converted).
   const convertHandwriting = async () => {
     if (!drawing || converting) return
     setConverting(true)
@@ -385,28 +395,20 @@ function WrittenAnswer({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({
-          image: drawing,
-          // Tell the model what's already been transcribed so it skips it.
-          previousText: convertedRef.current || undefined,
-        }),
+        body: JSON.stringify({ image: drawing, previousText: converted || undefined }),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
         toast.error(data?.error || 'Could not read the handwriting. Try writing more clearly.')
         return
       }
-      const converted = String(data?.text ?? '').trim()
-      if (!converted) {
+      const newText = String(data?.text ?? '').trim()
+      if (!newText) {
         toast.info('No new handwriting to convert.')
         return
       }
-      // Append only the new transcription to whatever is already in the box.
-      update(text ? `${text}\n${converted}` : converted, drawing)
-      convertedRef.current = convertedRef.current
-        ? `${convertedRef.current}\n${converted}`
-        : converted
-      toast.success('Handwriting converted. Review and edit if needed.')
+      update(text, converted ? `${converted}\n${newText}` : newText, drawing)
+      toast.success('Handwriting converted — see the preview below.')
     } catch {
       toast.error('Failed to convert handwriting')
     } finally {
@@ -416,22 +418,40 @@ function WrittenAnswer({
 
   return (
     <div className="space-y-1.5">
-      {/* Always a multi-line, expandable box (drag the bottom-right corner). */}
+      {/* Keyboard input — TYPED text only. Never receives handwriting. */}
       <textarea
         value={text}
         onFocus={onInteract}
-        onChange={e => update(e.target.value, drawing)}
+        onChange={e => update(e.target.value, converted, drawing)}
         placeholder={placeholder}
         rows={multiline ? 4 : 2}
         className={`${multiline ? 'min-h-[96px]' : 'min-h-[56px]'} resize-y ${baseField}`}
       />
-      {/* The answer box holds plain text only — math is rendered where the
-          answer is displayed (e.g. the tutor's grading view), not in the input. */}
+
+      {/* Preview — the converted handwriting, rendered (math via LaTeX). */}
+      {converted && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-[10px] font-medium uppercase tracking-wide text-gray-400">
+              Converted handwriting · preview
+            </span>
+            <button
+              type="button"
+              onClick={() => update(text, '', drawing)}
+              className="text-[11px] font-medium text-gray-500 hover:text-gray-700"
+            >
+              Clear
+            </button>
+          </div>
+          <MathText text={converted} className="text-sm text-gray-900" />
+        </div>
+      )}
+
       {showDraw ? (
         <div className="space-y-1.5">
           <DrawingPad
             value={drawing || undefined}
-            onChange={d => update(text, d)}
+            onChange={d => update(text, converted, d)}
             onInteract={onInteract}
           />
           {drawing && (

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -388,15 +388,26 @@ function SubmissionRow({
                         // are present.
                         const raw = typeof ans === 'string' ? ans : JSON.stringify(ans)
                         let text = raw
+                        let converted = ''
                         let drawing = ''
                         if (raw.startsWith('data:image')) {
                           text = ''
                           drawing = raw
                         } else if (raw.startsWith('{')) {
                           try {
-                            const o = JSON.parse(raw) as { text?: string; drawing?: string }
-                            if (o && (typeof o.text === 'string' || typeof o.drawing === 'string')) {
+                            const o = JSON.parse(raw) as {
+                              text?: string
+                              converted?: string
+                              drawing?: string
+                            }
+                            if (
+                              o &&
+                              (typeof o.text === 'string' ||
+                                typeof o.drawing === 'string' ||
+                                typeof o.converted === 'string')
+                            ) {
                               text = String(o.text ?? '')
+                              converted = String(o.converted ?? '')
                               drawing = String(o.drawing ?? '')
                             }
                           } catch {
@@ -407,7 +418,7 @@ function SubmissionRow({
                           <div className="mt-1">
                             {text && (
                               <div className="text-gray-800">
-                                <span className="text-gray-400">Answer: </span>
+                                <span className="text-gray-400">Typed: </span>
                                 {hasMath(text) ? (
                                   <MathText text={text} className="mt-0.5 text-gray-800" />
                                 ) : (
@@ -415,18 +426,24 @@ function SubmissionRow({
                                 )}
                               </div>
                             )}
+                            {converted && (
+                              <div className="mt-1 text-gray-800">
+                                <span className="text-gray-400">Handwriting (converted): </span>
+                                <MathText text={converted} className="mt-0.5 text-gray-800" />
+                              </div>
+                            )}
                             {drawing && (
                               <div className="mt-1">
-                                <span className="text-xs text-gray-400">Drawn:</span>
+                                <span className="text-xs text-gray-400">Handwriting (original):</span>
                                 {/* eslint-disable-next-line @next/next/no-img-element */}
                                 <img
                                   src={drawing}
-                                  alt="Student's drawn answer"
+                                  alt="Student's handwritten answer"
                                   className="mt-1 max-h-72 w-full rounded-md border border-gray-200 bg-white object-contain"
                                 />
                               </div>
                             )}
-                            {!text && !drawing && (
+                            {!text && !converted && !drawing && (
                               <p className="text-gray-400">No answer recorded.</p>
                             )}
                           </div>

--- a/tutorme-app/src/lib/grading/auto-grade.test.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.test.ts
@@ -93,6 +93,15 @@ describe('autoGradeDmi', () => {
     expect(q1).toMatchObject({ correct: false, needsReview: true })
   })
 
+  it('flags an answer with converted handwriting for review', () => {
+    const r = autoGradeDmi([{ id: 'q1', answer: 'Paris' }], {
+      q1: JSON.stringify({ text: '', converted: '$y=\\frac{4}{x}$', drawing: '' }),
+    })
+    expect(r.needsReview).toBe(1)
+    const q1 = r.questionResults?.find(x => x.questionId === 'q1')
+    expect(q1).toMatchObject({ needsReview: true })
+  })
+
   it('scores short items and excludes open-ended ones from the same task', () => {
     const mixed = [
       { id: 'q1', answer: 'Paris' }, // short, correct

--- a/tutorme-app/src/lib/grading/auto-grade.ts
+++ b/tutorme-app/src/lib/grading/auto-grade.ts
@@ -110,12 +110,14 @@ export function autoGradeDmi(
     const g = normalize(rawGiven)
     const expected = normalize(item.answer)
     const matched = g.length > 0 && (g === expected || ` ${g} `.includes(` ${expected} `))
-    // A drawn answer (a bare PNG data URL, or a mixed {text,drawing} answer that
-    // contains one) is an image — it can never be auto-matched, so always send it
-    // to the tutor for review instead of marking it wrong.
+    // An answer carrying a drawing (a bare PNG data URL or a {drawing} blob) or
+    // converted handwriting can't be reliably auto-matched, so always send it to
+    // the tutor for review instead of marking it wrong.
     const rawGivenStr = String(rawGiven)
     const isDrawn =
-      rawGivenStr.startsWith('data:image') || rawGivenStr.includes('"drawing":"data:image')
+      rawGivenStr.startsWith('data:image') ||
+      rawGivenStr.includes('"drawing":"data:image') ||
+      /"converted":"[^"]/.test(rawGivenStr)
     // Open-ended (long-key) items that weren't reproduced can't be auto-judged —
     // exclude and flag rather than penalize a possible paraphrase.
     const review = !matched && (isDrawn || wordCount(expected) > SHORT_ANSWER_MAX_WORDS)


### PR DESCRIPTION
Per the clarified flow: **handwriting → (Convert) → Preview**, and the keyboard box stays typed-text only.

The answer now has three independent parts (`{text, converted, drawing}`):
- **text** — keyboard box, **typed text only**; handwriting never writes here.
- **converted** — the handwriting transcription, shown in a **rendered Preview** box (math via LaTeX) after pressing *Convert handwriting → text*.
- **drawing** — the raw handwriting (kept for the tutor to verify).

Convert appends to `converted` (incremental — re-converting only adds new strokes) and **never touches the typed box**. `auto-grade` flags any answer with converted handwriting or a drawing for review; the tutor grading view shows **Typed / Handwriting (converted, rendered) / Handwriting (original image)** separately.

Restores the Preview removed in #399, now wired to handwriting only. typecheck + build clean; grader tests 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)