### PR TITLE
fix(dashboard): redesign Course Sessions dialog

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1088,7 +1088,7 @@ function TutorDashboardContent() {
                   )}
                 </div>
               ) : (
-                <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-2">
+                <div className="scrollbar-hide h-[460px] space-y-3 overflow-y-auto pr-2">
                   {courseSessions.length > 6 && (
                     <p className="text-muted-foreground pb-1 text-xs">
                       {courseSessions.length} sessions — scroll to see all
@@ -1130,11 +1130,11 @@ function TutorDashboardContent() {
                       return (
                         <div
                           key={session.id}
-                          className="border-border/30 bg-card/50 hover:border-border/50 hover:bg-card flex items-center justify-between rounded-lg border p-3 transition-all duration-200"
+                          className="border-border/30 bg-card hover:border-border/50 flex items-center justify-between rounded-lg border p-3 transition-all duration-200 hover:bg-white"
                         >
                           <div className="min-w-0 flex-1 space-y-1">
                             <div className="flex flex-wrap items-center gap-2">
-                              <p className="truncate font-medium">
+                              <p className="truncate font-medium text-gray-900">
                                 {sessionsCourseMeta?.name
                                   ? (() => {
                                       const [cat, nat] = sessionsCourseMeta.variantName
@@ -1297,36 +1297,20 @@ function TutorDashboardContent() {
             <Separator className="my-4" />
 
             <DialogFooter className="flex items-center justify-between sm:justify-between">
-              <div className="flex items-center gap-2 text-xs">
-                <AlertCircle className="h-4 w-4" />
-                <span>Add recurring sessions in the scheduler, or create a one-off session</span>
-              </div>
               <div className="flex flex-wrap items-center gap-2">
                 {selectedCourseForCancel && (
-                  <>
-                    <Button asChild variant="outline">
-                      <Link
-                        href={withLocalePath(
-                          `/tutor/courses/${selectedCourseForCancel.templateCourseId ?? selectedCourseForCancel.id}`
-                        )}
-                      >
-                        <CalendarClock className="mr-1 h-4 w-4" />
-                        +Add/Edit schedule
-                      </Link>
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() =>
-                        setOneTimeCourse({
-                          id: selectedCourseForCancel.id,
-                          name: selectedCourseForCancel.name,
-                        })
-                      }
-                    >
-                      <Video className="mr-1 h-4 w-4" />
-                      Create one-time session
-                    </Button>
-                  </>
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      setOneTimeCourse({
+                        id: selectedCourseForCancel.id,
+                        name: selectedCourseForCancel.name,
+                      })
+                    }
+                  >
+                    <Video className="mr-1 h-4 w-4" />
+                    Create one-time session
+                  </Button>
                 )}
                 <Button variant="modal-secondary-dark" onClick={() => setCancelModalOpen(false)}>
                   Close


### PR DESCRIPTION
1. Fixed height container (h-[460px]) showing exactly 5 session cards
2. Hide scrollbar while keeping scrollable (scrollbar-hide)
3. Session card default: light gray bg (bg-card), charcoal text (text-gray-900) Session card hover: white bg (hover:bg-white)
4. Close button: keep modal-secondary-dark (charcoal bg, white text, white outline)
5. Remove bottom text and AlertCircle icon completely
6. Remove +Add/Edit schedule button, place Create one-time session left of Close