### PR TITLE
feat(tutor): live tutor applies the task's PCI spec (TASK-6) [PR2/2]

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/TaskAiHelper.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/TaskAiHelper.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { Sparkles, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Minimal "Ask the AI tutor about this task" helper shown under a deployed
+ * task's questions. Passes the task id to `/api/ai/tutor` so the tutor applies
+ * that task's PCI (TASK-6). Academic integrity is enforced server-side: while an
+ * assessment is in progress the tutor gives procedural-only help (ASMT-15).
+ */
+export function TaskAiHelper({ taskId, subject }: { taskId: string | null; subject: string }) {
+  const [question, setQuestion] = useState('')
+  const [answer, setAnswer] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  if (!taskId) return null
+
+  const ask = async () => {
+    const message = question.trim()
+    if (!message || loading) return
+    setLoading(true)
+    setError('')
+    setAnswer('')
+    try {
+      const res = await fetch('/api/ai/tutor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          message,
+          subject: subject || 'General',
+          mode: 'socratic',
+          taskId,
+        }),
+      })
+      const data = (await res.json().catch(() => ({}))) as {
+        response?: string
+        error?: string
+      }
+      if (!res.ok || !data.response) {
+        setError(data.error || 'The AI tutor is unavailable right now.')
+        return
+      }
+      setAnswer(data.response)
+    } catch {
+      setError('Could not reach the AI tutor. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-indigo-100 bg-indigo-50/40 p-3">
+      <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-indigo-700">
+        <Sparkles className="h-3.5 w-3.5" />
+        Ask the AI tutor about this task
+      </div>
+      <textarea
+        value={question}
+        onChange={e => setQuestion(e.target.value)}
+        onKeyDown={e => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') ask()
+        }}
+        rows={2}
+        placeholder="Stuck? Ask for a hint on how to approach this…"
+        className="w-full resize-none rounded-md border border-gray-200 bg-white p-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-indigo-400 focus:outline-none"
+        disabled={loading}
+      />
+      <div className="mt-2 flex justify-end">
+        <Button size="sm" onClick={ask} disabled={loading || !question.trim()}>
+          {loading ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+          {loading ? 'Thinking…' : 'Ask'}
+        </Button>
+      </div>
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+      {answer && (
+        <div className="mt-2 whitespace-pre-wrap rounded-md border border-indigo-100 bg-white p-2 text-sm text-gray-800">
+          {answer}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -74,6 +74,7 @@ import type {
   ChatMessage,
 } from '@/lib/socket'
 import { normalizeDmiQuestionType, DMI_QUESTION_TYPE_LABELS } from '@/lib/assessment/question-types'
+import { TaskAiHelper } from './TaskAiHelper'
 
 type WhiteboardPages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
 type WhiteboardPage = WhiteboardPages[number]
@@ -2385,6 +2386,14 @@ function StudentFeedbackContent() {
                     <p className="text-sm text-gray-500">
                       {activeTask ? 'This task has no questions to answer.' : ''}
                     </p>
+                  )}
+                  {/* Ask the AI tutor about this task — applies the task's PCI
+                      (TASK-6). Integrity is enforced server-side (ASMT-15). */}
+                  {activeTask && (
+                    <TaskAiHelper
+                      taskId={activeTaskId}
+                      subject={sessionContext?.courseCategory || 'General'}
+                    />
                   )}
                 </div>
               ) : rightPanelTab === 'my-board' ? (

--- a/tutorme-app/src/app/api/ai/tutor/route.ts
+++ b/tutorme-app/src/app/api/ai/tutor/route.ts
@@ -10,6 +10,10 @@ import { z } from 'zod'
 import { runTutorChat } from '@/lib/agents/tutor-chat-service'
 import { hasActiveAssessment } from '@/lib/assessment/active-assessment'
 import { getServerSession, authOptions } from '@/lib/auth'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { normalizePciSpec } from '@/lib/assessment/pci-spec'
 
 type TutorMode = 'socratic' | 'direct' | 'lesson' | 'practice'
 
@@ -22,6 +26,8 @@ const TutorRequestSchema = z.object({
   voiceGender: z.enum(['female', 'male']).default('female'),
   voiceAccent: z.string().max(32).default('US'),
   conversationId: z.string().max(128).optional(),
+  /** The task the student is working on, so the tutor applies its PCI (TASK-6). */
+  taskId: z.string().max(100).optional(),
 })
 
 export async function POST(request: NextRequest) {
@@ -48,12 +54,35 @@ export async function POST(request: NextRequest) {
       voiceGender,
       voiceAccent,
       conversationId,
+      taskId,
     } = parsed.data
 
     const teachingMode: TutorMode = mode === 'hint' ? 'socratic' : mode
 
     // ASMT-15: refuse to solve assessment questions while one is in progress.
     const assessmentActive = await hasActiveAssessment(session.user.id)
+
+    // TASK-6: when the student names the task they're on, load that task's PCI
+    // (free-text + structured spec, persisted at deploy) so the tutor applies
+    // the tutor-authored instructional approach. Best-effort — a miss just
+    // falls back to generic tutoring, never an error.
+    let taskPci: string | null = null
+    let taskPciSpec = null as ReturnType<typeof normalizePciSpec>
+    if (taskId) {
+      try {
+        const [t] = await drizzleDb
+          .select({ pci: builderTask.pci, pciSpec: builderTask.pciSpec })
+          .from(builderTask)
+          .where(eq(builderTask.taskId, taskId))
+          .limit(1)
+        if (t) {
+          taskPci = typeof t.pci === 'string' && t.pci.trim() ? t.pci : null
+          taskPciSpec = normalizePciSpec(t.pciSpec)
+        }
+      } catch (taskErr) {
+        console.warn('[ai-tutor] task PCI load failed (non-critical):', taskErr)
+      }
+    }
 
     const response = await runTutorChat({
       userId: session.user.id,
@@ -66,6 +95,8 @@ export async function POST(request: NextRequest) {
       voiceAccent,
       chatHistory: [],
       assessmentActive,
+      taskPci,
+      taskPciSpec,
     })
 
     return NextResponse.json({

--- a/tutorme-app/src/lib/agents/tutor-chat-service.ts
+++ b/tutorme-app/src/lib/agents/tutor-chat-service.ts
@@ -6,6 +6,8 @@ import { findRelevantConcepts } from '@/lib/ai/subjects'
 import { extractWhiteboardItems } from '@/lib/ai/whiteboard-extract'
 import { classifyHintType, extractNextSteps } from '@/lib/agents/tutor'
 import { withAssessmentIntegrity } from '@/lib/assessment/active-assessment'
+import { withTaskPci } from '@/lib/assessment/task-pci-context'
+import type { PciSpec } from '@/lib/assessment/pci-spec'
 
 export interface TutorChatInput {
   userId: string
@@ -23,6 +25,14 @@ export interface TutorChatInput {
    * `hasActiveAssessment`.
    */
   assessmentActive?: boolean
+  /**
+   * The current task's PCI (TASK-6), when the student is working on a specific
+   * deployed task. Free-text notes and/or the finalized structured spec; the
+   * tutor applies them as instructional guidance for THIS task. Loaded by the
+   * caller from `builderTask` (persisted at deploy). No-op when absent.
+   */
+  taskPci?: string | null
+  taskPciSpec?: PciSpec | null
 }
 
 export interface TutorChatOutput {
@@ -81,12 +91,18 @@ export async function runTutorChat(input: TutorChatInput): Promise<TutorChatOutp
     userMessage: safeMessage,
   }
 
+  // TASK-6: when the student is on a specific task, apply that task's PCI as
+  // instructional guidance. Applied to the base prompt first, then the
+  // integrity directive is layered on top so it stays first/highest.
+  const taskAwarePrompt = withTaskPci(
+    buildCompletePrompt(promptConfig),
+    input.taskPci,
+    input.taskPciSpec
+  )
+
   // ASMT-15: while the student has a live assessment, constrain the tutor to
   // procedural-only help so it can't be used to solve in-progress questions.
-  const systemPrompt = withAssessmentIntegrity(
-    buildCompletePrompt(promptConfig),
-    input.assessmentActive === true
-  )
+  const systemPrompt = withAssessmentIntegrity(taskAwarePrompt, input.assessmentActive === true)
 
   const aiResponse = await generateWithFallback(systemPrompt, {
     temperature: 0.7,

--- a/tutorme-app/src/lib/assessment/pci-spec.test.ts
+++ b/tutorme-app/src/lib/assessment/pci-spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizePciSpec } from './pci-spec'
+import { normalizePciSpec, pciSpecToText } from './pci-spec'
 
 describe('normalizePciSpec (TASK-6)', () => {
   it('keeps only recognized, tutor-defined fields', () => {
@@ -31,5 +31,29 @@ describe('normalizePciSpec (TASK-6)', () => {
     expect(normalizePciSpec(null)).toBeNull()
     expect(normalizePciSpec('nope')).toBeNull()
     expect(normalizePciSpec(['a'])).toBeNull()
+  })
+})
+
+describe('pciSpecToText (TASK-6)', () => {
+  it('renders defined fields as labelled lines in canonical order', () => {
+    const text = pciSpecToText({
+      // deliberately out of canonical order to prove ordering is enforced
+      instructionalTone: 'Encouraging',
+      evaluationLogic: 'Award method marks.',
+      incorrectResponseBehavior: 'Give a socratic hint.',
+    })
+    expect(text).toBe(
+      [
+        'Evaluation logic: Award method marks.',
+        'Incorrect-response behaviour: Give a socratic hint.',
+        'Instructional tone: Encouraging',
+      ].join('\n')
+    )
+  })
+
+  it('returns "" for null/empty specs', () => {
+    expect(pciSpecToText(null)).toBe('')
+    expect(pciSpecToText(undefined)).toBe('')
+    expect(pciSpecToText({})).toBe('')
   })
 })

--- a/tutorme-app/src/lib/assessment/pci-spec.ts
+++ b/tutorme-app/src/lib/assessment/pci-spec.ts
@@ -66,3 +66,18 @@ export function normalizePciSpec(raw: unknown): PciSpec | null {
   }
   return Object.keys(out).length > 0 ? out : null
 }
+
+/**
+ * Render a `PciSpec` as human-/model-readable `Label: value` lines in the
+ * canonical field order, including only fields the tutor actually defined.
+ * Returns '' for a null/empty spec so callers can cheaply skip injection.
+ */
+export function pciSpecToText(spec: PciSpec | null | undefined): string {
+  if (!spec) return ''
+  const lines: string[] = []
+  for (const { key, label } of PCI_SPEC_FIELDS) {
+    const v = spec[key]
+    if (typeof v === 'string' && v.trim()) lines.push(`${label}: ${v.trim()}`)
+  }
+  return lines.join('\n')
+}

--- a/tutorme-app/src/lib/assessment/task-pci-context.test.ts
+++ b/tutorme-app/src/lib/assessment/task-pci-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { buildTaskPciDirective, withTaskPci } from './task-pci-context'
+
+describe('buildTaskPciDirective (TASK-6)', () => {
+  it('returns "" when neither free-text nor spec is present', () => {
+    expect(buildTaskPciDirective(null, null)).toBe('')
+    expect(buildTaskPciDirective('   ', {})).toBe('')
+    expect(buildTaskPciDirective(undefined, undefined)).toBe('')
+  })
+
+  it('includes the structured spec and the free-text notes when present', () => {
+    const out = buildTaskPciDirective('Be gentle with beginners.', {
+      evaluationLogic: 'Award method marks.',
+    })
+    expect(out).toContain('TASK GUIDANCE')
+    expect(out).toContain('Structured guidance:')
+    expect(out).toContain('Evaluation logic: Award method marks.')
+    expect(out).toContain("Tutor's notes:")
+    expect(out).toContain('Be gentle with beginners.')
+    // Never overrides the integrity rule.
+    expect(out).toContain('never solve an in-progress assessment')
+  })
+
+  it('works with only free-text or only a spec', () => {
+    expect(buildTaskPciDirective('notes only', null)).toContain('notes only')
+    expect(buildTaskPciDirective('notes only', null)).not.toContain('Structured guidance:')
+    expect(buildTaskPciDirective(null, { instructionalTone: 'Warm' })).toContain(
+      'Instructional tone: Warm'
+    )
+  })
+
+  it('caps very long free-text notes', () => {
+    const long = 'x'.repeat(9000)
+    const out = buildTaskPciDirective(long, null)
+    // 4000-char cap on the notes body (plus the surrounding directive text).
+    expect(out.length).toBeLessThan(5000)
+  })
+})
+
+describe('withTaskPci (TASK-6)', () => {
+  it('prepends the directive above the base prompt when PCI is present', () => {
+    const base = 'BASE SYSTEM PROMPT'
+    const out = withTaskPci(base, 'help kindly', { evaluationLogic: 'Exact match.' })
+    expect(out.endsWith(base)).toBe(true)
+    expect(out.indexOf('TASK GUIDANCE')).toBeLessThan(out.indexOf(base))
+  })
+
+  it('is a no-op when there is no task PCI', () => {
+    const base = 'BASE SYSTEM PROMPT'
+    expect(withTaskPci(base, null, null)).toBe(base)
+    expect(withTaskPci(base, '', {})).toBe(base)
+  })
+})

--- a/tutorme-app/src/lib/assessment/task-pci-context.ts
+++ b/tutorme-app/src/lib/assessment/task-pci-context.ts
@@ -1,0 +1,49 @@
+/**
+ * Task PCI context injection (Task PCI guardrail TASK-6, application).
+ *
+ * When a student is working on a specific deployed task, the live AI tutor
+ * should apply the tutor-authored PCI for that task — the free-text notes plus
+ * the finalized structured spec. This module turns those into a system-prompt
+ * directive, mirroring `withAssessmentIntegrity` (ASMT-15).
+ *
+ * The directive shapes the tutor's INSTRUCTIONAL behaviour (how to respond to
+ * correct/incorrect/partial answers, tone, whether to reveal reasoning, retry
+ * policy). It deliberately does NOT override the academic-integrity rule: while
+ * an assessment is in progress the tutor still must not solve it.
+ */
+
+import { pciSpecToText, type PciSpec } from './pci-spec'
+
+/**
+ * Build the task-PCI directive block from the free-text `pci` and/or structured
+ * spec. Returns '' when neither is present so callers can skip injection.
+ */
+export function buildTaskPciDirective(pci?: string | null, spec?: PciSpec | null): string {
+  const specText = pciSpecToText(spec)
+  const freeText = typeof pci === 'string' ? pci.trim() : ''
+  if (!specText && !freeText) return ''
+
+  const parts: string[] = [
+    'TASK GUIDANCE — HOW TO HELP ON THE CURRENT TASK',
+    'The tutor who set this task defined how a student should be guided on it. Apply this instructional approach when helping with THIS task — it governs your teaching behaviour (how to respond to correct, incorrect, partial, or no answer; tone; whether to explain reasoning; retry policy). It does NOT override the academic-integrity rule above: never solve an in-progress assessment.',
+  ]
+  if (specText) parts.push(`Structured guidance:\n${specText}`)
+  if (freeText) parts.push(`Tutor's notes:\n${freeText.slice(0, 4000)}`)
+  return parts.join('\n\n')
+}
+
+/**
+ * Prepend the task-PCI directive to a system prompt when task PCI is present.
+ * A no-op when neither the free-text `pci` nor the structured spec is defined.
+ *
+ * Ordering note: apply this to the BASE prompt, then wrap the result with
+ * `withAssessmentIntegrity` so the integrity directive stays first/highest.
+ */
+export function withTaskPci(
+  systemPrompt: string,
+  pci?: string | null,
+  spec?: PciSpec | null
+): string {
+  const directive = buildTaskPciDirective(pci, spec)
+  return directive ? `${directive}\n\n${systemPrompt}` : systemPrompt
+}


### PR DESCRIPTION
**PR2 of 2** — completes the arc. The live AI tutor now **consumes** the structured PCI spec (and free-text PCI) that PR1 (#535) persists at deploy, so the whole `pciSpec` investment is finally functional end-to-end.

## Backend chain
- **`pciSpecToText(spec)`** (`pci-spec.ts`) — renders a `PciSpec` as labelled lines in canonical order; `''` for null/empty. +tests.
- **`task-pci-context.ts`** — `withTaskPci()` / `buildTaskPciDirective()`: a system-prompt directive telling the tutor to apply the task's instructional approach (how to handle correct / incorrect / partial / no answer; tone; explanation; retry policy). It **explicitly does not override academic integrity**. +tests.
- **`runTutorChat`** — accepts `taskPci`/`taskPciSpec`, injects the directive into the base prompt, **then** layers `withAssessmentIntegrity` on top so the ASMT-15 directive stays first/highest.
- **`/api/ai/tutor`** — accepts optional `taskId`, best-effort loads `builderTask.pci` + `pciSpec` (populated by PR1), passes them through. A miss falls back to generic tutoring, never an error.

## Student surface
There was **no** task-scoped AI-tutor surface before (the subject chat is subject-level; the live feedback page had task context but no AI affordance). This adds a minimal, self-contained **"Ask the AI tutor about this task"** helper (`TaskAiHelper.tsx`) under a deployed task's questions in the live feedback page, passing `activeTaskId` so the tutor is task-scoped.

## Guardrail ordering (important)
Prompt layering is `[ASMT-15 integrity] → [task PCI guidance] → [base prompt]`. During an active assessment the integrity directive (procedural-help-only) sits above and overrides the task guidance, so this can't be used to solve an in-progress assessment. The task directive text reinforces this. Integrity is enforced server-side regardless of the new UI.

## Verification
`tsc` 0, build clean, eslint 0 errors, **74 unit tests pass** (pci-spec + new task-pci-context + assessment suite).

## ⚠️ Smoke-test
Deploy a task that has a finalized PCI/spec into a live session → as the student, open that task's tab → the **"Ask the AI tutor about this task"** box appears → ask a question → the reply should reflect the tutor's PCI approach (tone / how it handles a wrong answer). During an **active assessment**, the tutor should give procedural-only help and refuse to solve. A task with no PCI still tutors generically.

## UX note / your call
I kept the affordance intentionally minimal (single-turn hint box, not a full threaded chat) to limit surface area in the 3.1k-line feedback page. If you'd prefer it as a dedicated tab, threaded, or streamed, that's an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)