### PR TITLE
feat(task): structured PCI specification — engine (TASK-6, PR A)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -109,10 +109,11 @@ describe('/api/ai/pci-master', () => {
     return POST(req as unknown as NextRequest)
   }
 
-  it('task domain: extracts {reply,pci} — chat shows reply, pciDraft holds the finalized rubric (on tutor approval)', async () => {
+  it('task domain: extracts {reply,pci,spec} — reply, finalized rubric, and structured spec (on approval)', async () => {
     mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
     mocks.adkPciMasterChat.mockResolvedValue({
-      response: '{"reply":"What counts as a correct answer?","pci":"FINAL RUBRIC TEXT"}',
+      response:
+        '{"reply":"What counts as a correct answer?","pci":"FINAL RUBRIC TEXT","spec":{"evaluationLogic":"Exact match","retryPolicy":"unspecified","instructionalTone":"Encouraging"}}',
       conversationId: 'c1',
       parsed: null,
     })
@@ -126,6 +127,11 @@ describe('/api/ai/pci-master', () => {
     expect(data.response).toBe('What counts as a correct answer?')
     expect(data.response).not.toContain('{')
     expect(data.pciDraft).toBe('FINAL RUBRIC TEXT')
+    // TASK-6: structured spec, with the fabricated "unspecified" field dropped.
+    expect(data.pciSpec).toEqual({
+      evaluationLogic: 'Exact match',
+      instructionalTone: 'Encouraging',
+    })
   })
 
   it('task domain: suppresses a finalized rubric until the tutor signals approval (TASK-5)', async () => {

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -12,6 +12,7 @@ import { adkPciMasterChat } from '@/lib/adk-client'
 import { generateWithFallback } from '@/lib/agents'
 import { generateWithKimiVision } from '@/lib/ai/kimi'
 import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
+import { normalizePciSpec, type PciSpec } from '@/lib/assessment/pci-spec'
 import {
   guardrailSystemPrompt,
   runTaskGuardrails,
@@ -312,21 +313,25 @@ export async function POST(request: NextRequest) {
       )
 
     let pciDraft = ''
+    let pciSpec: PciSpec | null = null
     let pciUnconfirmed = false
     if (guardrailDomain) {
-      const env = parseLlmJson<{ reply?: string; pci?: string }>(response.response)
+      const env = parseLlmJson<{ reply?: string; pci?: string; spec?: unknown }>(response.response)
       if (env && (typeof env.reply === 'string' || typeof env.pci === 'string')) {
         if (typeof env.reply === 'string' && env.reply.trim()) {
           response.response = env.reply.trim()
         }
         if (typeof env.pci === 'string') pciDraft = env.pci.trim()
+        // TASK-6: the structured mirror of the finalized rubric.
+        pciSpec = normalizePciSpec(env.spec)
       }
       // Suppress a finalized rubric the model emitted without an explicit tutor
       // approval this turn — no silent finalization (the client Apply button is
-      // the second gate).
-      if (pciDraft && !tutorSignaledFinalize) {
+      // the second gate). The structured spec is gated the same way.
+      if ((pciDraft || pciSpec) && !tutorSignaledFinalize) {
         pciUnconfirmed = true
         pciDraft = ''
+        pciSpec = null
       }
     }
 
@@ -360,6 +365,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       response: response.response,
       pciDraft,
+      // TASK-6: the finalized rubric in structured form (null until finalized).
+      pciSpec,
       // True when the model proposed a finalized rubric but the tutor hasn't
       // signalled approval — the UI can prompt them to confirm before applying.
       pciUnconfirmed,

--- a/tutorme-app/src/lib/ai/guardrails/task-pci.ts
+++ b/tutorme-app/src/lib/ai/guardrails/task-pci.ts
@@ -158,9 +158,10 @@ Operating procedure (tutor setup) — this is a CONVERSATION, not a one-shot dum
 3. Confirming the summary is NOT the same as finalizing. Only treat the rubric as final when the tutor explicitly says to finalize/apply it.
 
 Output contract (ALWAYS obey):
-- Respond with ONE JSON object: {"reply": "...", "pci": "..."}.
+- Respond with ONE JSON object: {"reply": "...", "pci": "...", "spec": { ... }}.
 - "reply" = your conversational, plain-text message to the tutor (summary, a confirmation question, or the next rubric question). NEVER put JSON, code fences, field templates, or a full specification inside "reply".
 - "pci" = the finalized rubric as clean, readable plain text, and ONLY when the tutor has explicitly approved finalizing. Until then, "pci" MUST be an empty string "".
 - In the finalized "pci", include only what the tutor actually defined; for anything they did not define write "unspecified". Never invent retry counts, grading weights, strictness, partial-credit, reveal timing, or penalties, and never emit rows of "N/A".
+- "spec" = the finalized PCI in STRUCTURED form, present ONLY on finalization (otherwise omit it or use {}). Use ONLY these keys, and include ONLY the ones the tutor actually defined — OMIT the rest entirely (do not fill them with "unspecified"/"N/A"): instructionalContentReference, triggerEvent, evaluationLogic, correctResponseBehavior, incorrectResponseBehavior, partialUnderstandingBehavior, noResponseBehavior, explanationRules, retryPolicy, instructionalTone. Each value is a short plain-text description. "spec" is the structured mirror of "pci" — never fabricate a field the tutor didn't define.
 
 When information needed for reliable evaluation is missing or unclear, say so plainly and ask the tutor — do not fabricate certainty.`

--- a/tutorme-app/src/lib/assessment/pci-spec.test.ts
+++ b/tutorme-app/src/lib/assessment/pci-spec.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { normalizePciSpec } from './pci-spec'
+
+describe('normalizePciSpec (TASK-6)', () => {
+  it('keeps only recognized, tutor-defined fields', () => {
+    const spec = normalizePciSpec({
+      evaluationLogic: 'Award method marks even if the final answer is wrong.',
+      instructionalTone: 'Encouraging',
+      bogusField: 'ignored',
+    })
+    expect(spec).toEqual({
+      evaluationLogic: 'Award method marks even if the final answer is wrong.',
+      instructionalTone: 'Encouraging',
+    })
+  })
+
+  it('drops fabricated placeholders (unspecified / N/A / none / empty)', () => {
+    const spec = normalizePciSpec({
+      evaluationLogic: 'Exact match.',
+      retryPolicy: 'unspecified',
+      partialUnderstandingBehavior: 'N/A',
+      noResponseBehavior: '   ',
+      instructionalTone: 'none',
+    })
+    expect(spec).toEqual({ evaluationLogic: 'Exact match.' })
+  })
+
+  it('returns null when nothing is defined (or input is not an object)', () => {
+    expect(normalizePciSpec({ retryPolicy: 'unspecified' })).toBeNull()
+    expect(normalizePciSpec({})).toBeNull()
+    expect(normalizePciSpec(null)).toBeNull()
+    expect(normalizePciSpec('nope')).toBeNull()
+    expect(normalizePciSpec(['a'])).toBeNull()
+  })
+})

--- a/tutorme-app/src/lib/assessment/pci-spec.ts
+++ b/tutorme-app/src/lib/assessment/pci-spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Structured PCI Specification (Task PCI guardrail TASK-6, Specification).
+ *
+ * The finalized PCI is also expressed as a structured record with a fixed set
+ * of fields, so it's parseable/auditable and execution is consistent. Fields the
+ * tutor did not define are LEFT OUT (unspecified) — never fabricated for
+ * completeness. This lives alongside the free-text `pci` rubric (which stays for
+ * display and back-compat); the spec is the machine-readable form.
+ */
+
+export interface PciSpec {
+  /** Which lesson content / material the behavior refers to. */
+  instructionalContentReference?: string
+  /** What event triggers the PCI (e.g. "student submits an answer"). */
+  triggerEvent?: string
+  /** How a response is evaluated (the marking logic). */
+  evaluationLogic?: string
+  /** What to do on a correct response. */
+  correctResponseBehavior?: string
+  /** What to do on an incorrect response. */
+  incorrectResponseBehavior?: string
+  /** What to do on a partially-correct response (if the tutor defined it). */
+  partialUnderstandingBehavior?: string
+  /** What to do when the student gives no response (if defined). */
+  noResponseBehavior?: string
+  /** How/whether to explain reasoning. */
+  explanationRules?: string
+  /** Retry policy (if defined). */
+  retryPolicy?: string
+  /** Instructional tone. */
+  instructionalTone?: string
+}
+
+/** The canonical field order + human labels for prompts and UI. */
+export const PCI_SPEC_FIELDS: { key: keyof PciSpec; label: string }[] = [
+  { key: 'instructionalContentReference', label: 'Instructional content reference' },
+  { key: 'triggerEvent', label: 'Trigger event' },
+  { key: 'evaluationLogic', label: 'Evaluation logic' },
+  { key: 'correctResponseBehavior', label: 'Correct-response behaviour' },
+  { key: 'incorrectResponseBehavior', label: 'Incorrect-response behaviour' },
+  { key: 'partialUnderstandingBehavior', label: 'Partial-understanding behaviour' },
+  { key: 'noResponseBehavior', label: 'No-response behaviour' },
+  { key: 'explanationRules', label: 'Explanation rules' },
+  { key: 'retryPolicy', label: 'Retry policy' },
+  { key: 'instructionalTone', label: 'Instructional tone' },
+]
+
+/** Values that mean "the tutor didn't define this" — dropped, not fabricated. */
+const UNSPECIFIED_RE = /^(unspecified|n\/?a|none|not (defined|specified|provided|applicable))$/i
+
+/**
+ * Normalize a raw spec object into a clean `PciSpec` — keeping only recognized
+ * fields the tutor actually defined. Empty / "unspecified" / "N/A" values are
+ * dropped (TASK-6: undefined fields stay unspecified, never fabricated).
+ * Returns null when nothing is defined.
+ */
+export function normalizePciSpec(raw: unknown): PciSpec | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const src = raw as Record<string, unknown>
+  const out: PciSpec = {}
+  for (const { key } of PCI_SPEC_FIELDS) {
+    const v = src[key]
+    if (typeof v !== 'string') continue
+    const t = v.trim()
+    if (t && !UNSPECIFIED_RE.test(t)) out[key] = t
+  }
+  return Object.keys(out).length > 0 ? out : null
+}


### PR DESCRIPTION
**Task PCI — TASK-6 (Specification), PR A of 2.** The last deferred guardrail. Engine now; **storage + UI + grading follow in PR B**.

## Problem
The finalized PCI was **free-text only**. TASK-6 wants it also expressed as a **structured spec** (fixed field set) so it's parseable/auditable and execution is consistent — with undefined fields left **unspecified, never fabricated**.

## PR A — the engine
- **`PciSpec`** type + `PCI_SPEC_FIELDS` (the 10 fields: instructional-content-ref, trigger, evaluation logic, correct/incorrect/partial/no-response behavior, explanation rules, retry policy, tone) + **`normalizePciSpec()`** (pure, tested): keeps only recognized, tutor-defined fields; **drops** empty / "unspecified" / "N/A" placeholders; returns `null` when nothing is defined.
- **Prompt**: `TASK_PCI_SYSTEM_PROMPT`'s output contract now emits `{reply, pci, spec}` — `spec` present only on finalization, using the fixed keys, **omitting** undefined fields.
- **`pci-master`**: extracts + normalizes `spec`, gates it on tutor approval exactly like `pci` (no unconfirmed spec surfaces), returns `pciSpec`.

## Additive / back-compat
The free-text `pci` stays (display + existing grading unchanged); `spec` is a new, optional mirror. Nothing consumes `pciSpec` yet — **PR B** wires it into storage (in the audit record + a current-spec field), the PCI tab (structured display), and `ai-grade` (execution).

## Checks
- Unit tests for `normalizePciSpec` (keeps defined, drops fabricated, null-when-empty) + a route test asserting `{reply,pci,spec}` extraction with the "unspecified" field dropped. `tsc`/build/eslint clean; 26 tests green in the touched suites.

## ⚠️ Smoke-test (prompt change)
Finalize a task PCI via chat → the response now includes a `pciSpec` object with only the fields you defined. Normal chat/finalize behavior (reply + free-text rubric + Apply) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)