### PR TITLE
fix(ai): make PCI master resilient to transient Kimi failures

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -121,14 +121,20 @@ async function probeAdk(baseUrl: string): Promise<{
 
 export async function POST(request: NextRequest) {
   try {
-    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
-    if (rateLimitResponse) return rateLimitResponse
-
     const session =
       (await getSessionForRealm(request, 'tutor')) ?? (await getServerSession(authOptions, request))
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    // Rate-limit per authenticated user, not per IP, so co-located tutors behind
+    // one NAT/proxy don't share a single AI quota.
+    const { response: rateLimitResponse } = await withRateLimitPreset(
+      request,
+      'aiGenerate',
+      `user:${session.user.id}`
+    )
+    if (rateLimitResponse) return rateLimitResponse
 
     const body = await request.json().catch(() => null)
     const parsed = PciMasterRequestSchema.safeParse(body)
@@ -207,69 +213,90 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    if (pdfPages && pdfPages.length > 0) {
-      // Vision path: let the model actually SEE the attached document pages so it can
-      // summarize/critique real content instead of guessing from the title. Bypasses
-      // ADK (text-only) and goes straight to the vision-capable provider (Gemini).
-      const promptItems: Array<
-        { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
-      > = [
-        { type: 'text', text: `${activeSystemPrompt}\n\n${userPrompt}` },
-        ...pdfPages.map(url => ({ type: 'image_url' as const, image_url: { url } })),
-      ]
-      const visionText = await generateWithKimiVision(promptItems, {
-        temperature: activeTemperature,
-        maxTokens: 4096,
-        timeoutMs: 60000,
-      })
-      response = toCleanResponse(visionText)
-    } else if (adkBaseUrl) {
-      try {
-        // Guardrail enforcement on the ADK path. The ADK agent's instructions
-        // live in a separate service we can't edit from here, so we (a) pass the
-        // canonical guardrail prompt as a `systemPrompt` field for a future
-        // guardrail-aware ADK, and (b) — to enforce TODAY regardless of whether
-        // the remote service reads that field — prepend the prompt to the
-        // message the agent actually consumes. The warn-only validator below
-        // still runs on whatever ADK returns.
-        const adkMessage = guardrailDomain
-          ? `${activeSystemPrompt}\n\n---\nTutor message:\n${safeMessage}`
-          : safeMessage
-        response = await adkPciMasterChat({
-          userId: session.user.id,
-          sessionId,
-          message: adkMessage,
-          systemPrompt: guardrailDomain ? activeSystemPrompt : undefined,
-          context,
+    // Timeout + retry budget for the upstream model call. Moonshot/Kimi is the
+    // sole provider, so a slow or 5xx/429 response has no second provider to fall
+    // back to — bound each attempt and retry a couple of times before giving up.
+    const GEN_TIMEOUT_MS = 60_000
+    const GEN_RETRIES = 3
+    const fallbackOptions = {
+      temperature: activeTemperature,
+      maxTokens: 4096,
+      skipCache: true,
+      timeoutMs: GEN_TIMEOUT_MS,
+      retries: GEN_RETRIES,
+    }
+
+    try {
+      if (pdfPages && pdfPages.length > 0) {
+        // Vision path: let the model actually SEE the attached document pages so it can
+        // summarize/critique real content instead of guessing from the title. Bypasses
+        // ADK (text-only) and goes straight to the vision-capable provider (Gemini).
+        const promptItems: Array<
+          { type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }
+        > = [
+          { type: 'text', text: `${activeSystemPrompt}\n\n${userPrompt}` },
+          ...pdfPages.map(url => ({ type: 'image_url' as const, image_url: { url } })),
+        ]
+        const visionText = await generateWithKimiVision(promptItems, {
+          temperature: activeTemperature,
+          maxTokens: 4096,
+          timeoutMs: GEN_TIMEOUT_MS,
+          retries: GEN_RETRIES,
         })
-      } catch (error) {
-        if (!hasLocalProvider) {
-          return NextResponse.json(
-            { error: 'ADK provider error', status: 'adk_error' },
-            { status: 502 }
+        response = toCleanResponse(visionText)
+      } else if (adkBaseUrl) {
+        try {
+          // Guardrail enforcement on the ADK path. The ADK agent's instructions
+          // live in a separate service we can't edit from here, so we (a) pass the
+          // canonical guardrail prompt as a `systemPrompt` field for a future
+          // guardrail-aware ADK, and (b) — to enforce TODAY regardless of whether
+          // the remote service reads that field — prepend the prompt to the
+          // message the agent actually consumes. The warn-only validator below
+          // still runs on whatever ADK returns.
+          const adkMessage = guardrailDomain
+            ? `${activeSystemPrompt}\n\n---\nTutor message:\n${safeMessage}`
+            : safeMessage
+          response = await adkPciMasterChat({
+            userId: session.user.id,
+            sessionId,
+            message: adkMessage,
+            systemPrompt: guardrailDomain ? activeSystemPrompt : undefined,
+            context,
+          })
+        } catch (error) {
+          if (!hasLocalProvider) {
+            return NextResponse.json(
+              { error: 'ADK provider error', status: 'adk_error' },
+              { status: 502 }
+            )
+          }
+          console.warn('ADK PCI master failed, falling back to local providers:', error)
+          const fallback = await generateWithFallback(
+            `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
+            fallbackOptions
           )
+          response = toCleanResponse(fallback.content)
         }
-        console.warn('ADK PCI master failed, falling back to local providers:', error)
+      } else {
         const fallback = await generateWithFallback(
           `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
-          {
-            temperature: activeTemperature,
-            maxTokens: 4096,
-            skipCache: true,
-          }
+          fallbackOptions
         )
         response = toCleanResponse(fallback.content)
       }
-    } else {
-      const fallback = await generateWithFallback(
-        `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
+    } catch (providerError) {
+      // The upstream model failed (timeout / 429 / 5xx) after retries. Surface a
+      // retryable 503 with a friendly message instead of a generic 500 — the PCI
+      // chat shows this text and the tutor can simply send again.
+      console.error('PCI Master provider error:', providerError)
+      return NextResponse.json(
         {
-          temperature: activeTemperature,
-          maxTokens: 4096,
-          skipCache: true,
-        }
+          error: 'The AI model is briefly unavailable. Please try again in a moment.',
+          status: 'provider_unavailable',
+          retryable: true,
+        },
+        { status: 503, headers: { 'Retry-After': '5' } }
       )
-      response = toCleanResponse(fallback.content)
     }
 
     // Guardrail (task/assessment) output is a {"reply","pci"} envelope: `reply`

--- a/tutorme-app/src/lib/agents/orchestrator-llm.ts
+++ b/tutorme-app/src/lib/agents/orchestrator-llm.ts
@@ -28,6 +28,8 @@ interface AIOptions {
   temperature?: number
   maxTokens?: number
   timeoutMs?: number
+  /** Transient-failure retries for the direct provider call (default 1). */
+  retries?: number
   /** Skip response cache (default false for generate, true when cache not desired) */
   skipCache?: boolean
   /** Attribute token usage to a student/course/feature (recorded by the Kimi provider). */

--- a/tutorme-app/src/lib/ai/fetch-utils.test.ts
+++ b/tutorme-app/src/lib/ai/fetch-utils.test.ts
@@ -53,4 +53,34 @@ describe('ai/fetch-utils', () => {
     expect(res.ok).toBe(true)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
+
+  it('retries our own timeout abort when the caller did not cancel', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch' as any)
+      .mockRejectedValueOnce(abortError()) // our timeoutMs controller fired
+      .mockResolvedValueOnce({ ok: true, status: 200 } as any)
+
+    const res = await fetchWithTimeoutAndRetry(
+      'http://example.com',
+      {},
+      { retries: 1, retryBaseDelayMs: 1, timeoutMs: 50 }
+    )
+    expect(res.ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT retry a caller-initiated cancellation', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch' as any).mockRejectedValue(abortError())
+
+    await expect(
+      fetchWithTimeoutAndRetry(
+        'http://example.com',
+        { signal: controller.signal },
+        { retries: 2, retryBaseDelayMs: 1 }
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tutorme-app/src/lib/ai/fetch-utils.ts
+++ b/tutorme-app/src/lib/ai/fetch-utils.ts
@@ -64,8 +64,13 @@ export async function fetchWithTimeout(
  * Fetch wrapper with timeout + limited retries for transient failures.
  *
  * Retries:
- * - network errors (except AbortError)
+ * - network errors
+ * - our own request timeouts (the timeoutMs AbortController firing) — a slow
+ *   upstream is exactly the kind of transient worth one more shot
  * - HTTP statuses in retryOnStatuses
+ *
+ * Does NOT retry a caller-initiated cancellation (the AbortSignal passed in
+ * `init.signal`), since that means the caller intentionally gave up.
  */
 export async function fetchWithTimeoutAndRetry(
   input: RequestInfo | URL,
@@ -85,7 +90,10 @@ export async function fetchWithTimeoutAndRetry(
       if (attempt >= retries || !retryOnStatuses.includes(res.status)) return res
     } catch (err: any) {
       const name = err?.name
-      if (name === 'AbortError') throw err
+      // A caller-initiated cancellation must never be retried; only our own
+      // timeout abort (or a plain network error) is a transient worth retrying.
+      const callerAborted = !!(init.signal as AbortSignal | undefined)?.aborted
+      if (name === 'AbortError' && callerAborted) throw err
       if (attempt >= retries) throw err
     }
 

--- a/tutorme-app/src/lib/api/middleware.ts
+++ b/tutorme-app/src/lib/api/middleware.ts
@@ -368,11 +368,13 @@ type RateLimitPreset = 'login' | 'register' | 'paymentCreate' | 'enroll' | 'book
  */
 export async function withRateLimitPreset(
   req: NextRequest,
-  preset: RateLimitPreset
+  preset: RateLimitPreset,
+  identifier?: string
 ): Promise<{ response: NextResponse | null; remaining: number }> {
   const { allowed, remaining, resetAt } = await checkRateLimitPreset(
     req as unknown as Request,
-    preset
+    preset,
+    identifier
   )
   if (!allowed) {
     const retryAfter = Math.ceil((resetAt - Date.now()) / 1000)

--- a/tutorme-app/src/lib/security/rate-limit.test.ts
+++ b/tutorme-app/src/lib/security/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { checkRateLimit, getClientIdentifier } from './rate-limit'
+import { checkRateLimit, getClientIdentifier, checkRateLimitPreset } from './rate-limit'
 
 describe('rate-limit', () => {
   describe('checkRateLimit', () => {
@@ -75,6 +75,28 @@ describe('rate-limit', () => {
     it('returns unknown when no IP headers', () => {
       const req = new Request('http://x')
       expect(getClientIdentifier(req)).toBe('unknown:b3e1b807')
+    })
+  })
+
+  describe('checkRateLimitPreset', () => {
+    it('keys by identifier (per-user) rather than IP when one is provided', async () => {
+      const req = new Request('http://x', { headers: { 'x-forwarded-for': '1.1.1.1' } })
+      const userA = 'user:A-' + Date.now()
+      const userB = 'user:B-' + Date.now()
+      const a1 = await checkRateLimitPreset(req, 'aiGenerate', userA)
+      const a2 = await checkRateLimitPreset(req, 'aiGenerate', userA) // same user, same IP
+      const b1 = await checkRateLimitPreset(req, 'aiGenerate', userB) // different user, same IP
+      expect(a1.allowed).toBe(true)
+      expect(a2.remaining).toBe(a1.remaining - 1) // shares user A's bucket
+      expect(b1.remaining).toBe(a1.remaining) // independent bucket despite the same IP
+    })
+
+    it('falls back to IP keying when no identifier is given', async () => {
+      const ip = '203.0.113.' + (Date.now() % 200)
+      const req = new Request('http://x', { headers: { 'x-real-ip': ip } })
+      const first = await checkRateLimitPreset(req, 'aiGenerate')
+      const second = await checkRateLimitPreset(req, 'aiGenerate') // same IP
+      expect(second.remaining).toBe(first.remaining - 1)
     })
   })
 })

--- a/tutorme-app/src/lib/security/rate-limit.ts
+++ b/tutorme-app/src/lib/security/rate-limit.ts
@@ -149,19 +149,23 @@ export const RATE_LIMIT_PRESETS = {
   enroll: { max: 30, windowMs: 60 * 1000 },
   /** Class booking: 20 per minute per IP */
   booking: { max: 20, windowMs: 60 * 1000 },
-  /** AI generation/chat: 12 per minute per client identifier */
-  aiGenerate: { max: 12, windowMs: 60 * 1000 },
+  /** AI generation/chat: 30 per minute per client identifier (per-user when authenticated) */
+  aiGenerate: { max: 30, windowMs: 60 * 1000 },
 } as const
 
 /**
  * Check rate limit using a named preset. Key will be prefixed with the preset name.
+ *
+ * When `identifier` is supplied (e.g. a user id), the bucket is keyed by it
+ * instead of the client IP — so co-located users behind one NAT/proxy don't
+ * share a single quota. Falls back to the IP otherwise.
  */
 export async function checkRateLimitPreset(
   req: Request,
-  preset: keyof typeof RATE_LIMIT_PRESETS
+  preset: keyof typeof RATE_LIMIT_PRESETS,
+  identifier?: string
 ): Promise<RateLimitResult> {
-  const ip = getClientIdentifier(req)
-  const key = `${preset}:${ip}`
+  const key = `${preset}:${identifier ?? getClientIdentifier(req)}`
   const options = RATE_LIMIT_PRESETS[preset]
   return checkRateLimit(key, options)
 }


### PR DESCRIPTION
## Why

Smoke-testing the PCI chat in production (#476) surfaced two **pre-existing** failure modes from `/api/ai/pci-master`, both independent of that refactor:

- **429** — the app rate limit (`aiGenerate: 12/min`, **IP-keyed**) trips during a normal back-and-forth, and co-located tutors behind one NAT/proxy share a single bucket.
- **500 "Failed to get PCI Master response"** — Kimi/Moonshot is the **sole provider** (Gemini was removed), so any upstream timeout/429/5xx throws straight to a bare 500 with no real fallback. Made worse because the text path had **no timeout at all** and `fetchWithTimeoutAndRetry` **never retried timeouts**.

## What (the four fixes you asked for)

1. **Graceful degradation** — the provider call is wrapped; an upstream failure now returns a **retryable `503`** + `Retry-After` with a friendly message (*"The AI model is briefly unavailable. Please try again in a moment."*) instead of a generic 500. The PCI chat already renders this text, so the tutor just resends.
2. **Stronger retry** — `retries=3` on the chat path, and `fetchWithTimeoutAndRetry` now **retries our own request timeouts** (it previously threw immediately on any `AbortError`). Caller-initiated cancellations (`init.signal`) are still never retried.
3. **Bound the text path** — it was calling Kimi with **no timeout** (unbounded hang). Now uses the same **60s** ceiling as the vision path, so a stuck request fails fast and retries.
4. **Rate limit** — bump `aiGenerate` **12 → 30/min** and key it **per authenticated user** (`user:<id>`) instead of per IP; auth now runs before the limiter to supply the id.

## Tests / checks

- New unit tests: timeout-retry **vs** caller-cancel distinction (`fetch-utils.test.ts`), and per-identifier rate-limit keying (`rate-limit.test.ts`). 23 tests green in the touched suites.
- `tsc --noEmit` clean, `npm run build` clean, eslint 0 errors.
- Branch is up to date with `origin/main` (`40134bd`).

## ⚠️ Hand-off for smoke-test (not auto-merged)

The retry/timeout/503 paths only fire on a **real upstream failure**, which I can't force on demand here. Worth a quick check on a preview:
- Normal PCI send still works (happy path unchanged).
- The per-user limit (30/min) behaves; co-located users don't starve each other.
- If you can induce/await an upstream blip, confirm the chat shows the friendly "briefly unavailable" message and a resend succeeds (rather than a hard error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)