### PR TITLE
fix(course-builder): make Classroom display border color conditional

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8470,7 +8470,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                   ) : (
                                     <div
                                       className={cn(
-                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-violet-300 bg-white p-0'
+                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0',
+                                        mainTab === 'live'
+                                          ? 'border-orange-300'
+                                          : 'border-violet-300'
                                       )}
                                     >
                                       <PanelErrorBoundary


### PR DESCRIPTION
The inner display area border was hardcoded to border-violet-300 (purple) regardless of mode. Changed to conditional:
- Live mode (orange header): border-orange-300
- Test mode (purple header): border-violet-300

Matches the textarea wrapper which already had the correct conditional logic.