### PR TITLE
feat(assessment): tutor answers take precedence over uploaded schemes (ASMT-5)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-dmi-editor.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-dmi-editor.ts
@@ -56,8 +56,15 @@ export function useDmiEditor(deps: DmiEditorDeps) {
     itemId: string,
     patch: Partial<DMIQuestion>
   ) => {
+    // ASMT-5: when the tutor edits the answer/variants, record provenance so a
+    // later uploaded marking scheme won't overwrite the tutor's answer.
+    const touchesAnswer = 'answer' in patch || 'acceptableVariants' in patch
+    const effectivePatch: Partial<DMIQuestion> =
+      touchesAnswer && !('answerProvenance' in patch)
+        ? { ...patch, answerProvenance: 'tutor_edited' }
+        : patch
     const editItems = (arr: DMIQuestion[]) =>
-      arr.map(q => (q.id === itemId ? { ...q, ...patch } : q))
+      arr.map(q => (q.id === itemId ? { ...q, ...effectivePatch } : q))
     setItemsAndVersions(
       source,
       editItems,

--- a/tutorme-app/src/lib/assessment/marking-scheme.test.ts
+++ b/tutorme-app/src/lib/assessment/marking-scheme.test.ts
@@ -189,4 +189,42 @@ describe('applySchemeMatches', () => {
     expect(r.filled).toBe(0)
     expect(r.newRows).toHaveLength(0)
   })
+
+  it('ASMT-5: does not overwrite a tutor-authored answer, but still adds marks/rubric', () => {
+    const tutorItems = [
+      {
+        id: 'a',
+        questionNumber: 1,
+        questionLabel: '3(a)',
+        questionText: 'Q3a',
+        answer: 'tutor answer',
+        answerProvenance: 'tutor_edited',
+      },
+    ] as any
+    const r = applySchemeMatches(
+      tutorItems,
+      [{ ref: '3(a)', answer: 'scheme answer', marks: 3, rubric: 'award 3' }],
+      makeId
+    )
+    const patched = r.patchedItems[0]
+    expect(patched.answer).toBe('tutor answer') // tutor answer preserved
+    expect(patched.answerProvenance).toBe('tutor_edited') // provenance preserved
+    expect(patched.marks).toBe(3) // non-answer fields still applied
+    expect(patched.rubric).toBe('award 3')
+  })
+
+  it('ASMT-5: still overwrites an llm/scheme answer (no tutor precedence)', () => {
+    const llmItems = [
+      {
+        id: 'a',
+        questionNumber: 1,
+        questionLabel: '3(a)',
+        questionText: 'Q3a',
+        answer: 'old',
+        answerProvenance: 'answer_sheet_extracted',
+      },
+    ] as any
+    const r = applySchemeMatches(llmItems, [{ ref: '3(a)', answer: 'new' }], makeId)
+    expect(r.patchedItems[0].answer).toBe('new')
+  })
 })

--- a/tutorme-app/src/lib/assessment/marking-scheme.ts
+++ b/tutorme-app/src/lib/assessment/marking-scheme.ts
@@ -192,7 +192,15 @@ export function applySchemeMatches(
   const patchOnto = (arr: DMIQuestion[]) =>
     arr.map(q => {
       const patch = patchByRef.get(refKey(q.questionLabel ?? q.questionNumber))
-      return patch ? { ...q, ...patch } : q
+      if (!patch) return q
+      // ASMT-5: a tutor-authored answer takes precedence over an uploaded
+      // scheme. Preserve the tutor's answer / acceptableVariants / provenance;
+      // still let the scheme contribute non-answer fields (marks, rubric).
+      if (q.answerProvenance === 'tutor_provided' || q.answerProvenance === 'tutor_edited') {
+        const { answer: _a, acceptableVariants: _v, answerProvenance: _p, ...rest } = patch
+        return Object.keys(rest).length > 0 ? { ...q, ...rest } : q
+      }
+      return { ...q, ...patch }
     })
 
   const patchedExisting = patchOnto(items)


### PR DESCRIPTION
**P1 — item 1 of the Assessment Guardrails audit fixes.** (REQ 5, no migration.)

## Problem
An uploaded marking scheme overwrote tutor-entered answers **unconditionally** (`buildPatch` always stamped `answer_sheet_extracted`) — the opposite of the spec's *"tutor-provided answer schemes take precedence over all other sources."* And tutor edits never recorded provenance, so there was nothing to protect.

## Fix (two coupled changes)
- **`applySchemeMatches`** (`marking-scheme.ts`): when patching an item whose `answerProvenance` is `tutor_provided`/`tutor_edited`, preserve the tutor's `answer`, `acceptableVariants` and provenance; the scheme may still contribute non-answer fields (`marks`, `rubric`).
- **`applyDmiEdit`** (`use-dmi-editor.ts`): stamp `answerProvenance='tutor_edited'` when the tutor edits the answer/variants — which is what makes the precedence check actually protect anything.

## Checks
- New unit tests: tutor answer preserved (marks/rubric still applied); non-tutor answers (`answer_sheet_extracted`) still get overwritten. 20 tests green; `tsc`/build/eslint clean.

## ⚠️ Hand-off for smoke-test (not auto-merged)
Edit a question's answer in the DMI editor, then upload a marking scheme that covers it → the tutor's answer should **survive** (only marks/rubric fill in). A scheme applied to an un-edited (llm/scheme-sourced) answer still overwrites as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)