### PR TITLE
feat(schedule): New-schedule form in the Class Schedules modal + drop redundant View Sessions button

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1323,6 +1323,7 @@ function TutorDashboardContent() {
       <ScheduleViewModal
         courseId={scheduleCourse?.id ?? null}
         courseName={scheduleCourse?.name}
+        canCreate
         onClose={() => setScheduleCourse(null)}
       />
     </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -34,7 +34,6 @@ import {
   Users,
   AlertCircle,
   Ban,
-  Eye,
   CalendarClock,
   Pencil,
   Presentation,
@@ -839,20 +838,12 @@ function TutorDashboardContent() {
                               <Presentation className="mr-1 h-3 w-3" />
                               Classroom
                             </Button>
-                            {hasViewableSessions ? (
-                              <Button
-                                variant="default"
-                                size="sm"
-                                onClick={() => handleOpenSessionsModal(course)}
-                                className="bg-blue-600 text-white transition-all duration-200 hover:bg-white hover:text-blue-600"
-                              >
-                                <Eye className="mr-1 h-3 w-3" />
-                                View Sessions
-                              </Button>
-                            ) : (
-                              // Sessions come only from the course schedule — send the
-                              // tutor to the scheduler (course details page) to add slots
-                              // and publish, instead of creating an ad-hoc session.
+                            {/* When sessions exist, the "N sessions" count badge above
+                                already opens the sessions modal, so a separate "View
+                                Sessions" button here was redundant and has been removed.
+                                With no sessions yet, send the tutor to the scheduler
+                                (course details page) to add slots and publish. */}
+                            {!hasViewableSessions && (
                               <Button
                                 asChild
                                 variant="default"

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -10,7 +10,12 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Loader2, CalendarClock } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Loader2, CalendarClock, Plus } from 'lucide-react'
+import { toast } from 'sonner'
+import { ScheduleSlotEditor } from '@/app/[locale]/tutor/courses/[id]/components/ScheduleSlotEditor'
+import { DAYS, type ScheduleItem } from '@/app/[locale]/tutor/courses/[id]/constants'
 
 interface ScheduleSlot {
   dayOfWeek: string
@@ -52,6 +57,9 @@ interface ScheduleViewModalProps {
   selectedScheduleId?: string | null
   /** When provided, each non-current schedule gets a "Switch to this" button. */
   onSwitch?: (scheduleId: string) => Promise<void> | void
+  /** Tutor context: show a "New schedule" form that creates a schedule for this
+   *  course (POST /api/tutor/courses/[courseId]/schedules) and refreshes the list. */
+  canCreate?: boolean
 }
 
 export function ScheduleViewModal({
@@ -60,33 +68,102 @@ export function ScheduleViewModal({
   onClose,
   selectedScheduleId,
   onSwitch,
+  canCreate = false,
 }: ScheduleViewModalProps) {
   const [schedules, setSchedules] = useState<CourseSchedule[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [switchingId, setSwitchingId] = useState<string | null>(null)
 
-  useEffect(() => {
+  // "New schedule" form (tutor only).
+  const [showCreate, setShowCreate] = useState(false)
+  const [slots, setSlots] = useState<ScheduleItem[]>([
+    { dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 },
+  ])
+  const [weeks, setWeeks] = useState(8)
+  const [maxStudents, setMaxStudents] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  const loadSchedules = useCallback(async () => {
     if (!courseId) return
-    let cancelled = false
     setLoading(true)
     setError(null)
-    fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
-      .then(async res => {
-        if (!res.ok) throw new Error('failed')
-        const data = await res.json()
-        if (!cancelled) setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
-      })
-      .catch(() => {
-        if (!cancelled) setError('Could not load schedules')
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
+    try {
+      const res = await fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
+      if (!res.ok) throw new Error('failed')
+      const data = await res.json()
+      setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
+    } catch {
+      setError('Could not load schedules')
+    } finally {
+      setLoading(false)
     }
   }, [courseId])
+
+  useEffect(() => {
+    if (!courseId) return
+    void loadSchedules()
+  }, [courseId, loadSchedules])
+
+  // Reset the create form each time the modal opens for a course.
+  useEffect(() => {
+    if (!courseId) return
+    setShowCreate(false)
+    setSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
+    setWeeks(8)
+    setMaxStudents('')
+  }, [courseId])
+
+  const updateSlot = (index: number, field: keyof ScheduleItem, value: string | number) => {
+    setSlots(prev => {
+      const next = [...prev]
+      next[index] = { ...next[index], [field]: value }
+      return next
+    })
+  }
+  const removeSlot = (index: number) => setSlots(prev => prev.filter((_, i) => i !== index))
+  const addSlot = () =>
+    setSlots(prev => [...prev, { dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
+
+  const handleCreate = async () => {
+    if (!courseId || creating) return
+    if (slots.length === 0) {
+      toast.error('Add at least one weekly slot.')
+      return
+    }
+    setCreating(true)
+    try {
+      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token as string | undefined
+      const res = await fetch(`/api/tutor/courses/${courseId}/schedules`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
+        body: JSON.stringify({
+          schedule: slots,
+          weeksToSchedule: weeks,
+          maxStudents: maxStudents.trim() ? Number(maxStudents) : null,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data?.error || 'Failed to create schedule')
+      }
+      toast.success('Schedule created')
+      setShowCreate(false)
+      setSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
+      setWeeks(8)
+      setMaxStudents('')
+      await loadSchedules()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create schedule')
+    } finally {
+      setCreating(false)
+    }
+  }
 
   return (
     <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
@@ -188,6 +265,89 @@ export function ScheduleViewModal({
             </div>
           )}
         </div>
+
+        {canCreate && (
+          <div className="border-t border-gray-100 pt-3">
+            {!showCreate ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowCreate(true)}
+                className="gap-1.5"
+              >
+                <Plus className="h-4 w-4" />
+                New schedule
+              </Button>
+            ) : (
+              <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <h4 className="text-sm font-semibold text-gray-900">New schedule</h4>
+                  <span className="text-xs text-gray-400">
+                    Auto-named &ldquo;Schedule {schedules.length + 1}&rdquo;
+                  </span>
+                </div>
+                <div className="max-h-[30vh] space-y-2 overflow-y-auto">
+                  {slots.map((slot, i) => (
+                    <ScheduleSlotEditor
+                      key={i}
+                      slot={slot}
+                      index={i}
+                      onUpdate={updateSlot}
+                      onRemove={removeSlot}
+                    />
+                  ))}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addSlot}
+                  className="mt-2 gap-1"
+                >
+                  <Plus className="h-3.5 w-3.5" /> Add slot
+                </Button>
+                <div className="mt-3 flex flex-wrap items-end gap-3">
+                  <div className="space-y-1">
+                    <Label className="text-xs">Weeks</Label>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={52}
+                      value={weeks}
+                      onChange={e => setWeeks(Math.max(1, Number(e.target.value) || 1))}
+                      className="h-9 w-24"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Max students (optional)</Label>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="No limit"
+                      value={maxStudents}
+                      onChange={e => setMaxStudents(e.target.value)}
+                      className="h-9 w-32"
+                    />
+                  </div>
+                  <div className="ml-auto flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowCreate(false)}
+                      disabled={creating}
+                    >
+                      Cancel
+                    </Button>
+                    <Button size="sm" onClick={handleCreate} disabled={creating}>
+                      {creating ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+                      Create schedule
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         <DialogFooter align="end">
           <Button


### PR DESCRIPTION
Adds the ability to **create a new schedule from the Class Schedules modal** (the one that opens from a course card's **Schedule** button on the sessions tab).

## Context (your suspicion, checked)
The git history shows no create-schedule button was removed from the course cards — the other devops's recent changes were cosmetic, and this modal has been **view-only since it was introduced** (0 create/POST references in its entire history). Schedule *creation* always lived on the course scheduler page. So this is a **new** capability in the modal (per your request), not a revert.

## What
A tutor-only **"New schedule"** form inside `ScheduleViewModal`:
- Weekly **slots** (day / start time / duration) — add & remove, reusing the existing `ScheduleSlotEditor` so it matches the course scheduler.
- **Weeks to schedule** and optional **max students**.
- **Create** → POSTs `{ schedule, weeksToSchedule, maxStudents }` to the existing `/api/tutor/courses/[courseId]/schedules` (with CSRF), then refreshes the list in place. Auto-named "Schedule N" by the server.

## Correctness (template/published id)
Uses the **same `courseId` the modal already views**. The enrolled API keys schedules by that id and the tutor is its creator, so `verifyCourseOwnership` passes and a created schedule appears immediately on refetch — no template/published mismatch.

## Scope / safety
Gated behind a new `canCreate` prop — **only the tutor dashboard passes it**, so the student enroll view (view + "switch schedule") is unchanged.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
On the tutor dashboard sessions tab, click **Schedule** on a course card → **New schedule** → add a couple of slots, set weeks/max → **Create schedule** → it should appear in the grid immediately. Confirm the student enroll schedule modal shows no create form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)