### PR TITLE
fix(course-builder): align panels with top panel edges and fix desk animation

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
@@ -128,7 +128,10 @@ export function AiAssistantPanel({
     // Add messages one at a time with staggered delay
     infoBlocks.forEach((text, index) => {
       setTimeout(() => {
-        setMessages(prev => [...prev, { role: 'assistant', text, id: `info-${index}-${Date.now()}` }])
+        setMessages(prev => [
+          ...prev,
+          { role: 'assistant', text, id: `info-${index}-${Date.now()}` },
+        ])
         // Scroll to bottom after each message
         setTimeout(() => {
           messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -165,13 +168,13 @@ export function AiAssistantPanel({
   return (
     <div className="flex h-full flex-col gap-3">
       {/* Chat messages — scrollable area */}
-      <div className="flex-1 min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
+      <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
         {messages.length === 0 && !isAnimating ? (
           <p className="text-sm text-gray-400">Ask the AI Assistant anything.</p>
         ) : (
           <div className="space-y-3">
             <AnimatePresence initial={false}>
-              {messages.map((m) => (
+              {messages.map(m => (
                 <motion.div
                   key={m.id}
                   initial={{ opacity: 0, y: 20 }}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Send } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { AutoTextarea } from '@/components/ui/auto-textarea'
 
@@ -18,6 +19,14 @@ interface AiAssistantPanelProps {
   sessions?: SessionInfo[]
   studentsCount?: number
   liveSubmissions?: Array<{ taskId: string; studentId: string; submittedAt?: string | number }>
+  /** Whether the Analytics tab is currently active — triggers the intro animation */
+  isActive?: boolean
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  text: string
+  id: string
 }
 
 export function AiAssistantPanel({
@@ -26,23 +35,22 @@ export function AiAssistantPanel({
   sessions = [],
   studentsCount = 0,
   liveSubmissions = [],
+  isActive = true,
 }: AiAssistantPanelProps) {
   const [input, setInput] = useState('')
-  const [messages, setMessages] = useState<{ role: 'user' | 'assistant'; text: string }[]>([])
-  const hasLoadedRef = useRef(false)
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [isAnimating, setIsAnimating] = useState(false)
+  const hasAnimatedRef = useRef(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
 
-  // Load course data once on mount
-  useEffect(() => {
-    if (hasLoadedRef.current) return
-    hasLoadedRef.current = true
-
-    const lines: string[] = []
+  // Build course info message blocks
+  const buildCourseInfoMessages = useCallback((): string[] => {
+    const blocks: string[] = []
 
     if (courseName) {
-      lines.push(`Course Name: ${courseName}`)
+      blocks.push(`Course Name: ${courseName}`)
     }
 
-    // Commencement Date - first session date
     if (sessions.length > 0) {
       const sorted = [...sessions].sort(
         (a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
@@ -50,7 +58,7 @@ export function AiAssistantPanel({
       const firstSession = sorted[0]
       if (firstSession?.scheduledAt) {
         const date = new Date(firstSession.scheduledAt)
-        lines.push(
+        blocks.push(
           `Commencement Date: ${date.toLocaleDateString('en-US', {
             weekday: 'long',
             year: 'numeric',
@@ -62,7 +70,6 @@ export function AiAssistantPanel({
         )
       }
 
-      // Schedule - list all sessions
       const scheduleItems = sorted
         .map(s => {
           const date = new Date(s.scheduledAt)
@@ -75,16 +82,15 @@ export function AiAssistantPanel({
         })
         .join('\n')
       if (scheduleItems) {
-        lines.push(`Schedule:\n${scheduleItems}`)
+        blocks.push(`Schedule:\n${scheduleItems}`)
       }
 
-      // Next Session - upcoming session
       const now = Date.now()
       const upcoming = sorted.filter(s => new Date(s.scheduledAt).getTime() > now)
       if (upcoming.length > 0) {
         const next = upcoming[0]
         const date = new Date(next.scheduledAt)
-        lines.push(
+        blocks.push(
           `Next Session: ${next.title} — ${date.toLocaleDateString('en-US', {
             weekday: 'long',
             month: 'long',
@@ -94,57 +100,99 @@ export function AiAssistantPanel({
           })}`
         )
       } else {
-        lines.push('Next Session: No upcoming sessions')
+        blocks.push('Next Session: No upcoming sessions')
       }
     }
 
-    // Students Enrolled
-    lines.push(`Students Enrolled: ${studentsCount}`)
+    blocks.push(`Students Enrolled: ${studentsCount}`)
 
-    // Task Completion Rate
     const totalSubmissions = liveSubmissions.length
     const completedSubmissions = liveSubmissions.filter(s => s.submittedAt).length
     const completionRate =
       totalSubmissions > 0 ? Math.round((completedSubmissions / totalSubmissions) * 100) : 0
-    lines.push(`Task Completion Rate: ${completionRate}%`)
+    blocks.push(`Task Completion Rate: ${completionRate}%`)
 
-    if (lines.length > 0) {
-      setMessages([{ role: 'assistant', text: lines.join('\n\n') }])
-    }
+    return blocks
   }, [courseName, sessions, studentsCount, liveSubmissions])
+
+  // Animate course info messages in one at a time from the bottom
+  useEffect(() => {
+    if (!isActive || hasAnimatedRef.current) return
+
+    const infoBlocks = buildCourseInfoMessages()
+    if (infoBlocks.length === 0) return
+
+    hasAnimatedRef.current = true
+    setIsAnimating(true)
+
+    // Add messages one at a time with staggered delay
+    infoBlocks.forEach((text, index) => {
+      setTimeout(() => {
+        setMessages(prev => [...prev, { role: 'assistant', text, id: `info-${index}-${Date.now()}` }])
+        // Scroll to bottom after each message
+        setTimeout(() => {
+          messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+        }, 50)
+
+        // Clear animating flag after last message
+        if (index === infoBlocks.length - 1) {
+          setTimeout(() => setIsAnimating(false), 500)
+        }
+      }, index * 400)
+    })
+  }, [isActive, buildCourseInfoMessages])
 
   const handleSend = () => {
     if (!input.trim()) return
-    setMessages(prev => [...prev, { role: 'user', text: input.trim() }])
+    const userMsg: ChatMessage = { role: 'user', text: input.trim(), id: `user-${Date.now()}` }
+    setMessages(prev => [...prev, userMsg])
     setInput('')
-    // TODO: wire to AI backend
+
+    // TODO: wire to AI backend — for now simulate assistant response
+    setTimeout(() => {
+      const assistantMsg: ChatMessage = {
+        role: 'assistant',
+        text: 'I received your message. AI integration coming soon.',
+        id: `assistant-${Date.now()}`,
+      }
+      setMessages(prev => [...prev, assistantMsg])
+      setTimeout(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+      }, 50)
+    }, 1000)
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-3 px-1 pb-0">
-      {/* Chat display */}
-      <div className="flex-1 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
-        {messages.length === 0 ? (
+    <div className="flex h-full flex-col gap-3">
+      {/* Chat messages — scrollable area */}
+      <div className="flex-1 min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
+        {messages.length === 0 && !isAnimating ? (
           <p className="text-sm text-gray-400">Ask the AI Assistant anything.</p>
         ) : (
           <div className="space-y-3">
-            {messages.map((m, i) => (
-              <div
-                key={i}
-                className={`max-w-[90%] whitespace-pre-line rounded-lg px-3 py-2 text-sm ${
-                  m.role === 'user'
-                    ? 'ml-auto bg-blue-50 text-blue-900'
-                    : 'mr-auto bg-gray-50 text-gray-900'
-                }`}
-              >
-                {m.text}
-              </div>
-            ))}
+            <AnimatePresence initial={false}>
+              {messages.map((m) => (
+                <motion.div
+                  key={m.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.35, ease: 'easeOut' }}
+                  className={`max-w-[90%] whitespace-pre-line rounded-lg px-3 py-2 text-sm ${
+                    m.role === 'user'
+                      ? 'ml-auto bg-blue-50 text-blue-900'
+                      : 'mr-auto bg-gray-50 text-gray-900'
+                  }`}
+                >
+                  {m.text}
+                </motion.div>
+              ))}
+            </AnimatePresence>
+            <div ref={messagesEndRef} />
           </div>
         )}
       </div>
 
-      {/* Input */}
+      {/* Input — fixed at bottom */}
       <div className="shrink-0 rounded-xl border border-gray-200 bg-white p-2 shadow-sm">
         <div className="relative">
           <AutoTextarea

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AiAssistantPanel.tsx
@@ -128,10 +128,7 @@ export function AiAssistantPanel({
     // Add messages one at a time with staggered delay
     infoBlocks.forEach((text, index) => {
       setTimeout(() => {
-        setMessages(prev => [
-          ...prev,
-          { role: 'assistant', text, id: `info-${index}-${Date.now()}` },
-        ])
+        setMessages(prev => [...prev, { role: 'assistant', text, id: `info-${index}-${Date.now()}` }])
         // Scroll to bottom after each message
         setTimeout(() => {
           messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -168,13 +165,13 @@ export function AiAssistantPanel({
   return (
     <div className="flex h-full flex-col gap-3">
       {/* Chat messages — scrollable area */}
-      <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
+      <div className="flex-1 min-h-0 overflow-y-auto rounded-xl border border-gray-200 bg-white/80 p-3 shadow-sm">
         {messages.length === 0 && !isAnimating ? (
           <p className="text-sm text-gray-400">Ask the AI Assistant anything.</p>
         ) : (
           <div className="space-y-3">
             <AnimatePresence initial={false}>
-              {messages.map(m => (
+              {messages.map((m) => (
                 <motion.div
                   key={m.id}
                   initial={{ opacity: 0, y: 20 }}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10392,6 +10392,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                     >
                                       <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
                                         <AiAssistantPanel
+                                          isActive={insightsTab === 'analytics'}
                                           sessionId={insightsProps.sessionId}
                                           courseName={courseName}
                                           sessions={insightsProps.sessions?.map((s: any) => ({

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -757,7 +757,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [])
 
-    const centerColWidth = viewportWidth - 32 - leftPanelWidth - 24 - rightPanelWidth - 24 - 32
+    const centerColWidth = viewportWidth - leftPanelWidth - 24 - rightPanelWidth - 24
 
     const [leftPanelResizing, setLeftPanelResizing] = useState(false)
     const leftPanelRef = useRef<HTMLDivElement>(null)
@@ -6337,7 +6337,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
           className="flex h-full w-full flex-1 flex-col bg-gray-50/50 px-0 pt-0"
         >
           <div
-            className="relative flex h-full w-full px-7 pb-6 pt-0 sm:px-8"
+            className="relative flex h-full w-full pb-6 pt-0"
             style={{
               gap: '24px',
             }}
@@ -6386,7 +6386,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
                     Curriculum
                   </div>
-                  <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-0 pt-5">
+                  <CardContent className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pb-0 pt-5">
                     {mainTab !== 'live' && mainTab !== 'test-pci' && canEdit && (
                       <Button
                         size="sm"
@@ -10311,7 +10311,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                     'relative z-40 flex min-h-0 shrink-0 flex-col',
                     rightPanelHidden
                       ? 'bg-transparent shadow-none'
-                      : 'items-end rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                      : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                   )}
                   style={{ width: rightPanelWidth, flexShrink: 0 }}
                 >
@@ -10331,7 +10331,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                             Desk
                           </div>
                           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                            <div className="shrink-0 px-2 pt-4">
+                            <div className="shrink-0 px-4 pt-4">
                               <Tabs
                                 value={liveRightPanelTab}
                                 onValueChange={value => {
@@ -10356,9 +10356,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                 </TabsList>
                               </Tabs>
                             </div>
-                            <div className="min-h-0 flex-1 overflow-hidden p-3 pt-2">
+                            <div className="min-h-0 flex-1 overflow-hidden p-4 pt-2">
                               {insightsProps ? (
-                                <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-blue-50 p-3 pb-4">
+                                <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-blue-50 p-4 pb-4">
                                   <Tabs
                                     value={insightsTab}
                                     onValueChange={value =>
@@ -10569,7 +10569,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                         onToggleHidden={setRightPanelHidden}
                         liveSubmissions={insightsProps?.liveSubmissions}
                         headerExtra={
-                          <div className="px-2 pt-4">
+                          <div className="px-4 pt-4">
                             <Tabs
                               value={liveRightPanelTab}
                               onValueChange={value => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -284,9 +284,9 @@ export function SubmissionsPanel({
         <div className="sticky top-0 z-10 flex h-9 items-center justify-center rounded-t-[20px] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
           Desk
         </div>
-        {headerExtra && <div className="px-2">{headerExtra}</div>}
+        {headerExtra && <div className="px-4">{headerExtra}</div>}
 
-        <ScrollArea className={cn('min-h-0 flex-1', headerExtra ? 'p-3 pt-0' : 'p-3')}>
+        <ScrollArea className={cn('min-h-0 flex-1', headerExtra ? 'p-4 pt-0' : 'p-4')}>
           {loading ? (
             <div className="flex items-center gap-2 text-sm text-slate-600">
               <Loader2 className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Changes

### Panel Alignment
- Removed horizontal padding from panel parent container to align side panels with top panel inner content edges
- Added consistent px-4 inner padding to panel content areas (Curriculum CardContent, Desk insights view, SubmissionsPanel ScrollArea)

### Desk Panel Close Animation
- Removed items-end from Desk panel outer container
- Panel now collapses left-to-right, matching Curriculum panel behavior

### Center Panel Width
- Updated centerColWidth formula to account for removed outer padding

### Panel Widths
- Both panels standardized at 380px

## Testing
- [ ] Verify Curriculum panel left edge aligns with top panel inner edge
- [ ] Verify Desk panel right edge aligns with top panel inner edge
- [ ] Test Desk panel close animation direction (left-to-right)
- [ ] Verify toggle buttons positioned at panel edges with overlap