### PR TITLE
feat(pci): persist task PCI + structured spec at deploy (TASK-6) [PR1/2]

### DIFF
--- a/tutorme-app/drizzle/0064_buildertask_pcispec.sql
+++ b/tutorme-app/drizzle/0064_buildertask_pcispec.sql
@@ -1,0 +1,7 @@
+-- BuilderTask.pciSpec: the structured PCI spec (TASK-6) finalized in the builder,
+-- persisted at deploy so the live tutor can apply it during student interaction.
+-- Nullable JSONB — only present once a tutor finalizes a structured spec.
+-- Tutor-only evaluation layer; never broadcast to students. Idempotent: a no-op
+-- where the column already exists (also applied via startup-schema-fix.ts so a
+-- revision that skips migrations still has the column before it serves traffic).
+ALTER TABLE "BuilderTask" ADD COLUMN IF NOT EXISTS "pciSpec" jsonb;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1781800000000,
       "tag": "0063_user_status",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1781900000000,
+      "tag": "0064_buildertask_pcispec",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1092,11 +1092,32 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // then runs the real deploy with the chosen mode applied to the payload.
     const deployTaskWithDialog = useCallback(
       (payload: LiveTask) => {
+        // Attach the tutor's PCI (free-text `instructions` + finalized structured
+        // spec) so the server can persist it for the live tutor + grader. Looked
+        // up from the source task when the caller didn't supply it. Deploy-only —
+        // the server never broadcasts it to students.
+        let src: Task | undefined
+        for (const mod of nodes) {
+          for (const lesson of mod.lessons) {
+            const found = lesson.tasks?.find(t => t.id === payload.id)
+            if (found) {
+              src = found
+              break
+            }
+          }
+          if (src) break
+        }
+        const enriched: LiveTask = {
+          ...payload,
+          pci:
+            payload.pci ?? (typeof src?.instructions === 'string' ? src.instructions : undefined),
+          pciSpec: payload.pciSpec ?? src?.pciSpec,
+        }
         setDeployDialog({
-          run: reveal => insightsProps?.onDeployTask?.({ ...payload, answerReveal: reveal }),
+          run: reveal => insightsProps?.onDeployTask?.({ ...enriched, answerReveal: reveal }),
         })
       },
-      [insightsProps]
+      [insightsProps, nodes]
     )
 
     // Active tab tracking for Enter button
@@ -2967,6 +2988,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
             marks: item.marks,
           })),
           answerReveal: reveal,
+          // Tutor's PCI (free-text) for server-side use by the live tutor +
+          // grader. Deploy-only; never broadcast to students. (Assessments have
+          // no structured pciSpec — that's a task-builder concept.)
+          pci: assessmentBuilder.taskPci || undefined,
           deployedAt: Date.now(),
           polls: [],
           questions: [],
@@ -8879,6 +8904,15 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                             marks: item.marks,
                                                           })) || [],
                                                         answerReveal: reveal,
+                                                        // Tutor's PCI + structured
+                                                        // spec for the live tutor +
+                                                        // grader (deploy-only; never
+                                                        // sent to students).
+                                                        pci:
+                                                          typeof task.instructions === 'string'
+                                                            ? task.instructions
+                                                            : undefined,
+                                                        pciSpec: task.pciSpec,
                                                         deployedAt: Date.now(),
                                                         polls: [],
                                                         questions: [],

