### PR TITLE
fix(course-builder): standardize Live/Test center panel wrapper to ma…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8117,13 +8117,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
-                      mainTab === 'live' ? 'border-orange-200' : 'border-purple-200'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border-0 bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                     )}
                   >
                     <div
                       className={cn(
-                        'flex h-9 shrink-0 items-center justify-center rounded-t-2xl px-4 text-sm font-semibold text-white',
+                        'flex h-9 shrink-0 items-center justify-center rounded-t-[20px] px-4 text-sm font-semibold text-white',
                         mainTab === 'live'
                           ? 'bg-gradient-to-br from-orange-500 to-orange-600'
                           : 'bg-gradient-to-br from-violet-500 to-purple-600'

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
@@ -139,7 +139,9 @@ export function InsightsReportView({
                       >
                         {a.studentName}
                       </button>
-                      <p className="mt-0.5 whitespace-pre-wrap text-sm text-slate-700">{a.answer}</p>
+                      <p className="mt-0.5 whitespace-pre-wrap text-sm text-slate-700">
+                        {a.answer}
+                      </p>
                     </div>
                   ))}
                 </div>

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -2222,10 +2222,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
           const rawLabels = Array.isArray(data.options)
             ? data.options.map(o => String(o ?? '').trim()).filter(Boolean)
             : []
-          const labels =
-            rawLabels.length >= 2
-              ? rawLabels.slice(0, 8)
-              : ['A', 'B', 'C', 'D', 'E']
+          const labels = rawLabels.length >= 2 ? rawLabels.slice(0, 8) : ['A', 'B', 'C', 'D', 'E']
           const poll: LiveTaskPoll = {
             id: `poll-${taskId}-${Date.now()}`,
             taskId,


### PR DESCRIPTION
…tch Builder mode

- Change center panel Card from rounded-2xl + colored border to rounded-[20px] + border-0
- Use bg-[#FFFFFF] instead of bg-white for consistency
- Use rounded-t-[20px] for header instead of rounded-t-2xl
- Live session panel wrapper now visually identical to Builder mode
- Header gradient colors intentionally preserved (orange for live, purple for test, blue/pink for builder)