### PR TITLE
fix(chat/ai-assistant): make headers flush with panel top and sides

### DIFF
--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -43,7 +43,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   return (
     <Card className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       {/* Full-width Chat header */}
-      <div className="flex h-12 shrink-0 items-center justify-center bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
+      <div className="flex h-12 shrink-0 items-center justify-center rounded-t-2xl bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
         Chat
       </div>
 

--- a/tutorme-app/src/components/support/support-ai-assistant.tsx
+++ b/tutorme-app/src/components/support/support-ai-assistant.tsx
@@ -49,7 +49,7 @@ export function SupportAiAssistant() {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-white">
-      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-[#E5E7EB] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4">
+      <div className="flex h-12 shrink-0 items-center gap-2 rounded-t-2xl border-b border-[#E5E7EB] bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4">
         <Bot className="h-5 w-5 text-white" />
         <h3 className="text-sm font-semibold text-white">AI Assistant</h3>
       </div>

--- a/tutorme-app/src/components/support/support-page.tsx
+++ b/tutorme-app/src/components/support/support-page.tsx
@@ -85,7 +85,7 @@ export function SupportPage({ subtitle, heroGradient, topics }: SupportPageProps
           {/* Content + Assistant */}
           <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-hidden p-5 sm:flex-row">
             {/* FAQ / Content panel */}
-            <Card className="shadow-elevation-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white p-5">
+            <Card className="shadow-elevation-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white">
               <div className="flex-shrink-0 border-b border-[#E5E7EB] p-4">
                 <h2 className="text-lg font-semibold text-slate-900">{activeTopicData.title}</h2>
                 <p className="text-sm text-slate-500">{activeTopicData.description}</p>
@@ -105,7 +105,7 @@ export function SupportPage({ subtitle, heroGradient, topics }: SupportPageProps
 
             {/* AI Assistant panel */}
             {showAssistant && (
-              <div className="shadow-elevation-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white p-5">
+              <div className="shadow-elevation-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white">
                 <SupportAiAssistant />
               </div>
             )}


### PR DESCRIPTION
- messaging-panel.tsx: Add rounded-t-2xl to Chat header to match Card rounding
- support-ai-assistant.tsx: Add rounded-t-2xl to AI Assistant header
- support-page.tsx: Remove p-5 padding from AI Assistant wrapper so header is flush

Fixes applied to both tutor and student accounts since they share the same components.