### PR TITLE
fix(course-builder): align panels with top panel and fix desk animation

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6083,7 +6083,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
           className="flex h-full w-full flex-1 flex-col bg-gray-50/50 px-0 pt-0"
         >
           <div
-            className="relative flex h-full w-full pb-6 pt-0"
+            className="relative flex h-full w-full px-7 pb-6 pt-0 sm:px-8"
             style={{
               gap: '24px',
             }}
@@ -6111,7 +6111,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
             <div
               className={cn(
-                'relative z-40 flex min-h-0 shrink-0 flex-col',
+                'relative z-40 flex min-h-0 shrink-0 flex-col items-end',
                 leftPanelHidden
                   ? 'bg-transparent shadow-none'
                   : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
@@ -10035,7 +10035,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 {/* Right panel content - grid child with consistent wrapper */}
                 <div
                   className={cn(
-                    'relative z-40 flex min-h-0 shrink-0 flex-col',
+                    'relative z-40 flex min-h-0 shrink-0 flex-col items-end',
                     rightPanelHidden
                       ? 'bg-transparent shadow-none'
                       : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'


### PR DESCRIPTION
- Restore px-7 sm:px-8 horizontal padding to align side panels with top panel edges
- Add items-end to right panel wrapper so Desk panel collapses left-to-right
- Fixes panels being flush with viewport and wrong close animation direction