### PR TITLE
fix(revenue-dashboard): fix tabs background, padding, and overflow

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/RevenueDashboard.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/RevenueDashboard.tsx
@@ -479,7 +479,7 @@ export function RevenueDashboard({
 
             {/* Tabs */}
             <Tabs value={activeTab} onValueChange={setActiveTab as any} className="mt-4 px-4">
-              <TabsList className="bg-muted grid w-full grid-cols-4">
+              <TabsList className="grid w-full grid-cols-4 bg-white">
                 <TabsTrigger value="overview" className="text-xs">
                   Overview
                 </TabsTrigger>
@@ -496,8 +496,8 @@ export function RevenueDashboard({
             </Tabs>
 
             <CardContent className="flex-1 p-0">
-              <ScrollArea className="h-[calc(100%-180px)]">
-                <div className="px-4 pb-4">
+              <ScrollArea className="h-full">
+                <div className="px-4 pb-4 pt-4">
                   {activeTab === 'overview' && (
                     <div className="space-y-4">
                       {/* Key Metrics */}


### PR DESCRIPTION
1. TabsList: Change bg-muted to bg-white for white pill-shaped tabs background
2. Add pt-4 padding between tabs and content cards below
3. Fix overflow: Replace fragile h-[calc(100%-180px)] with h-full so ScrollArea properly fills remaining flex space without distorting the header