### PR TITLE
fix(course-builder): PCI tab scroll + single lesson picker

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9034,15 +9034,15 @@ FEEDBACK: [one or two short sentences explaining the score]`
                           </div>
 
                           {/* Content area */}
-                          <div className="relative flex-1 rounded-none border-0 bg-transparent p-0 shadow-none">
+                          <div className="relative min-h-0 flex-1 rounded-none border-0 bg-transparent p-0 shadow-none">
                             {/* Task Builder Tab */}
                             <TabsContent
                               value="task"
                               className="flex h-full flex-col space-y-px overflow-hidden data-[state=inactive]:hidden"
                             >
-                              <div className="flex flex-1 gap-px overflow-hidden">
+                              <div className="flex min-h-0 flex-1 gap-px overflow-hidden">
                                 {/* Main content with tabs */}
-                                <div className="flex flex-1 flex-col overflow-hidden">
+                                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                                   <Tabs
                                     value={taskBuilderActiveTab}
                                     onValueChange={v => {
@@ -9539,9 +9539,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
                               value="assessment"
                               className="flex h-full flex-col space-y-px overflow-hidden data-[state=inactive]:hidden"
                             >
-                              <div className="flex flex-1 gap-px overflow-hidden">
+                              <div className="flex min-h-0 flex-1 gap-px overflow-hidden">
                                 {/* Main content with tabs */}
-                                <div className="flex flex-1 flex-col overflow-hidden">
+                                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                                   <Tabs
                                     value={assessmentBuilderActiveTab}
                                     onValueChange={v => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/LessonSelectorDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/LessonSelectorDialog.tsx
@@ -123,9 +123,12 @@ export function LessonSelectorDialog({
               </Select>
             </div>
 
-            {!isNewLesson && lessons.length > 0 && (
+            {/* Each lesson node normally holds a single inner lesson, so the node
+                select above is the only picker needed. Only surface this second
+                select to disambiguate the rare node that has multiple lessons. */}
+            {!isNewLesson && lessons.length > 1 && (
               <div className="space-y-2">
-                <Label>Lesson</Label>
+                <Label>Sub-lesson</Label>
                 <Select value={selectedLessonId} onValueChange={setSelectedLessonId}>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a lesson" />


### PR DESCRIPTION
Two follow-ups from the last round.

## 1. PCI tab can't scroll long content (real fix)
My previous PR (#481) moved the guidance into the scroll container, but it **still didn't scroll** — because the scroll div never got a bounded height. Tracing the chain from the bounded `CardContent` down:

```
CardContent (h-full flex-col) ✓
  Tabs[mainBuilder] (h-full flex-col)
    Content area (relative flex-1)              ← missing min-h-0 ✗
      TabsContent[task/assessment] (h-full flex-col)
        row (flex flex-1)                       ← missing min-h-0 ✗
          col (flex flex-1 flex-col)            ← missing min-h-0 ✗
            Tabs[content/pci] (h-full)
              TabsContent[pci] (min-h-0 flex-1) ✓
                scroll div (min-h-0 flex-1 overflow-y-auto) ← never bounded
```

The `flex-1` links (**Content area** + both builders' **row**/**col**) lacked `min-h-0`, so with tall content they grew past their allotment and the `h-full` descendants resolved against the grown height — the `overflow-y-auto` container had nothing to scroll within. Added `min-h-0` to those links so the bounded height propagates all the way down. Now the PCI guidance + policy + chat scroll properly, in both the task and assessment builders.

## 2. Lesson picker showed two selects
When loading a document via its kebab, the "select target lesson" dialog had **two** selects (node + inner lesson). A lesson node normally holds exactly one inner lesson, so the second was redundant. Now it shows a **single** select; the inner-lesson select only appears (relabeled "Sub-lesson") for the rare node with more than one lesson.

## Testing
- `npm run typecheck` passes; prettier + eslint clean (0 errors).
- The scroll fix is verified by reading the full flex height chain to the bounded `Card`/`CardContent` root; couldn't exercise in a running app here.

## Note
`min-h-0` is the standard, low-risk flexbox fix (it enables proper bounding, which these `overflow-hidden` containers already intend) and is shared by the Slide/content and assessment tabs — those already have internal scroll, so bounding only makes them behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)