### PR TITLE
feat(assessment): block deploy until open questions have a rubric (ASMT-8)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -117,6 +117,7 @@ import {
   type DmiQuestionType,
 } from '@/lib/assessment/question-types'
 import { deriveExamContext, EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
+import { findOpenItemsMissingRubric } from '@/lib/assessment/assessment-gates'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -2877,6 +2878,18 @@ FEEDBACK: [one or two short sentences explaining the score]`
         }
         if (!insightsProps?.sessionId) {
           toast.error('Select a course session for insights')
+          return
+        }
+
+        // ASMT-8: block deploy until every open-response question has a marking
+        // pathway (a rubric, or an explicit "manual marking" note).
+        const missingRubric = findOpenItemsMissingRubric(assessmentDmiItems)
+        if (missingRubric.length > 0) {
+          toast.error(
+            `Add marking guidance for ${missingRubric.length} open question${
+              missingRubric.length > 1 ? 's' : ''
+            } (${missingRubric.join(', ')}) before deploying — or mark them for manual grading.`
+          )
           return
         }
 
@@ -11078,24 +11091,53 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                 className="min-h-[36px] w-full resize-y rounded-md border border-gray-300 p-2 text-sm text-gray-900"
                               />
                             </div>
-                            {isOpenEnded && (
-                              <div className="mt-2">
-                                <label className="mb-1 block text-xs font-medium text-gray-600">
-                                  Marking guidance (optional)
-                                </label>
-                                <textarea
-                                  value={item.rubric || ''}
-                                  disabled={!canEdit}
-                                  placeholder="How to award the marks…"
-                                  onChange={e =>
-                                    applyDmiEdit(dmiEditor.source, item.id, {
-                                      rubric: e.target.value,
-                                    })
-                                  }
-                                  className="min-h-[36px] w-full resize-y rounded-md border border-gray-300 p-2 text-sm text-gray-900"
-                                />
-                              </div>
-                            )}
+                            {isOpenEnded &&
+                              (() => {
+                                // short/long are gated at deploy (ASMT-8); other
+                                // "open-ish" types keep the rubric optional.
+                                const rubricRequired =
+                                  item.questionType === 'short' || item.questionType === 'long'
+                                return (
+                                  <div className="mt-2">
+                                    <div className="mb-1 flex items-center justify-between gap-2">
+                                      <label className="block text-xs font-medium text-gray-600">
+                                        Marking guidance{' '}
+                                        {rubricRequired ? (
+                                          <span className="font-semibold text-red-600">
+                                            (required)
+                                          </span>
+                                        ) : (
+                                          '(optional)'
+                                        )}
+                                      </label>
+                                      {rubricRequired && canEdit && (
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            applyDmiEdit(dmiEditor.source, item.id, {
+                                              rubric: 'Manual marking — tutor grades by hand.',
+                                            })
+                                          }
+                                          className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
+                                        >
+                                          Manual marking only
+                                        </button>
+                                      )}
+                                    </div>
+                                    <textarea
+                                      value={item.rubric || ''}
+                                      disabled={!canEdit}
+                                      placeholder="How to award the marks…"
+                                      onChange={e =>
+                                        applyDmiEdit(dmiEditor.source, item.id, {
+                                          rubric: e.target.value,
+                                        })
+                                      }
+                                      className="min-h-[36px] w-full resize-y rounded-md border border-gray-300 p-2 text-sm text-gray-900"
+                                    />
+                                  </div>
+                                )
+                              })()}
                           </div>
                         )
                       })}

--- a/tutorme-app/src/lib/ai/guardrails/validate.ts
+++ b/tutorme-app/src/lib/ai/guardrails/validate.ts
@@ -210,7 +210,9 @@ export function validateAssessmentOutput(
       })
     }
 
-    // ASMT-8: open questions need a rubric pathway before confirmation.
+    // ASMT-8: open questions need a rubric pathway before confirmation. This is
+    // a generation-time advisory (the tutor adds rubrics before deploy); the
+    // hard block lives at the deploy gate (findOpenItemsMissingRubric).
     if (isOpen && !q.rubric) {
       violations.push({
         ruleId: 'ASMT-8',

--- a/tutorme-app/src/lib/assessment/assessment-gates.test.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { findOpenItemsMissingRubric } from './assessment-gates'
+
+describe('findOpenItemsMissingRubric (ASMT-8)', () => {
+  it('flags open (short/long) questions with no rubric, by label', () => {
+    const missing = findOpenItemsMissingRubric([
+      { questionType: 'long', questionLabel: '1(a)', rubric: '' },
+      { questionType: 'short', questionNumber: 2, rubric: '   ' },
+    ])
+    expect(missing).toEqual(['1(a)', 'Q2'])
+  })
+
+  it('passes when open questions have a rubric (including a manual-marking note)', () => {
+    expect(
+      findOpenItemsMissingRubric([
+        { questionType: 'long', questionLabel: '1', rubric: 'Award 2 for method, 1 for answer.' },
+        {
+          questionType: 'short',
+          questionLabel: '2',
+          rubric: 'Manual marking — tutor grades by hand.',
+        },
+      ])
+    ).toEqual([])
+  })
+
+  it('does not gate closed/auto-graded or untyped legacy items', () => {
+    expect(
+      findOpenItemsMissingRubric([
+        { questionType: 'mcq', questionLabel: '1', rubric: '' },
+        { questionType: 'fill_blank', questionLabel: '2', rubric: '' },
+        { questionType: 'matching', questionLabel: '3', rubric: '' },
+        { questionType: undefined, questionLabel: '4', rubric: '' },
+      ])
+    ).toEqual([])
+  })
+})

--- a/tutorme-app/src/lib/assessment/assessment-gates.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.ts
@@ -1,0 +1,38 @@
+/**
+ * Pre-deploy gates for assessments (Assessment guardrails).
+ *
+ * These are pure, testable checks the deploy path runs to BLOCK (not just warn)
+ * when a spec invariant is violated. ASMT-8: every open-response question must
+ * have a rubric pathway defined before the assessment can be confirmed/deployed.
+ */
+
+import { isOpenDmiType } from './question-types'
+
+export interface RubricGateItem {
+  questionType?: string | null
+  questionLabel?: string | null
+  questionNumber?: number | null
+  /** Marking guidance / rubric pathway (free text, or a "manual marking" note). */
+  rubric?: string | null
+}
+
+/**
+ * ASMT-8: returns the labels of open-response questions that have NO rubric
+ * pathway (empty/whitespace `rubric`). An empty result means the gate passes.
+ *
+ * Only genuinely open types (`short`/`long`) are gated — closed and auto-graded
+ * types don't need a rubric, and untyped legacy items are not blocked.
+ */
+export function findOpenItemsMissingRubric(items: RubricGateItem[]): string[] {
+  const missing: string[] = []
+  for (const it of items) {
+    if (!isOpenDmiType(it.questionType)) continue
+    if (!it.rubric || !it.rubric.trim()) {
+      missing.push(
+        (it.questionLabel && it.questionLabel.trim()) ||
+          (it.questionNumber != null ? `Q${it.questionNumber}` : '?')
+      )
+    }
+  }
+  return missing
+}

--- a/tutorme-app/src/lib/assessment/question-types.ts
+++ b/tutorme-app/src/lib/assessment/question-types.ts
@@ -80,6 +80,18 @@ export const CHOICE_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([
  */
 export const FALLBACK_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set([])
 
+/**
+ * Open-response types whose answers can't be auto-graded and therefore need a
+ * marking rubric/pathway before an assessment can be deployed (ASMT-8). Closed
+ * types (mcq, fill_blank, matching, …) are auto-graded and don't require one.
+ */
+export const OPEN_DMI_TYPES: ReadonlySet<DmiQuestionType> = new Set(['short', 'long'])
+
+/** True when the value is an open-response type that requires a rubric pathway. */
+export function isOpenDmiType(value: unknown): value is DmiQuestionType {
+  return typeof value === 'string' && OPEN_DMI_TYPES.has(value as DmiQuestionType)
+}
+
 export function isDmiQuestionType(value: unknown): value is DmiQuestionType {
   return typeof value === 'string' && (DMI_QUESTION_TYPES as readonly string[]).includes(value)
 }


### PR DESCRIPTION
**P0 — item 2 of the Assessment Guardrails audit fixes.** (REQ 8, a direct spec **conflict**.)

## Problem
The spec mandates *blocking* assessment confirmation until every open-ended question has a rubric pathway. The implementation was **warn-only**: ASMT-8 was `severity:'warning'`, nothing consumed `hasBlocking`, and the rubric field was literally labelled "(optional)". Open questions could deploy with **no marking guidance**, making them ungradeable / inconsistently graded.

## Fix — real code enforcement at the deploy gate
- `OPEN_DMI_TYPES` / `isOpenDmiType` (`short`, `long`) in `question-types.ts`.
- `findOpenItemsMissingRubric()` — pure, tested gate (`lib/assessment/assessment-gates.ts`).
- `handleDeployAssessmentDmi` **blocks deploy** and names the offending questions when any open item has an empty rubric.
- The DMI editor shows **"(required)"** for `short`/`long` and a one-click **"Manual marking only"** button, so the manual-grading pathway (a valid ASMT-8 source) satisfies the gate without typing a fake rubric.

## Scope / safety
- Only genuinely-open `short`/`long` are gated → closed/auto-graded and untyped legacy items are never blocked (no false blocks).
- The generation-time validator stays warn-only (rubrics are added before deploy, not at parse time) — comment-only change there.
- Shared guardrails module otherwise untouched; **Task PCI path unaffected**.

## Checks
- New unit tests for the gate (open-missing → flagged; manual-note → passes; closed/untyped → ignored). `tsc` clean, build clean, eslint 0 errors.

## ⚠️ Hand-off for smoke-test (not auto-merged)
Needs a tutor flow I can't fully stage headlessly: open an assessment with a `short`/`long` question, clear its marking guidance, hit **Deploy** → should be blocked with the question named; add guidance (or click **Manual marking only**) → deploy proceeds. Happy path (all rubrics present, or no open questions) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)