### PR TITLE
fix: classroom back button not clickable due to absolute positioned t…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -951,7 +951,7 @@ function CourseBuilderInsightsRouteInner({
                     )}
 
                   {activeMainTab === 'live' && (
-                    <h1 className="text-foreground absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="text-foreground flex flex-1 items-center justify-center gap-2 text-2xl font-bold tracking-tight">
                       {model.course?.name && (
                         <span className="text-muted-foreground text-xl font-normal">
                           {model.course.name}


### PR DESCRIPTION
…itle overlay

The h1 title in Classroom mode used absolute left-0 right-0 positioning, which spanned the full header width and overlapped the back button, preventing clicks from reaching it. Changed to flex flex-1 to match Test mode behavior, keeping the title centered without overlapping.