### PR TITLE
change(schedule): "New schedule" opens the main scheduler instead of an inline form

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -190,7 +190,11 @@ function TutorDashboardContent() {
   const locale = typeof params?.locale === 'string' ? params.locale : 'en'
   const hasLocalePrefix = pathname.startsWith(`/${locale}/`)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
-  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
+  const [scheduleCourse, setScheduleCourse] = useState<{
+    id: string
+    name: string
+    schedulerHref: string
+  } | null>(null)
   // Course context for creating a one-time (non-schedule) session from the sessions modal.
   const [oneTimeCourse, setOneTimeCourse] = useState<{ id: string; name: string } | null>(null)
   // Course name + variant for the sessions modal (from the sessions API).
@@ -880,7 +884,16 @@ function TutorDashboardContent() {
                               size="sm"
                               className="border-white/30 bg-[#36454F] text-white transition-all duration-200 hover:border-transparent hover:bg-white hover:text-purple-500"
                               onClick={() =>
-                                setScheduleCourse({ id: course.id, name: course.name })
+                                setScheduleCourse({
+                                  id: course.id,
+                                  name: course.name,
+                                  // "New schedule" in the modal opens the main
+                                  // scheduler on the course-details page (template
+                                  // id, like the "Schedule sessions" link).
+                                  schedulerHref: withLocalePath(
+                                    `/tutor/courses/${course.templateCourseId ?? course.id}#course-schedule`
+                                  ),
+                                })
                               }
                             >
                               <CalendarClock className="mr-1 h-3 w-3" />
@@ -1314,7 +1327,7 @@ function TutorDashboardContent() {
       <ScheduleViewModal
         courseId={scheduleCourse?.id ?? null}
         courseName={scheduleCourse?.name}
-        canCreate
+        createHref={scheduleCourse?.schedulerHref}
         onClose={() => setScheduleCourse(null)}
       />
     </div>

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
 import {
   Dialog,
   DialogContent,
@@ -10,12 +11,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Loader2, CalendarClock, Plus } from 'lucide-react'
-import { toast } from 'sonner'
-import { ScheduleSlotEditor } from '@/app/[locale]/tutor/courses/[id]/components/ScheduleSlotEditor'
-import { DAYS, type ScheduleItem } from '@/app/[locale]/tutor/courses/[id]/constants'
 
 interface ScheduleSlot {
   dayOfWeek: string
@@ -57,9 +53,9 @@ interface ScheduleViewModalProps {
   selectedScheduleId?: string | null
   /** When provided, each non-current schedule gets a "Switch to this" button. */
   onSwitch?: (scheduleId: string) => Promise<void> | void
-  /** Tutor context: show a "New schedule" form that creates a schedule for this
-   *  course (POST /api/tutor/courses/[courseId]/schedules) and refreshes the list. */
-  canCreate?: boolean
+  /** Tutor context: when set, show a "New schedule" button that opens the main
+   *  scheduler (the course-details page) at this href. */
+  createHref?: string | null
 }
 
 export function ScheduleViewModal({
@@ -68,102 +64,34 @@ export function ScheduleViewModal({
   onClose,
   selectedScheduleId,
   onSwitch,
-  canCreate = false,
+  createHref,
 }: ScheduleViewModalProps) {
   const [schedules, setSchedules] = useState<CourseSchedule[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [switchingId, setSwitchingId] = useState<string | null>(null)
 
-  // "New schedule" form (tutor only).
-  const [showCreate, setShowCreate] = useState(false)
-  const [slots, setSlots] = useState<ScheduleItem[]>([
-    { dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 },
-  ])
-  const [weeks, setWeeks] = useState(8)
-  const [maxStudents, setMaxStudents] = useState('')
-  const [creating, setCreating] = useState(false)
-
-  const loadSchedules = useCallback(async () => {
+  useEffect(() => {
     if (!courseId) return
+    let cancelled = false
     setLoading(true)
     setError(null)
-    try {
-      const res = await fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
-      if (!res.ok) throw new Error('failed')
-      const data = await res.json()
-      setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
-    } catch {
-      setError('Could not load schedules')
-    } finally {
-      setLoading(false)
-    }
-  }, [courseId])
-
-  useEffect(() => {
-    if (!courseId) return
-    void loadSchedules()
-  }, [courseId, loadSchedules])
-
-  // Reset the create form each time the modal opens for a course.
-  useEffect(() => {
-    if (!courseId) return
-    setShowCreate(false)
-    setSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
-    setWeeks(8)
-    setMaxStudents('')
-  }, [courseId])
-
-  const updateSlot = (index: number, field: keyof ScheduleItem, value: string | number) => {
-    setSlots(prev => {
-      const next = [...prev]
-      next[index] = { ...next[index], [field]: value }
-      return next
-    })
-  }
-  const removeSlot = (index: number) => setSlots(prev => prev.filter((_, i) => i !== index))
-  const addSlot = () =>
-    setSlots(prev => [...prev, { dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
-
-  const handleCreate = async () => {
-    if (!courseId || creating) return
-    if (slots.length === 0) {
-      toast.error('Add at least one weekly slot.')
-      return
-    }
-    setCreating(true)
-    try {
-      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
-      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token as string | undefined
-      const res = await fetch(`/api/tutor/courses/${courseId}/schedules`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
-        },
-        body: JSON.stringify({
-          schedule: slots,
-          weeksToSchedule: weeks,
-          maxStudents: maxStudents.trim() ? Number(maxStudents) : null,
-        }),
+    fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
+      .then(async res => {
+        if (!res.ok) throw new Error('failed')
+        const data = await res.json()
+        if (!cancelled) setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
       })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data?.error || 'Failed to create schedule')
-      }
-      toast.success('Schedule created')
-      setShowCreate(false)
-      setSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
-      setWeeks(8)
-      setMaxStudents('')
-      await loadSchedules()
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create schedule')
-    } finally {
-      setCreating(false)
+      .catch(() => {
+        if (!cancelled) setError('Could not load schedules')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
     }
-  }
+  }, [courseId])
 
   return (
     <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
@@ -266,86 +194,14 @@ export function ScheduleViewModal({
           )}
         </div>
 
-        {canCreate && (
+        {createHref && (
           <div className="border-t border-gray-100 pt-3">
-            {!showCreate ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowCreate(true)}
-                className="gap-1.5"
-              >
+            <Button asChild variant="outline" size="sm" className="gap-1.5">
+              <Link href={createHref}>
                 <Plus className="h-4 w-4" />
                 New schedule
-              </Button>
-            ) : (
-              <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-3">
-                <div className="mb-2 flex items-center justify-between">
-                  <h4 className="text-sm font-semibold text-gray-900">New schedule</h4>
-                  <span className="text-xs text-gray-400">
-                    Auto-named &ldquo;Schedule {schedules.length + 1}&rdquo;
-                  </span>
-                </div>
-                <div className="max-h-[30vh] space-y-2 overflow-y-auto">
-                  {slots.map((slot, i) => (
-                    <ScheduleSlotEditor
-                      key={i}
-                      slot={slot}
-                      index={i}
-                      onUpdate={updateSlot}
-                      onRemove={removeSlot}
-                    />
-                  ))}
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addSlot}
-                  className="mt-2 gap-1"
-                >
-                  <Plus className="h-3.5 w-3.5" /> Add slot
-                </Button>
-                <div className="mt-3 flex flex-wrap items-end gap-3">
-                  <div className="space-y-1">
-                    <Label className="text-xs">Weeks</Label>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={52}
-                      value={weeks}
-                      onChange={e => setWeeks(Math.max(1, Number(e.target.value) || 1))}
-                      className="h-9 w-24"
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs">Max students (optional)</Label>
-                    <Input
-                      type="number"
-                      min={1}
-                      placeholder="No limit"
-                      value={maxStudents}
-                      onChange={e => setMaxStudents(e.target.value)}
-                      className="h-9 w-32"
-                    />
-                  </div>
-                  <div className="ml-auto flex items-center gap-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setShowCreate(false)}
-                      disabled={creating}
-                    >
-                      Cancel
-                    </Button>
-                    <Button size="sm" onClick={handleCreate} disabled={creating}>
-                      {creating ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
-                      Create schedule
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
+              </Link>
+            </Button>
           </div>
         )}
 


### PR DESCRIPTION
Per your feedback: the **"New schedule"** button in the Class Schedules modal should open the **main scheduler**, not the inline mini-form.

## Change
- The modal's **"New schedule"** button now navigates to the full scheduler on the course-details page (`/tutor/courses/[templateId]#course-schedule` — same template id the "Schedule sessions" link uses), rather than expanding an inline create form.
- Removed the inline form (slots / weeks / max students) and its POST + CSRF logic. The modal is now **view schedules + a "New schedule" link**.
- Prop `canCreate` → **`createHref`**; the dashboard passes the scheduler URL.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
Tutor dashboard → sessions tab → **Schedule** on a course card → the modal lists schedules with a **New schedule** button → clicking it opens the course scheduler (scrolled to the schedule section). Student enroll view unchanged (no button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)