### PR TITLE
fix(course-builder): disable panel width transition on initial mount

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -744,6 +744,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [rightPanelWidth] = useState(380)
     const [leftPanelWidth, setLeftPanelWidth] = useState(380)
     const [viewportWidth, setViewportWidth] = useState(1920)
+    // Disable width transition on initial mount to prevent expanding animation
+    const [panelsMounted, setPanelsMounted] = useState(false)
+    useEffect(() => {
+      // Small delay to ensure initial render is complete before enabling transitions
+      const timer = setTimeout(() => setPanelsMounted(true), 50)
+      return () => clearTimeout(timer)
+    }, [])
     // Peek animation state for side panel toggles
     const [isLeftPeeking, setIsLeftPeeking] = useState(false)
     const [isRightPeeking, setIsRightPeeking] = useState(false)
@@ -6337,7 +6344,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
             <div
               className={cn(
-                'relative z-40 flex min-h-0 shrink-0 flex-col transition-[width] duration-500 ease-in-out',
+                'relative z-40 flex min-h-0 shrink-0 flex-col',
+                panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '',
                 leftPanelHidden
                   ? 'bg-transparent shadow-none'
                   : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
@@ -6347,7 +6355,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
             >
               <div
                 className={cn(
-                  'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
+                  'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]',
+                  panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
                   leftPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
                 )}
               >
@@ -8126,7 +8135,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
             {/* CENTER PANEL - width tracks the visible side panels (expands when
                 one is hidden), animated to match the panel collapse. */}
             <div
-              className="flex min-h-0 flex-col items-center transition-[width] duration-500 ease-in-out"
+              className={cn(
+                'flex min-h-0 flex-col items-center',
+                panelsMounted ? 'transition-[width] duration-500 ease-in-out' : ''
+              )}
               style={{ width: centerColWidth, flexShrink: 0 }}
             >
               <div className="flex h-full min-h-0 w-full flex-col items-stretch">
@@ -10282,7 +10294,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 {/* Right panel content - grid child with consistent wrapper */}
                 <div
                   className={cn(
-                    'relative z-40 flex min-h-0 shrink-0 flex-col items-end transition-[width] duration-500 ease-in-out',
+                    'relative z-40 flex min-h-0 shrink-0 flex-col items-end',
+                    panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '',
                     rightPanelHidden
                       ? 'bg-transparent shadow-none'
                       : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
@@ -10291,7 +10304,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 >
                   <div
                     className={cn(
-                      'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
+                      'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]',
+                      panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
                       rightPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
                     )}
                   >


### PR DESCRIPTION
## Problem

The Course Builder panels animate their width from 0 to calculated width on every page load, causing a visible expanding animation that looks like the right panel (Desk) is sliding in from the right edge.

## Root Cause

The  CSS transition applies to both initial render AND user-triggered panel hide/show. On mount, the panel width goes from 0 to the calculated width over 500ms.

## Fix

Add a  state that starts  and becomes  after 50ms via . Conditionally apply the width transition only when  is true.

## Changes

- Left panel outer:  only after mount
- Left panel inner:  only after mount
- Center panel:  only after mount
- Right panel outer:  only after mount
- Right panel inner:  only after mount

## Result

| Scenario | Before | After |
|----------|--------|-------|
| Initial page load | Panels animate expanding from 0 width | Panels render at final width immediately |
| User clicks hide/show pill | Smooth 500ms animation | Smooth 500ms animation (unchanged) |
| Peek animation on pills | Smooth width pulse | Smooth width pulse (unchanged) |