### PR TITLE
fix(course-builder): correct panel alignment and center column width

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -757,7 +757,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [])
 
-    const centerColWidth = viewportWidth - 48 - leftPanelWidth - rightPanelWidth - 48
+    const centerColWidth = viewportWidth - 32 - leftPanelWidth - rightPanelWidth - 32
 
     const [leftPanelResizing, setLeftPanelResizing] = useState(false)
     const leftPanelRef = useRef<HTMLDivElement>(null)
@@ -6365,20 +6365,15 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
             <div
               className={cn(
-                'relative z-40 -ml-7 flex min-h-0 shrink-0 flex-col sm:-ml-8',
+                'relative z-40 flex min-h-0 shrink-0 flex-col rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)] transition-all duration-500 ease-in-out',
                 leftPanelHidden
-                  ? 'bg-transparent shadow-none'
-                  : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                  ? '-translate-x-[calc(100%+1rem)] opacity-0'
+                  : 'translate-x-0 opacity-100'
               )}
               ref={leftPanelRef}
               style={{ width: leftPanelWidth, flexShrink: 0 }}
             >
-              <div
-                className={cn(
-                  'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
-                  leftPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
-                )}
-              >
+              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]">
                 <Card
                   padding="none"
                   className="flex h-full min-h-0 flex-1 flex-col rounded-[20px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF]"
@@ -10307,19 +10302,14 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 {/* Right panel content - grid child with consistent wrapper */}
                 <div
                   className={cn(
-                    'relative z-40 flex min-h-0 shrink-0 flex-col',
+                    'relative z-40 flex min-h-0 shrink-0 flex-col rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)] transition-all duration-500 ease-in-out',
                     rightPanelHidden
-                      ? 'bg-transparent shadow-none'
-                      : 'items-end rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                      ? 'translate-x-[calc(100%+1rem)] opacity-0'
+                      : 'translate-x-0 opacity-100'
                   )}
                   style={{ width: rightPanelWidth, flexShrink: 0 }}
                 >
-                  <div
-                    className={cn(
-                      'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
-                      rightPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
-                    )}
-                  >
+                  <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]">
                     {mainTab === 'live' && liveRightPanelTab === 'insights' ? (
                       <div className="flex h-full min-h-0 flex-col">
                         <Card


### PR DESCRIPTION
- Revert incorrect -ml-7 sm:-ml-8 negative margin on Curriculum panel that caused it to extend past the left edge of the hero panel
- Fix centerColWidth calculation from 48 to 32 on both sides to match actual sm:px-8 (32px) container padding, preventing the center panel from being too wide and pushing the Desk panel out of alignment