### PR TITLE
fix(pci): surface the rubric reliably so "Apply to PCI" actually appears

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9603,7 +9603,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           {taskPciDraft && (
                                             <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
                                               <span>
-                                                Finalized rubric ready to apply to the PCI field.
+                                                Rubric ready — click Apply to save it as your
+                                                marking policy.
                                               </span>
                                               <Button
                                                 size="sm"
@@ -10118,7 +10119,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           {assessmentPciDraftMap[loadedAssessmentId || ''] && (
                                             <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
                                               <span>
-                                                Finalized rubric ready to apply to the PCI field.
+                                                Rubric ready — click Apply to save it as your
+                                                marking policy.
                                               </span>
                                               <Button
                                                 size="sm"

--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -134,7 +134,7 @@ describe('/api/ai/pci-master', () => {
     })
   })
 
-  it('task domain: suppresses a finalized rubric until the tutor signals approval (TASK-5)', async () => {
+  it('task domain: offers the rubric but flags it unconfirmed until the tutor applies (TASK-5)', async () => {
     mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: '{"reply":"Here is the finalized rubric.","pci":"FINAL RUBRIC TEXT"}',
@@ -142,11 +142,13 @@ describe('/api/ai/pci-master', () => {
       parsed: null,
     })
 
-    // No approval phrase → the engine must NOT surface the draft, and flags it.
+    // No approval phrase this turn → the rubric is still OFFERED so the Apply
+    // button appears, but flagged unconfirmed. The tutor's Apply click is the
+    // explicit TASK-5 confirmation; nothing auto-applies.
     const res = await postBody({ message: 'what do you think?', context: { type: 'task' } })
     const data = await res.json()
 
-    expect(data.pciDraft).toBe('')
+    expect(data.pciDraft).toBe('FINAL RUBRIC TEXT')
     expect(data.pciUnconfirmed).toBe(true)
   })
 

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -325,13 +325,13 @@ export async function POST(request: NextRequest) {
         // TASK-6: the structured mirror of the finalized rubric.
         pciSpec = normalizePciSpec(env.spec)
       }
-      // Suppress a finalized rubric the model emitted without an explicit tutor
-      // approval this turn — no silent finalization (the client Apply button is
-      // the second gate). The structured spec is gated the same way.
+      // A rubric the model emitted without the tutor typing an explicit approval
+      // this turn is still OFFERED (so the "Apply to PCI" button reliably appears
+      // whenever there's something to apply) but flagged `pciUnconfirmed`. The
+      // tutor's explicit Apply click is the TASK-5 confirmation — nothing is
+      // applied without it, so this never silently finalizes.
       if ((pciDraft || pciSpec) && !tutorSignaledFinalize) {
         pciUnconfirmed = true
-        pciDraft = ''
-        pciSpec = null
       }
     }
 


### PR DESCRIPTION
Implements the recommended fix for the "Apply to PCI" button (your Task 3 question).

## The problem
The `pci-master` route **blanked** the finalized rubric (`pciDraft`/`pciSpec`) whenever the tutor hadn't *typed* an approval phrase that turn — a two-gate design (a typed phrase **and** the Apply click). In real use the phrase rarely matched, so the emerald **"Apply to PCI"** button almost never rendered and tutors couldn't one-click apply the rubric they'd built.

## The fix
Make the **Apply click the single explicit confirmation** (TASK-5): still emit the rubric + spec so the button reliably appears whenever there's something to apply, and keep the `pciUnconfirmed` flag for context. **Nothing auto-applies** — the tutor still has to click — so this never silently finalizes.

- `api/ai/pci-master/route.ts`: drop the `pciDraft = ''; pciSpec = null` suppression; keep `pciUnconfirmed = true`.
- Banner wording: "Finalized rubric ready to apply…" → **"Rubric ready — click Apply to save it as your marking policy"** (accurate now that a rubric can surface mid-iteration).
- Updated the route test to assert the rubric now surfaces **with** `pciUnconfirmed: true`.

## Guardrail note (TASK-5)
Confirmation stays mandatory — it's just relocated from "type a magic phrase" to "click Apply." The client only ever writes the PCI on that explicit click (`applyTaskPciDraft` / `applyAssessmentPciDraft`); there is no auto-apply path.

## Verification
`tsc` 0, build clean, eslint 0 errors, all 7 pci-master route tests pass.

## ⚠️ Smoke-test
On a task/assessment PCI tab, chat a marking rule → the assistant proposes a rubric → the green **"Apply to PCI"** banner now appears (previously it usually didn't) → click it → it lands in "Current marking policy" and the banner clears. It should NOT apply on its own without the click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)