### PR TITLE
fix(support): match main panel shadow to Analytics page styling

### DIFF
--- a/tutorme-app/src/components/support/support-page.tsx
+++ b/tutorme-app/src/components/support/support-page.tsx
@@ -57,7 +57,7 @@ export function SupportPage({ subtitle, heroGradient, topics }: SupportPageProps
 
       {/* Lower panel */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
-        <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#E5E7EB] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+        <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white p-5 shadow-[0_18px_60px_rgba(0,0,0,0.28)] ring-1 ring-black/5">
           {/* Mode selector cards */}
           <div className="grid flex-shrink-0 grid-cols-2 gap-3 p-5 pb-3 sm:grid-cols-4">
             {topics.map(topic => {


### PR DESCRIPTION
- Increase shadow from 0.14/45px to 0.28/60px for stronger floating effect
- Add ring-1 ring-black/5 for subtle outer border
- Add p-5 padding to match SessionCalendarPanel
- Change radius from rounded-[16px] to rounded-2xl (24px)