### PR TITLE
feat(assessment): section structure — model + parse (ASMT-4, PR A)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -118,6 +118,7 @@ import {
 } from '@/lib/assessment/question-types'
 import { deriveExamContext, EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
 import { reverifyAssessment } from '@/lib/assessment/assessment-gates'
+import { deriveSections, deriveTotalMarks } from '@/lib/assessment/sections'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
 import { findEvaluationLeaks } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
@@ -2725,6 +2726,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
           pairs: Array.isArray(q.pairs) ? q.pairs : undefined,
           hotspotImageUrl: q.hotspotImageUrl,
           regions: Array.isArray(q.regions) ? q.regions : undefined,
+          // Paper section this part belongs to (ASMT-4), when present.
+          section: typeof q.section === 'string' && q.section.trim() ? q.section.trim() : undefined,
         }))
 
         // Study material: students see the GENERATED questions (with options) on
@@ -2782,6 +2785,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
           createdAt: Date.now(),
           taskId: isTask ? loadedTaskId || undefined : undefined,
           assessmentId: !isTask ? loadedAssessmentId || undefined : undefined,
+          // ASMT-4: section grouping + total marks derived from the questions.
+          sections: deriveSections(dmiItems),
+          totalMarks: deriveTotalMarks(dmiItems),
         }
 
         if (isTask) {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -92,6 +92,28 @@ export interface DMIQuestion {
   hotspotImageUrl?: string
   /** Correct clickable regions for `hotspot` (answer key, not shown to student). */
   regions?: import('@/lib/assessment/question-types').DmiHotspotRegion[]
+  /** The paper section this question belongs to (e.g. "Section A"), when the
+   *  paper is divided into sections (ASMT-4). Drives section grouping. */
+  section?: string
+  /** The expected response format, distinct from the input control `questionType`
+   *  (e.g. "numeric", "explanation", "diagram"). Reserved (ASMT-4); populated by
+   *  a later pass. */
+  responseType?: string
+  /** Source materials this question depends on — passage/figure/table refs
+   *  (ASMT-4). Reserved; populated by a later pass. */
+  sourceDependencies?: string[]
+}
+
+/** A section of an assessment paper (ASMT-4): a titled group of questions. */
+export interface DMISection {
+  id: string
+  title: string
+  /** Section-level instructions, when present on the paper. */
+  instructions?: string
+  /** Total marks for the section (sum of its questions). */
+  marks?: number
+  /** Ids of the DMIQuestions in this section, in paper order. */
+  questionIds: string[]
 }
 
 export interface DMIVersion {
@@ -107,6 +129,11 @@ export interface DMIVersion {
    *  that adapts to each board's standard. */
   examBody?: string
   subject?: string
+  /** Section grouping derived from the questions' `section` tags (ASMT-4).
+   *  Empty/absent when the paper has no sections. */
+  sections?: DMISection[]
+  /** Total marks across all questions (ASMT-4 metadata). */
+  totalMarks?: number
 }
 
 export interface Task extends WithDifficultyVariants {

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -99,6 +99,10 @@ Rules:
   on the paper when visible (e.g. "[5]" -> 5); if none is shown, use 1. For study_material, assign
   sensible marks (1 for an objective item like mcq/true_false/fill_blank; 2-10 for short/long
   answers by depth).
+- "section" (OPTIONAL): the section heading this part falls under, EXACTLY as printed on the paper
+  (e.g. "Section A", "Section B: Data Response", "Part II"). Include it on EVERY field when the paper
+  is divided into sections, using the same string for all parts in one section; OMIT it entirely when
+  the paper has no sections. Never invent a section that isn't on the paper.
 - "answer" and "rubric": ONLY for study_material (you wrote the questions, so you know the key).
   "answer" = the correct answer — for mcq/true_false give the correct option's LETTER (A, B, C, …);
   for short/fill_blank the expected answer; for long a concise model answer. "rubric" = one short
@@ -115,13 +119,13 @@ EXAMPLE — Question 1 has parts (a),(b)(i),(b)(ii),(c); Question 2 has (a),(b).
 {"label":"Question 2(b)","type":"long"}
 ]}
 
-EXAMPLE — a MIXED paper: a multiple-choice section (Q1-Q2, five options each) then a free-response
-question (Q3 with parts (a),(b)). Correct JSON:
+EXAMPLE — a MIXED paper with sections: "Section A" is multiple-choice (Q1-Q2, five options each),
+"Section B" is a free-response question (Q3 with parts (a),(b)). Correct JSON:
 {"documentKind":"question_paper","fields":[
-{"label":"Question 1","type":"mcq","options":["A","B","C","D","E"]},
-{"label":"Question 2","type":"mcq","options":["A","B","C","D","E"]},
-{"label":"Question 3(a)","type":"short"},
-{"label":"Question 3(b)","type":"long"}
+{"label":"Question 1","type":"mcq","options":["A","B","C","D","E"],"section":"Section A"},
+{"label":"Question 2","type":"mcq","options":["A","B","C","D","E"],"section":"Section A"},
+{"label":"Question 3(a)","type":"short","section":"Section B"},
+{"label":"Question 3(b)","type":"long","section":"Section B"}
 ]}
 Output the JSON object and nothing else.`
 
@@ -138,6 +142,8 @@ interface ParsedDmiQuestion {
   questionType: DmiQuestionType
   options?: string[]
   pairs?: { left: string; right: string }[]
+  /** Section heading this part falls under (ASMT-4), when the paper has sections. */
+  section?: string
 }
 
 interface ParsedDmiResponse {
@@ -184,6 +190,7 @@ function parseDmiJson(raw: string): ParsedDmiResponse | null {
         pairs?: unknown
         answer?: unknown
         marks?: unknown
+        section?: unknown
         rubric?: unknown
       }>
     }
@@ -216,6 +223,7 @@ function parseDmiJson(raw: string): ParsedDmiResponse | null {
               .filter(p => p.left && p.right)
           : undefined
         const marksNum = Number(f.marks)
+        const section = typeof f.section === 'string' ? f.section.trim() : ''
         const qType = normalizeTypeToken(typeof f.type === 'string' ? f.type : undefined)
         const rawAnswer = allowAnswerKey ? String(f.answer ?? '').trim() : ''
         // For mcq the student submits an option LETTER (A–E), so store the key as
@@ -232,6 +240,7 @@ function parseDmiJson(raw: string): ParsedDmiResponse | null {
           questionType: qType,
           options: options && options.length > 0 ? options : undefined,
           pairs: pairs && pairs.length > 0 ? pairs : undefined,
+          section: section || undefined,
         }
       })
       .filter(q => q.questionText)

--- a/tutorme-app/src/lib/assessment/assessment-gates.test.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.test.ts
@@ -77,3 +77,21 @@ describe('reverifyAssessment (ASMT-12)', () => {
     ).toEqual([])
   })
 })
+
+describe('reverifyAssessment — section consistency (ASMT-4)', () => {
+  it('flags a partially-sectioned paper', () => {
+    const issues = reverifyAssessment([
+      { id: 'a', questionType: 'mcq', questionLabel: '1', answer: 'A', section: 'Section A' },
+      { id: 'b', questionType: 'mcq', questionLabel: '2', answer: 'B' }, // no section
+    ])
+    expect(issues.some(i => i.kind === 'section')).toBe(true)
+  })
+
+  it('accepts a fully-sectioned paper', () => {
+    const issues = reverifyAssessment([
+      { id: 'a', questionType: 'mcq', questionLabel: '1', answer: 'A', section: 'Section A' },
+      { id: 'b', questionType: 'mcq', questionLabel: '2', answer: 'B', section: 'Section B' },
+    ])
+    expect(issues.some(i => i.kind === 'section')).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/assessment/assessment-gates.ts
+++ b/tutorme-app/src/lib/assessment/assessment-gates.ts
@@ -7,6 +7,7 @@
  */
 
 import { isOpenDmiType } from './question-types'
+import { hasPartialSectioning } from './sections'
 
 export interface RubricGateItem {
   questionType?: string | null
@@ -45,10 +46,12 @@ export interface ReverifyItem extends RubricGateItem {
   acceptableVariants?: string[] | null
   pairs?: unknown[] | null
   regions?: unknown[] | null
+  section?: string | null
+  id?: string
 }
 
 export interface ReverifyIssue {
-  kind: 'numbering' | 'rubric' | 'answer-mapping'
+  kind: 'numbering' | 'rubric' | 'answer-mapping' | 'section'
   label: string
   message: string
 }
@@ -143,6 +146,17 @@ export function reverifyAssessment(items: ReverifyItem[]): ReverifyIssue[] {
         })
       }
     }
+  }
+
+  // ASMT-4: section-structure consistency — a paper should be fully sectioned or
+  // not at all; partial sectioning means a section heading was missed.
+  if (hasPartialSectioning(items.map(it => ({ id: it.id ?? '', section: it.section })))) {
+    issues.push({
+      kind: 'section',
+      label: 'sections',
+      message:
+        'Some questions are assigned to a section and others are not — assign every question to its section, or remove the section headings.',
+    })
   }
 
   return issues

--- a/tutorme-app/src/lib/assessment/sections.test.ts
+++ b/tutorme-app/src/lib/assessment/sections.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { deriveSections, deriveTotalMarks, hasPartialSectioning } from './sections'
+
+describe('deriveTotalMarks', () => {
+  it('sums marks, defaulting unmarked questions to 1', () => {
+    expect(deriveTotalMarks([{ id: 'a', marks: 5 }, { id: 'b' }, { id: 'c', marks: 2 }])).toBe(8)
+  })
+})
+
+describe('deriveSections', () => {
+  it('groups by section tag in first-appearance order with summed marks', () => {
+    const secs = deriveSections([
+      { id: 'a', section: 'Section A', marks: 2 },
+      { id: 'b', section: 'Section A', marks: 3 },
+      { id: 'c', section: 'Section B', marks: 5 },
+    ])
+    expect(secs.map(s => s.title)).toEqual(['Section A', 'Section B'])
+    expect(secs[0]).toMatchObject({ marks: 5, questionIds: ['a', 'b'] })
+    expect(secs[1]).toMatchObject({ marks: 5, questionIds: ['c'] })
+  })
+
+  it('returns [] for an unsectioned paper', () => {
+    expect(deriveSections([{ id: 'a', marks: 1 }, { id: 'b' }])).toEqual([])
+  })
+})
+
+describe('hasPartialSectioning', () => {
+  it('flags a partially-sectioned paper', () => {
+    expect(hasPartialSectioning([{ id: 'a', section: 'A' }, { id: 'b' }])).toBe(true)
+  })
+  it('is false when fully sectioned or fully unsectioned', () => {
+    expect(
+      hasPartialSectioning([
+        { id: 'a', section: 'A' },
+        { id: 'b', section: 'B' },
+      ])
+    ).toBe(false)
+    expect(hasPartialSectioning([{ id: 'a' }, { id: 'b' }])).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/assessment/sections.ts
+++ b/tutorme-app/src/lib/assessment/sections.ts
@@ -1,0 +1,69 @@
+/**
+ * Section derivation for assessments (Assessment guardrail ASMT-4).
+ *
+ * Questions carry an optional `section` tag (the paper heading they fall under).
+ * These pure helpers group the flat question list into `DMISection`s and compute
+ * the paper's total marks — the canonical source of truth for section structure,
+ * so the model/version never drift from the items.
+ */
+
+/** Default marks for a question with no explicit allocation (matches grading). */
+const DEFAULT_MARKS = 1
+
+export interface SectionableItem {
+  id: string
+  section?: string | null
+  marks?: number | null
+}
+
+export interface DerivedSection {
+  id: string
+  title: string
+  marks: number
+  questionIds: string[]
+}
+
+function itemMarks(it: SectionableItem): number {
+  return typeof it.marks === 'number' && it.marks > 0 ? it.marks : DEFAULT_MARKS
+}
+
+/** Total marks across all questions (each unmarked question counts as 1). */
+export function deriveTotalMarks(items: SectionableItem[]): number {
+  return items.reduce((sum, it) => sum + itemMarks(it), 0)
+}
+
+/**
+ * Group questions into sections by their `section` tag, in first-appearance
+ * order, summing each section's marks. Returns [] when no question is tagged
+ * (an unsectioned paper).
+ */
+export function deriveSections(items: SectionableItem[]): DerivedSection[] {
+  const order: string[] = []
+  const byTitle = new Map<string, DerivedSection>()
+  for (const it of items) {
+    const title = (it.section ?? '').trim()
+    if (!title) continue
+    let sec = byTitle.get(title)
+    if (!sec) {
+      sec = { id: `sec-${order.length + 1}`, title, marks: 0, questionIds: [] }
+      byTitle.set(title, sec)
+      order.push(title)
+    }
+    sec.questionIds.push(it.id)
+    sec.marks += itemMarks(it)
+  }
+  return order.map(t => byTitle.get(t) as DerivedSection)
+}
+
+/**
+ * ASMT-4 section-structure consistency: a paper should be either fully
+ * sectioned or not sectioned at all. Returns true when the sectioning is
+ * partial (some questions tagged, some not) — an inconsistency worth flagging.
+ */
+export function hasPartialSectioning(items: SectionableItem[]): boolean {
+  let tagged = 0
+  for (const it of items) {
+    if ((it.section ?? '').trim()) tagged++
+  }
+  return tagged > 0 && tagged < items.length
+}


### PR DESCRIPTION
**P2 — REQ 4 (section structure), PR A of 2.** Model + parse; the builder UI + student delivery follow in **PR B**.

## Problem
The Assessment PCI had **no section structure** — `DMIVersion` was a flat question array. The spec's "each section has a title, instructions, mark allocation, and its questions" + the total-marks metadata were missing, and the re-verification section check couldn't exist.

## What's in PR A
- **Data model** (additive JSONB — back-compat, **no SQL migration**): `DMISection {id,title,instructions?,marks,questionIds}`; `DMIVersion.sections` / `.totalMarks`; `DMIQuestion.section` (the paper heading) + reserved `responseType` / `sourceDependencies` fields.
- **Parse**: `generate-dmi`'s prompt now emits an optional per-field `"section"` heading (omitted entirely for unsectioned papers); the parser carries it through.
- **Derivation**: `deriveSections()` / `deriveTotalMarks()` (pure, tested) build the grouping + total from the questions — **single source of truth**, so the model/version can't drift. The builder populates the new version with them.
- **Re-verify**: gains the deferred ASMT-4 **section-structure check** — a paper must be fully sectioned or not at all (partial sectioning = a missed heading).

## Scope
- No UI yet — sections are stored on the version but not rendered; that's **PR B** (render grouped by section + carry section layout into the student delivery payload).
- `responseType`/`sourceDependencies` are added to the model as reserved fields (populated by a later pass).

## Checks
- Unit tests for `deriveSections`/`deriveTotalMarks`/`hasPartialSectioning` and the reverify section check. `tsc`/build/eslint clean.

## ⚠️ Smoke-test (prompt change — the sensitive part)
The only runtime-behavior change is the **`generate-dmi` prompt** now asking for an optional `section`. Please confirm: parsing a **sectioned** exam still extracts all questions (and now tags them with sections); parsing an **unsectioned** paper still works unchanged (no spurious sections). The existing flat behavior is preserved when no sections are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)