### PR TITLE
fix(task): server-side confirmation gate for PCI finalization (TASK-5)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -109,7 +109,7 @@ describe('/api/ai/pci-master', () => {
     return POST(req as unknown as NextRequest)
   }
 
-  it('task domain: extracts {reply,pci} — chat shows reply, pciDraft holds the finalized rubric', async () => {
+  it('task domain: extracts {reply,pci} — chat shows reply, pciDraft holds the finalized rubric (on tutor approval)', async () => {
     mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: '{"reply":"What counts as a correct answer?","pci":"FINAL RUBRIC TEXT"}',
@@ -117,7 +117,8 @@ describe('/api/ai/pci-master', () => {
       parsed: null,
     })
 
-    const res = await postBody({ message: 'help', context: { type: 'task' } })
+    // The tutor's message signals approval, so the finalized rubric surfaces.
+    const res = await postBody({ message: 'looks good, finalize it', context: { type: 'task' } })
     const data = await res.json()
 
     expect(res.status).toBe(200)
@@ -125,6 +126,22 @@ describe('/api/ai/pci-master', () => {
     expect(data.response).toBe('What counts as a correct answer?')
     expect(data.response).not.toContain('{')
     expect(data.pciDraft).toBe('FINAL RUBRIC TEXT')
+  })
+
+  it('task domain: suppresses a finalized rubric until the tutor signals approval (TASK-5)', async () => {
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.adkPciMasterChat.mockResolvedValue({
+      response: '{"reply":"Here is the finalized rubric.","pci":"FINAL RUBRIC TEXT"}',
+      conversationId: 'c1',
+      parsed: null,
+    })
+
+    // No approval phrase → the engine must NOT surface the draft, and flags it.
+    const res = await postBody({ message: 'what do you think?', context: { type: 'task' } })
+    const data = await res.json()
+
+    expect(data.pciDraft).toBe('')
+    expect(data.pciUnconfirmed).toBe(true)
   })
 
   it('task domain: empty pci until finalized (no draft surfaced)', async () => {

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -303,7 +303,16 @@ export async function POST(request: NextRequest) {
     // is the conversational chat text, `pci` is the finalized rubric (non-empty
     // only after the tutor approves finalizing). Extract both so the chat never
     // shows a raw spec and the builder can write a clean PCI to the field.
+    // TASK-5 (Confirmation): the tutor's message must explicitly signal approval
+    // before the engine presents a finalized rubric — the model alone cannot
+    // finalize. Used both to gate the draft and to inform the validator.
+    const tutorSignaledFinalize =
+      /\b(confirm(ed)?|finali[sz]e|approve[d]?|looks good|go ahead|activate|apply it|lock it in|use (that|this)|that'?s (right|correct|good|it)|sounds good|save it|agreed)\b/i.test(
+        safeMessage
+      )
+
     let pciDraft = ''
+    let pciUnconfirmed = false
     if (guardrailDomain) {
       const env = parseLlmJson<{ reply?: string; pci?: string }>(response.response)
       if (env && (typeof env.reply === 'string' || typeof env.pci === 'string')) {
@@ -311,6 +320,13 @@ export async function POST(request: NextRequest) {
           response.response = env.reply.trim()
         }
         if (typeof env.pci === 'string') pciDraft = env.pci.trim()
+      }
+      // Suppress a finalized rubric the model emitted without an explicit tutor
+      // approval this turn — no silent finalization (the client Apply button is
+      // the second gate).
+      if (pciDraft && !tutorSignaledFinalize) {
+        pciUnconfirmed = true
+        pciDraft = ''
       }
     }
 
@@ -328,12 +344,9 @@ export async function POST(request: NextRequest) {
     // surface them to the tutor. Flip to blocking later by gating on severity.
     let guardrailWarnings: GuardrailViolation[] = []
     if (guardrailDomain === 'task') {
-      const finalizing = /\b(confirm|finali[sz]e|approve|looks good|go ahead|activate)\b/i.test(
-        safeMessage
-      )
       guardrailWarnings = runTaskGuardrails(response.response, {
         sourceContent: context?.content,
-        finalizing,
+        finalizing: tutorSignaledFinalize,
         finalizedPci: pciDraft,
       }).violations
       if (guardrailWarnings.length > 0) {
@@ -347,6 +360,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       response: response.response,
       pciDraft,
+      // True when the model proposed a finalized rubric but the tutor hasn't
+      // signalled approval — the UI can prompt them to confirm before applying.
+      pciUnconfirmed,
       conversationId: response.conversationId,
       parsed: response.parsed ?? null,
       guardrailWarnings,


### PR DESCRIPTION
**Task PCI — P1 #4 (Confirmation / no silent finalization).**

## Problem
The engine passed through **any** `pci` the model emitted, so a finalized rubric could surface (the green "ready to apply" banner) on any turn — the only real gate was the human clicking Apply. The doc's strongest guardrail ("Confirmation is mandatory; no silent finalization") was **prompt-only on the server**.

## Fix
`pci-master` now suppresses a finalized rubric **unless the tutor's message this turn explicitly signals approval** (`confirm`/`finalize`/`approve`/`looks good`/`apply`/`lock it in`/`use that`/…). When the model proposes finalizing without that signal, `pciDraft` is cleared and **`pciUnconfirmed: true`** is returned so the UI can prompt the tutor to confirm. The client **Apply** button remains the second gate.

## Why it won't annoy tutors
In the normal flow the model only emits `pci` *after* the tutor approves, and the (broadened) signal matches that approval — so the draft passes straight through. The gate only fires when the model **finalizes prematurely** (the exact case the doc forbids).

## Scope
- `pci-master` route only (independent of the unmerged #498). The `pciUnconfirmed` flag is returned for the UI to surface; wiring a "confirm to finalize" hint is a small follow-up.
- The source-of-truth doc `docs/guardrails/tasks-pci.md` already exists in main — no doc change needed.

## Checks
- `tsc`/build/eslint clean.

## ⚠️ Smoke-test
Build a PCI via chat; if the assistant proposes a finalized rubric **before** you approve, the Apply banner should **not** appear. After you say "finalize / looks good / apply", the rubric becomes applyable as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)