--- a/tutorme-app/src/lib/db/schema/tables/builder.ts
+++ b/tutorme-app/src/lib/db/schema/tables/builder.ts
@@ -34,6 +34,11 @@ export const builderTask = pgTable(
     title: text('title').notNull(),
     content: text('content').notNull(), // Content tab content
     pci: text('pci').notNull(), // PCI tab content (instructions)
+    // Structured PCI spec (TASK-6): the normalized PciSpec object finalized in
+    // the builder, persisted at deploy so the live tutor can apply it. Nullable
+    // — only present once the tutor finalizes a structured spec. Tutor-only
+    // evaluation layer; never broadcast to students.
+    pciSpec: jsonb('pciSpec'),
     details: text('details'), // Additional details
     type: enums.builderTaskTypeEnum('type').notNull().default('task'),
     status: enums.builderTaskStatusEnum('status').notNull().default('draft'),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -136,6 +136,11 @@ BEGIN
   END IF;
 END $$;
 
+-- BuilderTask.pciSpec (structured PCI spec, TASK-6) — persisted at deploy so the
+-- live tutor can apply it. Mirrors drizzle/0064; also applied here so a revision
+-- that skips migrations still has the column before it serves traffic.
+ALTER TABLE "BuilderTask" ADD COLUMN IF NOT EXISTS "pciSpec" jsonb;
+
 -- TaskDeploymentStatus enum
 DO $$
 BEGIN

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -25,6 +25,7 @@ import {
   course,
 } from '@/lib/db/schema'
 import { autoGradeDmi } from '@/lib/grading/auto-grade'
+import { normalizePciSpec } from '@/lib/assessment/pci-spec'
 import { initFeedbackHandlers, initPollHandlers } from './socket-server'
 import { activePolls, sessionPolls, cleanupStaleSocketState } from '@/lib/socket'
 import type { PollState } from '@/lib/socket'
@@ -155,6 +156,13 @@ export interface LiveTask {
     acceptableVariants?: string[]
     marks?: number
   }>
+  /** Tutor's task PCI (free-text marking/instruction content) + finalized
+   *  structured spec (TASK-6). Sent tutor→server on deploy ONLY and persisted
+   *  server-side so the live tutor and grader can apply them; NEVER copied into
+   *  the student broadcast (normalizedTask) — this is the hidden evaluation
+   *  layer, same handling as answerKey. */
+  pci?: string
+  pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
   /** Tutor's answer-reveal policy: 'instant' | 'after_submit' | 'hidden' | 'student_choice'. */
   answerReveal?: 'instant' | 'after_submit' | 'hidden' | 'student_choice'
   deployedAt: number
@@ -1273,6 +1281,12 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 })
                 lesson = { lessonId: newLessonId }
               }
+              // Tutor's marking basis, carried on the deploy payload (never in
+              // the student broadcast). Refreshed on each deploy so the live
+              // tutor + grader see the latest PCI; only these columns are
+              // updated on conflict, so a saved task's title/content is kept.
+              const taskPci = typeof task.pci === 'string' ? task.pci.slice(0, 20000) : ''
+              const taskPciSpec = normalizePciSpec(task.pciSpec)
               await drizzleDb
                 .insert(builderTask)
                 .values({
@@ -1282,14 +1296,18 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   tutorId,
                   title: normalizedTask.title || 'Untitled',
                   content: normalizedTask.content || '',
-                  pci: '',
+                  pci: taskPci,
+                  pciSpec: taskPciSpec,
                   type: normalizedTask.source,
                   status: 'published',
                   publishedAt: now,
                   createdAt: now,
                   updatedAt: now,
                 })
-                .onConflictDoNothing({ target: builderTask.taskId })
+                .onConflictDoUpdate({
+                  target: builderTask.taskId,
+                  set: { pci: taskPci, pciSpec: taskPciSpec, updatedAt: now },
+                })
 
               // Persist the answer key + marks server-side so live submissions
               // auto-grade against it. Carried on the deploy payload's
@@ -1618,6 +1636,10 @@ export async function initEnhancedSocketServer(server: NetServer) {
             }
 
             // 2) builderTask — FK target for taskSubmission; read by the Grading page.
