### PR TITLE
fix(course-builder): size panels to the real container, not the window

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -764,7 +764,32 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [])
 
-    const centerColWidth = viewportWidth - leftPanelWidth - 24 - rightPanelWidth - 24 - 32
+    // The builder is rendered inside the inset dashboard area (a fixed sidebar +
+    // margins take ~272px), NOT the full window — so sizing the panels from
+    // window.innerWidth overshot the real container by ~270px and pushed the
+    // right panel off the edge (clipped by the ancestor overflow-hidden). Measure
+    // the actual layout row instead so the three fixed-width panels tile exactly,
+    // in every host (dashboard, live/insights) and nav state.
+    const layoutRowRef = useRef<HTMLDivElement | null>(null)
+    const [layoutRowWidth, setLayoutRowWidth] = useState(0)
+    useEffect(() => {
+      const el = layoutRowRef.current
+      if (!el || typeof ResizeObserver === 'undefined') return
+      const update = () => setLayoutRowWidth(el.clientWidth)
+      update()
+      const ro = new ResizeObserver(update)
+      ro.observe(el)
+      return () => ro.disconnect()
+    }, [])
+
+    // clientWidth includes the row's own horizontal padding (pl-[17px] pr-4 = 33px).
+    // Fall back to the window measure only until the observer takes its first
+    // reading (avoids a 1-frame flash of a negative width during hydration).
+    const availableRowWidth = (layoutRowWidth > 0 ? layoutRowWidth : viewportWidth) - 33
+    const centerColWidth = Math.max(
+      320,
+      availableRowWidth - leftPanelWidth - 24 - rightPanelWidth - 24
+    )
 
     const [leftPanelResizing, setLeftPanelResizing] = useState(false)
     const leftPanelRef = useRef<HTMLDivElement>(null)
@@ -6182,6 +6207,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
           className="flex h-full w-full flex-1 flex-col bg-gray-50/50 px-0 pt-0"
         >
           <div
+            ref={layoutRowRef}
             className="relative flex h-full w-full pb-6 pl-[17px] pr-4 pt-0 sm:pl-[17px] sm:pr-4"
             style={{
               gap: '24px',


### PR DESCRIPTION
## The bug ("extra container at the back" in a live session)
The course builder's 3-panel layout sized its columns from **`window.innerWidth`**:
- `centerColWidth = window.innerWidth − 840` (left/right fixed at **380** each, all `flexShrink: 0`).

But the builder is rendered inside the **inset dashboard main area** — the tutor layout has a fixed `w-60` sidebar + margins (`ml-64`, `w-[calc(100%-17rem)]` ≈ **272px** removed) and clips with `overflow-hidden`. So the row was sized ~**270px wider than its actual container**:
- The right **"Desk"** panel got pushed past the edge and **clipped**.
- The mis-sized row stopped tiling, so the wrapper backgrounds (`bg-gray-50/50` on the Tabs, `bg-[#fafafc]` on the insights route) **showed through behind** the panels — the "extra container at the back."
- Left/right panels are `z-40` while the center has no `z-index`, so any overlap from the overflow painted the side panels **over** the center classroom card.

## The fix
Measure the **actual layout row** with a `ResizeObserver` and size the center column from that instead of the window:
- `availableRowWidth = rowClientWidth − 33` (the row's `pl-[17px] pr-4` padding)
- `centerColWidth = max(320, availableRowWidth − leftPanelWidth − 24 − rightPanelWidth − 24)`
- `window.innerWidth` is kept **only** as a pre-hydration fallback until the observer's first reading (avoids a 1-frame negative-width flash).

Now the three fixed-width panels tile exactly regardless of host (dashboard vs live/insights) or nav state (open/collapsed).

## Verification
`tsc` 0, build clean, eslint 0 errors. Self-contained sizing change — no logic/state changes beyond the measurement.

## ⚠️ Smoke-test (visual — please confirm)
Open the course builder, then a **live session** → the right "Desk" panel should be fully visible (not clipped), the three panels tile with even 24px gaps and no background "container" showing behind them. Toggle the dashboard nav open/collapsed and resize the window → panels still fit. Check the normal (non-live) builder too — same overflow existed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)