### PR TITLE
fix(layout): handle locale prefix in Course Details page path detection

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -151,8 +151,8 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
   const isCourseBuilder = pathname?.includes('/courses/') && pathname?.includes('/builder')
 
   // Check if we're on the Course Publish page (course detail page) - hide sidebar for focused editing
-  // Pattern: /tutor/courses/[id] but not sub-paths like /tasks or /enrollments
-  const isCoursePublishPage = pathname?.match(/^\/tutor\/courses\/[^\/]+$/) !== null
+  // Pattern: /tutor/courses/[id] or /:locale/tutor/courses/[id] but not sub-paths like /tasks or /enrollments
+  const isCoursePublishPage = pathname?.match(/^(\/[^\/]+)?\/tutor\/courses\/[^\/]+$/) !== null
 
   // Auto-close on My Page, Reports, Account Settings, and Support; auto-open elsewhere
   useEffect(() => {


### PR DESCRIPTION
## Problem

The  regex only matched  but with next-intl v4,  from  returns locale-prefixed paths like . This caused the Course Details page to fall through to the default layout with , preventing scrolling and causing panel layout issues (panels left-justified, contracting when closed).

## Root Cause

The regex  did not account for the locale segment that next-intl prepends to the pathname.

## Fix

Update regex to optionally match locale prefix:
- Before: 
- After: 

This now correctly matches:
-  (default locale, no prefix)
-  (locale prefix)
-  (locale prefix with hyphen)

And correctly excludes:
-  (sub-paths)
-  (other pages)

## Visual Fixes

| Before | After |
|--------|-------|
| Page not scrollable | Scrollable with  |
| Panels left-justified | Full-width panels |
| Panels contract when closed | Consistent panel width |