### PR TITLE
fix(course-builder): show course name in Test mode top panel

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -974,9 +974,9 @@ function CourseBuilderInsightsRouteInner({
                   )}
                   {activeMainTab === 'test-pci' && (
                     <h1 className="text-foreground flex flex-1 items-center justify-center gap-2 text-2xl font-bold tracking-tight">
-                      {currentCourse?.name && (
+                      {(model.course?.name || currentCourse?.name) && (
                         <span className="text-muted-foreground ml-2 text-xl font-normal">
-                          {currentCourse.name}
+                          {model.course?.name || currentCourse?.name}
                         </span>
                       )}
                     </h1>


### PR DESCRIPTION
Use model.course?.name as fallback in Test mode header, matching Classroom mode behavior. Previously only currentCourse?.name was used which could be undefined when the course wasn't found in the courses/draftCourses arrays.