### PR TITLE
fix(course-builder): remove thin inner panel outlines + fix chat pane…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8452,10 +8452,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                   ) : (
                                     <div
                                       className={cn(
-                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0',
-                                        mainTab === 'live'
-                                          ? 'border-orange-300'
-                                          : 'border-violet-300'
+                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl bg-white p-0'
                                       )}
                                     >
                                       <PanelErrorBoundary
@@ -8847,8 +8844,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                               !(mainTab === 'live' && testPciActiveTab === 'student1') && (
                                 <div
                                   className={cn(
-                                    'mt-1 w-full rounded-2xl border bg-white transition-all duration-300',
-                                    mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
+                                    'mt-1 w-full rounded-2xl bg-white transition-all duration-300'
                                   )}
                                 >
                                   <div className="relative flex w-full flex-col p-px">

--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -41,7 +41,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   const ListIcon = list.icon
 
   return (
-    <Card className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+    <Card className="flex h-full w-full flex-col overflow-hidden rounded-2xl border-0 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       {/* Full-width Chat header */}
       <div className="flex h-12 shrink-0 items-center justify-center rounded-t-2xl bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
         Chat


### PR DESCRIPTION
…l header flush

- Remove colored borders from inner content wrappers in Live/Test mode (border-orange-300 and border-violet-300 on tab content and input areas)
- Remove border from Chat panel Card wrapper for flush header effect
- Chat header now visually flush with panel edges, matching AI Assistant panel