### PR TITLE
fix(layout): handle locale prefix in insights page sidebar check

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -141,7 +141,10 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   const isCoursePublishPage = pathname?.match(/^\/tutor\/courses\/[^\/]+$/) !== null
 
   // Insights page has its own layout with course builder integrated
-  const isInsightsPage = pathname === '/tutor/insights' || pathname?.startsWith('/tutor/insights/')
+  const isInsightsPage =
+    pathname === `${localePrefix}/tutor/insights` ||
+    pathname?.startsWith(`${localePrefix}/tutor/insights/`) ||
+    /\/tutor\/insights(\/|$)/.test(pathname || '')
 
   // Auto-close on My Page, Reports, Account Settings, and Support; auto-open elsewhere
   useEffect(() => {


### PR DESCRIPTION
The isInsightsPage check didn't account for i18n locale prefixes (e.g., /en/tutor/insights), causing the sidebar to incorrectly show on insights pages when a locale was present in the URL.

Update the check to match the locale-prefixed path like other page checks (isMyPage, etc.) do.