### PR TITLE
feat(pci): step-by-step PCI walkthrough on the PCI tab (task vs assessment)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -324,6 +324,7 @@ import {
   type PollResultBlock,
   type QuestionResultBlock,
 } from './builder-parts/InsightsReportView'
+import { PciWalkthrough } from './builder-parts/PciWalkthrough'
 
 // ============================================
 // BUILDER MODAL COMPONENTS
@@ -425,8 +426,9 @@ function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
         <p>
           <b>PCI is your marking instruction</b> for this {noun} — <i>how</i> you want answers
           marked, not the questions themselves. Chat your rules below; the assistant turns them into
-          a finalized <b>rubric</b>. Click <b>Apply to PCI</b> to save it — it then guides the AI
-          grading suggestions and how an uploaded marking scheme is read.
+          a finalized <b>rubric</b>. Save it under <b>Current marking policy</b> (use <b>Edit</b> to
+          paste or refine) — it then guides the AI grading suggestions and how an uploaded marking
+          scheme is read.
         </p>
         <p className="font-semibold">Things worth telling it:</p>
         <ul className="list-disc space-y-0.5 pl-4">
@@ -439,9 +441,10 @@ function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
           <li>&ldquo;One mark per valid point, maximum 4.&rdquo;</li>
         </ul>
         <p className="text-blue-700/80">
-          Flow: chat &rarr; the assistant proposes a rubric &rarr; <b>Apply to PCI</b> &rarr;
-          it&rsquo;s saved and used when grading. The answer key itself comes from the DMI / an
-          uploaded marking scheme — PCI is the <i>policy</i> on top.
+          Flow: chat &rarr; the assistant proposes a rubric &rarr; set it as your{' '}
+          <b>Current marking policy</b> &rarr; it&rsquo;s saved and used when grading. The answer
+          key itself comes from the DMI / an uploaded marking scheme — PCI is the <i>policy</i> on
+          top.
         </p>
       </div>
     </details>
@@ -6036,7 +6039,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
             value={value}
             readOnly={!canEdit}
             onChange={e => setCurrentPci(source, e.target.value)}
-            placeholder="The marking policy used when grading… (or chat below and Apply to PCI)"
+            placeholder="The marking policy used when grading… (chat below to draft one, then paste/refine it here)"
             className="mt-1.5 min-h-[80px] w-full resize-y rounded-md border border-gray-300 p-2 text-xs text-gray-900"
           />
         ) : value.trim() ? (
@@ -6045,8 +6048,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
           </p>
         ) : (
           <p className="mt-1 italic text-slate-400">
-            None yet — chat below and click &ldquo;Apply to PCI&rdquo;, or Edit to type one. This is
-            what guides AI grading.
+            None yet — chat below to draft one, then click <b>Edit</b> to paste or type it here.
+            This is what guides AI grading.
           </p>
         )}
         {/* TASK-6: the structured specification mirror, when one was finalized. */}
@@ -9556,7 +9559,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       value="pci"
                                       className="mt-0.5 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
-                                      <div className="flex h-full min-h-0 flex-col rounded-2xl border border-blue-200 bg-white p-4 shadow-sm">
+                                      <div className="relative flex h-full min-h-0 flex-col rounded-2xl border border-blue-200 bg-white p-4 shadow-sm">
+                                        <PciWalkthrough kind="task" />
                                         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-1">
                                           <PciGuidance kind="task" />
                                           {renderCurrentPci('task', activeTaskPci)}
@@ -9989,6 +9993,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       className="mt-2 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
                                       <div className="relative flex h-full min-h-0 flex-col rounded-2xl border border-[#EC4899] bg-white p-4 shadow-sm">
