### PR TITLE
fix(course-builder): center the live-tab course-name title across the header

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -951,7 +951,7 @@ function CourseBuilderInsightsRouteInner({
                     )}
 
                   {activeMainTab === 'live' && (
-                    <h1 className="text-foreground flex flex-1 items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="text-foreground absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
                       {model.course?.name && (
                         <span className="text-muted-foreground text-xl font-normal">
                           {model.course.name}

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -951,7 +951,10 @@ function CourseBuilderInsightsRouteInner({
                     )}
 
                   {activeMainTab === 'live' && (
-                    <h1 className="text-foreground absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    // Centered across the full header via absolute positioning;
+                    // pointer-events-none so the overlay never blocks the back
+                    // button / header controls underneath it.
+                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
                       {model.course?.name && (
                         <span className="text-muted-foreground text-xl font-normal">
                           {model.course.name}


### PR DESCRIPTION
Re-applies the one still-relevant, unconflicted change from **#460** (by @Solocorndotco) onto current `main`, per the triage of his open PRs.

## What
The live-tab header title used `flex flex-1 … justify-center`, which centers it only within its own flex portion — so it reads off-center relative to the whole header when siblings (wifi signal, mode tabs, session badge) are present. This switches it to `absolute left-0 right-0 mx-auto` so it's centered across the full header width.

One-line className change on the `activeMainTab === 'live'` `<h1>` in `CourseBuilderInsightsRoute.tsx`.

## Why only this bit
#460 is 78 commits stale and entangled with the merged #479. Its other changes are already on main (Lessons/Interact narrow width; the live-block span's `ml-2` removal via #468) or overlap #479's panel rework. So only this genuinely-new, conflict-free change is carried over; #460 itself is best redone fresh by the author.

## Checks
- `tsc --noEmit` clean, `npm run build` clean, eslint 0 errors, prettier clean.
- Branch is on latest `main` (`2b6832515`).

## ⚠️ Needs a quick visual check before merge
This is a **layout** change (absolute positioning), which I can't runtime-verify here. Please eyeball the live-session header on a preview: the course-name title should be centered across the full header, **without overlapping** the wifi signal, the mode tabs, or the session/countdown badge. If absolute positioning causes overlap at narrow widths, it may want a `pointer-events-none` / max-width guard instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)