### PR TITLE
feat(assessment): section structure — UI + delivery (ASMT-4, PR B)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   useCallback,
   Suspense,
+  Fragment,
   type ComponentProps,
 } from 'react'
 import { useSession } from 'next-auth/react'
@@ -2328,46 +2329,55 @@ function StudentFeedbackContent() {
                 <div className="space-y-4">
                   {activeTask?.dmiItems && activeTask.dmiItems.length > 0 ? (
                     <div className="space-y-3">
-                      {activeTask.dmiItems.map(item => {
+                      {activeTask.dmiItems.map((item, idx) => {
                         const qType = normalizeDmiQuestionType(item.questionType)
+                        // Section heading (ASMT-4): show it once, before the first
+                        // question of each section.
+                        const prevSection =
+                          idx > 0 ? activeTask.dmiItems?.[idx - 1]?.section : undefined
+                        const showSection = !!item.section && item.section !== prevSection
                         return (
-                          <div
-                            key={item.id}
-                            className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-                          >
-                            <div className="mb-2 flex items-start justify-between gap-2">
-                              <p className="text-sm font-medium text-gray-800">
-                                {/* The label is usually self-numbered ("Question 1(a)"); only
-                                    prepend the counter for older free-text questions. */}
-                                {/^\s*(?:question\b|\d)/i.test(item.questionText)
-                                  ? item.questionText
-                                  : `${(item.questionLabel ?? item.questionNumber) ? `${item.questionLabel ?? item.questionNumber}. ` : ''}${item.questionText}`}
-                              </p>
-                              <div className="flex shrink-0 items-center gap-1">
-                                {typeof item.marks === 'number' && item.marks > 0 && (
-                                  <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-600">
-                                    {item.marks} {item.marks === 1 ? 'mark' : 'marks'}
-                                  </span>
-                                )}
-                                {qType !== 'long' && (
-                                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
-                                    {DMI_QUESTION_TYPE_LABELS[qType]}
-                                  </span>
-                                )}
+                          <Fragment key={item.id}>
+                            {showSection && (
+                              <div className="mt-1 border-b border-indigo-100 pb-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+                                {item.section}
                               </div>
+                            )}
+                            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                              <div className="mb-2 flex items-start justify-between gap-2">
+                                <p className="text-sm font-medium text-gray-800">
+                                  {/* The label is usually self-numbered ("Question 1(a)"); only
+                                    prepend the counter for older free-text questions. */}
+                                  {/^\s*(?:question\b|\d)/i.test(item.questionText)
+                                    ? item.questionText
+                                    : `${(item.questionLabel ?? item.questionNumber) ? `${item.questionLabel ?? item.questionNumber}. ` : ''}${item.questionText}`}
+                                </p>
+                                <div className="flex shrink-0 items-center gap-1">
+                                  {typeof item.marks === 'number' && item.marks > 0 && (
+                                    <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-600">
+                                      {item.marks} {item.marks === 1 ? 'mark' : 'marks'}
+                                    </span>
+                                  )}
+                                  {qType !== 'long' && (
+                                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+                                      {DMI_QUESTION_TYPE_LABELS[qType]}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                              <DmiAnswerField
+                                item={item}
+                                value={taskAnswers[item.id] ?? ''}
+                                // Once the student starts working, stop auto-following
+                                // the tutor so their navigation can't yank the student
+                                // away from what they're answering.
+                                onInteract={() => setFollowTutor(false)}
+                                onValueChange={next =>
+                                  setTaskAnswers(prev => ({ ...prev, [item.id]: next }))
+                                }
+                              />
                             </div>
-                            <DmiAnswerField
-                              item={item}
-                              value={taskAnswers[item.id] ?? ''}
-                              // Once the student starts working, stop auto-following
-                              // the tutor so their navigation can't yank the student
-                              // away from what they're answering.
-                              onInteract={() => setFollowTutor(false)}
-                              onValueChange={next =>
-                                setTaskAnswers(prev => ({ ...prev, [item.id]: next }))
-                              }
-                            />
-                          </div>
+                          </Fragment>
                         )
                       })}
                     </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -11019,6 +11019,11 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                   Q{item.questionLabel ?? item.questionNumber}.
                                 </span>
                                 {item.questionText}
+                                {item.section && (
+                                  <span className="ml-2 inline-block rounded-full bg-indigo-50 px-2 py-0.5 align-middle text-[10px] font-medium text-indigo-600">
+                                    {item.section}
+                                  </span>
+                                )}
                               </p>
                               <div className="flex shrink-0 items-center gap-2">
                                 <label className="flex items-center gap-1 text-xs text-gray-600">

--- a/tutorme-app/src/lib/assessment/student-dmi.test.ts
+++ b/tutorme-app/src/lib/assessment/student-dmi.test.ts
@@ -44,3 +44,17 @@ describe('toStudentDmiItem (ASMT-10/13 layer separation)', () => {
     expect(safe.options).toEqual(['a', 'b'])
   })
 })
+
+describe('toStudentDmiItem — section passthrough (ASMT-4)', () => {
+  it('carries the section title (delivery-layer, safe to show)', () => {
+    const safe = toStudentDmiItem({
+      id: 'q1',
+      questionNumber: 1,
+      questionText: 'Q',
+      questionType: 'short',
+      // @ts-expect-error structural item carries section
+      section: 'Section A',
+    })
+    expect(safe.section).toBe('Section A')
+  })
+})

--- a/tutorme-app/src/lib/assessment/student-dmi.ts
+++ b/tutorme-app/src/lib/assessment/student-dmi.ts
@@ -26,6 +26,8 @@ export interface DeployableDmiItem {
   hotspotImageUrl?: string
   /** Correct clickable regions for hotspot — answer key. */
   regions?: DmiHotspotRegion[]
+  /** Paper section heading (delivery-layer — safe to show students). */
+  section?: string
 }
 
 /** The student-safe DMI item broadcast to learners — carries no answer key. */
@@ -45,6 +47,8 @@ export interface StudentDmiItem {
    * about the correct pairing. Never includes the correspondence itself.
    */
   matchBank?: string[]
+  /** Paper section heading (delivery-layer — the student sees the structure). */
+  section?: string
 }
 
 /**
@@ -63,6 +67,7 @@ export function toStudentDmiItem(item: DeployableDmiItem): StudentDmiItem {
     questionType: item.questionType,
     options: item.options,
     hotspotImageUrl: item.hotspotImageUrl,
+    section: item.section,
   }
   if (
     (item.questionType === 'matching' || item.questionType === 'drag_drop') &&

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -127,6 +127,8 @@ export interface LiveTaskDmiItem {
   matchPrompts?: string[]
   /** Sorted option bank for matching & drag_drop — never the correct pairing. */
   matchBank?: string[]
+  /** Paper section heading (delivery-layer — shown to the student). */
+  section?: string
 }
 
 export interface LiveTaskSourceDocument {
@@ -1451,6 +1453,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
                         ? (d.matchPrompts as string[])
                         : undefined,
                       matchBank: Array.isArray(d.matchBank) ? (d.matchBank as string[]) : undefined,
+                      section: typeof d.section === 'string' ? d.section : undefined,
                     })
                   )
                 : undefined,

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -74,6 +74,8 @@ export interface LiveTaskDmiItem {
   matchPrompts?: string[]
   /** Sorted option bank for matching & drag_drop — never the correct pairing. */
   matchBank?: string[]
+  /** Paper section heading (delivery-layer — shown to the student). */
+  section?: string
 }
 
 export interface LiveTaskSourceDocument {


### PR DESCRIPTION
**P2 — REQ 4 (section structure), PR B of 2.** Builds on the merged PR A (#495, model + parse). Completes REQ 4.

## What
Surfaces the section grouping to both the tutor and the student — the spec's **Delivery Layer "section layout"** (REQ 10) + **"preserve verified structure"** (REQ 13):

- **Delivery:** `toStudentDmiItem` + `LiveTaskDmiItem` (both definitions) + the socket sync path now carry the `section` **title**. It's delivery-layer (a heading, not an answer key), so it's safe to broadcast — answers / rubrics / `pairs` / `regions` stay stripped exactly as before (#491 unchanged).
- **Student view:** the assessment groups questions under their section heading, shown once before the first question of each section.
- **Builder:** the DMI editor shows a section badge on each question row.

## Safety
- The section title is the **only** new field crossing to students; the answer-key stripping from #491 is untouched. Unit test confirms `toStudentDmiItem` passes the section through (and the existing tests confirm it still emits no answer-key fields).

## Checks
- `tsc`/build/eslint clean; student-dmi unit tests green.

## ⚠️ Smoke-test (live-classroom render)
With PR A merged, generate a **sectioned** assessment, deploy it to a live session, and as the student confirm the questions render **grouped under their section headings** and are still answerable (incl. matching/hotspot from #491). An **unsectioned** paper should render as a flat list exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)