+            //    Carry the tutor's PCI + structured spec (deploy-only; never
+            //    broadcast). Refreshed on conflict without clobbering title/content.
+            const completedPci = typeof task.pci === 'string' ? task.pci.slice(0, 20000) : ''
+            const completedPciSpec = normalizePciSpec(task.pciSpec)
             await drizzleDb
               .insert(builderTask)
               .values({
@@ -1627,14 +1649,18 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 tutorId,
                 title: task.title || 'Untitled',
                 content: task.content || '',
-                pci: '',
+                pci: completedPci,
+                pciSpec: completedPciSpec,
                 type: task.source,
                 status: 'published',
                 publishedAt: now,
                 createdAt: now,
                 updatedAt: now,
               })
-              .onConflictDoNothing({ target: builderTask.taskId })
+              .onConflictDoUpdate({
+                target: builderTask.taskId,
+                set: { pci: completedPci, pciSpec: completedPciSpec, updatedAt: now },
+              })
 
             // 3) deployedMaterial — without it, the in-session SubmissionsPanel
             //    (/submissions-tree) and live panel filter the submission out.

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -115,6 +115,11 @@ export interface LiveTask {
   }>
   /** Tutor's answer-reveal policy for this deploy (default 'instant'). */
   answerReveal?: AnswerReveal
+  /** Tutor's task PCI (free-text) + finalized structured spec (TASK-6). Sent
+   *  tutor→server on deploy ONLY so the live tutor + grader can apply them;
+   *  NEVER broadcast to students — hidden evaluation layer, like answerKey. */
+  pci?: string
+  pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]


### PR DESCRIPTION
**PR1 of 2** for the live tutor consuming the tutor's structured PCI spec (you chose the full task-aware flow). This PR is the persistence foundation; PR2 adds the live-tutor consumption.

## The gap this uncovered
`builderTask.pci` was written as `''` at **both** deploy handlers in `socket-server-enhanced.ts` — the real PCI lived only in `courseLesson.builderData` JSONB and was never synced to the normalized row. So the AI grader's "PCI takes precedence" block was **always empty in practice** (it fell back to the DMI rubric/model answer). And there was nowhere to persist the finalized structured `pciSpec` at all.

## What this does
- **Schema:** adds a nullable `pciSpec` JSONB column to `BuilderTask` (`drizzle/0064` + `startup-schema-fix.ts`, so a revision that skips migrations still gets the column before serving traffic — matches the repo's prod drift pattern).
- **Deploy payload:** extends `LiveTask` (server + client socket types) with deploy-only `pci` + `pciSpec`, documented with the **same "tutor→server ONLY, NEVER broadcast to students" handling as `answerKey`** (hidden evaluation layer — ASMT-10/13).
- **Persistence:** both deploy handlers now write the real free-text `pci` **and** the normalized `pciSpec`, refreshed on re-deploy via `onConflictDoUpdate` (only those columns — `title`/`content` preserved).
- **Builder:** attaches the source task's PCI (free-text `instructions` + `pciSpec`) to the deploy payload — centrally in `deployTaskWithDialog` (inline `nodes` lookup) and at the two direct `onDeployTask` sites (task deploy + assessment deploy; assessments carry free-text `pci` only, as they have no structured spec).

## Side-effect fix
Populating the real `builderTask.pci` means the AI grader's PCI-precedence block is now actually filled for deployed tasks — closing the always-empty gap that predates this work.

## Guardrail safety
`pci`/`pciSpec` are read from the raw deploy payload server-side and persisted; they are **never** added to `normalizedTask` (the student broadcast) — verified they follow the exact `answerKey` isolation pattern.

## Verification
`tsc` 0 errors, build clean, eslint 0 errors, 25 relevant unit tests pass (pci-spec / marking-basis / auto-grade / active-assessment).

## ⚠️ Smoke-test
Deploy a saved task (with a finalized PCI/spec) into a live session → `BuilderTask` row for that task should now have a non-empty `pci` and a populated `pciSpec` JSONB; the student broadcast must NOT contain either. Re-deploying refreshes both without changing title/content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)