### PR TITLE
fix(landing): use fixed launch date for countdown timer

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -1702,13 +1702,12 @@ const CountdownTimer = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    // Hardcoded launch date: 39 days from now
-    // All browsers show the same countdown regardless of when they first visit
-    const LAUNCH_DAYS = 39
-    const targetDate = new Date(Date.now() + LAUNCH_DAYS * 24 * 60 * 60 * 1000).getTime()
+    // Fixed launch date: September 1, 2026 at 00:00:00 UTC
+    // This ensures the countdown actually counts down to a real date
+    const LAUNCH_DATE = new Date('2026-09-01T00:00:00Z').getTime()
 
     const calculate = () => {
-      const diff = targetDate - Date.now()
+      const diff = LAUNCH_DATE - Date.now()
       if (diff <= 0) {
         setTimeLeft({ days: 0, hours: 0, minutes: 0, seconds: 0 })
         return

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6294,7 +6294,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
         >
           <div
             ref={layoutRowRef}
-            className="relative flex h-full w-full pb-6 pl-[17px] pr-4 pt-0 sm:pl-[17px] sm:pr-4"
+            className={cn(
+              'relative flex h-full w-full pl-[17px] pr-4 pt-0 sm:pl-[17px] sm:pr-4',
+              mainTab !== 'live' && 'pb-6'
+            )}
             style={{
               gap: '24px',
             }}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6294,7 +6294,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
         >
           <div
             ref={layoutRowRef}
-            className="relative flex h-full w-full pl-[17px] pr-4 pt-0 sm:pl-[17px] sm:pr-4"
+            className="relative flex h-full w-full pb-6 pl-[17px] pr-4 pt-0 sm:pl-[17px] sm:pr-4"
             style={{
               gap: '24px',
             }}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:bg-white/10 focus:text-white focus:outline-none focus-visible:!shadow-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:bg-white/10 focus:text-white focus:outline-none focus-visible:ring-0 focus-visible:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:bg-white/10 focus:text-white focus:outline-none focus-visible:ring-0 focus-visible:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:bg-white/10 focus:text-white focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION
The countdown was calculating 39 days from the current time every time the page loaded, so it was always stuck around 38-39 days and never actually counted down.

Changed to use a fixed launch date (September 1, 2026) so the countdown correctly decreases over time and shows the real time remaining until launch.