### PR TITLE
feat(task): capture a PCI approval audit log (TASK-18 Data Capture)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -852,6 +852,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       taskContent: string
       taskPci: string
       details: string
+      /** Append-only PCI approval audit log (TASK-18). */
+      pciHistory?: import('@/lib/assessment/pci').PciAuditRecord[]
       sourceDocument?: {
         fileName: string
         fileUrl: string
@@ -923,10 +925,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Directly set the saved PCI (the marking policy used by grading) for the
     // active context — the active task extension, the base task, or the
     // assessment. Mirrors where applyTaskPciDraft / applyAssessmentPciDraft write.
-    const setCurrentPci = (source: 'task' | 'assessment', text: string) => {
+    const setCurrentPci = (
+      source: 'task' | 'assessment',
+      text: string,
+      audit?: import('@/lib/assessment/pci').PciAuditRecord
+    ) => {
       if (source === 'task') {
-        setTaskBuilder(prev =>
-          prev.activeExtensionId
+        setTaskBuilder(prev => {
+          const base = prev.activeExtensionId
             ? {
                 ...prev,
                 extensions: prev.extensions.map(ext =>
@@ -934,7 +940,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 ),
               }
             : { ...prev, taskPci: text }
-        )
+          // TASK-18: record the approval (transcript + approved text) on a real
+          // "Apply to PCI" — not on a manual edit/clear (which pass no audit).
+          return audit ? { ...base, pciHistory: [...(prev.pciHistory ?? []), audit] } : base
+        })
       } else {
         setAssessmentBuilder(prev => ({ ...prev, taskPci: text }))
       }
@@ -1502,6 +1511,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           taskContent: content,
           taskPci: task.instructions || '',
           details: task.shortDescription || '',
+          // TASK-18: carry the PCI approval audit log so saves preserve/extend it.
+          pciHistory: task.pciHistory,
           sourceDocument: task.sourceDocument,
           extensions: (task.extensions || []).map(ext => ({
             ...ext,
@@ -1744,6 +1755,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   shortDescription: taskBuilder.details,
                   description: taskBuilder.taskContent,
                   instructions: taskBuilder.taskPci,
+                  // TASK-18: persist the PCI approval audit log with the task.
+                  pciHistory: taskBuilder.pciHistory,
                   extensions: taskBuilder.extensions,
                   dmiItems: taskDmiItems,
                   dmiVersions: taskDmiVersions,

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -142,6 +142,9 @@ export interface Task extends WithDifficultyVariants {
   shortDescription?: string
   description: string
   instructions: string
+  /** Append-only audit log of PCI approvals (TASK-18). Each "Apply to PCI"
+   *  records the transcript + approved text for auditability/versioning. */
+  pciHistory?: import('@/lib/assessment/pci').PciAuditRecord[]
   extensions?: Array<{
     id: string
     name: string

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
@@ -101,7 +101,20 @@ describe('usePci', () => {
     })
     act(() => result.current.applyTaskPciDraft())
 
-    expect(setCurrentPci).toHaveBeenCalledWith('task', 'FINAL')
+    // TASK-18: applies the draft AND captures an audit record (approved text +
+    // the transcript of tutor turns + the LLM reply).
+    expect(setCurrentPci).toHaveBeenCalledWith(
+      'task',
+      'FINAL',
+      expect.objectContaining({
+        approvedPci: 'FINAL',
+        transcript: expect.arrayContaining([
+          expect.objectContaining({ role: 'user', content: 'q' }),
+          expect.objectContaining({ role: 'assistant' }),
+        ]),
+        approvedAt: expect.any(Number),
+      })
+    )
     expect(getThread(result.current.pci, taskTarget).draft).toBe('')
   })
 

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -2,7 +2,7 @@
 
 import { useReducer } from 'react'
 import { toast } from 'sonner'
-import type { PciMessage } from '@/lib/assessment/pci'
+import type { PciMessage, PciAuditRecord } from '@/lib/assessment/pci'
 import {
   pciReducer,
   initialPciState,
@@ -40,7 +40,7 @@ interface UsePciDeps {
   }
   assessmentBuilder: { taskContent: string; taskPci: string; title: string }
   /** Writes the finalized rubric to the active task/assessment PCI field. */
-  setCurrentPci: (source: 'task' | 'assessment', text: string) => void
+  setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
   currentAssessmentDocument?: PciSourceDoc
   autoCreateTask: () => { id?: string } | null | undefined
@@ -66,9 +66,17 @@ export function usePci(deps: UsePciDeps) {
 
   const applyTaskPciDraft = () => {
     const target = activeTaskTarget()
-    const draft = getThread(pci, target).draft
+    const thread = getThread(pci, target)
+    const draft = thread.draft
     if (!draft) return
-    deps.setCurrentPci('task', draft)
+    // TASK-18 (Data Capture): record the approval — the transcript (tutor's
+    // words + the LLM's interpretation/summary) and the approved PCI together.
+    const audit: PciAuditRecord = {
+      approvedPci: draft,
+      transcript: thread.messages,
+      approvedAt: Date.now(),
+    }
+    deps.setCurrentPci('task', draft, audit)
     dispatch({ type: 'clearDraft', target })
     toast.success('Rubric applied to PCI')
   }

--- a/tutorme-app/src/lib/assessment/pci.ts
+++ b/tutorme-app/src/lib/assessment/pci.ts
@@ -11,6 +11,23 @@ export interface PciMessage {
 }
 
 /**
+ * An auditable record of one PCI approval (Task PCI guardrail TASK-18, Data
+ * Capture). Captures the three layers the spec wants kept separate: what the
+ * tutor said + how the LLM interpreted it (the `transcript`), and the final
+ * approved behavior (`approvedPci`). Appended on each "Apply to PCI", so the
+ * list is a version history of approvals.
+ */
+export interface PciAuditRecord {
+  /** The approved PCI text applied this time. */
+  approvedPci: string
+  /** The chat transcript at approval: tutor turns (user) + LLM interpretation/
+   *  summary (assistant). */
+  transcript: PciMessage[]
+  /** Epoch ms when the tutor applied it. */
+  approvedAt: number
+}
+
+/**
  * Parse a saved PCI transcript ("User: …\nAssistant: …") back into chat messages.
  * Lines with no role prefix continue the current message; leading prose with no
  * prefix is treated as an assistant message (e.g. a finalized rubric applied


### PR DESCRIPTION
**Task PCI — P1 #3 (Data Capture / auditability — the doc's headline gap).**

## Problem
Only the final applied rubric string was persisted (`task.instructions`). The tutor's **original instructions** and the **LLM's interpretation/summary** were discarded, and there was **no versioning**. The Data Capture guardrail wants the three layers kept separately — *what the tutor said / how it was interpreted / what was approved* — for "auditability, versioning, and future model training."

## Fix
On each **"Apply to PCI"** the task records a `PciAuditRecord { approvedPci, transcript, approvedAt }`:
- **`transcript`** = the chat at approval (tutor turns + the LLM's interpretation/summary) → captures *said* + *interpreted*;
- **`approvedPci`** = the approved behavior;
- appended to **`task.pciHistory`**, so the list is a **version history** of approvals.

Wiring: `usePci.applyTaskPciDraft` builds the record from the reducer transcript + draft; `setCurrentPci` appends it **only on a real apply** (manual edit/clear record nothing); it persists with the task via `builderData` (**additive JSONB — no SQL migration**) and is **loaded back** so saves preserve/extend the log (no clobber).

## Scope
- **Task-scoped** (this is the Task PCI doc). Assessment auditability can follow the same pattern later.
- No new UI to *view* the history yet — this PR captures + persists it (the auditable record now exists). A history viewer is a small follow-up.

## Checks
- usePci test asserts the apply captures the audit record (approved text + transcript with the tutor turn and the LLM reply). 19 tests green; `tsc`/build/eslint clean.

## ⚠️ Smoke-test
Build a task PCI via chat → **Apply to PCI** → Save → reload the task: the applied PCI persists as before, and `task.pciHistory` now carries the approval(s) with their transcripts (visible in the saved `builderData`). A manual edit of the PCI box should **not** add a history entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)