### PR TITLE
fix(course-builder): align Curriculum panel and fix open/close animation

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6364,7 +6364,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
             </div>
 
             <div
-              className="relative z-40 flex min-h-0 shrink-0 flex-col rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]"
+              className={cn(
+                'relative z-40 -ml-7 flex min-h-0 shrink-0 flex-col sm:-ml-8',
+                leftPanelHidden
+                  ? 'bg-transparent shadow-none'
+                  : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+              )}
               ref={leftPanelRef}
               style={{ width: leftPanelWidth, flexShrink: 0 }}
             >
@@ -10301,7 +10306,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
                 {/* Right panel content - grid child with consistent wrapper */}
                 <div
-                  className="relative z-40 flex min-h-0 shrink-0 flex-col rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]"
+                  className={cn(
+                    'relative z-40 flex min-h-0 shrink-0 flex-col',
+                    rightPanelHidden
+                      ? 'bg-transparent shadow-none'
+                      : 'items-end rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                  )}
                   style={{ width: rightPanelWidth, flexShrink: 0 }}
                 >
                   <div


### PR DESCRIPTION
- Add negative left margin (-ml-7 sm:-ml-8) to Curriculum panel to align its left edge flush with the hero panel's left edge
- Fix ghost container on closed panels by conditionally removing shadow and rounded corners from outer wrapper when hidden
- Fix Desk panel animation direction by adding items-end so content shrinks toward the right edge when closing instead of toward the left
- Middle panel size and position remain unchanged