### PR TITLE
fix(account): white background and Analytics-style panel shadows

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8134,7 +8134,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border-0 bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
+                      mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
                     )}
                   >
                     <div
@@ -8861,7 +8862,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                               !(mainTab === 'live' && testPciActiveTab === 'student1') && (
                                 <div
                                   className={cn(
-                                    'mt-1 w-full rounded-2xl border border-violet-300 bg-white transition-all duration-300'
+                                    'mt-1 w-full rounded-2xl border bg-white transition-all duration-300',
+                                    mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
                                   )}
                                 >
                                   <div className="relative flex w-full flex-col p-px">

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -70,7 +70,7 @@ const LANGUAGES = [
 ]
 
 const SECTION_CARD_CLASS =
-  'overflow-hidden bg-white rounded-[16px] border border-slate-200 shadow-sm'
+  'overflow-hidden bg-white rounded-[16px] shadow-[0_14px_45px_rgba(0,0,0,0.14)]'
 
 interface PaymentMethod {
   id: string
@@ -650,7 +650,7 @@ export default function TutorSettings() {
 
       {/* Mode selector + tab content */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
-        <Card className="flex h-full flex-col overflow-hidden rounded-[16px] border-0 shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+        <Card className="flex h-full flex-col overflow-hidden rounded-[16px] border-0 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
             <div className="flex-shrink-0 p-4">
               <TabsList className="relative flex w-full gap-1.5 rounded-xl bg-[#1F2933] p-1.5">


### PR DESCRIPTION
## Changes

- Add explicit bg-white to main Card wrapper to override grey bg-card default
- Change SECTION_CARD_CLASS from subtle shadow-sm to Analytics-style floating shadow
- Remove border from panels to match Analytics clean floating design

## Visual Fixes

| Before | After |
|--------|-------|
| Grey Card background | White background |
| Weak shadow-sm panels | Floating shadow-[0_14px_45px_rgba(0,0,0,0.14)] panels |

Matches Analytics page panel design.