### PR TITLE
fix(course-builder): use CSS Grid for panel layout with fixed center …

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -685,6 +685,18 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [rightPanelHidden, setRightPanelHidden] = useState(false)
     const [rightPanelWidth] = useState(380)
     const [leftPanelWidth, setLeftPanelWidth] = useState(340)
+    const [viewportWidth, setViewportWidth] = useState(1920)
+
+    useEffect(() => {
+      const handleResize = () => setViewportWidth(window.innerWidth)
+      if (typeof window !== 'undefined') {
+        setViewportWidth(window.innerWidth)
+        window.addEventListener('resize', handleResize)
+        return () => window.removeEventListener('resize', handleResize)
+      }
+    }, [])
+
+    const centerColWidth = viewportWidth - leftPanelWidth - rightPanelWidth - 48
     const [leftPanelResizing, setLeftPanelResizing] = useState(false)
     const leftPanelRef = useRef<HTMLDivElement>(null)
     const [assetsOpen, setAssetsOpen] = useState(true)
@@ -6256,7 +6268,13 @@ FEEDBACK: [your explanation]`
           }}
           className="flex h-full w-full flex-1 flex-col bg-gray-50/50 px-6 pt-0"
         >
-          <div className="relative flex h-full w-full min-w-0 flex-1 gap-6 pb-6 pt-0">
+          <div
+            className="relative grid h-full w-full min-w-0 pb-6 pt-0"
+            style={{
+              gridTemplateColumns: `${leftPanelHidden ? '0px' : leftPanelWidth}px minmax(0, ${centerColWidth}px) ${rightPanelHidden ? '0px' : rightPanelWidth}px`,
+              gap: '24px',
+            }}
+          >
             {/* LEFT PANEL - Course Structure (resizable, ~75% of original width) */}
             {/* Floating collapsed/expanded pill */}
             <div
@@ -6274,7 +6292,7 @@ FEEDBACK: [your explanation]`
 
             {!leftPanelHidden && (
               <div
-                className="relative z-40 order-1 flex min-h-0 shrink-0 flex-col"
+                className="relative z-40 flex min-h-0 shrink-0 flex-col"
                 ref={leftPanelRef}
                 style={{ width: leftPanelWidth }}
               >
@@ -8194,7 +8212,7 @@ FEEDBACK: [your explanation]`
                       </div>
                       {!rightPanelHidden && (
                         <div
-                          className="relative z-40 order-3 flex h-full min-h-0 shrink-0 flex-col"
+                          className="relative z-40 flex h-full min-h-0 shrink-0 flex-col"
                           style={{ width: rightPanelWidth }}
                         >
                           <div className="flex h-full min-h-0 flex-col">
@@ -8487,16 +8505,8 @@ FEEDBACK: [your explanation]`
               </>
             )}
 
