### PR TITLE
fix(account): add visible border to Card to distinguish panel from page

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -744,6 +744,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [rightPanelWidth] = useState(380)
     const [leftPanelWidth, setLeftPanelWidth] = useState(380)
     const [viewportWidth, setViewportWidth] = useState(1920)
+    // Disable width transition on initial mount to prevent expanding animation
+    const [panelsMounted, setPanelsMounted] = useState(false)
+    useEffect(() => {
+      // Small delay to ensure initial render is complete before enabling transitions
+      const timer = setTimeout(() => setPanelsMounted(true), 50)
+      return () => clearTimeout(timer)
+    }, [])
     // Peek animation state for side panel toggles
     const [isLeftPeeking, setIsLeftPeeking] = useState(false)
     const [isRightPeeking, setIsRightPeeking] = useState(false)
@@ -6337,7 +6344,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
             <div
               className={cn(
-                'relative z-40 flex min-h-0 shrink-0 flex-col transition-[width] duration-500 ease-in-out',
+                'relative z-40 flex min-h-0 shrink-0 flex-col',
+                panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '',
                 leftPanelHidden
                   ? 'bg-transparent shadow-none'
                   : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
@@ -6347,7 +6355,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
             >
               <div
                 className={cn(
-                  'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
+                  'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]',
+                  panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
                   leftPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
                 )}
               >
@@ -8126,7 +8135,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
             {/* CENTER PANEL - width tracks the visible side panels (expands when
                 one is hidden), animated to match the panel collapse. */}
             <div
-              className="flex min-h-0 flex-col items-center transition-[width] duration-500 ease-in-out"
+              className={cn('flex min-h-0 flex-col items-center', panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '')}
               style={{ width: centerColWidth, flexShrink: 0 }}
             >
               <div className="flex h-full min-h-0 w-full flex-col items-stretch">
@@ -10282,7 +10291,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 {/* Right panel content - grid child with consistent wrapper */}
                 <div
                   className={cn(
-                    'relative z-40 flex min-h-0 shrink-0 flex-col items-end transition-[width] duration-500 ease-in-out',
+                    'relative z-40 flex min-h-0 shrink-0 flex-col items-end',
+                    panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '',
                     rightPanelHidden
                       ? 'bg-transparent shadow-none'
                       : 'rounded-[20px] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
@@ -10291,7 +10301,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 >
                   <div
                     className={cn(
-                      'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px] transition-all duration-500 ease-in-out',
+                      'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]',
+                  panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
                       rightPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
                     )}
                   >

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8135,7 +8135,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
             {/* CENTER PANEL - width tracks the visible side panels (expands when
                 one is hidden), animated to match the panel collapse. */}
             <div
-              className={cn('flex min-h-0 flex-col items-center', panelsMounted ? 'transition-[width] duration-500 ease-in-out' : '')}
+              className={cn(
+                'flex min-h-0 flex-col items-center',
+                panelsMounted ? 'transition-[width] duration-500 ease-in-out' : ''
+              )}
               style={{ width: centerColWidth, flexShrink: 0 }}
             >
               <div className="flex h-full min-h-0 w-full flex-col items-stretch">
@@ -10302,7 +10305,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   <div
                     className={cn(
                       'flex h-full min-h-0 flex-col overflow-hidden rounded-[20px]',
-                  panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
+                      panelsMounted ? 'transition-all duration-500 ease-in-out' : '',
                       rightPanelHidden ? 'w-0 opacity-0' : 'w-full opacity-100'
                     )}
                   >

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -650,9 +650,9 @@ export default function TutorSettings() {
 
       {/* Mode selector + tab content */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
-        <Card className="flex h-full flex-col overflow-hidden rounded-[16px] border-0 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+        <Card className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
-            <div className="flex-shrink-0 p-4">
+            <div className="flex-shrink-0">
               <TabsList className="relative flex w-full gap-1.5 rounded-xl bg-[#1F2933] p-1.5">
                 <TabsTrigger
                   value="profile"


### PR DESCRIPTION
## Problem

The Account page mode selector (charcoal tabs bar) appeared to float without a visible container. The Card wrapping the tabs had  and no padding, making it completely indistinguishable from the white page background.

## Root Cause

The Analytics page uses  which has a visible border (), padding (), and a subtle ring (). The Account page Card had none of these.

## Fix

Apply the same panel styling to the Account page Card:
- Add  for visible panel edges
- Add  padding (moved from inner div to Card)
- Add  for subtle depth
- Remove  and shadow (replaced with border+ring)

## Visual Result

| Before | After |
|--------|-------|
| Invisible panel boundary | Clearly defined panel with light grey border |
| Charcoal tabs appear floating | Tabs sit inside a visible white container |