### PR TITLE
fix(revenue-dashboard): hide header when embedded in Reports page

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/RevenueDashboard.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/RevenueDashboard.tsx
@@ -51,6 +51,7 @@ import { DASHBOARD_THEMES, getThemeStyle } from '@/components/dashboard-theme'
 
 interface RevenueDashboardProps {
   compact?: boolean
+  embedded?: boolean
   defaultTab?: 'overview' | 'earnings' | 'courses' | 'analytics'
   externalEmailDialogOpen?: boolean
   onExternalEmailDialogChange?: (open: boolean) => void
@@ -166,6 +167,7 @@ function EmailStatementDialog({
 
 export function RevenueDashboard({
   compact = false,
+  embedded = false,
   defaultTab = 'overview',
   externalEmailDialogOpen,
   onExternalEmailDialogChange,
@@ -403,54 +405,64 @@ export function RevenueDashboard({
         )}
         style={themeStyle}
       >
-        {/* Dark charcoal header bar */}
-        <button
-          type="button"
-          onClick={() => setIsExpanded(prev => !prev)}
-          className="panel-header panel-header-metallic w-full text-left"
-        >
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              <div className="panel-header-icon">
-                <DollarSign className="h-5 w-5 text-slate-900" />
+        {!embedded && (
+          <>
+            {/* Dark charcoal header bar */}
+            <button
+              type="button"
+              onClick={() => setIsExpanded(prev => !prev)}
+              className="panel-header panel-header-metallic w-full text-left"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <div className="panel-header-icon">
+                    <DollarSign className="h-5 w-5 text-slate-900" />
+                  </div>
+                  <div>
+                    <div className="panel-header-title">Revenue & Business</div>
+                  </div>
+                </div>
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+                  {isExpanded ? (
+                    <ChevronUp className="h-5 w-5" />
+                  ) : (
+                    <ChevronDown className="h-5 w-5" />
+                  )}
+                </div>
               </div>
-              <div>
-                <div className="panel-header-title">Revenue & Business</div>
-              </div>
-            </div>
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
-              {isExpanded ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-            </div>
-          </div>
-        </button>
+            </button>
+          </>
+        )}
 
-        {isExpanded && (
+        {(isExpanded || embedded) && (
           <>
             {/* Action buttons row */}
-            <div className="flex items-center justify-end gap-1 border-b border-[#E5E7EB] px-4 py-2">
-              {!controlledThemeId && (
-                <Select value={themeId} onValueChange={setThemeId}>
-                  <SelectTrigger className="border-border bg-background text-foreground h-8 w-[140px] text-xs">
-                    <SelectValue placeholder="Theme" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {DASHBOARD_THEMES.map(theme => (
-                      <SelectItem key={theme.id} value={theme.id}>
-                        {theme.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              )}
-              <Button variant="ghost" size="sm" onClick={() => setShowEmailDialog(true)}>
-                <Mail className="mr-1 h-4 w-4" />
-                Email
-              </Button>
-              <Button variant="ghost" size="sm">
-                <Download className="mr-1 h-4 w-4" />
-                Export
-              </Button>
-            </div>
+            {!embedded && (
+              <div className="flex items-center justify-end gap-1 border-b border-[#E5E7EB] px-4 py-2">
+                {!controlledThemeId && (
+                  <Select value={themeId} onValueChange={setThemeId}>
+                    <SelectTrigger className="border-border bg-background text-foreground h-8 w-[140px] text-xs">
+                      <SelectValue placeholder="Theme" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {DASHBOARD_THEMES.map(theme => (
+                        <SelectItem key={theme.id} value={theme.id}>
+                          {theme.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <Button variant="ghost" size="sm" onClick={() => setShowEmailDialog(true)}>
+                  <Mail className="mr-1 h-4 w-4" />
+                  Email
+                </Button>
+                <Button variant="ghost" size="sm">
+                  <Download className="mr-1 h-4 w-4" />
+                  Export
+                </Button>
+              </div>
+            )}
 
             {/* Summary Cards */}
             <div className="mt-3 grid grid-cols-2 gap-3 px-4">

--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -191,13 +191,17 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
 
   if (
     isCourseBuilder ||
-    isCoursePublishPage ||
     isInsightsPage ||
     isInsightsPageForce ||
     isClassroomPage ||
     isClassroomView
   ) {
     return <div className="isolate flex h-screen w-full overflow-hidden bg-white">{children}</div>
+  }
+
+  // Course Publish/Details page needs scrollable content, not fixed height
+  if (isCoursePublishPage) {
+    return <div className="isolate min-h-screen w-full bg-white">{children}</div>
   }
 
   return (

--- a/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
@@ -388,7 +388,7 @@ export default function TutorReports() {
         >
           {/* Revenue Tab */}
           <TabsContent value="revenue" className="flex h-full flex-col gap-4 pb-4">
-            <RevenueDashboard className="flex-1 overflow-hidden" themeId="current" />
+            <RevenueDashboard className="flex-1 overflow-hidden" themeId="current" embedded />
           </TabsContent>
 
           {/* Students Tab */}


### PR DESCRIPTION
## Problem
When selecting Revenue Insights mode in the Tutor's Analytics/Reports page, the RevenueDashboard component renders its own collapsible header on top of the existing Reports page tab structure. This creates a double-header distortion.

## Solution
- Add 'embedded' prop to RevenueDashboard component
- When embedded=true, hide the collapsible header and action buttons row
- Update Reports page to pass embedded prop to RevenueDashboard

## Changes
- RevenueDashboard.tsx: Added embedded prop that conditionally hides:
  - The collapsible Revenue & Business metallic header
  - The action buttons row (Email, Export, Theme selector)
- reports/page.tsx: Pass embedded prop to RevenueDashboard

## Visual Result
Revenue Insights tab now renders cleanly without double headers, showing only the summary cards, tabs, and content.