### PR TITLE
feat(live): poll/question history + flexible poll options (True/False, Yes/No, custom)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -2427,15 +2427,18 @@ function StudentFeedbackContent() {
                               <div key={poll.id} className="rounded-lg border bg-white p-4">
                                 <p className="text-sm font-medium text-gray-900">{poll.question}</p>
                                 <div className="mt-3 flex flex-wrap gap-2">
-                                  {poll.options.map(option => (
+                                  {(
+                                    poll.optionLabels ??
+                                    poll.options.map((_, i) => String.fromCharCode(65 + i))
+                                  ).map((label, i) => (
                                     <Button
-                                      key={`${poll.id}-${option}`}
-                                      variant={selectedValue === option ? 'default' : 'outline'}
+                                      key={`${poll.id}-${i}`}
+                                      variant={selectedValue === i ? 'default' : 'outline'}
                                       size="sm"
                                       disabled={poll.status === 'closed'}
-                                      onClick={() => handlePollVote(poll, option)}
+                                      onClick={() => handlePollVote(poll, i)}
                                     >
-                                      {option}
+                                      {label}
                                     </Button>
                                   ))}
                                 </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -321,8 +321,8 @@ import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { useCourseBuilderState } from './hooks/useCourseBuilderState'
 import {
   InsightsReportView,
-  type PollResultOption,
-  type QuestionAnswerEntry,
+  type PollResultBlock,
+  type QuestionResultBlock,
 } from './builder-parts/InsightsReportView'
 
 // ============================================
@@ -1383,6 +1383,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       Record<string, 'analytics' | 'poll' | 'question'>
     >({})
     const [pollPromptMap, setPollPromptMap] = useState<Record<string, string>>({})
+    // Poll option set per task: 'letters' (A–E), 'tf' (True/False), 'yn' (Yes/No),
+    // or 'custom' (tutor-typed). Custom labels held in pollCustomOptionsMap.
+    const [pollOptionModeMap, setPollOptionModeMap] = useState<
+      Record<string, 'letters' | 'tf' | 'yn' | 'custom'>
+    >({})
+    const [pollCustomOptionsMap, setPollCustomOptionsMap] = useState<Record<string, string>>({})
     const [questionPromptMap, setQuestionPromptMap] = useState<Record<string, string>>({})
     const [showAIPollMap, setShowAIPollMap] = useState<Record<string, boolean>>({})
     const [showAIQuestionMap, setShowAIQuestionMap] = useState<Record<string, boolean>>({})
@@ -1407,29 +1413,47 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       [insightsProps?.liveTasks, currentInsightsId]
     )
 
-    const pollResults = useMemo<PollResultOption[]>(() => {
-      const poll = activeLiveTask?.polls?.[activeLiveTask.polls.length - 1]
-      if (!poll) return []
-      const total = poll.responses.length
-      const optionCount = poll.options?.length ?? 0
-      return Array.from({ length: optionCount }, (_, i) => {
-        const responders = poll.responses.filter(r => r.value === i)
-        return {
-          label: `Option ${String.fromCharCode(65 + i)}`,
-          count: responders.length,
-          percent: total > 0 ? Math.round((responders.length / total) * 100) : 0,
-          students: responders.map(r => studentNameById.get(r.studentId) || 'Student'),
-        }
-      })
+    // ALL polls for the active task (newest first) so sending a new poll no
+    // longer hides the previous ones. Each option's tally is by 0-based index,
+    // labelled from the poll's optionLabels (True/False, Yes/No, custom) with an
+    // A/B/C… fallback for legacy polls.
+    const pollResults = useMemo<PollResultBlock[]>(() => {
+      const polls = activeLiveTask?.polls ?? []
+      return polls
+        .map(poll => {
+          const total = poll.responses.length
+          const optionCount = poll.options?.length ?? 0
+          return {
+            id: poll.id,
+            question: poll.question,
+            totalResponses: total,
+            options: Array.from({ length: optionCount }, (_, i) => {
+              const responders = poll.responses.filter(r => r.value === i)
+              return {
+                label: poll.optionLabels?.[i] ?? `Option ${String.fromCharCode(65 + i)}`,
+                count: responders.length,
+                percent: total > 0 ? Math.round((responders.length / total) * 100) : 0,
+                students: responders.map(r => studentNameById.get(r.studentId) || 'Student'),
+              }
+            }),
+          }
+        })
+        .reverse()
     }, [activeLiveTask, studentNameById])
 
-    const questionAnswers = useMemo<QuestionAnswerEntry[]>(() => {
-      const q = activeLiveTask?.questions?.[activeLiveTask.questions.length - 1]
-      if (!q) return []
-      return q.responses.map(r => ({
-        studentName: studentNameById.get(r.studentId) || 'Student',
-        answer: r.answer,
-      }))
+    // ALL questions for the active task (newest first), each with its answers.
+    const questionResults = useMemo<QuestionResultBlock[]>(() => {
+      const questions = activeLiveTask?.questions ?? []
+      return questions
+        .map(q => ({
+          id: q.id,
+          prompt: q.prompt,
+          answers: q.responses.map(r => ({
+            studentName: studentNameById.get(r.studentId) || 'Student',
+            answer: r.answer,
+          })),
+        }))
+        .reverse()
     }, [activeLiveTask, studentNameById])
 
     const setInsightsTab = (val: 'analytics' | 'poll' | 'question') =>
@@ -1446,6 +1470,68 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const pollPrompt = pollPromptMap[currentInsightsId] ?? 'Did you find this task difficult'
     const setPollPrompt = (val: string) =>
       setPollPromptMap(prev => ({ ...prev, [currentInsightsId]: val }))
+
+    const pollOptionMode = pollOptionModeMap[currentInsightsId] ?? 'letters'
+    const setPollOptionMode = (val: 'letters' | 'tf' | 'yn' | 'custom') =>
+      setPollOptionModeMap(prev => ({ ...prev, [currentInsightsId]: val }))
+    const pollCustomOptions = pollCustomOptionsMap[currentInsightsId] ?? ''
+    const setPollCustomOptions = (val: string) =>
+      setPollCustomOptionsMap(prev => ({ ...prev, [currentInsightsId]: val }))
+
+    // Resolve the chosen preset to explicit labels. `letters` returns undefined
+    // so the server applies its A–E default; custom is split on newlines/commas.
+    const resolvePollOptions = (): string[] | undefined => {
+      if (pollOptionMode === 'tf') return ['True', 'False']
+      if (pollOptionMode === 'yn') return ['Yes', 'No']
+      if (pollOptionMode === 'custom') {
+        const opts = pollCustomOptions
+          .split(/[\n,]/)
+          .map(s => s.trim())
+          .filter(Boolean)
+          .slice(0, 8)
+        return opts.length >= 2 ? opts : undefined
+      }
+      return undefined
+    }
+
+    // Shared option-set picker rendered above every poll composer. Preset chips
+    // + a custom field (one option per line / comma-separated).
+    const POLL_OPTION_PRESETS: { id: 'letters' | 'tf' | 'yn' | 'custom'; label: string }[] = [
+      { id: 'letters', label: 'A–E' },
+      { id: 'tf', label: 'True/False' },
+      { id: 'yn', label: 'Yes/No' },
+      { id: 'custom', label: 'Custom' },
+    ]
+    const pollOptionPicker = (
+      <div className="mb-2">
+        <div className="flex flex-wrap gap-1.5">
+          {POLL_OPTION_PRESETS.map(preset => (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => setPollOptionMode(preset.id)}
+              className={cn(
+                'rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors',
+                pollOptionMode === preset.id
+                  ? 'border-blue-600 bg-blue-600 text-white'
+                  : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-50'
+              )}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+        {pollOptionMode === 'custom' && (
+          <textarea
+            value={pollCustomOptions}
+            onChange={e => setPollCustomOptions(e.target.value)}
+            rows={2}
+            placeholder="One option per line — e.g. Agree / Disagree / Unsure"
+            className="mt-1.5 w-full resize-none rounded-lg border border-blue-100 bg-white p-2 text-xs text-gray-900 placeholder:text-gray-400 focus:border-blue-400 focus:outline-none"
+          />
+        )}
+      </div>
+    )
 
     const questionPrompt =
       questionPromptMap[currentInsightsId] ?? 'Do you have a question about this task?'
@@ -8209,6 +8295,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                 }
                                               />
                                             )}
+                                            {pollOptionPicker}
                                             <div className="mt-2 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
                                               <div className="relative">
                                                 <MentionTextarea
@@ -8256,6 +8343,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                       insightsProps.onSendPoll({
                                                         taskId: currentInsightsId,
                                                         question: pollPrompt,
+                                                        options: resolvePollOptions(),
                                                       })
                                                       setPollPrompt('')
                                                     }}
@@ -8290,7 +8378,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                             ) : (
                                               <InsightsReportView
                                                 type="question"
-                                                questionAnswers={questionAnswers}
+                                                questionResults={questionResults}
                                                 onMentionStudent={name =>
                                                   setQuestionPrompt(
                                                     questionPrompt
@@ -10272,6 +10360,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           }
                                         />
                                       </div>
+                                      {pollOptionPicker}
                                       <div className="mt-2 shrink-0 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
                                         <div className="relative">
                                           <MentionTextarea
@@ -10317,6 +10406,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                 insightsProps.onSendPoll({
                                                   taskId: currentInsightsId,
                                                   question: pollPrompt,
+                                                  options: resolvePollOptions(),
                                                 })
                                                 setPollPrompt('')
                                               }}
@@ -10334,7 +10424,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
                                         <InsightsReportView
                                           type="question"
-                                          questionAnswers={questionAnswers}
+                                          questionResults={questionResults}
                                           onMentionStudent={name =>
                                             setQuestionPrompt(
                                               questionPrompt

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
@@ -12,24 +12,41 @@ export interface QuestionAnswerEntry {
   answer: string
 }
 
+/** One sent poll + its tallied options. */
+export interface PollResultBlock {
+  id: string
+  question: string
+  totalResponses: number
+  options: PollResultOption[]
+}
+
+/** One sent question + its answers. */
+export interface QuestionResultBlock {
+  id: string
+  prompt: string
+  answers: QuestionAnswerEntry[]
+}
+
 /**
- * Live poll / free-response results for the active task. All data is real,
- * derived from the deployed task's socket responses (see CourseBuilder) — there
- * is no placeholder/mock data here. Clicking a student name @-mentions them.
+ * Live poll / free-response results for the active task. Shows the FULL history
+ * of polls/questions sent for this task (newest first) — sending a new one no
+ * longer hides the previous. All data is real, derived from the deployed task's
+ * socket responses (see CourseBuilder). Clicking a student name @-mentions them.
  */
 export function InsightsReportView({
   type,
   pollResults = [],
-  questionAnswers = [],
+  questionResults = [],
   onMentionStudent,
 }: {
   type: 'poll' | 'question'
-  pollResults?: PollResultOption[]
-  questionAnswers?: QuestionAnswerEntry[]
+  pollResults?: PollResultBlock[]
+  questionResults?: QuestionResultBlock[]
   onMentionStudent: (studentName: string) => void
 }) {
   const isPoll = type === 'poll'
-  const hasData = isPoll ? pollResults.length > 0 : questionAnswers.length > 0
+  const hasData = isPoll ? pollResults.length > 0 : questionResults.length > 0
+  const count = isPoll ? pollResults.length : questionResults.length
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden rounded-2xl border border-blue-100 bg-white/60 p-3 shadow-sm backdrop-blur-md">
@@ -37,68 +54,98 @@ export function InsightsReportView({
         <span className="text-sm font-semibold uppercase tracking-wider text-blue-800">
           {isPoll ? 'Poll Results' : 'Question Results'}
         </span>
+        {count > 0 && (
+          <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-600">
+            {count} sent
+          </span>
+        )}
       </div>
-      <div className="flex-1 overflow-y-auto pr-2">
+      <div className="flex-1 space-y-3 overflow-y-auto pr-2">
         {!hasData ? (
           <p className="py-8 text-center text-xs text-slate-400">
             {isPoll
-              ? 'No poll responses yet. Send a poll to the class to see results here.'
-              : 'No responses yet. Ask the class a question to see answers here.'}
+              ? 'No polls sent yet. Send a poll to the class to see results here.'
+              : 'No questions sent yet. Ask the class a question to see answers here.'}
           </p>
         ) : isPoll ? (
-          <div className="space-y-4">
-            {pollResults.map(item => (
-              <div
-                key={item.label}
-                className="rounded-xl border border-transparent p-2 shadow-sm transition-colors hover:border-blue-100 hover:bg-white"
-              >
-                <div className="mb-1.5 flex justify-between text-xs font-medium text-slate-700">
-                  <span>{item.label}</span>
-                  <span className="text-blue-600">
-                    {item.count} ({item.percent}%)
-                  </span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+          pollResults.map(poll => (
+            <div
+              key={poll.id}
+              className="rounded-2xl border border-blue-100 bg-white/70 p-2.5 shadow-sm"
+            >
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <p className="text-xs font-semibold text-slate-800">{poll.question}</p>
+                <span className="shrink-0 text-[11px] text-slate-400">
+                  {poll.totalResponses} {poll.totalResponses === 1 ? 'vote' : 'votes'}
+                </span>
+              </div>
+              <div className="space-y-2.5">
+                {poll.options.map((item, i) => (
                   <div
-                    className="h-full rounded-full bg-blue-500"
-                    style={{ width: `${item.percent}%` }}
-                  />
-                </div>
-                {item.students.length > 0 && (
-                  <div className="mt-1.5 flex flex-wrap gap-1">
-                    {item.students.map(s => (
-                      <button
-                        key={s}
-                        type="button"
-                        onClick={() => onMentionStudent(s)}
-                        className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 hover:bg-blue-100"
-                      >
-                        {s}
-                      </button>
-                    ))}
+                    key={`${poll.id}-${i}`}
+                    className="rounded-lg p-1.5 transition-colors hover:bg-blue-50/50"
+                  >
+                    <div className="mb-1 flex justify-between text-xs font-medium text-slate-700">
+                      <span>{item.label}</span>
+                      <span className="text-blue-600">
+                        {item.count} ({item.percent}%)
+                      </span>
+                    </div>
+                    <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                      <div
+                        className="h-full rounded-full bg-blue-500"
+                        style={{ width: `${item.percent}%` }}
+                      />
+                    </div>
+                    {item.students.length > 0 && (
+                      <div className="mt-1.5 flex flex-wrap gap-1">
+                        {item.students.map((s, si) => (
+                          <button
+                            key={`${poll.id}-${i}-${si}`}
+                            type="button"
+                            onClick={() => onMentionStudent(s)}
+                            className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 hover:bg-blue-100"
+                          >
+                            {s}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                   </div>
-                )}
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          ))
         ) : (
-          <div className="space-y-2">
-            {questionAnswers.map((a, i) => (
-              <div
-                key={`${a.studentName}-${i}`}
-                className="rounded-xl border border-slate-100 bg-white/50 p-2"
-              >
-                <button
-                  type="button"
-                  onClick={() => onMentionStudent(a.studentName)}
-                  className="text-xs font-semibold text-blue-700 hover:underline"
-                >
-                  {a.studentName}
-                </button>
-                <p className="mt-0.5 whitespace-pre-wrap text-sm text-slate-700">{a.answer}</p>
-              </div>
-            ))}
-          </div>
+          questionResults.map(q => (
+            <div
+              key={q.id}
+              className="rounded-2xl border border-blue-100 bg-white/70 p-2.5 shadow-sm"
+            >
+              <p className="mb-2 text-xs font-semibold text-slate-800">{q.prompt}</p>
+              {q.answers.length === 0 ? (
+                <p className="text-[11px] text-slate-400">No answers yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {q.answers.map((a, i) => (
+                    <div
+                      key={`${q.id}-${a.studentName}-${i}`}
+                      className="rounded-xl border border-slate-100 bg-white/50 p-2"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => onMentionStudent(a.studentName)}
+                        className="text-xs font-semibold text-blue-700 hover:underline"
+                      >
+                        {a.studentName}
+                      </button>
+                      <p className="mt-0.5 whitespace-pre-wrap text-sm text-slate-700">{a.answer}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
         )}
       </div>
     </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -379,7 +379,7 @@ export interface CourseBuilderInsightsProps {
   }[]
   /** Present only inside a live session; deploy buttons hide when undefined. */
   onDeployTask?: (task: LiveTask) => void
-  onSendPoll: (payload: { taskId: string; question: string }) => void
+  onSendPoll: (payload: { taskId: string; question: string; options?: string[] }) => void
   onSendQuestion: (payload: { taskId: string; prompt: string }) => void
   students?: LiveStudent[]
   metrics?: EngagementMetrics | null

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -1112,7 +1112,7 @@ function TutorInsightsPageInner() {
     socket.emit('task:deploy', { roomId: sessionId, task })
   }
 
-  const handleSendPoll = (payload: { taskId: string; question: string }) => {
+  const handleSendPoll = (payload: { taskId: string; question: string; options?: string[] }) => {
     if (!socket || !sessionId) return
     const check = checkSessionActive()
     if (!check.ok) {
@@ -1124,6 +1124,7 @@ function TutorInsightsPageInner() {
       taskId: payload.taskId,
       type: 'poll',
       prompt: payload.question,
+      options: payload.options,
     })
   }
 

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -95,7 +95,11 @@ export interface LiveTaskPoll {
   id: string
   taskId: string
   question: string
+  /** Option indices [0..n-1]; a vote's `value` is the chosen index. */
   options: number[]
+  /** Display labels per option index (['True','False'], ['Yes','No'], custom).
+   *  Absent ⇒ render A/B/C/… by index. */
+  optionLabels?: string[]
   status: 'open' | 'closed'
   responses: LiveTaskPollResponse[]
   createdAt: number
@@ -2144,6 +2148,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
         taskId?: string
         type: 'poll' | 'question' | 'tutor:state_sync'
         prompt?: string
+        /** Poll option labels chosen by the tutor (True/False, Yes/No, custom).
+         *  Omitted ⇒ default A–E. */
+        options?: string[]
         payload?: unknown
       }) => {
         if (socket.data.role !== 'tutor') return
@@ -2210,11 +2217,22 @@ export async function initEnhancedSocketServer(server: NetServer) {
         }
 
         if (type === 'poll') {
+          // Tutor-chosen labels (True/False, Yes/No, custom); fall back to A–E.
+          // Sanitized: trimmed, non-empty, deduped-by-position, capped at 8.
+          const rawLabels = Array.isArray(data.options)
+            ? data.options.map(o => String(o ?? '').trim()).filter(Boolean)
+            : []
+          const labels =
+            rawLabels.length >= 2
+              ? rawLabels.slice(0, 8)
+              : ['A', 'B', 'C', 'D', 'E']
           const poll: LiveTaskPoll = {
             id: `poll-${taskId}-${Date.now()}`,
             taskId,
             question: prompt || 'Did you find this task difficult?',
-            options: [1, 2, 3, 4, 5],
+            // Index-based options; a vote's `value` is the chosen 0-based index.
+            options: labels.map((_, i) => i),
+            optionLabels: labels,
             status: 'open',
             responses: [],
             createdAt: Date.now(),

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -41,7 +41,12 @@ export interface LiveTaskPoll {
   id: string
   taskId: string
   question: string
+  /** Option indices [0..n-1]; a vote's `value` is the chosen index. Length = the
+   *  number of options. */
   options: number[]
+  /** Display labels per option index (e.g. ['True','False'], ['Yes','No'], or
+   *  custom). Absent ⇒ render A/B/C/… by index (back-compat). */
+  optionLabels?: string[]
   status: 'open' | 'closed'
   responses: LiveTaskPollResponse[]
   createdAt: number


### PR DESCRIPTION
Two live-session poll/question improvements you asked for.

## 1. Previous polls/questions no longer disappear
The data was never lost — the server correctly appends every poll/question to `task.polls[]` / `task.questions[]`. But the **tutor view rendered only the last one**:
```js
const poll = activeLiveTask?.polls?.[activeLiveTask.polls.length - 1]   // ← only the latest
```
Now the tutor sees the **full history** (newest first): `InsightsReportView` is rewritten to render each poll as its own block (question + option bars + voter chips) and each question as prompt + answers, with a "N sent" count. Students already mapped the whole array, so their side is unchanged.

## 2. Poll options beyond A–E
A **preset picker** sits above every poll composer: **A–E · True/False · Yes/No · Custom**. Picking **Custom** reveals a field for your own options (one per line / comma-separated, max 8). The chosen labels thread through `onSendPoll → insight:send →` the server, which stores `optionLabels` on the poll (absent ⇒ A–E, fully back-compatible). Students render the labels; the tutor's results show them too.

## Bonus: fixed a latent vote off-by-one
Students voted `value = 1..5` while the tutor tallied `value === 0..4`, so votes landed on the wrong option and option 5 never counted. Everything is now **0-based index**: the student renders labels and votes the index; server and tutor tally by index. (Ephemeral live polls, so no migration needed.)

## Files
- `socket-types.ts` / `socket-server-enhanced.ts`: `LiveTaskPoll.optionLabels`; `insight:send` accepts `options` and builds index-based options + labels.
- `builder-parts/InsightsReportView.tsx`: history render (poll & question blocks).
- `CourseBuilder.tsx`: results derive all polls/questions; preset picker + custom state; both composers + both send calls wired.
- `student/feedback/page.tsx`: render `optionLabels`, vote by index.
- `insights/page.tsx` / `builder-types.ts`: thread `options` through `onSendPoll`.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
In a live session on a deployed task: send a poll, then send another → both remain visible in the tutor's Poll Results (newest first); same for questions. Pick **True/False** (or **Yes/No** / **Custom**) → students see those exact buttons; after votes, the tutor's bars are labelled correctly and counts match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)