### PR TITLE
feat(assessment): document confidence scoring (ASMT-2)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2703,6 +2703,19 @@ FEEDBACK: [one or two short sentences explaining the score]`
           notify(`Guardrail ${w.ruleId}: ${w.message}`)
         }
 
+        // ASMT-2: warn the tutor when the document parsed with low/medium
+        // confidence so they verify before proceeding ("pause" on Low).
+        const confidence = data.confidence as
+          | { level: 'High' | 'Medium' | 'Low'; reasons?: string[] }
+          | null
+          | undefined
+        if (confidence && confidence.level !== 'High') {
+          const reason = confidence.reasons?.[0] ? ` ${confidence.reasons[0]}` : ''
+          const msg = `${confidence.level} confidence parsing this document — please verify the extracted questions.${reason}`
+          if (confidence.level === 'Low') toast.error(msg)
+          else toast.warning(msg)
+        }
+
         if (questions.length === 0) {
           toast.warning('No questions could be generated. Try adding more content.')
           return

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -18,6 +18,7 @@ import {
   type DmiQuestionType,
 } from '@/lib/assessment/question-types'
 import { extractQuestionRef } from '@/lib/assessment/marking-scheme'
+import { scoreDocumentConfidence } from '@/lib/assessment/confidence'
 import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
@@ -478,11 +479,19 @@ export async function POST(request: NextRequest) {
     // Warn-only assessment guardrails. Checks wording fidelity against the
     // source (ASMT-4) and other structural rules where data is available.
     // Non-blocking — surfaced as `guardrailWarnings` and logged server-side.
+    // ASMT-2: score how reliably the document was parsed (question papers only;
+    // study material is tutor-defined). Feeds the Low→pause guardrail and is
+    // surfaced to the tutor.
+    const confidence =
+      type === 'assessment' && documentKind === 'question_paper'
+        ? scoreDocumentConfidence(questions, content)
+        : null
+
     let guardrailWarnings: GuardrailViolation[] = []
     if (type === 'assessment') {
       guardrailWarnings = runAssessmentGuardrails(
         { title, questions: questions.map(q => ({ questionText: q.questionText })) },
-        { sourceContent: content }
+        { sourceContent: content, confidence: confidence?.level }
       ).violations
       if (guardrailWarnings.length > 0) {
         console.warn(
@@ -503,6 +512,9 @@ export async function POST(request: NextRequest) {
       needsQuestionSpec: documentKind === 'study_material' && !questionSpec,
       questions,
       guardrailWarnings,
+      // ASMT-2 document confidence (null for study material). Low → the builder
+      // warns the tutor to verify before proceeding.
+      confidence,
     })
   } catch (error) {
     console.error('Generate DMI error:', error)

--- a/tutorme-app/src/lib/assessment/confidence.test.ts
+++ b/tutorme-app/src/lib/assessment/confidence.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { scoreDocumentConfidence } from './confidence'
+
+describe('scoreDocumentConfidence (ASMT-2)', () => {
+  it('Low when nothing parsed', () => {
+    const r = scoreDocumentConfidence([], 'some text')
+    expect(r.level).toBe('Low')
+    expect(r.reasons[0]).toMatch(/No questions/)
+  })
+
+  it('High for a clean paper: references + marks present, numbering intact', () => {
+    const items = [
+      { questionLabel: '1', marks: 2 },
+      { questionLabel: '2', marks: 3 },
+      { questionLabel: '3', marks: 5 },
+    ]
+    const r = scoreDocumentConfidence(items, 'a'.repeat(200))
+    expect(r.level).toBe('High')
+    expect(r.reasons).toEqual([])
+  })
+
+  it('Medium when some marks are missing but structure is mostly intact', () => {
+    const items = [
+      { questionLabel: '1', marks: 2 },
+      { questionLabel: '2', marks: 3 },
+      { questionLabel: '3' }, // no marks
+      { questionLabel: '4' }, // no marks
+    ]
+    const r = scoreDocumentConfidence(items, 'a'.repeat(200))
+    expect(r.level).toBe('Medium')
+    expect(r.reasons.join(' ')).toMatch(/Mark allocations/)
+  })
+
+  it('Low when references are largely missing', () => {
+    const items = [{ marks: 2 }, { marks: 3 }, { questionLabel: '3', marks: 1 }]
+    const r = scoreDocumentConfidence(items, 'a'.repeat(200))
+    expect(r.level).toBe('Low')
+  })
+
+  it('Low on a big numbering gap (missing pages)', () => {
+    const items = [
+      { questionLabel: '1', marks: 1 },
+      { questionLabel: '2', marks: 1 },
+      { questionLabel: '9', marks: 1 }, // gap of 6
+    ]
+    const r = scoreDocumentConfidence(items, 'a'.repeat(200))
+    expect(r.level).toBe('Low')
+    expect(r.signals.numberingGaps).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/tutorme-app/src/lib/assessment/confidence.ts
+++ b/tutorme-app/src/lib/assessment/confidence.ts
@@ -1,0 +1,85 @@
+/**
+ * Document Confidence Scoring (Assessment guardrail ASMT-2).
+ *
+ * Before trusting a parsed assessment, score how reliably the document was
+ * read, so the tutor is warned when structure is missing (Low → pause and ask
+ * for clarification; Medium → proceed but flag). Computed deterministically
+ * from the parsed questions + source text — no extra LLM call.
+ *
+ * Only meaningful for an extracted question PAPER; for tutor-authored study
+ * material the tutor defines the structure, so confidence isn't scored.
+ */
+
+export type ConfidenceLevel = 'High' | 'Medium' | 'Low'
+
+export interface ConfidenceItem {
+  questionText?: string | null
+  questionLabel?: string | null
+  marks?: number | null
+}
+
+export interface ConfidenceResult {
+  level: ConfidenceLevel
+  /** Short tutor-facing reasons for a non-High score. */
+  reasons: string[]
+  signals: {
+    questionCount: number
+    withReference: number
+    withMarks: number
+    numberingGaps: number
+  }
+}
+
+/** Score parsing confidence for an extracted question paper. */
+export function scoreDocumentConfidence(
+  items: ConfidenceItem[],
+  sourceContent?: string | null
+): ConfidenceResult {
+  const questionCount = items.length
+
+  // Nothing parsed → Low (the parse effectively failed).
+  if (questionCount === 0) {
+    return {
+      level: 'Low',
+      reasons: ['No questions could be parsed from the document.'],
+      signals: { questionCount: 0, withReference: 0, withMarks: 0, numberingGaps: 0 },
+    }
+  }
+
+  const withReference = items.filter(i => !!(i.questionLabel && i.questionLabel.trim())).length
+  const withMarks = items.filter(i => typeof i.marks === 'number' && (i.marks as number) > 0).length
+
+  // Numbering gaps: missing integers within the observed reference range
+  // (a strong signal of missing/truncated pages).
+  const nums = items
+    .map(i => {
+      const m = (i.questionLabel || '').match(/\d+/)
+      return m ? parseInt(m[0], 10) : null
+    })
+    .filter((n): n is number => n != null)
+  let numberingGaps = 0
+  if (nums.length > 1) {
+    const uniq = [...new Set(nums)].sort((a, b) => a - b)
+    const span = uniq[uniq.length - 1] - uniq[0] + 1
+    numberingGaps = Math.max(0, span - uniq.length)
+  }
+
+  const refRatio = withReference / questionCount
+  const markRatio = withMarks / questionCount
+
+  const reasons: string[] = []
+  if (refRatio < 0.8) reasons.push('Many questions have no recognizable reference/number.')
+  if (markRatio < 0.8) reasons.push('Mark allocations are missing on many questions.')
+  if (numberingGaps > 0) {
+    reasons.push(`Question numbering has ${numberingGaps} gap(s) — pages may be missing.`)
+  }
+  if (sourceContent != null && sourceContent.trim().length < 40) {
+    reasons.push('The document text is very short or may not have been read.')
+  }
+
+  let level: ConfidenceLevel = 'High'
+  if (refRatio < 0.4 || markRatio < 0.4 || numberingGaps >= 2) level = 'Low'
+  else if (reasons.length > 0) level = 'Medium'
+
+  return { level, reasons, signals: { questionCount, withReference, withMarks, numberingGaps } }
+}


### PR DESCRIPTION
**P2 — item 1 of the Assessment Guardrails audit fixes.** (REQ 2.)

## Problem
The validator could *consume* a confidence value, but **nothing ever computed one** — `ctx.confidence` was always `undefined`, so the Low→pause check was dead code and the pipeline auto-proceeded regardless of how badly a document parsed.

## Fix
- **`scoreDocumentConfidence()`** (pure, tested) derives **High / Medium / Low** from the parsed questions + source text: reference coverage, mark-allocation coverage, and numbering gaps (a missing-page signal). Returns tutor-facing reasons.
- `generate-dmi` computes it for **extracted question papers** (study material is tutor-defined → skipped), feeds the level into `runAssessmentGuardrails` (so the **ASMT-2 Low check now actually fires**), and returns it in the response.
- The builder warns the tutor on **Low** (error toast — "verify before proceeding") and **Medium** (advisory), surfacing the first reason.

## Deferred
Section-structure and answer-sheet-alignment confidence dimensions wait for the section data model (next P2 item).

## Checks
- Unit tests for Low (nothing parsed / missing refs / numbering gap), Medium (some marks missing), High (clean paper). `tsc`/build/eslint clean.

## ⚠️ Smoke-test
Upload a clean exam PDF → no confidence warning (High). Upload a partial/garbled scan (missing marks or page gaps) → a Low/Medium toast prompting verification. Study material is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)