### PR TITLE
feat(grading): grader consumes responseType + sourceDependencies (ASMT-4)

### DIFF
--- a/tutorme-app/src/app/api/tutor/submissions/[submissionId]/ai-grade/route.ts
+++ b/tutorme-app/src/app/api/tutor/submissions/[submissionId]/ai-grade/route.ts
@@ -121,12 +121,38 @@ export async function POST(
     // The tutor's PCI instructions (truncated) steer how this task is marked.
     const pci = basis.pci.slice(0, 2000)
 
+    // Question metadata (ASMT-4): the expected answer format and any source
+    // materials this part depends on. These sharpen how the grader reads the
+    // answer without adding a marking basis the tutor didn't provide.
+    const responseType =
+      typeof item.responseType === 'string' && item.responseType.trim()
+        ? item.responseType.trim().slice(0, 200)
+        : ''
+    const sourceDeps = Array.isArray(item.sourceDependencies)
+      ? (item.sourceDependencies as unknown[])
+          .map(s => String(s).trim())
+          .filter(Boolean)
+          .slice(0, 20)
+      : []
+
     // Only include the parts that exist; no fabricated "(none)" fallbacks that
     // invite the model to invent a basis.
     const pciBlock = pci ? `Tutor's marking instructions (PCI):\n${pci}\n\n` : ''
     const rubricBlock = rubric ? `Marking rubric:\n${rubric}\n\n` : ''
     const modelBlock = modelAnswer ? `Model answer:\n${modelAnswer}\n\n` : ''
-    const prompt = `${pciBlock}Question:\n${questionText || '(not provided)'}\n\n${rubricBlock}${modelBlock}Student answer:\n${studentAnswer}`
+    // Tell the grader the expected answer format so it evaluates the right kind
+    // of response (e.g. a numeric value vs a proof vs a sketch description).
+    const responseTypeBlock = responseType
+      ? `Expected answer format: ${responseType}. Grade the answer as this kind of response.\n\n`
+      : ''
+    // Safe-failure caveat (TASK-10/19): the grader was NOT given the referenced
+    // source material, so it must not penalise the student for details of that
+    // material it cannot see.
+    const sourceDepsBlock =
+      sourceDeps.length > 0
+        ? `This question depends on source material you were NOT given: ${sourceDeps.join(', ')}. Judge the answer on the reasoning and method you can assess; do not penalise the student for details of those materials you cannot see.\n\n`
+        : ''
+    const prompt = `${pciBlock}Question:\n${questionText || '(not provided)'}\n\n${responseTypeBlock}${rubricBlock}${modelBlock}${sourceDepsBlock}Student answer:\n${studentAnswer}`
 
     let aiResponse: string
     try {


### PR DESCRIPTION
Makes the `responseType` / `sourceDependencies` fields populated in #532 **functional** — until now they were written + persisted but nothing read them.

## What
The AI-grade prompt (`api/tutor/submissions/[submissionId]/ai-grade`) now includes, per question, when present:
- **`responseType`** → `Expected answer format: <…>. Grade the answer as this kind of response.` — steers the grader to evaluate the right kind of response (a numeric value vs a proof vs a sketch description).
- **`sourceDependencies`** → a **safe-failure caveat** (TASK-10/19): the grader was *not* given the referenced figure/passage/table, so it is explicitly told to judge on the reasoning/method it can assess and **not penalise** the student for details of source material it cannot see. This directly prevents an over-harsh score when a question leans on an unseen figure.

Both blocks are additive and truthiness-guarded (omitted when the field is absent), input-clamped (`responseType` ≤200 chars, ≤20 deps), and add **no** marking basis the tutor didn't provide — the free-text PCI, rubric and model answer stay the authoritative basis with unchanged precedence.

## On the structured PciSpec
I evaluated folding the structured `PciSpec` (from the TASK-6 refactor) into the grader and deliberately left it out: its marking-relevant substance (evaluation logic, correct/incorrect-response behaviour) is *already* carried into the grader via the free-text `pci` block, while its remaining fields (trigger event, retry policy, tone, no-response behaviour) describe **live-tutoring** behaviour, not grading. Wiring the raw spec in would mean fragile `builderData` tree-navigation for redundant signal. If you want the spec consumed where it *is* relevant, the live tutor agent is the right surface — happy to do that as a separate PR.

## Verification
`tsc` / build / eslint clean. Prompt blocks mirror the existing inline `pciBlock`/`rubricBlock`/`modelBlock` pattern.

## ⚠️ Smoke-test
On a task whose DMI has a part with a `responseType` and a `sourceDependencies` (e.g. "refer to Figure 2"), click **AI Assist** on that answer → the grading suggestion should reflect the expected format and should not dock marks for the unseen figure. Parts without these fields grade exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)