### PR TITLE
fix(live): handwriting icon on DMI + Desk submissions count stuck at 0

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -36,6 +36,7 @@ import {
   Send,
   Bell,
   Loader2,
+  NotebookPen,
   Layout,
   ArrowLeft,
   LogOut,
@@ -473,9 +474,11 @@ function WrittenAnswer({
         <button
           type="button"
           onClick={() => setShowDraw(true)}
-          className="inline-flex items-center gap-1 rounded-full border border-[#F17623] bg-[#FFF4EC] px-3 py-1 text-xs font-semibold text-[#9a4a12] transition-colors hover:bg-[#ffe9d8]"
+          className="inline-flex items-center gap-1.5 rounded-full border border-[#F17623] bg-[#FFF4EC] px-3 py-1 text-xs font-semibold text-[#9a4a12] transition-colors hover:bg-[#ffe9d8]"
         >
-          + Add a drawing
+          {/* Paper-and-pen icon signals this is for handwriting, not just drawing. */}
+          <NotebookPen className="h-3.5 w-3.5" />
+          Write or draw
         </button>
       )}
     </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
@@ -116,49 +116,82 @@ export function SubmissionsPanel({
     prevOpenRef.current = { ...open }
   }, [open])
 
-  useEffect(() => {
-    if (!courseId) return
-    // Skip fetch for draft/placeholder course IDs
-    if (courseId === 'insights-draft' || courseId === 'builder-draft') {
-      setError(null)
-      setData(null)
-      return
-    }
-    setLoading(true)
-    setError(null)
-    fetch(`/api/tutor/courses/${courseId}/submissions-tree`, { cache: 'no-store' })
-      .then(async res => {
+  const loadTree = useCallback(
+    async (preserveOpen: boolean) => {
+      if (!courseId) return
+      // Skip fetch for draft/placeholder course IDs
+      if (courseId === 'insights-draft' || courseId === 'builder-draft') {
+        setError(null)
+        setData(null)
+        return
+      }
+      // A background refetch (preserveOpen) must not flash the loading spinner or
+      // wipe the tree on a transient failure — keep showing the current data.
+      if (!preserveOpen) {
+        setLoading(true)
+        setError(null)
+      }
+      try {
+        const res = await fetch(`/api/tutor/courses/${courseId}/submissions-tree`, {
+          cache: 'no-store',
+        })
         const contentType = res.headers.get('content-type') || ''
         if (!contentType.includes('application/json')) {
-          if (res.status !== 404) {
+          if (!preserveOpen && res.status !== 404) {
             setError(res.ok ? 'Failed to load submissions' : `Server error (${res.status})`)
           }
-          setData(null)
+          if (!preserveOpen) setData(null)
           return
         }
         const json = await res.json()
         if (!res.ok || json?.error) {
           // Silently ignore 404 — course may not have sessions/submissions yet.
           // Only show errors for actual failures, not empty data.
-          if (res.status !== 404) {
+          if (!preserveOpen && res.status !== 404) {
             setError(json?.error || 'Failed to load submissions')
           }
-          setData(null)
+          if (!preserveOpen) setData(null)
           return
         }
         setData(json)
-        const nextOpen: Record<string, boolean> = { course: true }
-        ;(json?.lessons || []).forEach((l: any) => {
-          nextOpen[`lesson_${l.id}`] = true
-        })
-        setOpen(nextOpen)
-      })
-      .catch(err => {
-        setError(err?.message || 'Failed to load submissions')
-        setData(null)
-      })
-      .finally(() => setLoading(false))
-  }, [courseId])
+        // Only auto-expand on the first load — a refetch must not collapse or
+        // re-expand folders the tutor has toggled.
+        if (!preserveOpen) {
+          const nextOpen: Record<string, boolean> = { course: true }
+          ;(json?.lessons || []).forEach((l: any) => {
+            nextOpen[`lesson_${l.id}`] = true
+          })
+          setOpen(nextOpen)
+        }
+      } catch (err) {
+        if (!preserveOpen) {
+          setError(err instanceof Error ? err.message : 'Failed to load submissions')
+          setData(null)
+        }
+      } finally {
+        if (!preserveOpen) setLoading(false)
+      }
+    },
+    [courseId]
+  )
+
+  useEffect(() => {
+    loadTree(false)
+  }, [loadTree])
+
+  // A live "Task Complete" persists the submission — and self-heals the
+  // deployed-material / participant rows — server-side, asynchronously. The tree
+  // is otherwise built from a single mount-time REST snapshot, so tasks deployed
+  // or submitted after mount never appeared and the Tasks/Assessments counts
+  // stayed at 0. Refetch shortly after each new live submission so both the
+  // deployed items and the persisted rows show up. Debounced so a burst of
+  // completions triggers one refetch; `open` selection is preserved.
+  const liveSubmissionCount = liveSubmissions?.length ?? 0
+  useEffect(() => {
+    if (liveSubmissionCount === 0) return
+    const t = setTimeout(() => loadTree(true), 1500)
+    return () => clearTimeout(t)
+  }, [liveSubmissionCount, loadTree])
 
   const lessons = useMemo(() => {
     const ls = data?.lessons || []


### PR DESCRIPTION
Two live-session fixes.

## 1. DMI answer field — signal handwriting, not just drawing
`student/feedback/page.tsx`: the `+ Add a drawing` text button is replaced with a **`NotebookPen` (paper-and-pen) icon + "Write or draw"**, so students understand the pad accepts handwriting (which the "Convert handwriting → text" flow then transcribes), not only freehand drawing.

## 2. Desk → Submissions count stuck at 0 after a student submits
**Root cause (not a race — a stale snapshot):** `SubmissionsPanel` fetched `/api/tutor/courses/[courseId]/submissions-tree` **once**, with `useEffect(…, [courseId])`. The per-student **Tasks/Assessments** counts are `deployedItems.filter(has a submission).length` — and *both* the deployed items and the persisted submissions come only from that one mount-time snapshot. So a task deployed or submitted **after** the panel mounted never entered the tree, and the `liveSubmissions` socket overlay can't attach a completion to an item that isn't there → the count reads **0**.

**Fix:** refactor the fetch into `loadTree(preserveOpen)` and **refetch ~1.5s after each new live submission**. The server persists the `taskSubmission` and self-heals the `deployedMaterial`/`sessionParticipant` rows asynchronously on `task:complete`, so a short debounced refetch brings in both the deployed items and the submissions, and the counts update. Details:
- Debounced (1.5s) so a burst of completions triggers a single refetch.
- Background refetch **preserves** the tutor's expanded folders (no auto-collapse/expand) and **does not** wipe the tree or flash the loading spinner on a transient failure.
- The immediate `liveSubmissions` overlay is unchanged, so completions on items already in the tree still show instantly.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
In a live session with a deployed task/assessment: as a student, submit it → on the tutor **Desk → Submissions**, the student's **Tasks**/**Assessments** folder count should go from 0 → 1 within ~1.5s (expanded folders stay expanded). On the student side, the DMI answer field now shows a paper-and-pen icon + "Write or draw".

🤖 Generated with [Claude Code](https://claude.com/claude-code)