### PR TITLE
fix(course-builder): make the PCI tab scrollable with long content

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9349,9 +9349,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       className="mt-0.5 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
                                       <div className="flex h-full min-h-0 flex-col rounded-2xl border border-blue-200 bg-white p-4 shadow-sm">
-                                        <PciGuidance kind="task" />
-                                        {renderCurrentPci('task', activeTaskPci)}
                                         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-1">
+                                          <PciGuidance kind="task" />
+                                          {renderCurrentPci('task', activeTaskPci)}
                                           {activeTaskPciMessages.length === 0 && (
                                             <p className="text-muted-foreground text-xs">
                                               Start a PCI chat to build instructions with the
@@ -9855,9 +9855,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           </div>
                                         </div>
 
-                                        <PciGuidance kind="assessment" />
-                                        {renderCurrentPci('assessment', assessmentBuilder.taskPci)}
                                         <div className="mt-6 min-h-0 flex-1 space-y-4 overflow-y-auto p-1">
+                                          <PciGuidance kind="assessment" />
+                                          {renderCurrentPci(
+                                            'assessment',
+                                            assessmentBuilder.taskPci
+                                          )}
                                           {(
                                             assessmentPciMessagesMap[loadedAssessmentId || ''] || []
                                           ).length === 0 && (


### PR DESCRIPTION
## Problem
On the **PCI tab** (task and assessment), when there's long content you can't scroll — it's clipped.

## Cause
The **PciGuidance** block (an `<details open>` with a lot of text) and the **Current marking policy (PCI)** box were rendered as **non-shrinking siblings above** the `flex-1 overflow-y-auto` chat area. With long content, those siblings consumed the column height and squeezed the scroll area toward zero; since the tab's ancestors are `overflow-hidden`, the overflowing content was clipped with no scrollbar.

## Fix
Move `PciGuidance` and the current-PCI box **inside** the existing `flex-1 overflow-y-auto` container (both the task and assessment PCI tabs), so the guidance + policy + chat scroll together as one region, with the message input pinned below. Two-line move per tab — no other behavior change.

## Testing
- `npm run typecheck` passes; prettier + eslint clean (0 errors).
- Verified by reading the flex height chain (the content tab's sibling uses the same bounded `h-full min-h-0` ancestors and scrolls correctly). Not exercised in a running app here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)