### PR TITLE
fix(account): match Analytics page panel design

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -652,7 +652,7 @@ export default function TutorSettings() {
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
         <Card className="flex h-full flex-col overflow-hidden rounded-[16px] border-0 shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
-            <TabsList className="grid w-full grid-cols-4 gap-1 bg-slate-100 p-1 sm:grid-cols-8">
+            <TabsList className="grid w-full grid-cols-4 gap-1 p-1 sm:grid-cols-8">
               <TabsTrigger value="profile" className="text-xs">
                 Profile
               </TabsTrigger>

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -35,8 +35,8 @@ export function CollapsibleCard({
         className={cn(
           'overflow-hidden p-0',
           flush
-            ? 'rounded-b-[16px] border-x border-b border-slate-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
-            : 'rounded-[16px] border border-slate-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
+            ? 'rounded-b-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]'
+            : 'rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]',
           className
         )}
       >


### PR DESCRIPTION
1. TabsList: Remove bg-slate-100 to match default dark shadcn tabs styling
2. CollapsibleCard shadow: Change from layered shadow to single shadow matching Analytics panels: shadow-[0_14px_45px_rgba(0,0,0,0.14)]
3. CollapsibleCard border: Remove border-slate-200 to match Analytics (no border on container panels)

This makes Account Settings panels visually identical to Analytics panels:
- Same shadow/floating effect
- Same border radius (16px)
- Same border style (none on container)
- Same tab selector styling (dark default shadcn)