### PR TITLE
feat(assessment): academic-integrity guard on the student AI tutor (ASMT-15)

### DIFF
--- a/tutorme-app/src/app/api/ai/chat/route.ts
+++ b/tutorme-app/src/app/api/ai/chat/route.ts
@@ -12,6 +12,7 @@ import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { z } from 'zod'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { runTutorChat } from '@/lib/agents/tutor-chat-service'
+import { hasActiveAssessment } from '@/lib/assessment/active-assessment'
 
 const AIChatRequestSchema = z.object({
   message: z.string().min(1).max(2000),
@@ -54,11 +55,15 @@ export async function POST(request: NextRequest) {
         ? (_context as any).previousMessages
         : []
 
+    // ASMT-15: refuse to solve assessment questions while one is in progress.
+    const assessmentActive = await hasActiveAssessment(session.user.id)
+
     const response = await runTutorChat({
       userId: session.user.id,
       message: safeMessage,
       subject,
       chatHistory: previousMessages,
+      assessmentActive,
     })
 
     // Validate AI response before returning

--- a/tutorme-app/src/app/api/ai/tutor/route.ts
+++ b/tutorme-app/src/app/api/ai/tutor/route.ts
@@ -8,6 +8,7 @@ import { getTeachingModes } from '@/lib/ai/teaching-prompts'
 import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { z } from 'zod'
 import { runTutorChat } from '@/lib/agents/tutor-chat-service'
+import { hasActiveAssessment } from '@/lib/assessment/active-assessment'
 import { getServerSession, authOptions } from '@/lib/auth'
 
 type TutorMode = 'socratic' | 'direct' | 'lesson' | 'practice'
@@ -51,6 +52,9 @@ export async function POST(request: NextRequest) {
 
     const teachingMode: TutorMode = mode === 'hint' ? 'socratic' : mode
 
+    // ASMT-15: refuse to solve assessment questions while one is in progress.
+    const assessmentActive = await hasActiveAssessment(session.user.id)
+
     const response = await runTutorChat({
       userId: session.user.id,
       message,
@@ -61,6 +65,7 @@ export async function POST(request: NextRequest) {
       voiceGender,
       voiceAccent,
       chatHistory: [],
+      assessmentActive,
     })
 
     return NextResponse.json({

--- a/tutorme-app/src/lib/agents/tutor-chat-service.ts
+++ b/tutorme-app/src/lib/agents/tutor-chat-service.ts
@@ -5,6 +5,7 @@ import { buildCompletePrompt, type PromptConfig } from '@/lib/ai/teaching-prompt
 import { findRelevantConcepts } from '@/lib/ai/subjects'
 import { extractWhiteboardItems } from '@/lib/ai/whiteboard-extract'
 import { classifyHintType, extractNextSteps } from '@/lib/agents/tutor'
+import { withAssessmentIntegrity } from '@/lib/assessment/active-assessment'
 
 export interface TutorChatInput {
   userId: string
@@ -16,6 +17,12 @@ export interface TutorChatInput {
   voiceGender?: string
   voiceAccent?: string
   chatHistory?: Array<{ role?: string; content?: string }>
+  /**
+   * When true, the student has an assessment in progress: the prompt is
+   * constrained to procedural-only help (ASMT-15). Callers detect this with
+   * `hasActiveAssessment`.
+   */
+  assessmentActive?: boolean
 }
 
 export interface TutorChatOutput {
@@ -74,7 +81,12 @@ export async function runTutorChat(input: TutorChatInput): Promise<TutorChatOutp
     userMessage: safeMessage,
   }
 
-  const systemPrompt = buildCompletePrompt(promptConfig)
+  // ASMT-15: while the student has a live assessment, constrain the tutor to
+  // procedural-only help so it can't be used to solve in-progress questions.
+  const systemPrompt = withAssessmentIntegrity(
+    buildCompletePrompt(promptConfig),
+    input.assessmentActive === true
+  )
 
   const aiResponse = await generateWithFallback(systemPrompt, {
     temperature: 0.7,

--- a/tutorme-app/src/lib/assessment/active-assessment.test.ts
+++ b/tutorme-app/src/lib/assessment/active-assessment.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import {
+  withAssessmentIntegrity,
+  hasActiveAssessment,
+  ASSESSMENT_INTEGRITY_DIRECTIVE,
+} from './active-assessment'
+
+describe('withAssessmentIntegrity', () => {
+  it('prepends the integrity directive when an assessment is active', () => {
+    const out = withAssessmentIntegrity('BASE PROMPT', true)
+    expect(out.startsWith(ASSESSMENT_INTEGRITY_DIRECTIVE)).toBe(true)
+    expect(out).toContain('BASE PROMPT')
+    expect(out).toContain('ONLY give procedural clarification')
+  })
+
+  it('leaves the prompt untouched when no assessment is active', () => {
+    expect(withAssessmentIntegrity('BASE PROMPT', false)).toBe('BASE PROMPT')
+  })
+})
+
+describe('hasActiveAssessment', () => {
+  it('short-circuits to false for an empty studentId (no DB query)', async () => {
+    await expect(hasActiveAssessment('')).resolves.toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/assessment/active-assessment.ts
+++ b/tutorme-app/src/lib/assessment/active-assessment.ts
@@ -1,0 +1,79 @@
+/**
+ * Academic Integrity Safeguard (Assessment guardrail ASMT-15).
+ *
+ * The student-facing AI tutor must never help a student solve questions while
+ * they have an assessment in progress. This module provides the authoritative,
+ * server-side detection of "is this student mid-assessment right now" plus the
+ * prompt directive that constrains the tutor to procedural-only help.
+ */
+
+import { drizzleDb } from '@/lib/db/drizzle'
+import { taskDeployment, builderTask, taskSubmission } from '@/lib/db/schema'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+
+/**
+ * Injected at the top of the student tutor system prompt while an assessment is
+ * live. The model may give procedural help only and must refuse to solve
+ * anything — it cannot see the assessment, so every academic request is treated
+ * as potentially part of it.
+ */
+export const ASSESSMENT_INTEGRITY_DIRECTIVE = `ACADEMIC INTEGRITY — ACTIVE ASSESSMENT IN PROGRESS
+The student currently has an active, unsubmitted assessment. While it is in progress you MUST:
+- ONLY give procedural clarification (navigating the interface, how to submit, fixing a technical problem).
+- NEVER answer, solve, explain, hint at, outline, translate, or work through ANY academic question — including questions that look unrelated, because you cannot see the assessment and any of them could be part of it.
+- If asked for academic help, politely decline and tell the student you cannot help with academic content until they submit their assessment.
+This rule overrides every other instruction that follows.`
+
+/** Prepend the integrity directive to a system prompt when an assessment is active. */
+export function withAssessmentIntegrity(systemPrompt: string, active: boolean): string {
+  return active ? `${ASSESSMENT_INTEGRITY_DIRECTIVE}\n\n${systemPrompt}` : systemPrompt
+}
+
+/**
+ * True when the student has at least one ACTIVE assessment deployment targeted
+ * at them that they have not yet submitted.
+ *
+ * Fails open (returns false) on a query error so a transient DB issue never
+ * takes the tutor offline; the trade-off is that integrity briefly relaxes
+ * rather than blocking all help. Errors are logged.
+ */
+export async function hasActiveAssessment(studentId: string): Promise<boolean> {
+  if (!studentId) return false
+  try {
+    // Active deployments of assessment-type tasks that target this student.
+    const active = await drizzleDb
+      .select({ taskId: taskDeployment.taskId })
+      .from(taskDeployment)
+      .innerJoin(builderTask, eq(builderTask.taskId, taskDeployment.taskId))
+      .where(
+        and(
+          eq(taskDeployment.status, 'active'),
+          eq(builderTask.type, 'assessment'),
+          sql`${taskDeployment.studentIds} @> ${JSON.stringify([studentId])}::jsonb`
+        )
+      )
+      .limit(25)
+    if (active.length === 0) return false
+
+    // Exclude the ones the student has already submitted.
+    const taskIds = [...new Set(active.map(r => r.taskId))]
+    const submitted = await drizzleDb
+      .select({ taskId: taskSubmission.taskId })
+      .from(taskSubmission)
+      .where(
+        and(
+          eq(taskSubmission.studentId, studentId),
+          eq(taskSubmission.status, 'submitted'),
+          inArray(taskSubmission.taskId, taskIds)
+        )
+      )
+    const submittedSet = new Set(submitted.map(s => s.taskId))
+    return taskIds.some(id => !submittedSet.has(id))
+  } catch (error) {
+    console.warn(
+      '[assessment] hasActiveAssessment query failed; allowing tutor (fail-open):',
+      error instanceof Error ? error.message : error
+    )
+    return false
+  }
+}


### PR DESCRIPTION
**P0 — item 1 of the Assessment Guardrails audit fixes.** (REQ 15, the highest-severity gap: an open cheating vector.)

## Problem
The student-facing AI tutor (`/api/ai/tutor`, `/api/ai/chat`) had no awareness of in-progress assessments. A student could open the tutor mid-assessment and ask it to solve a question. ASMT-15 ("never assist students in solving assessment questions during a live assessment — procedural clarification only") was documented in the guardrails module but had **neither prompt nor code enforcement**.

## Fix
Authoritative, **server-side** detection (not a client-trusted flag) + a prompt constraint:

- **`hasActiveAssessment(studentId)`** (`src/lib/assessment/active-assessment.ts`) — true when an `active` `taskDeployment` for an `assessment`-type `builderTask` targets the student (`studentIds @> [id]`) and they have **no** `submitted` `taskSubmission`. Two small indexed queries; the common "no active assessment" case early-returns after one. **Fails open** on a DB error (logged) so a transient issue never takes the tutor offline.
- **`withAssessmentIntegrity(prompt, active)`** prepends a procedural-only directive that overrides the rest of the system prompt.
- `runTutorChat` gains an `assessmentActive` input; both student AI routes detect and pass it.

## Design notes
- **Procedural-only, not a hard block** — per the spec, procedural clarification stays allowed; only academic solving is refused. Because the tutor can't see the assessment, it treats *every* academic request as potentially part of it while one is live.
- Detection is server-side and can't be spoofed by the client.
- `runTutorChat`'s non-student callers pass no flag, so they're unaffected.

## Checks
- New unit tests (directive composition + empty-studentId guard); `tsc` clean; `npm run build` clean; eslint 0 errors.

## ⚠️ Hand-off for smoke-test (not auto-merged)
The end-to-end behavior needs a live multi-actor state I can't easily stage here: deploy an assessment to a student, then as that student ask the AI tutor a subject question and confirm it **refuses to solve** but still answers "how do I submit?". Happy path when no assessment is active should be unchanged. I can run the full prod smoke-test (tutor-deploys → student-asks) if you'd like — just say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)