### PR TITLE
feat(pci): spotlight-highlight the control each walkthrough step points at

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -414,6 +414,7 @@ function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
   return (
     <details
       open
+      data-pci-anchor="guidance"
       className="group mb-3 rounded-xl border border-blue-200 bg-blue-50/70 px-3 py-2 text-xs text-blue-900"
     >
       <summary className="flex cursor-pointer list-none items-center gap-1.5 font-semibold">
@@ -6010,7 +6011,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
       : taskBuilder.taskPci
     // Read-only-with-edit "Current marking policy" box shown atop a PCI tab.
     const renderCurrentPci = (source: 'task' | 'assessment', value: string) => (
-      <div className="mb-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+      <div
+        data-pci-anchor="current-pci"
+        className="mb-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs"
+      >
         <div className="flex items-center justify-between gap-2">
           <span className="font-semibold text-slate-700">Current marking policy (PCI)</span>
           <div className="flex items-center gap-2">
@@ -6026,6 +6030,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
             {canEdit && (
               <button
                 type="button"
+                data-pci-anchor="edit-pci"
                 onClick={() => setEditingCurrentPci(v => !v)}
                 className="font-semibold text-blue-700 hover:underline"
               >
@@ -9559,7 +9564,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       value="pci"
                                       className="mt-0.5 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
-                                      <div className="relative flex h-full min-h-0 flex-col rounded-2xl border border-blue-200 bg-white p-4 shadow-sm">
+                                      <div
+                                        data-pci-container="task"
+                                        className="relative flex h-full min-h-0 flex-col rounded-2xl border border-blue-200 bg-white p-4 shadow-sm"
+                                      >
                                         <PciWalkthrough kind="task" />
                                         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-1">
                                           <PciGuidance kind="task" />
@@ -9622,7 +9630,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           <GuardrailWarningsBanner
                                             warnings={taskPciGuardrailWarnings}
                                           />
-                                          <div className="mt-2 w-full rounded-2xl border border-blue-300 bg-white/90 backdrop-blur-md transition-all duration-300">
+                                          <div
+                                            data-pci-anchor="chat-input"
+                                            className="mt-2 w-full rounded-2xl border border-blue-300 bg-white/90 backdrop-blur-md transition-all duration-300"
+                                          >
                                             <div className="relative flex w-full flex-col p-px">
                                               <div className="flex w-full flex-col">
                                                 <MentionTextarea
@@ -9658,6 +9669,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                     disabled={
                                                       taskPciLoading || !activeTaskPciInput.trim()
                                                     }
+                                                    data-pci-anchor="send"
                                                     onClick={() => handlePciSend('task')}
                                                     aria-label="Send"
                                                   >
@@ -9992,7 +10004,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       value="pci"
                                       className="mt-2 flex h-full min-h-0 flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
-                                      <div className="relative flex h-full min-h-0 flex-col rounded-2xl border border-[#EC4899] bg-white p-4 shadow-sm">
+                                      <div
+                                        data-pci-container="assessment"
+                                        className="relative flex h-full min-h-0 flex-col rounded-2xl border border-[#EC4899] bg-white p-4 shadow-sm"
+                                      >
                                         <PciWalkthrough kind="assessment" />
                                         {/* Centered Pill for Test, Generate DMI, and Version History */}
                                         <div className="pointer-events-none absolute left-1/2 top-0 z-20 flex -translate-x-1/2 items-center justify-center">
@@ -10004,6 +10019,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                             <Button
                                               variant="ghost"
                                               size="sm"
+                                              data-pci-anchor="generate-dmi"
                                               className="h-6 px-2 text-xs font-medium text-gray-600 hover:text-gray-900"
                                               disabled={dmiGenerating || !canEdit}
                                               onClick={() => {
@@ -10033,6 +10049,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                 <Button
                                                   variant="ghost"
                                                   size="sm"
+                                                  data-pci-anchor="edit-marks"
                                                   className="h-6 px-2 text-xs font-medium text-[#F17623] hover:text-[#d9651a]"
                                                   disabled={!canEdit}
                                                   title="Set marks per question and review the AI answers"
@@ -10147,7 +10164,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               ] || []
                                             }
                                           />
-                                          <div className="mt-2 w-full rounded-2xl border border-purple-300 bg-white/90 backdrop-blur-md transition-all duration-300">
+                                          <div
+                                            data-pci-anchor="chat-input"
+                                            className="mt-2 w-full rounded-2xl border border-purple-300 bg-white/90 backdrop-blur-md transition-all duration-300"
+                                          >
                                             <div className="relative flex w-full flex-col p-px">
                                               <div className="flex w-full flex-col">
                                                 <MentionTextarea
@@ -10193,6 +10213,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                         ] || ''
                                                       ).trim()
                                                     }
+                                                    data-pci-anchor="send"
                                                     onClick={() => handlePciSend('assessment')}
                                                     aria-label="Send"
                                                   >

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Compass, X, ChevronLeft, ChevronRight, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -10,6 +10,9 @@ interface Step {
   body: string
   /** Optional example bullets shown under the body. */
   bullets?: string[]
+  /** data-pci-anchor value of the control this step points at, for the spotlight
+   *  highlight. Resolved within the nearest [data-pci-container]. */
+  anchor?: string
 }
 
 /**
@@ -32,10 +35,12 @@ function buildSteps(kind: 'task' | 'assessment'): Step[] {
     {
       title: 'Skim the quick tip',
       body: 'Open “What is PCI & what to ask” at the top of this tab for examples of the kinds of rules worth setting.',
+      anchor: 'guidance',
     },
     {
       title: 'Chat your marking rules',
       body: 'Use the assistant box at the bottom (“Ask the PCI assistant…”). Tell it, in plain words, how answers should be marked. For example:',
+      anchor: 'chat-input',
       bullets: [
         'Award method marks even if the final answer is wrong.',
         'Accept any value within ±0.1, and equivalent fractions.',
@@ -47,10 +52,12 @@ function buildSteps(kind: 'task' | 'assessment'): Step[] {
     {
       title: 'Review the rubric',
       body: 'The assistant replies with a finalized rubric. Read it, and keep chatting to refine it until it matches how you mark.',
+      anchor: 'chat-input',
     },
     {
       title: 'Save it as your marking policy',
       body: 'In “Current marking policy (PCI)”, click Edit, paste or refine the rubric, then Done. That saved text is exactly what the AI grader uses.',
+      anchor: 'edit-pci',
     },
   ]
 
@@ -69,10 +76,12 @@ function buildSteps(kind: 'task' | 'assessment'): Step[] {
     {
       title: 'Build the answer key (DMI)',
       body: 'Assessments also need an answer key. On the assessment content, click Generate DMI to extract the questions and answers.',
+      anchor: 'generate-dmi',
     },
     {
       title: 'Verify marks & answers',
       body: 'Open “Edit marks & answers” to check each question’s marks and correct answers before it goes live.',
+      anchor: 'edit-marks',
     },
     {
       title: 'Optional: upload a marking scheme',
@@ -91,12 +100,13 @@ function buildSteps(kind: 'task' | 'assessment'): Step[] {
  * remembered (localStorage) so it's available in every lesson without nagging.
  */
 export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
-  const steps = buildSteps(kind)
+  const steps = useMemo(() => buildSteps(kind), [kind])
   const storageKey = 'pci-walkthrough:collapsed'
 
   const [collapsed, setCollapsed] = useState(false)
   const [step, setStep] = useState(0)
   const [hydrated, setHydrated] = useState(false)
+  const cardRef = useRef<HTMLDivElement | null>(null)
 
   // Restore the tutor's collapse preference on mount (default: expanded the
   // first time so they discover it). Avoids an SSR/client mismatch by only
@@ -124,6 +134,41 @@ export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
     setStep(s => Math.min(s, steps.length - 1))
   }, [steps.length])
 
