### PR TITLE
fix(layout): robust insights page nav detection for SSR/hydration

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -98,10 +98,15 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   const isAccountPage = pathname?.includes('/tutor/settings')
   const isSupportPage = pathname?.includes('/tutor/support') || pathname?.includes('/tutor/help')
 
-  // Insights page has its own layout with course builder integrated
+  // Use a robust pathname check for insights page detection that works across
+  // SSR and client-side hydration, handling both prefixed and non-prefixed paths.
+  // With next-intl localePrefix: 'as-needed', the pathname may include the locale
+  // segment during SSR (e.g., /en/tutor/insights) but not on the client.
   const isInsightsPage =
-    pathname === `${localePrefix}/tutor/insights` ||
-    pathname?.startsWith(`${localePrefix}/tutor/insights/`) ||
+    pathname === '/tutor/insights' ||
+    pathname?.startsWith('/tutor/insights/') ||
+    pathname?.endsWith('/tutor/insights') ||
+    pathname?.includes('/tutor/insights/') ||
     /\/tutor\/insights(\/|$)/.test(pathname || '')
 
   const isFloatingPage =
@@ -176,6 +181,7 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   }, [])
 
   // Force insights pages to have no nav and no wrapper
+  // Use a robust check that handles locale-prefixed paths during SSR
   const isInsightsPageForce = pathname?.includes('/tutor/insights')
 
   if (isCourseBuilder || isCoursePublishPage || isInsightsPage || isInsightsPageForce) {


### PR DESCRIPTION
The navigation sidebar was incorrectly rendering on insights pages (live sessions and course builder) due to SSR/client-side hydration mismatches with next-intl's localePrefix: 'as-needed'.

During SSR, usePathname from next/navigation may return a locale-prefixed path (e.g., /en/tutor/insights) even though the actual URL doesn't show it, because the [locale] dynamic segment is part of the App Router file structure. The previous localePrefix-based check failed to catch these cases during SSR.

Replace the fragile localePrefix-based check with a robust multi-pattern match that handles all pathname variations:
- /tutor/insights (default locale, no prefix)
- /en/tutor/insights (default locale with prefix during SSR)
- /zh-CN/tutor/insights (non-default locale)
- /tutor/insights/... (sub-paths)

Fixes next-intl hydration issues #1573, #2011