### PR TITLE
feat(task): structured PCI spec — storage + display (TASK-6, PR B)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -126,6 +126,7 @@ import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
 import { getThread, type PciTarget } from './hooks/pci-reducer'
 import { parsePciTranscript, type PciMessage } from '@/lib/assessment/pci'
+import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
@@ -854,6 +855,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       details: string
       /** Append-only PCI approval audit log (TASK-18). */
       pciHistory?: import('@/lib/assessment/pci').PciAuditRecord[]
+      /** Current approved structured PCI spec (TASK-6). */
+      pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
       sourceDocument?: {
         fileName: string
         fileUrl: string
@@ -942,7 +945,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             : { ...prev, taskPci: text }
           // TASK-18: record the approval (transcript + approved text) on a real
           // "Apply to PCI" — not on a manual edit/clear (which pass no audit).
-          return audit ? { ...base, pciHistory: [...(prev.pciHistory ?? []), audit] } : base
+          // TASK-6: `pciSpec` holds the current approved structured spec.
+          return audit
+            ? { ...base, pciHistory: [...(prev.pciHistory ?? []), audit], pciSpec: audit.spec }
+            : base
         })
       } else {
         setAssessmentBuilder(prev => ({ ...prev, taskPci: text }))
@@ -1513,6 +1519,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           details: task.shortDescription || '',
           // TASK-18: carry the PCI approval audit log so saves preserve/extend it.
           pciHistory: task.pciHistory,
+          // TASK-6: carry the current approved structured spec.
+          pciSpec: task.pciSpec,
           sourceDocument: task.sourceDocument,
           extensions: (task.extensions || []).map(ext => ({
             ...ext,
@@ -1757,6 +1765,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   instructions: taskBuilder.taskPci,
                   // TASK-18: persist the PCI approval audit log with the task.
                   pciHistory: taskBuilder.pciHistory,
+                  // TASK-6: persist the current approved structured spec.
+                  pciSpec: taskBuilder.pciSpec,
                   extensions: taskBuilder.extensions,
                   dmiItems: taskDmiItems,
                   dmiVersions: taskDmiVersions,
@@ -5894,6 +5904,22 @@ FEEDBACK: [one or two short sentences explaining the score]`
             None yet — chat below and click &ldquo;Apply to PCI&rdquo;, or Edit to type one. This is
             what guides AI grading.
           </p>
+        )}
+        {/* TASK-6: the structured specification mirror, when one was finalized. */}
+        {source === 'task' && taskBuilder.pciSpec && !editingCurrentPci && (
+          <div className="mt-2 border-t border-slate-200 pt-2">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+              Structured specification
+            </p>
+            <dl className="space-y-1">
+              {PCI_SPEC_FIELDS.filter(f => taskBuilder.pciSpec?.[f.key]).map(f => (
+                <div key={f.key} className="grid grid-cols-[minmax(0,9rem)_1fr] gap-2">
+                  <dt className="text-slate-500">{f.label}</dt>
+                  <dd className="text-slate-700">{taskBuilder.pciSpec?.[f.key]}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
         )}
       </div>
     )

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -145,6 +145,8 @@ export interface Task extends WithDifficultyVariants {
   /** Append-only audit log of PCI approvals (TASK-18). Each "Apply to PCI"
    *  records the transcript + approved text for auditability/versioning. */
   pciHistory?: import('@/lib/assessment/pci').PciAuditRecord[]
+  /** Current approved structured PCI spec (TASK-6), when finalized. */
+  pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
   extensions?: Array<{
     id: string
     name: string

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.test.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.test.ts
@@ -122,4 +122,20 @@ describe('pciReducer', () => {
     expect(s0.task.input).toBe('') // original untouched
     expect(s1).not.toBe(s0)
   })
+
+  it('sendSuccess holds a structured spec; clearDraft clears draft and spec (TASK-6)', () => {
+    let s = pciReducer(initialPciState(), { type: 'sendStart', target: task, userMessage: 'q' })
+    s = pciReducer(s, {
+      type: 'sendSuccess',
+      target: task,
+      assistant: { role: 'assistant', content: 'a' },
+      draft: 'RUBRIC',
+      spec: { evaluationLogic: 'Exact match' },
+      warnings: [],
+    })
+    expect(getThread(s, task).draftSpec).toEqual({ evaluationLogic: 'Exact match' })
+    s = pciReducer(s, { type: 'clearDraft', target: task })
+    expect(getThread(s, task).draft).toBe('')
+    expect(getThread(s, task).draftSpec).toBeUndefined()
+  })
 })

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
@@ -23,6 +23,8 @@ export interface PciThread {
   errorHint: string
   /** Finalized rubric awaiting "Apply to PCI" (empty until the model finalizes). */
   draft: string
+  /** Structured form of the finalized rubric (TASK-6), when the model emitted one. */
+  draftSpec?: import('@/lib/assessment/pci-spec').PciSpec
   guardrailWarnings: PciGuardrailWarning[]
 }
 
@@ -63,6 +65,7 @@ export type PciAction =
       target: PciTarget
       assistant: PciMessage
       draft?: string
+      spec?: import('@/lib/assessment/pci-spec').PciSpec
       warnings: PciGuardrailWarning[]
     }
   | { type: 'sendError'; target: PciTarget; hint: string; assistant: PciMessage }
@@ -108,11 +111,12 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
       })
 
     case 'sendSuccess':
-      // Append the assistant reply, hold any finalized draft, clear the error,
-      // record guardrail warnings, and stop loading.
+      // Append the assistant reply, hold any finalized draft + structured spec,
+      // clear the error, record guardrail warnings, and stop loading.
       return patch(state, action.target, {
         messages: [...getThread(state, action.target).messages, action.assistant],
         ...(action.draft ? { draft: action.draft } : {}),
+        ...(action.spec ? { draftSpec: action.spec } : {}),
         errorHint: '',
         guardrailWarnings: action.warnings,
         loading: false,
@@ -129,7 +133,7 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
       return patch(state, action.target, { loading: false })
 
     case 'clearDraft':
-      return patch(state, action.target, { draft: '' })
+      return patch(state, action.target, { draft: '', draftSpec: undefined })
 
     case 'reset':
       return initialPciState()

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
@@ -124,4 +124,28 @@ describe('usePci', () => {
     act(() => result.current.resetPci())
     expect(getThread(result.current.pci, taskTarget).input).toBe('')
   })
+
+  it('applyTaskPciDraft carries the structured spec into the audit record (TASK-6)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        response: 'ok',
+        pciDraft: 'FINAL',
+        pciSpec: { evaluationLogic: 'Exact match' },
+        guardrailWarnings: [],
+      }),
+    }) as unknown as typeof fetch
+    const setCurrentPci = vi.fn()
+    const { result } = renderHook(() => usePci(deps({ setCurrentPci })))
+    act(() => result.current.setPciInput(taskTarget, 'q'))
+    await act(async () => {
+      await result.current.handlePciSend('task')
+    })
+    act(() => result.current.applyTaskPciDraft())
+    expect(setCurrentPci).toHaveBeenCalledWith(
+      'task',
+      'FINAL',
+      expect.objectContaining({ spec: { evaluationLogic: 'Exact match' } })
+    )
+  })
 })

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -70,9 +70,11 @@ export function usePci(deps: UsePciDeps) {
     const draft = thread.draft
     if (!draft) return
     // TASK-18 (Data Capture): record the approval — the transcript (tutor's
-    // words + the LLM's interpretation/summary) and the approved PCI together.
+    // words + the LLM's interpretation/summary), the approved PCI, and its
+    // structured form (TASK-6) together.
     const audit: PciAuditRecord = {
       approvedPci: draft,
+      spec: thread.draftSpec,
       transcript: thread.messages,
       approvedAt: Date.now(),
     }
@@ -210,6 +212,8 @@ export function usePci(deps: UsePciDeps) {
         target,
         assistant: { role: 'assistant', content: data.response || 'Unable to respond.' },
         draft: draft || undefined,
+        // TASK-6: the structured spec mirror (present only on finalization).
+        spec: data.pciSpec || undefined,
         warnings,
       })
     } catch (error) {

--- a/tutorme-app/src/lib/assessment/pci.ts
+++ b/tutorme-app/src/lib/assessment/pci.ts
@@ -20,6 +20,9 @@ export interface PciMessage {
 export interface PciAuditRecord {
   /** The approved PCI text applied this time. */
   approvedPci: string
+  /** The structured form of the approved PCI (TASK-6), when the model produced
+   *  one. Undefined when only free text was finalized. */
+  spec?: import('./pci-spec').PciSpec
   /** The chat transcript at approval: tutor turns (user) + LLM interpretation/
    *  summary (assistant). */
   transcript: PciMessage[]


### PR DESCRIPTION
**Task PCI — TASK-6 (Specification), PR B of 2.** Builds on the merged PR A (#522). Completes TASK-6 — the last deferred guardrail.

## What
Captures, persists, and displays the structured `pciSpec` the engine now emits:
- **Capture:** `PciAuditRecord` gains `spec`; the reducer thread carries `draftSpec` (set on send, cleared with the draft); `usePci` reads `data.pciSpec` on send and folds it into the audit record on **Apply to PCI**.
- **Persist:** the current approved spec is stored on the task as `pciSpec` (**additive JSONB — no migration**) and loaded back so saves preserve it.
- **Display:** the PCI tab renders the structured spec beneath the free-text policy, showing **only the tutor-defined fields** (undefined fields simply don't appear — no fabricated "unspecified" rows).

## Scope
- **Grading unchanged:** `ai-grade` still uses the free-text `pci` (the spec mirrors it); the structured form is the auditable/displayable representation. Threading the spec into `ai-grade` (which reads the separate `builderTask` store) would be a further step and isn't needed for correctness.

## Checks
- New tests: reducer holds/clears `draftSpec`; `usePci` folds the spec into the audit record. `tsc`/build/eslint clean; 16 tests green in the touched suites.

## ⚠️ Smoke-test
Finalize a task PCI via chat (with a couple of defined behaviours) → **Apply to PCI** → the "Current marking policy" box now shows a **Structured specification** list of the defined fields. Save + reload → it persists. A PCI with no structured spec (older/free-text) shows just the free-text policy as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)