### PR TITLE
fix(course-builder): center Test mode course name in top panel

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -963,9 +963,9 @@ function CourseBuilderInsightsRouteInner({
                     </h1>
                   )}
                   {activeMainTab === 'test-pci' && (
-                    <h1 className="text-foreground flex flex-1 items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
                       {(model.course?.name || currentCourse?.name) && (
-                        <span className="text-muted-foreground ml-2 text-xl font-normal">
+                        <span className="text-muted-foreground text-xl font-normal">
                           {model.course?.name || currentCourse?.name}
                         </span>
                       )}


### PR DESCRIPTION
- Use absolute positioning (pointer-events-none absolute left-0 right-0 mx-auto) to truly center the course name across the full header width
- Matches Live mode centering behavior