### PR TITLE
fix(support): apply Analytics panel white background and shadow to lo…

### DIFF
--- a/tutorme-app/src/components/support/support-page.tsx
+++ b/tutorme-app/src/components/support/support-page.tsx
@@ -57,7 +57,7 @@ export function SupportPage({ subtitle, heroGradient, topics }: SupportPageProps
 
       {/* Lower panel */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
-        <Card className="flex h-full flex-col overflow-hidden">
+        <Card className="flex h-full flex-col overflow-hidden bg-white shadow-[0_18px_60px_rgba(0,0,0,0.16)] ring-1 ring-black/5">
           {/* Mode selector cards */}
           <div className="grid flex-shrink-0 grid-cols-2 gap-3 p-5 pb-3 sm:grid-cols-4">
             {topics.map(topic => {


### PR DESCRIPTION
…wer panel

Add bg-white, shadow-[0_18px_60px_rgba(0,0,0,0.16)], and ring-1 ring-black/5 to the Support page lower panel Card to match the Analytics page floating panel design with white background and visible shadow.