+  // Spotlight: outline the control the current step points at (resolved within
+  // this PCI container so task/assessment anchors never cross) and scroll it into
+  // view. Uses outline (not border/ring) so it never shifts layout. Restores the
+  // element's prior inline styles on step change / collapse / unmount.
+  useEffect(() => {
+    if (collapsed) return
+    const anchor = steps[step]?.anchor
+    if (!anchor) return
+    const container = cardRef.current?.closest('[data-pci-container]')
+    const el = container?.querySelector<HTMLElement>(`[data-pci-anchor="${anchor}"]`)
+    if (!el) return
+
+    const prev = {
+      outline: el.style.outline,
+      outlineOffset: el.style.outlineOffset,
+      borderRadius: el.style.borderRadius,
+      boxShadow: el.style.boxShadow,
+      transition: el.style.transition,
+    }
+    el.style.transition = 'box-shadow 200ms ease'
+    el.style.outline = '2px solid #2563eb'
+    el.style.outlineOffset = '3px'
+    if (!el.style.borderRadius) el.style.borderRadius = '10px'
+    el.style.boxShadow = '0 0 0 6px rgba(37, 99, 235, 0.12)'
+    el.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+
+    return () => {
+      el.style.outline = prev.outline
+      el.style.outlineOffset = prev.outlineOffset
+      el.style.borderRadius = prev.borderRadius
+      el.style.boxShadow = prev.boxShadow
+      el.style.transition = prev.transition
+    }
+  }, [step, collapsed, steps])
+
   if (!hydrated) return null
 
   if (collapsed) {
@@ -145,7 +190,10 @@ export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
   const isLast = step === steps.length - 1
 
   return (
-    <div className="absolute bottom-4 right-4 z-30 w-[300px] overflow-hidden rounded-2xl border border-blue-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.18)]">
+    <div
+      ref={cardRef}
+      className="absolute bottom-4 right-4 z-30 w-[300px] overflow-hidden rounded-2xl border border-blue-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.18)]"
+    >
       <div className="flex items-center gap-2 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-3 py-2 text-white">
         <Compass className="h-4 w-4" />
         <span className="text-sm font-semibold">


### PR DESCRIPTION
Follow-up to #560 — the walkthrough now **points at the real control** for each step.

## How
- Added stable `data-pci-anchor` attributes to the actual controls: the **guidance** banner, the **Current marking policy** box + its **Edit** button, the **chat input**, the **send** button, and (assessment-only) **Generate DMI** and **Edit marks & answers**. The two PCI tab containers carry `data-pci-container="task" | "assessment"`.
- On each step, `PciWalkthrough` resolves its anchor **within its own container** (so the task and assessment copies never cross-highlight), draws an **outline + soft box-shadow** around it (outline, not border/ring → zero layout shift), and scrolls it into view. The element's prior inline styles are restored on step change / collapse / unmount.
- Steps with no on-page target (intro, "review the rubric", upload-scheme-in-modal, done) simply don't highlight — no dangling spotlight.

Anchor → step mapping: skim tip → guidance; chat rules / review → chat input; save → Edit button; build answer key → Generate DMI; verify → Edit marks & answers.

## Verification
`tsc` 0, build clean, eslint 0 errors. `data-*` props pass cleanly through the shadcn Button.

## ⚠️ Smoke-test (visual)
Task PCI tab: step through the guide — the guidance banner, chat box, then the Edit button each get a blue outline and scroll into view; collapsing clears the highlight. Assessment PCI tab: later steps additionally outline Generate DMI and Edit marks & answers. Confirm no leftover outline when you move off a step or collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)