### PR TITLE
fix(settings): improve panel scroll behavior and default open state

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -1109,7 +1109,6 @@ export default function TutorSettings() {
                 className={SECTION_CARD_CLASS}
                 title="Billing History"
                 description="View and download your invoices and receipts"
-                defaultOpen
               >
                 <div className="space-y-4 p-6">
                   {billingHistory.map(invoice => (

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -26,7 +26,7 @@ export function CollapsibleCard({
   children,
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen)
-  const cardRef = useAutoScrollOnExpand(open, { delay: 400, margin: 16 })
+  const cardRef = useAutoScrollOnExpand(open, { delay: 400, margin: 16, block: 'start' })
 
   return (
     <div ref={cardRef}>


### PR DESCRIPTION
- Change CollapsibleCard scroll behavior from 'nearest' to 'start' so panels scroll to top of viewport
- Remove defaultOpen from secondary panels in Billing tab (Billing History)
- Ensures only top panel is open by default in each tab
- Fixes panels being partially offscreen when opened