### PR TITLE
fix(layout): add insights page to floating page check to remove wrapper

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -97,6 +97,13 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   const isSubmissionsPage = pathname?.includes('/tutor/submissions')
   const isAccountPage = pathname?.includes('/tutor/settings')
   const isSupportPage = pathname?.includes('/tutor/support') || pathname?.includes('/tutor/help')
+
+  // Insights page has its own layout with course builder integrated
+  const isInsightsPage =
+    pathname === `${localePrefix}/tutor/insights` ||
+    pathname?.startsWith(`${localePrefix}/tutor/insights/`) ||
+    /\/tutor\/insights(\/|$)/.test(pathname || '')
+
   const isFloatingPage =
     isDashboardPage ||
     isReportsPage ||
@@ -140,12 +147,6 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   // Check if we're on the Course Publish page (course detail page) - hide sidebar for focused editing
   // Pattern: /tutor/courses/[id] but not sub-paths like /tasks or /enrollments
   const isCoursePublishPage = pathname?.match(/^\/tutor\/courses\/[^\/]+$/) !== null
-
-  // Insights page has its own layout with course builder integrated
-  const isInsightsPage =
-    pathname === `${localePrefix}/tutor/insights` ||
-    pathname?.startsWith(`${localePrefix}/tutor/insights/`) ||
-    /\/tutor\/insights(\/|$)/.test(pathname || '')
 
   // Auto-close on My Page, Reports, Account Settings, and Support; auto-open elsewhere
   useEffect(() => {

--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -104,7 +104,8 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
     isSubmissionsPage ||
     isAccountPage ||
     isMyPage ||
-    isSupportPage
+    isSupportPage ||
+    isInsightsPage
   const [desktopNavOpen, setDesktopNavOpen] = useState(
     !isMyPage &&
       !isReportsPage &&


### PR DESCRIPTION
The live session page (/tutor/insights) was showing the white rounded wrapper with shadow because isInsightsPage was not included in the isFloatingPage check. Even though there is an early return for insights pages, adding it to isFloatingPage ensures the wrapper styling is consistently applied as a fallback.

This removes the white background wrapper, rounded corners, and shadow that were appearing around the live session and course builder pages.