### PR TITLE
feat(assessment): re-verify consistency before deploy (ASMT-12)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -117,7 +117,7 @@ import {
   type DmiQuestionType,
 } from '@/lib/assessment/question-types'
 import { deriveExamContext, EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
-import { findOpenItemsMissingRubric } from '@/lib/assessment/assessment-gates'
+import { reverifyAssessment } from '@/lib/assessment/assessment-gates'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
 import { findEvaluationLeaks } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
@@ -2873,15 +2873,18 @@ FEEDBACK: [one or two short sentences explaining the score]`
           return
         }
 
-        // ASMT-8: block deploy until every open-response question has a marking
-        // pathway (a rubric, or an explicit "manual marking" note).
-        const missingRubric = findOpenItemsMissingRubric(assessmentDmiItems)
-        if (missingRubric.length > 0) {
-          toast.error(
-            `Add marking guidance for ${missingRubric.length} open question${
-              missingRubric.length > 1 ? 's' : ''
-            } (${missingRubric.join(', ')}) before deploying — or mark them for manual grading.`
-          )
+        // ASMT-12: re-verify the assessment is internally consistent and fully
+        // gradable before generating the final/deployed DMI. Covers ASMT-8
+        // (open-question rubric), numbering integrity, and answer-key mapping;
+        // blocks deploy on any issue.
+        const reverifyIssues = reverifyAssessment(assessmentDmiItems)
+        if (reverifyIssues.length > 0) {
+          const shown = reverifyIssues
+            .slice(0, 3)
+            .map(i => i.message)
+            .join(' ')
+          const more = reverifyIssues.length > 3 ? ` (+${reverifyIssues.length - 3} more)` : ''
+          toast.error(`Cannot deploy — ${shown}${more}`)
           return
         }
 

--- a/tutorme-app/src/lib/assessment/assessment-gates.test.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { findOpenItemsMissingRubric } from './assessment-gates'
+import { findOpenItemsMissingRubric, reverifyAssessment } from './assessment-gates'
 
 describe('findOpenItemsMissingRubric (ASMT-8)', () => {
   it('flags open (short/long) questions with no rubric, by label', () => {
@@ -30,6 +30,49 @@ describe('findOpenItemsMissingRubric (ASMT-8)', () => {
         { questionType: 'fill_blank', questionLabel: '2', rubric: '' },
         { questionType: 'matching', questionLabel: '3', rubric: '' },
         { questionType: undefined, questionLabel: '4', rubric: '' },
+      ])
+    ).toEqual([])
+  })
+})
+
+describe('reverifyAssessment (ASMT-12)', () => {
+  it('passes a consistent, fully-keyed assessment', () => {
+    expect(
+      reverifyAssessment([
+        { questionType: 'long', questionLabel: '1', rubric: 'award 3' },
+        { questionType: 'mcq', questionLabel: '2', answer: 'B' },
+        { questionType: 'matching', questionLabel: '3', pairs: [{ left: 'a', right: 'b' }] },
+        { questionType: 'hotspot', questionLabel: '4', regions: [{ x: 0, y: 0, w: 1, h: 1 }] },
+      ])
+    ).toEqual([])
+  })
+
+  it('flags duplicate question references (numbering integrity)', () => {
+    const issues = reverifyAssessment([
+      { questionType: 'mcq', questionLabel: '1(a)', answer: 'A' },
+      { questionType: 'mcq', questionLabel: '1a', answer: 'B' }, // same ref normalized
+    ])
+    expect(issues.some(i => i.kind === 'numbering')).toBe(true)
+  })
+
+  it('flags open questions without a rubric and closed questions without an answer key', () => {
+    const issues = reverifyAssessment([
+      { questionType: 'long', questionLabel: '1', rubric: '' },
+      { questionType: 'mcq', questionLabel: '2', answer: '' },
+      { questionType: 'matching', questionLabel: '3', pairs: [] },
+    ])
+    expect(issues.filter(i => i.kind === 'rubric')).toHaveLength(1)
+    expect(issues.filter(i => i.kind === 'answer-mapping')).toHaveLength(2)
+  })
+
+  it('leaves untyped legacy items lenient (not blocked)', () => {
+    expect(reverifyAssessment([{ questionLabel: '1', answer: '' }])).toEqual([])
+  })
+
+  it('accepts acceptableVariants as an answer key for closed types', () => {
+    expect(
+      reverifyAssessment([
+        { questionType: 'fill_blank', questionLabel: '1', answer: '', acceptableVariants: ['x'] },
       ])
     ).toEqual([])
   })

--- a/tutorme-app/src/lib/assessment/assessment-gates.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.ts
@@ -36,3 +36,114 @@ export function findOpenItemsMissingRubric(items: RubricGateItem[]): string[] {
   }
   return missing
 }
+
+/** Closed text types that are auto-graded against an `answer` string. */
+const CLOSED_TEXT_TYPES = new Set(['mcq', 'true_false', 'multiple_response', 'fill_blank'])
+
+export interface ReverifyItem extends RubricGateItem {
+  answer?: string | null
+  acceptableVariants?: string[] | null
+  pairs?: unknown[] | null
+  regions?: unknown[] | null
+}
+
+export interface ReverifyIssue {
+  kind: 'numbering' | 'rubric' | 'answer-mapping'
+  label: string
+  message: string
+}
+
+function reverifyLabel(it: ReverifyItem): string {
+  return (
+    (it.questionLabel && it.questionLabel.trim()) ||
+    (it.questionNumber != null ? `Q${it.questionNumber}` : '?')
+  )
+}
+
+/** Normalized question reference for numbering-integrity (e.g. "1(a)" == "1a"). */
+function reverifyRef(it: ReverifyItem): string {
+  const raw =
+    it.questionLabel?.trim() || (it.questionNumber != null ? String(it.questionNumber) : '')
+  return raw.toLowerCase().replace(/[\s()._-]/g, '')
+}
+
+/**
+ * ASMT-12: re-verify an assessment is internally consistent and fully gradable
+ * before the final/deployed DMI is generated. Returns the blocking issues found
+ * (empty = passes):
+ *  - numbering integrity: question references must be unique
+ *  - rubric completeness: open (short/long) questions need a marking pathway
+ *  - answer mapping: auto-graded types need their answer key (closed → answer,
+ *    matching/drag_drop → pairs, hotspot → regions)
+ *
+ * Untyped legacy items are left lenient (skipped) so old assessments don't
+ * suddenly fail to deploy. Section-structure and mark-validity checks are
+ * deferred until the section data model lands (P2).
+ */
+export function reverifyAssessment(items: ReverifyItem[]): ReverifyIssue[] {
+  const issues: ReverifyIssue[] = []
+
+  // Numbering integrity — duplicate references break answer/grade mapping.
+  const counts = new Map<string, number>()
+  for (const it of items) {
+    const ref = reverifyRef(it)
+    if (ref) counts.set(ref, (counts.get(ref) ?? 0) + 1)
+  }
+  for (const [ref, n] of counts) {
+    if (n > 1) {
+      issues.push({
+        kind: 'numbering',
+        label: ref,
+        message: `Question reference "${ref}" is used ${n} times — references must be unique.`,
+      })
+    }
+  }
+
+  for (const it of items) {
+    const type = (it.questionType ?? '').toString()
+    const label = reverifyLabel(it)
+
+    if (isOpenDmiType(type)) {
+      if (!it.rubric || !it.rubric.trim()) {
+        issues.push({
+          kind: 'rubric',
+          label,
+          message: `Open question ${label} has no marking guidance (add one, or mark it for manual grading).`,
+        })
+      }
+      continue // open items grade by rubric, not an answer key
+    }
+
+    const hasAnswer =
+      !!(it.answer && it.answer.trim()) ||
+      (Array.isArray(it.acceptableVariants) && it.acceptableVariants.length > 0)
+
+    if (CLOSED_TEXT_TYPES.has(type)) {
+      if (!hasAnswer) {
+        issues.push({
+          kind: 'answer-mapping',
+          label,
+          message: `Question ${label} has no answer key — set one or upload a marking scheme.`,
+        })
+      }
+    } else if (type === 'matching' || type === 'drag_drop') {
+      if (!(Array.isArray(it.pairs) && it.pairs.length > 0)) {
+        issues.push({
+          kind: 'answer-mapping',
+          label,
+          message: `Question ${label} has no correct pairs defined.`,
+        })
+      }
+    } else if (type === 'hotspot') {
+      if (!(Array.isArray(it.regions) && it.regions.length > 0)) {
+        issues.push({
+          kind: 'answer-mapping',
+          label,
+          message: `Question ${label} has no correct regions defined.`,
+        })
+      }
+    }
+  }
+
+  return issues
+}


### PR DESCRIPTION
**P1 — item 2 of the Assessment Guardrails audit fixes.** (REQ 12, no migration.)

## Problem
None of the spec's 6 PCI re-verification checks ran, and final generation was never blocked on inconsistency.

## Fix — a blocking re-verification gate at deploy
- **`reverifyAssessment()`** (pure, tested) reports blocking issues:
  - **numbering integrity** — question references must be unique (normalized, so "1(a)"=="1a")
  - **rubric completeness** — open (short/long) questions need a marking pathway *(supersedes the standalone ASMT-8 gate from #487)*
  - **answer mapping** — auto-graded types need their key (closed → `answer`/variants, matching/drag_drop → `pairs`, hotspot → `regions`)
- `handleDeployAssessmentDmi` blocks deploy and names the issues; the deterministic eval-layer strip (#491) still runs after.

## Scope / deferred
- **Untyped legacy items stay lenient** (skipped) so old assessments don't suddenly fail to deploy.
- **Section-structure** and **mark-validity** checks are deferred until the section data model lands (P2).
- The **state-machine transitions** (ASMT-11/14, `Edited → Final unless re-verified`) are the next, **migration-bearing** PR.

## Checks
- New unit tests (passes when consistent; flags duplicate refs, missing rubric, missing answer key; lenient on untyped; accepts `acceptableVariants`). `tsc`/build/eslint clean.

## ⚠️ New blocking conditions — worth a smoke-test
This **broadens** what blocks deploy beyond #487 (now also duplicate refs + missing answer keys for typed closed questions). Please confirm a normal, fully-defined assessment still deploys, and that the new blocks fire with clear messages. If any condition feels too aggressive for your workflows, it's a one-line tweak in `reverifyAssessment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)