### PR TITLE
fix(assessment): stop leaking matching/hotspot answer keys to students (ASMT-10/13)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -671,10 +671,9 @@ function DmiAnswerField({
   // (left = item, right = correct target). Supports native HTML5 drag AND a
   // tap-to-place fallback (select an item, then tap a bin) for touch devices.
   // Answer is stored as a JSON map of item -> chosen target.
-  if (type === 'drag_drop' && item.pairs && item.pairs.length > 0) {
-    const pairs = item.pairs
-    const dndItems = pairs.map(p => p.left)
-    const targets = Array.from(new Set(pairs.map(p => p.right)))
+  if (type === 'drag_drop' && item.matchPrompts && item.matchPrompts.length > 0) {
+    const dndItems = item.matchPrompts
+    const targets = item.matchBank ?? []
     let placement: Record<string, string> = {}
     try {
       const parsed = value ? JSON.parse(value) : {}
@@ -779,11 +778,9 @@ function DmiAnswerField({
 
   // Matching — show each left prompt with a dropdown of the (sorted) right
   // values. The answer is stored as a JSON map of left -> chosen right.
-  if (type === 'matching' && item.pairs && item.pairs.length > 0) {
-    const pairs = item.pairs
-    const rightBank = Array.from(new Set(pairs.map(p => p.right))).sort((a, b) =>
-      a.localeCompare(b)
-    )
+  if (type === 'matching' && item.matchPrompts && item.matchPrompts.length > 0) {
+    const prompts = item.matchPrompts
+    const rightBank = (item.matchBank ?? []).slice().sort((a, b) => a.localeCompare(b))
     let answerMap: Record<string, string> = {}
     try {
       const parsed = value ? JSON.parse(value) : {}
@@ -797,14 +794,14 @@ function DmiAnswerField({
     }
     return (
       <div className="space-y-2">
-        {pairs.map(p => (
-          <div key={p.left} className="flex items-center gap-2 text-sm">
-            <span className="flex-1 text-gray-800">{p.left}</span>
+        {prompts.map(left => (
+          <div key={left} className="flex items-center gap-2 text-sm">
+            <span className="flex-1 text-gray-800">{left}</span>
             <span className="shrink-0 text-gray-300">→</span>
             <select
-              value={answerMap[p.left] ?? ''}
+              value={answerMap[left] ?? ''}
               onFocus={onInteract}
-              onChange={e => setMatch(p.left, e.target.value)}
+              onChange={e => setMatch(left, e.target.value)}
               className={`w-44 shrink-0 ${baseField}`}
             >
               <option value="">Choose…</option>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -117,6 +117,8 @@ import {
   type DmiQuestionType,
 } from '@/lib/assessment/question-types'
 import { deriveExamContext, EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
+import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
+import { findEvaluationLeaks } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -2283,19 +2285,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             title: homeworkItem.title || 'Homework',
             content: homeworkItem.description || '',
             source: 'homework',
-            dmiItems:
-              homeworkItem.dmiItems?.map(i => ({
-                id: i.id,
-                questionNumber: i.questionNumber,
-                questionLabel: i.questionLabel,
-                questionText: i.questionText,
-                marks: i.marks,
-                questionType: i.questionType,
-                options: i.options,
-                pairs: i.pairs,
-                hotspotImageUrl: i.hotspotImageUrl,
-                regions: i.regions,
-              })) || [],
+            // Student-safe projection (strips answer key incl. matching pairs /
+            // hotspot regions). See toStudentDmiItem.
+            dmiItems: homeworkItem.dmiItems?.map(toStudentDmiItem) || [],
             // Answer key + marks for server-side grading (never sent to students).
             answerKey:
               homeworkItem.dmiItems?.map(i => ({
@@ -2880,26 +2872,26 @@ FEEDBACK: [one or two short sentences explaining the score]`
           return
         }
 
+        // Student-safe DMI: strips the answer key, including matching `pairs`
+        // and hotspot `regions` (which ARE the answer). See toStudentDmiItem.
+        const studentDmiItems = assessmentDmiItems.map(toStudentDmiItem)
+        // ASMT-10/13: deterministic guarantee the student payload carries no
+        // evaluation data — block deploy if anything leaks through.
+        const leaks = findEvaluationLeaks(studentDmiItems)
+        if (leaks.length > 0) {
+          console.error('[assessment] evaluation-layer leak in student payload:', leaks)
+          toast.error(
+            'Internal error: answer data was present in the student view. Deploy blocked.'
+          )
+          return
+        }
+
         const task: LiveTask = {
           id: loadedAssessmentId,
           title: assessmentBuilder.title || 'Assessment',
           content: assessmentBuilder.taskContent,
           source: 'assessment',
-          dmiItems: assessmentDmiItems.map(item => ({
-            id: item.id,
-            questionNumber: item.questionNumber,
-            questionLabel: item.questionLabel,
-            questionText: item.questionText,
-            // Marks are shown to students; the answer key / rubric is NOT deployed.
-            marks: item.marks,
-            // Carry the answer-input type + options/pairs so the student gets the
-            // right control (e.g. mcq letter choices), not a plain textarea.
-            questionType: item.questionType,
-            options: item.options,
-            pairs: item.pairs,
-            hotspotImageUrl: item.hotspotImageUrl,
-            regions: item.regions,
-          })),
+          dmiItems: studentDmiItems,
           // Answer key + marks for server-side auto-grading. Sent to the server
           // only — never broadcast to students.
           answerKey: assessmentDmiItems.map(item => ({
@@ -8788,22 +8780,13 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                         title: task.title || 'Task',
                                                         content: task.description || '',
                                                         source: 'task',
+                                                        // Student-safe projection
+                                                        // (strips answer key incl.
+                                                        // matching pairs / hotspot
+                                                        // regions).
                                                         dmiItems:
-                                                          task.dmiItems?.map(item => ({
-                                                            id: item.id,
-                                                            questionNumber: item.questionNumber,
-                                                            questionLabel: item.questionLabel,
-                                                            questionText: item.questionText,
-                                                            // Marks shown to students; carry the input
-                                                            // type + options so mcq/etc. render the right
-                                                            // control. Answer key / rubric stay server-side.
-                                                            marks: item.marks,
-                                                            questionType: item.questionType,
-                                                            options: item.options,
-                                                            pairs: item.pairs,
-                                                            hotspotImageUrl: item.hotspotImageUrl,
-                                                            regions: item.regions,
-                                                          })) || [],
+                                                          task.dmiItems?.map(toStudentDmiItem) ||
+                                                          [],
                                                         // Answer key + marks for
                                                         // server-side grading (never
                                                         // sent to students).

--- a/tutorme-app/src/lib/ai/guardrails/serialize.ts
+++ b/tutorme-app/src/lib/ai/guardrails/serialize.ts
@@ -37,6 +37,10 @@ const EVALUATION_KEYS = new Set([
   'prepopulated_answer',
   'sampleResponse',
   'sample_response',
+  // Interactive answer keys: the correct correspondence (matching/drag_drop) and
+  // the correct clickable areas (hotspot) — never deliver these to students.
+  'pairs',
+  'regions',
 ])
 
 /**

--- a/tutorme-app/src/lib/assessment/student-dmi.test.ts
+++ b/tutorme-app/src/lib/assessment/student-dmi.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { toStudentDmiItem } from './student-dmi'
+
+describe('toStudentDmiItem (ASMT-10/13 layer separation)', () => {
+  const base = { id: 'q1', questionNumber: 1, questionText: 'Match them' }
+
+  it('never emits pairs/regions/answer-key fields', () => {
+    const safe = toStudentDmiItem({
+      ...base,
+      questionType: 'matching',
+      pairs: [
+        { left: 'Dog', right: 'Bark' },
+        { left: 'Cat', right: 'Meow' },
+      ],
+      // @ts-expect-error — extra evaluation fields must not survive the projection
+      answer: 'Dog=Bark;Cat=Meow',
+      rubric: 'secret',
+      regions: [{ x: 0, y: 0, w: 1, h: 1 }],
+    })
+    expect('pairs' in safe).toBe(false)
+    expect('regions' in safe).toBe(false)
+    expect('answer' in safe).toBe(false)
+    expect('rubric' in safe).toBe(false)
+  })
+
+  it('keeps prompts in order but a SORTED bank (no pairing leak)', () => {
+    const safe = toStudentDmiItem({
+      ...base,
+      questionType: 'matching',
+      pairs: [
+        { left: 'Dog', right: 'Woof' },
+        { left: 'Cat', right: 'Meow' },
+        { left: 'Cow', right: 'Moo' },
+      ],
+    })
+    expect(safe.matchPrompts).toEqual(['Dog', 'Cat', 'Cow']) // prompt order preserved
+    expect(safe.matchBank).toEqual(['Meow', 'Moo', 'Woof']) // sorted — not the answer order
+  })
+
+  it('does not add match fields to non-matching types', () => {
+    const safe = toStudentDmiItem({ ...base, questionType: 'mcq', options: ['a', 'b'] })
+    expect(safe.matchPrompts).toBeUndefined()
+    expect(safe.matchBank).toBeUndefined()
+    expect(safe.options).toEqual(['a', 'b'])
+  })
+})

--- a/tutorme-app/src/lib/assessment/student-dmi.ts
+++ b/tutorme-app/src/lib/assessment/student-dmi.ts
@@ -1,0 +1,78 @@
+/**
+ * Student-safe projection of a DMI item (ASMT-10 / ASMT-13 — Delivery vs
+ * Evaluation layer separation).
+ *
+ * The matching/drag_drop `pairs` and hotspot `regions` ARE the answer key (the
+ * correct correspondence / correct clickable areas). Broadcasting them to
+ * students leaks the answers even though the UI only shows a shuffled bank. This
+ * is the single choke point every student-facing DMI payload must go through:
+ * it keeps the prompts + option bank a learner needs to answer, but never the
+ * correct correspondence, and strips all other evaluation fields.
+ */
+
+import type { DmiMatchPair, DmiHotspotRegion, DmiQuestionType } from './question-types'
+
+/** A tutor-side DMI item as built in the assessment / task builder. */
+export interface DeployableDmiItem {
+  id: string
+  questionNumber: number
+  questionLabel?: string
+  questionText: string
+  marks?: number
+  questionType?: DmiQuestionType
+  options?: string[]
+  /** Correct left↔right pairing for matching/drag_drop — answer key. */
+  pairs?: DmiMatchPair[]
+  hotspotImageUrl?: string
+  /** Correct clickable regions for hotspot — answer key. */
+  regions?: DmiHotspotRegion[]
+}
+
+/** The student-safe DMI item broadcast to learners — carries no answer key. */
+export interface StudentDmiItem {
+  id: string
+  questionNumber: number
+  questionLabel?: string
+  questionText: string
+  marks?: number
+  questionType?: DmiQuestionType
+  options?: string[]
+  hotspotImageUrl?: string
+  /** Prompts (left items / drag items) for matching & drag_drop, in order. */
+  matchPrompts?: string[]
+  /**
+   * The option bank (unique right values), SORTED so its order reveals nothing
+   * about the correct pairing. Never includes the correspondence itself.
+   */
+  matchBank?: string[]
+}
+
+/**
+ * Project a tutor DMI item to its student-safe form. Drops every evaluation
+ * field — answers, rubrics, and crucially `pairs`/`regions`. For matching and
+ * drag_drop the student still gets the prompts and a sorted option bank, but
+ * never which prompt maps to which option.
+ */
+export function toStudentDmiItem(item: DeployableDmiItem): StudentDmiItem {
+  const safe: StudentDmiItem = {
+    id: item.id,
+    questionNumber: item.questionNumber,
+    questionLabel: item.questionLabel,
+    questionText: item.questionText,
+    marks: item.marks,
+    questionType: item.questionType,
+    options: item.options,
+    hotspotImageUrl: item.hotspotImageUrl,
+  }
+  if (
+    (item.questionType === 'matching' || item.questionType === 'drag_drop') &&
+    item.pairs &&
+    item.pairs.length > 0
+  ) {
+    safe.matchPrompts = item.pairs.map(p => p.left)
+    // Unique rights, sorted: the bank a student picks from, with the correct
+    // correspondence (and any left-order correlation) destroyed.
+    safe.matchBank = [...new Set(item.pairs.map(p => p.right))].sort((a, b) => a.localeCompare(b))
+  }
+  return safe
+}

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -121,12 +121,12 @@ export interface LiveTaskDmiItem {
   questionType?: import('./assessment/question-types').DmiQuestionType
   /** Options for choice types (mcq / true_false / multiple_response). */
   options?: string[]
-  /** Correct left↔right pairs for `matching` (the right values form the bank). */
-  pairs?: import('./assessment/question-types').DmiMatchPair[]
   /** Image the student clicks for a `hotspot` item. */
   hotspotImageUrl?: string
-  /** Correct clickable regions for `hotspot` (answer key, not shown to student). */
-  regions?: import('./assessment/question-types').DmiHotspotRegion[]
+  /** Prompts (left items / drag items) for matching & drag_drop, in order. */
+  matchPrompts?: string[]
+  /** Sorted option bank for matching & drag_drop — never the correct pairing. */
+  matchBank?: string[]
 }
 
 export interface LiveTaskSourceDocument {
@@ -1443,14 +1443,14 @@ export async function initEnhancedSocketServer(server: NetServer) {
                       marks: typeof d.marks === 'number' ? (d.marks as number) : undefined,
                       questionType: d.questionType as LiveTaskDmiItem['questionType'],
                       options: Array.isArray(d.options) ? (d.options as string[]) : undefined,
-                      pairs: Array.isArray(d.pairs)
-                        ? (d.pairs as LiveTaskDmiItem['pairs'])
-                        : undefined,
                       hotspotImageUrl:
                         typeof d.hotspotImageUrl === 'string' ? d.hotspotImageUrl : undefined,
-                      regions: Array.isArray(d.regions)
-                        ? (d.regions as LiveTaskDmiItem['regions'])
+                      // Student-safe matching/drag_drop fields only; pairs/regions
+                      // (the answer key) are never reconstructed onto a broadcast.
+                      matchPrompts: Array.isArray(d.matchPrompts)
+                        ? (d.matchPrompts as string[])
                         : undefined,
+                      matchBank: Array.isArray(d.matchBank) ? (d.matchBank as string[]) : undefined,
                     })
                   )
                 : undefined,

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -68,12 +68,12 @@ export interface LiveTaskDmiItem {
   questionType?: import('../assessment/question-types').DmiQuestionType
   /** Options for choice types (mcq / true_false / multiple_response). */
   options?: string[]
-  /** Correct left↔right pairs for `matching` (the right values form the bank). */
-  pairs?: import('../assessment/question-types').DmiMatchPair[]
   /** Image the student clicks for a `hotspot` item. */
   hotspotImageUrl?: string
-  /** Correct clickable regions for `hotspot` (answer key, not shown to student). */
-  regions?: import('../assessment/question-types').DmiHotspotRegion[]
+  /** Prompts (left items / drag items) for matching & drag_drop, in order. */
+  matchPrompts?: string[]
+  /** Sorted option bank for matching & drag_drop — never the correct pairing. */
+  matchBank?: string[]
 }
 
 export interface LiveTaskSourceDocument {


### PR DESCRIPTION
**P0 — item 3 of the Assessment Guardrails audit fixes. Security fix (active answer leak).**

## Problem
The deploy path sent **`pairs`** (the correct left↔right correspondence for matching/drag_drop) and **`regions`** (the correct clickable areas for hotspot) straight to students. The student UI only *visually* shuffles — the correct answer sat in the broadcast/network payload, readable by any student. That's a live cheating vector for **every interactive question type**. And `stripEvaluationLayer` wouldn't have caught it because `pairs`/`regions` weren't in `EVALUATION_KEYS`.

## Fix — one student-safe choke point
- **`toStudentDmiItem()`** (`lib/assessment/student-dmi.ts`) projects a tutor DMI item to its student-safe form: keeps the **prompts** + a **sorted option bank** (order reveals no pairing) for matching/drag_drop, the image for hotspot, and **drops `pairs`/`regions`** and every other evaluation field. Applied at **all three** student-facing deploy sites (assessment, task, homework) and the socket sync path.
- `LiveTaskDmiItem` (both duplicate definitions) drops `pairs`/`regions`, adds `matchPrompts`/`matchBank`; the student render uses those.
- `pairs`/`regions` added to `EVALUATION_KEYS`; the assessment deploy now runs **`findEvaluationLeaks()`** over the student payload and **blocks deploy on any leak** (deterministic backstop).

## Safety
- **Grading unaffected** — `autoGradeDmi` never read `pairs`/`regions`; the tutor's source DMI retains them server-side.
- Touches the **shared live-deploy path** (not just assessment) because the leak affected both task and assessment deploys — a security issue I couldn't responsibly leave in the task path. No Task PCI *guardrail behavior* is changed.
- New unit tests assert the projection emits no answer-key fields and that the bank is sorted (no pairing leak).

## ⚠️ Hand-off for smoke-test (not auto-merged) — live-classroom path
Please verify on a preview: deploy an assessment/task containing a **matching** (and ideally **drag-drop**/**hotspot**) question to a live session, then as the student confirm the question still **renders and is answerable** (prompts + option dropdown/bins; hotspot image clickable) and that **grading still works** on submit. The fix is deterministic + unit-tested, but this is the heavily-used live path so a real render/grade check is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)