-            {/* CENTER PANEL - Flexible width with max-width cap */}
-            <div
-              className="order-2 flex min-h-0 flex-1 flex-col items-center"
-              style={{
-                maxWidth:
-                  leftPanelHidden && rightPanelHidden
-                    ? undefined
-                    : `calc(100vw - ${(leftPanelHidden ? 0 : leftPanelWidth) + (rightPanelHidden ? 0 : rightPanelWidth) + 48}px)`,
-              }}
-            >
+            {/* CENTER PANEL - Fixed width based on 3-panel layout */}
+            <div className="flex min-h-0 flex-col items-center">
               <div className="flex h-full min-h-0 w-full flex-1 grow flex-col items-stretch">
                 {mainTab !== 'builder' && (
                   <Card

--- a/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
@@ -18,6 +18,7 @@ import {
 
 import {
   BarChart3,
+  DollarSign,
   Loader2,
   ChevronRight,
   ChevronDown,
@@ -132,6 +133,10 @@ export default function TutorReports() {
   const [globalAttentionStudents, setGlobalAttentionStudents] = useState<Student[]>([])
   const [globalAllStudents, setGlobalAllStudents] = useState<Student[]>([])
   const [loadingGlobals, setLoadingGlobals] = useState(true)
+
+  const [revenueExpanded, setRevenueExpanded] = useState(true)
+  const [rosterExpanded, setRosterExpanded] = useState(true)
+  const [reportsExpanded, setReportsExpanded] = useState(true)
 
   interface AnalyticsData {
     totalCourses: number
@@ -384,104 +389,195 @@ export default function TutorReports() {
         >
           {/* Revenue Tab */}
           <TabsContent value="revenue" className="h-full overflow-hidden bg-white">
-            <RevenueDashboard className="border-0 bg-white shadow-none" themeId="current" />
+            <div className="flex flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+              <button
+                type="button"
+                onClick={() => setRevenueExpanded(prev => !prev)}
+                className="panel-header panel-header-metallic w-full text-left"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="panel-header-icon">
+                      <DollarSign className="h-5 w-5 text-slate-900" />
+                    </div>
+                    <div>
+                      <div className="panel-header-title">Revenue & Business</div>
+                    </div>
+                  </div>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+                    {revenueExpanded ? (
+                      <ChevronUp className="h-5 w-5" />
+                    ) : (
+                      <ChevronDown className="h-5 w-5" />
+                    )}
+                  </div>
+                </div>
+              </button>
+              {revenueExpanded && (
+                <div className="min-h-0 flex-1 p-6">
+                  <RevenueDashboard className="border-0 bg-white shadow-none" themeId="current" />
+                </div>
+              )}
+            </div>
           </TabsContent>
 
           {/* Students Tab */}
           <TabsContent value="students" className="h-full overflow-y-auto">
-            <div className="h-full space-y-6">
-              <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="text-xl font-bold text-slate-800">Student Roster</h2>
-                  <p className="mt-1 text-sm text-slate-500">
-                    Manage and view all enrolled students
-                  </p>
-                </div>
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Search students..."
-                    value={searchQuery}
-                    onChange={e => setSearchQuery(e.target.value)}
-                    className="w-64 border-slate-200 bg-slate-50/50"
-                  />
-                  <Select value={selectedCluster} onValueChange={setSelectedCluster}>
-                    <SelectTrigger className="w-40 border-slate-200 bg-slate-50/50">
-                      <SelectValue placeholder="Filter by cluster" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All Students</SelectItem>
-                      <SelectItem value="advanced">Advanced</SelectItem>
-                      <SelectItem value="intermediate">Intermediate</SelectItem>
-                      <SelectItem value="struggling">Needs Support</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div className="space-y-3">
-                {filteredStudents.length === 0 ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 py-10 text-center text-sm text-slate-500">
-                    {searchQuery ? 'No students match your search.' : 'No students enrolled yet.'}
-                  </div>
-                ) : (
-                  filteredStudents.map(student => (
-                    <div
-                      key={student.id}
-                      className="flex items-center justify-between rounded-[12px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] p-4 transition-all duration-200 ease-in-out hover:bg-slate-50 hover:shadow-sm"
-                    >
-                      <div className="flex items-center gap-4">
-                        <Avatar className="h-10 w-10">
-                          <AvatarFallback className="bg-indigo-50 font-medium text-indigo-600">
-                            {student.name.charAt(0)}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div>
-                          <p className="font-semibold text-slate-800">{student.name}</p>
-                          <p className="text-xs font-medium text-slate-500">{student.email}</p>
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-6">
-                        <div className="text-right">
-                          <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-                            Courses
-                          </p>
-                          <p className="font-semibold text-slate-700">{student.courseCount ?? 0}</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-                            Classes
-                          </p>
-                          <p className="font-semibold text-slate-700">{student.classCount ?? 0}</p>
-                        </div>
-                        {student.cluster && (
-                          <Badge
-                            className={cn(
-                              getClusterBadgeClass(student.cluster),
-                              'border-0 font-semibold'
-                            )}
-                          >
-                            {getClusterLabel(student.cluster)}
-                          </Badge>
-                        )}
-                        <Link href={`/tutor/reports/${student.id}`}>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="text-slate-400 hover:bg-slate-100 hover:text-slate-800"
-                          >
-                            <ChevronRight className="h-4 w-4" />
-                          </Button>
-                        </Link>
-                      </div>
+            <div className="flex flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+              <button
+                type="button"
+                onClick={() => setRosterExpanded(prev => !prev)}
+                className="panel-header panel-header-metallic w-full text-left"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="panel-header-icon">
+                      <Users className="h-5 w-5 text-slate-900" />
                     </div>
-                  ))
-                )}
-              </div>
+                    <div>
+                      <div className="panel-header-title">Student Roster</div>
+                    </div>
+                  </div>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+                    {rosterExpanded ? (
+                      <ChevronUp className="h-5 w-5" />
+                    ) : (
+                      <ChevronDown className="h-5 w-5" />
+                    )}
+                  </div>
+                </div>
+              </button>
+              {rosterExpanded && (
+                <div className="h-full space-y-6 p-6">
+                  <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="text-xl font-bold text-slate-800">Student Roster</h2>
+                      <p className="mt-1 text-sm text-slate-500">
+                        Manage and view all enrolled students
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Input
+                        placeholder="Search students..."
+                        value={searchQuery}
+                        onChange={e => setSearchQuery(e.target.value)}
+                        className="w-64 border-slate-200 bg-slate-50/50"
+                      />
+                      <Select value={selectedCluster} onValueChange={setSelectedCluster}>
+                        <SelectTrigger className="w-40 border-slate-200 bg-slate-50/50">
+                          <SelectValue placeholder="Filter by cluster" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Students</SelectItem>
+                          <SelectItem value="advanced">Advanced</SelectItem>
+                          <SelectItem value="intermediate">Intermediate</SelectItem>
+                          <SelectItem value="struggling">Needs Support</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    {filteredStudents.length === 0 ? (
+                      <div className="rounded-xl border border-dashed border-slate-200 py-10 text-center text-sm text-slate-500">
+                        {searchQuery
+                          ? 'No students match your search.'
+                          : 'No students enrolled yet.'}
+                      </div>
+                    ) : (
+                      filteredStudents.map(student => (
+                        <div
+                          key={student.id}
+                          className="flex items-center justify-between rounded-[12px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] p-4 transition-all duration-200 ease-in-out hover:bg-slate-50 hover:shadow-sm"
+                        >
+                          <div className="flex items-center gap-4">
+                            <Avatar className="h-10 w-10">
+                              <AvatarFallback className="bg-indigo-50 font-medium text-indigo-600">
+                                {student.name.charAt(0)}
+                              </AvatarFallback>
+                            </Avatar>
+                            <div>
+                              <p className="font-semibold text-slate-800">{student.name}</p>
+                              <p className="text-xs font-medium text-slate-500">{student.email}</p>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-6">
+                            <div className="text-right">
+                              <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                                Courses
+                              </p>
+                              <p className="font-semibold text-slate-700">
+                                {student.courseCount ?? 0}
+                              </p>
+                            </div>
+                            <div className="text-right">
+                              <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                                Classes
+                              </p>
+                              <p className="font-semibold text-slate-700">
+                                {student.classCount ?? 0}
+                              </p>
+                            </div>
+                            {student.cluster && (
+                              <Badge
+                                className={cn(
+                                  getClusterBadgeClass(student.cluster),
+                                  'border-0 font-semibold'
+                                )}
+                              >
+                                {getClusterLabel(student.cluster)}
+                              </Badge>
+                            )}
+                            <Link href={`/tutor/reports/${student.id}`}>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="text-slate-400 hover:bg-slate-100 hover:text-slate-800"
+                              >
+                                <ChevronRight className="h-4 w-4" />
+                              </Button>
+                            </Link>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           </TabsContent>
 
           {/* Reports Tab */}
           <TabsContent value="reports" className="h-full overflow-y-auto">
-            <StudentReportsTab />
+            <div className="flex flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+              <button
+                type="button"
+                onClick={() => setReportsExpanded(prev => !prev)}
+                className="panel-header panel-header-metallic w-full text-left"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <div className="panel-header-icon">
+                      <BarChart3 className="h-5 w-5 text-slate-900" />
+                    </div>
+                    <div>
+                      <div className="panel-header-title">Student Reports</div>
+                    </div>
+                  </div>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+                    {reportsExpanded ? (
+                      <ChevronUp className="h-5 w-5" />
+                    ) : (
+                      <ChevronDown className="h-5 w-5" />
+                    )}
+                  </div>
+                </div>
+              </button>
+              {reportsExpanded && (
+                <div className="min-h-0 flex-1 p-6">
+                  <StudentReportsTab />
+                </div>
+              )}
+            </div>
           </TabsContent>
 
           {/* Courses & Classes Tab */}

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -434,7 +434,9 @@ function SubmissionRow({
                             )}
                             {drawing && (
                               <div className="mt-1">
-                                <span className="text-xs text-gray-400">Handwriting (original):</span>
+                                <span className="text-xs text-gray-400">
+                                  Handwriting (original):
+                                </span>
                                 {/* eslint-disable-next-line @next/next/no-img-element */}
                                 <img
                                   src={drawing}


### PR DESCRIPTION
…column width

- Replace flexbox with CSS Grid for the three-panel layout
- Center column width is always calculated as viewport - left(340px) - right(380px) - gap(48px)
- When side panels are hidden, their grid column becomes 0px, leaving empty space
- Middle panel stays at its '3-panel-open' width regardless of side panel state
- Middle panel can shrink when viewport shrinks (minmax(0, ...))
- Left and right panels stay fixed at their edges
- Remove order-* classes since grid handles placement
- Add viewport resize listener to update center column width dynamically