### PR TITLE
fix(live-video): fix live-session video joins (student token + tutor expired-room)

### DIFF
--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -194,11 +194,51 @@ export const GET = withAuth(
 
     const sessionDuration = liveSessionRow.durationMinutes ?? 240
     // Resilient: a Daily token hiccup must not 500 the whole classroom (chat /
-    // whiteboard / roster still load; the room is public so video can still join).
+    // whiteboard / roster still load). NOTE: rooms are token-gated (private), so a
+    // null token means the tutor CANNOT join the video — hence the recreate below.
     let token: string | null = null
+    let roomUrl = liveSessionRow.roomUrl
     if (liveSessionRow.roomId) {
+      // Rooms expire (durationMinutes + buffer). Reopening a session after that
+      // would mint a token for a dead room and fail every tutor join. Recreate it
+      // once and persist — mirroring the student join route — so the tutor lands
+      // in a live room. The compare-and-set on roomId avoids double-recreation.
+      let activeRoomId = liveSessionRow.roomId
       try {
-        token = await dailyProvider.createMeetingToken(liveSessionRow.roomId, tutorId, {
+        const roomLive = await dailyProvider.isRoomActive(liveSessionRow.roomId)
+        if (!roomLive) {
+          const fresh = await dailyProvider.createRoom(liveSessionRow.tutorId, {
+            maxParticipants: Math.min((liveSessionRow.maxStudents ?? 9) + 1, 50),
+            durationMinutes: liveSessionRow.durationMinutes ?? 120,
+          })
+          const updated = await drizzleDb
+            .update(liveSession)
+            .set({ roomId: fresh.id, roomUrl: fresh.url })
+            .where(
+              and(eq(liveSession.sessionId, classId), eq(liveSession.roomId, liveSessionRow.roomId))
+            )
+            .returning({ roomId: liveSession.roomId, roomUrl: liveSession.roomUrl })
+          if (updated.length > 0) {
+            activeRoomId = fresh.id
+            roomUrl = fresh.url
+          } else {
+            const [current] = await drizzleDb
+              .select({ roomId: liveSession.roomId, roomUrl: liveSession.roomUrl })
+              .from(liveSession)
+              .where(eq(liveSession.sessionId, classId))
+              .limit(1)
+            if (current?.roomId) {
+              activeRoomId = current.roomId
+              roomUrl = current.roomUrl
+            }
+            dailyProvider.deleteRoom(fresh.id).catch(() => {})
+          }
+        }
+      } catch (err: any) {
+        console.error('[tutor classes GET] room re-check/recreate failed:', err?.message)
+      }
+      try {
+        token = await dailyProvider.createMeetingToken(activeRoomId, tutorId, {
           isOwner: true,
           durationMinutes: sessionDuration,
         })
@@ -243,7 +283,7 @@ export const GET = withAuth(
         subject: liveSessionRow.category,
         status: liveSessionRow.status,
         roomId: liveSessionRow.roomId,
-        roomUrl: liveSessionRow.roomUrl,
+        roomUrl,
         token,
         scheduledAt: liveSessionRow.scheduledAt?.toISOString?.() ?? null,
         startedAt: liveSessionRow.startedAt?.toISOString?.() ?? null,

--- a/tutorme-app/src/lib/video/daily-provider.ts
+++ b/tutorme-app/src/lib/video/daily-provider.ts
@@ -145,14 +145,13 @@ export class DailyCoProvider implements VideoProvider {
           room_name: roomName,
           user_id: userId,
           is_owner: isOwner,
-          ...(isOwner
-            ? {}
-            : {
-                start_video_off: true,
-                permissions: {
-                  canSendVideo: false,
-                },
-              }),
+          // Students start with their camera off. NOTE: a non-standard
+          // `permissions: { canSendVideo: false }` used to sit here — that key
+          // isn't part of Daily's meeting-token schema, so the /meeting-tokens
+          // call rejected it (400), token creation threw, and students were
+          // handed a null token for a PRIVATE room → every join failed ("Try
+          // again"). `start_video_off` covers the camera-off intent on its own.
+          ...(isOwner ? {} : { start_video_off: true }),
           exp: expiry,
         },
       }),


### PR DESCRIPTION
Fixes the **"Try again"** error when opening the video in a live session. Two independent join bugs — one per role — plus a config note.

## Bug 1 — Students (invalid token permissions)
Rooms are created **`privacy: 'private'`**, so a valid meeting token is required to join. The student (non-owner) token was minted with `permissions: { canSendVideo: false }` — **not** a key in Daily's meeting-token schema. Daily's `/meeting-tokens` rejects it (400) → `createMeetingToken` throws → the join route hands the student a **null token** → private-room join fails every time. **Fix:** removed the invalid key; `start_video_off: true` (kept) already starts students camera-off. Owners were never in that block.

## Bug 2 — Tutors (expired room not recreated)
The student join route recreates an expired Daily room, but the tutor's session load (`GET /api/tutor/classes/[id]`) minted a token for the stored `roomId` **without checking it**. Once the room expired, the tutor got a token for a dead room (or null) → every join failed. **Fix:** mirror the join route — re-check the room, recreate + persist once if gone, mint the token for the live room, return the refreshed `roomUrl`. Also fixed the stale comment that claimed the room is public (it's private).

## If it STILL fails for everyone after this
The remaining suspect is a **`DAILY_API_KEY` that's invalid or rotated** in prod — that fails token creation for *both* roles regardless of code. Server logs will show `[Join] Daily.co token creation failed` / `[tutor classes GET] Daily token creation failed` (a Daily 401). Verify the key in the Cloud Run env / Daily dashboard.

## Verification
`tsc` 0, build clean, eslint 0 errors on both files.

## ⚠️ Smoke-test
Open the video in a live session as **student** and as **tutor** → both should connect instead of "Try again," including on a session whose room had expired (it gets recreated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)