### PR TITLE
feat(student): distinguish provisional (auto) vs tutor-finalized grades

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -122,7 +122,12 @@ export default function StudentAssignmentsPage() {
       }
       const data = await res.json()
       if (data.alreadySubmitted) {
-        toast.info(`Already submitted. Score: ${data.existingScore ?? 'N/A'}%`)
+        const scoreTxt = data.existingScore != null ? `${Math.round(data.existingScore)}%` : 'N/A'
+        toast.info(
+          data.existingGraded
+            ? `Graded by your tutor: ${scoreTxt}${data.existingFeedback ? ` — ${data.existingFeedback}` : ''}`
+            : `Submitted — provisional score ${scoreTxt} (auto-graded; awaiting your tutor).`
+        )
         return
       }
       // Map to QuizModal question format

--- a/tutorme-app/src/app/[locale]/student/work/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/work/page.tsx
@@ -132,7 +132,12 @@ function AssignmentsTab() {
       }
       const data = await res.json()
       if (data.alreadySubmitted) {
-        toast.info(`Already submitted. Score: ${data.existingScore ?? 'N/A'}%`)
+        const scoreTxt = data.existingScore != null ? `${Math.round(data.existingScore)}%` : 'N/A'
+        toast.info(
+          data.existingGraded
+            ? `Graded by your tutor: ${scoreTxt}${data.existingFeedback ? ` — ${data.existingFeedback}` : ''}`
+            : `Submitted — provisional score ${scoreTxt} (auto-graded; awaiting your tutor).`
+        )
         return
       }
       setActiveTask({

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -102,7 +102,12 @@ export async function GET(
 
     // Existing submission (if any) for this student
     const [existing] = await drizzleDb
-      .select({ score: taskSubmission.score, status: taskSubmission.status })
+      .select({
+        score: taskSubmission.score,
+        status: taskSubmission.status,
+        tutorApproved: taskSubmission.tutorApproved,
+        tutorFeedback: taskSubmission.tutorFeedback,
+      })
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
       .limit(1)
@@ -140,6 +145,10 @@ export async function GET(
     return NextResponse.json({
       alreadySubmitted: existing != null,
       existingScore: existing?.score ?? null,
+      // Whether the tutor has finalized the grade (vs the automatic provisional
+      // score). Lets the student see "graded by your tutor" + any feedback.
+      existingGraded: existing?.status === 'graded' || existing?.tutorApproved === true,
+      existingFeedback: existing?.tutorFeedback ?? null,
       task: {
         id: task.taskId,
         title: task.title,

--- a/tutorme-app/src/components/quiz/quiz-modal.tsx
+++ b/tutorme-app/src/components/quiz/quiz-modal.tsx
@@ -225,6 +225,13 @@ export function QuizModal({
                     ? 'Good effort! Keep practicing.'
                     : 'Keep studying! You will improve.'}
               </p>
+              {/* This just-submitted score is the automatic grade. Written answers
+                  are flagged for the tutor, who may review and adjust it — so it's
+                  provisional until the tutor finalizes it. */}
+              <div className="mx-auto mt-3 max-w-sm rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                <span className="font-semibold">Provisional score</span> — auto-graded now. Your
+                tutor may review and adjust it (especially written answers).
+              </div>
             </div>
 
             <div className="space-y-4">


### PR DESCRIPTION
Follow-up to the grading investigation: students had no way to tell an **automatic provisional** score from a **tutor-finalized** one, and never saw tutor feedback. This adds that distinction where students view their grade.

## Changes
- **QuizModal results** (post-submit): a **"Provisional score — auto-graded; your tutor may review and adjust it"** banner under the score. Right after submit the grade is always the automatic one (open-ended answers are flagged for tutor review), so this sets the right expectation.
- **GET `/api/student/assignments/[taskId]`**: now also returns `existingGraded` (`status === 'graded' || tutorApproved`) and `existingFeedback` (`tutorFeedback`).
- **Re-opening a submitted assignment** (assignments + work pages): the toast now reads either **"Graded by your tutor: N% — <feedback>"** (final) or **"Submitted — provisional score N% (auto-graded; awaiting your tutor)"** (provisional).

Reflects the real data model: auto-grade leaves `status: 'submitted'` / `tutorApproved: false`; a tutor's `/grade` sets `status: 'graded'` / `tutorApproved: true` + `tutorFeedback`.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
Submit an assessment → results show the "Provisional" banner. Re-open it before the tutor grades → "provisional … awaiting your tutor." After the tutor grades/approves it (with feedback) → "Graded by your tutor: N% — <feedback>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)