+                                        <PciWalkthrough kind="assessment" />
                                         {/* Centered Pill for Test, Generate DMI, and Version History */}
                                         <div className="pointer-events-none absolute left-1/2 top-0 z-20 flex -translate-x-1/2 items-center justify-center">
                                           <div className="pointer-events-auto flex h-11 items-center gap-1 rounded-b-xl border-x border-b border-[#E5E7EB] bg-white/90 px-2 shadow-sm backdrop-blur-sm">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Compass, X, ChevronLeft, ChevronRight, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+interface Step {
+  title: string
+  body: string
+  /** Optional example bullets shown under the body. */
+  bullets?: string[]
+}
+
+/**
+ * Steps for a TASK (no DMI — purely a marking policy) vs an ASSESSMENT (marking
+ * policy PLUS an answer key built from the DMI / an uploaded marking scheme).
+ * Deliberately avoids any "Apply to PCI" button — the reliable save path is the
+ * "Current marking policy → Edit" box.
+ */
+function buildSteps(kind: 'task' | 'assessment'): Step[] {
+  const noun = kind === 'assessment' ? 'assessment' : 'task'
+  const shared: Step[] = [
+    {
+      title: 'What PCI is',
+      body: `PCI is your marking instruction for this ${noun} — how you want answers marked, not the questions themselves. It guides the AI's grading suggestions.`,
+    },
+    {
+      title: "You're on the PCI tab",
+      body: `Everything for marking this ${noun} lives here (the Brain icon). No PCI means the AI has no marking policy to follow.`,
+    },
+    {
+      title: 'Skim the quick tip',
+      body: 'Open “What is PCI & what to ask” at the top of this tab for examples of the kinds of rules worth setting.',
+    },
+    {
+      title: 'Chat your marking rules',
+      body: 'Use the assistant box at the bottom (“Ask the PCI assistant…”). Tell it, in plain words, how answers should be marked. For example:',
+      bullets: [
+        'Award method marks even if the final answer is wrong.',
+        'Accept any value within ±0.1, and equivalent fractions.',
+        'Require correct units — deduct 1 mark if missing.',
+        'Mark to IB / AP / Cambridge mark schemes.',
+        'One mark per valid point, maximum 4.',
+      ],
+    },
+    {
+      title: 'Review the rubric',
+      body: 'The assistant replies with a finalized rubric. Read it, and keep chatting to refine it until it matches how you mark.',
+    },
+    {
+      title: 'Save it as your marking policy',
+      body: 'In “Current marking policy (PCI)”, click Edit, paste or refine the rubric, then Done. That saved text is exactly what the AI grader uses.',
+    },
+  ]
+
+  if (kind === 'task') {
+    return [
+      ...shared,
+      {
+        title: "You're set",
+        body: 'This PCI now guides AI grading for this task. Tasks don’t need an answer key — the policy is enough. Repeat for each lesson’s task.',
+      },
+    ]
+  }
+
+  return [
+    ...shared,
+    {
+      title: 'Build the answer key (DMI)',
+      body: 'Assessments also need an answer key. On the assessment content, click Generate DMI to extract the questions and answers.',
+    },
+    {
+      title: 'Verify marks & answers',
+      body: 'Open “Edit marks & answers” to check each question’s marks and correct answers before it goes live.',
+    },
+    {
+      title: 'Optional: upload a marking scheme',
+      body: 'In that editor, use “Upload marking scheme” to auto-fill every answer from your marking-scheme PDF.',
+    },
+    {
+      title: "You're set",
+      body: 'PCI (the policy) and the DMI (the answer key) together drive grading. Repeat for each assessment.',
+    },
+  ]
+}
+
+/**
+ * A collapsible floating guide that walks a tutor through building the PCI for
+ * the current task/assessment, first step to last. Collapsed state is
+ * remembered (localStorage) so it's available in every lesson without nagging.
+ */
+export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
+  const steps = buildSteps(kind)
+  const storageKey = 'pci-walkthrough:collapsed'
+
+  const [collapsed, setCollapsed] = useState(false)
+  const [step, setStep] = useState(0)
+  const [hydrated, setHydrated] = useState(false)
+
+  // Restore the tutor's collapse preference on mount (default: expanded the
+  // first time so they discover it). Avoids an SSR/client mismatch by only
+  // reading after mount.
+  useEffect(() => {
+    try {
+      setCollapsed(localStorage.getItem(storageKey) === '1')
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true)
+  }, [])
+
+  const persistCollapsed = (next: boolean) => {
+    setCollapsed(next)
+    try {
+      localStorage.setItem(storageKey, next ? '1' : '0')
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Clamp the step if the step set changes (task ↔ assessment).
+  useEffect(() => {
+    setStep(s => Math.min(s, steps.length - 1))
+  }, [steps.length])
+
+  if (!hydrated) return null
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={() => persistCollapsed(false)}
+        className="absolute bottom-4 right-4 z-30 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 shadow-lg transition-colors hover:bg-blue-50"
+        title="Open the PCI walkthrough"
+      >
+        <Compass className="h-3.5 w-3.5" />
+        PCI guide
+      </button>
+    )
+  }
+
+  const current = steps[step]
+  const isFirst = step === 0
+  const isLast = step === steps.length - 1
+
+  return (
+    <div className="absolute bottom-4 right-4 z-30 w-[300px] overflow-hidden rounded-2xl border border-blue-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.18)]">
+      <div className="flex items-center gap-2 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-3 py-2 text-white">
+        <Compass className="h-4 w-4" />
+        <span className="text-sm font-semibold">
+          PCI walkthrough{kind === 'assessment' ? ' · assessment' : ' · task'}
+        </span>
+        <button
+          type="button"
+          onClick={() => persistCollapsed(true)}
+          className="ml-auto rounded-full p-0.5 text-white/80 hover:bg-white/20 hover:text-white"
+          title="Collapse"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="px-3 py-3">
+        <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-blue-500">
+          Step {step + 1} of {steps.length}
+        </div>
+        <p className="text-sm font-semibold text-slate-800">{current.title}</p>
+        <p className="mt-1 text-xs leading-relaxed text-slate-600">{current.body}</p>
+        {current.bullets && (
+          <ul className="mt-2 list-disc space-y-0.5 pl-4 text-xs text-slate-600">
+            {current.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-slate-100 px-3 py-2">
+        <div className="flex items-center gap-1">
+          {steps.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setStep(i)}
+              aria-label={`Go to step ${i + 1}`}
+              className={cn(
+                'h-1.5 rounded-full transition-all',
+                i === step ? 'w-4 bg-blue-600' : 'w-1.5 bg-slate-200 hover:bg-slate-300'
+              )}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            disabled={isFirst}
+            onClick={() => setStep(s => Math.max(0, s - 1))}
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            Back
+          </Button>
+          {isLast ? (
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 bg-emerald-600 px-2 text-xs text-white hover:bg-emerald-500"
+              onClick={() => persistCollapsed(true)}
+            >
+              <Check className="mr-0.5 h-3.5 w-3.5" />
+              Done
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              onClick={() => setStep(s => Math.min(steps.length - 1, s + 1))}
+            >
+              Next
+              <ChevronRight className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements the approved plan for a hand-holding PCI walkthrough.

## What
A collapsible **floating guide** (`PciWalkthrough`) pinned bottom-right of the **PCI tab** that walks a tutor through building the PCI, first step to last. Header + step counter + Back/Next + progress dots; collapses to a small **"PCI guide"** pill and remembers that choice in `localStorage` (so it's there in every lesson but never nags).

## Task vs Assessment (Task 2)
It detects the active builder and shows the matching steps:
- **Task (no DMI):** what PCI is → you're on the PCI tab → skim the tip → chat your marking rules (with examples) → review the rubric → **save it under "Current marking policy → Edit"** → done (tasks need no answer key).
- **Assessment (has DMI):** the same six, then → **Generate DMI** (answer key) → **verify marks & answers** → optional **upload marking scheme** → done.

## The "Apply to PCI" reminder (Task 3)
The walkthrough **never** tells tutors to click "Apply to PCI" — that button only renders behind a *gated* finalized draft and isn't reliably reachable, which is why you don't see it. Instead it teaches the reliable **Current marking policy → Edit** save path. I also fixed the **stale help text** that referenced the button: the `PciGuidance` banner (two spots) and the current-PCI textarea placeholder + empty-state. (The conditional emerald-banner buttons themselves are left as-is — the plan didn't propose removing them.)

## Files
- New `builder-parts/PciWalkthrough.tsx` (self-contained; steps, collapse/persist, nav).
- `CourseBuilder.tsx`: mounted in both the task-PCI and assessment-PCI tab containers (`kind="task"` / `kind="assessment"`); stale-text fixes.

## Verification
`tsc` 0, build clean, eslint 0 errors. Self-contained UI addition.

## ⚠️ Smoke-test (visual — I couldn't drive the tutor UI here)
Open a **task** → PCI tab: the guide appears bottom-right with the 7 task steps (no DMI mention); Back/Next + dots work; collapse → "PCI guide" pill; reopen; the choice persists on reload. Open an **assessment** → PCI tab: 10 steps including Generate DMI / marking scheme. Confirm the guide doesn't permanently block the chat input (collapse to type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)