### PR TITLE
fix(assessment-builder): simplify borders to single pink outline

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8900,10 +8900,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                     <Card
                       padding="none"
                       className={cn(
-                        'flex h-full w-full flex-shrink-0 flex-col overflow-hidden rounded-[20px] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
-                        mainBuilderTab === 'assessment'
-                          ? 'border border-[#EC4899]'
-                          : 'border border-blue-200'
+                        'flex h-full w-full flex-shrink-0 flex-col overflow-hidden rounded-[20px] border border-[#EC4899] bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                       )}
                     >
                       <div
@@ -9534,7 +9531,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       className="mt-3 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
                                       <div
-                                        className="relative flex h-full min-h-0 flex-row overflow-hidden rounded-2xl border border-purple-200 bg-white shadow-sm"
+                                        className="relative flex h-full min-h-0 flex-row overflow-hidden rounded-2xl border border-[#EC4899] bg-white shadow-sm"
                                         onDragOver={e => e.preventDefault()}
                                         onDrop={(e: any) => {
                                           if (!canEdit) return
@@ -9558,9 +9555,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           <div
                                             className={cn(
                                               'relative flex h-full flex-col bg-[#FBFCFD]',
-                                              assessmentPdfVisible ? 'w-1/2' : 'w-full',
-                                              mainBuilderTab === 'assessment' &&
-                                                'border border-[#EC4899]'
+                                              assessmentPdfVisible ? 'w-1/2' : 'w-full'
                                             )}
                                           >
                                             <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#E5E7EB] bg-white px-2">
@@ -9813,14 +9808,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       value="pci"
                                       className="mt-2 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
-                                      <div
-                                        className={cn(
-                                          'relative flex h-full min-h-0 flex-col rounded-2xl bg-white p-4 shadow-sm',
-                                          mainBuilderTab === 'assessment'
-                                            ? 'border border-[#EC4899]'
-                                            : 'border border-purple-200'
-                                        )}
-                                      >
+                                      <div className="relative flex h-full min-h-0 flex-col rounded-2xl border border-[#EC4899] bg-white p-4 shadow-sm">
                                         {/* Centered Pill for Test, Generate DMI, and Version History */}
                                         <div className="pointer-events-none absolute left-1/2 top-0 z-20 flex -translate-x-1/2 items-center justify-center">
                                           <div className="pointer-events-auto flex h-11 items-center gap-1 rounded-b-xl border-x border-b border-[#E5E7EB] bg-white/90 px-2 shadow-sm backdrop-blur-sm">


### PR DESCRIPTION
Remove all conditional border logic that was creating double borders and corner distortions. All assessment builder borders are now consistently #EC4899 (header pink):

- Outer Card: border-[#EC4899] (removed conditional, was adding double border)
- Inner content wrapper: border-[#EC4899] (changed from purple-200)
- Inner left panel: removed extra border that was creating double line
- PCI container: border-[#EC4899] (removed conditional)