### PR TITLE
fix(layout): force bypass nav and wrapper for insights pages

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -175,7 +175,10 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
     return () => clearInterval(interval)
   }, [])
 
-  if (isCourseBuilder || isCoursePublishPage || isInsightsPage) {
+  // Force insights pages to have no nav and no wrapper
+  const isInsightsPageForce = pathname?.includes('/tutor/insights')
+
+  if (isCourseBuilder || isCoursePublishPage || isInsightsPage || isInsightsPageForce) {
     return <>{children}</>
   }
 

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
-import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { useAutoScrollOnExpand } from '@/hooks/use-auto-scroll-on-expand'
 
@@ -32,8 +31,7 @@ export function CollapsibleCard({
 
   return (
     <div ref={cardRef}>
-      <Card
-        elevation="none"
+      <div
         className={cn(
           'overflow-hidden p-0',
           flush
@@ -73,7 +71,7 @@ export function CollapsibleCard({
             <div className={contentClassName}>{children}</div>
           </div>
         </div>
-      </Card>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Add an additional isInsightsPageForce check using a simpler pathname includes check to ensure the tutor nav and white wrapper are always bypassed for /tutor/insights routes.