### PR TITLE
feat(schedule): open the schedule editor in a modal (not the course page)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -190,11 +190,7 @@ function TutorDashboardContent() {
   const locale = typeof params?.locale === 'string' ? params.locale : 'en'
   const hasLocalePrefix = pathname.startsWith(`/${locale}/`)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
-  const [scheduleCourse, setScheduleCourse] = useState<{
-    id: string
-    name: string
-    schedulerHref: string
-  } | null>(null)
+  const [scheduleCourse, setScheduleCourse] = useState<{ id: string; name: string } | null>(null)
   // Course context for creating a one-time (non-schedule) session from the sessions modal.
   const [oneTimeCourse, setOneTimeCourse] = useState<{ id: string; name: string } | null>(null)
   // Course name + variant for the sessions modal (from the sessions API).
@@ -884,16 +880,7 @@ function TutorDashboardContent() {
                               size="sm"
                               className="border-white/30 bg-[#36454F] text-white transition-all duration-200 hover:border-transparent hover:bg-white hover:text-purple-500"
                               onClick={() =>
-                                setScheduleCourse({
-                                  id: course.id,
-                                  name: course.name,
-                                  // "New schedule" in the modal opens the main
-                                  // scheduler on the course-details page (template
-                                  // id, like the "Schedule sessions" link).
-                                  schedulerHref: withLocalePath(
-                                    `/tutor/courses/${course.templateCourseId ?? course.id}#course-schedule`
-                                  ),
-                                })
+                                setScheduleCourse({ id: course.id, name: course.name })
                               }
                             >
                               <CalendarClock className="mr-1 h-3 w-3" />
@@ -1327,7 +1314,7 @@ function TutorDashboardContent() {
       <ScheduleViewModal
         courseId={scheduleCourse?.id ?? null}
         courseName={scheduleCourse?.name}
-        createHref={scheduleCourse?.schedulerHref}
+        canCreate
         onClose={() => setScheduleCourse(null)}
       />
     </div>

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -12,6 +11,9 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Loader2, CalendarClock, Plus } from 'lucide-react'
+import { toast } from 'sonner'
+import { VariantScheduleEditor } from '@/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor'
+import { DAYS, type ScheduleItem } from '@/app/[locale]/tutor/courses/[id]/constants'
 
 interface ScheduleSlot {
   dayOfWeek: string
@@ -53,9 +55,10 @@ interface ScheduleViewModalProps {
   selectedScheduleId?: string | null
   /** When provided, each non-current schedule gets a "Switch to this" button. */
   onSwitch?: (scheduleId: string) => Promise<void> | void
-  /** Tutor context: when set, show a "New schedule" button that opens the main
-   *  scheduler (the course-details page) at this href. */
-  createHref?: string | null
+  /** Tutor context: show a "New schedule" button that opens the schedule editor
+   *  (the same one as the course scheduler) in place and creates the schedule
+   *  (POST /api/tutor/courses/[courseId]/schedules), then refreshes the list. */
+  canCreate?: boolean
 }
 
 export function ScheduleViewModal({
@@ -64,156 +67,247 @@ export function ScheduleViewModal({
   onClose,
   selectedScheduleId,
   onSwitch,
-  createHref,
+  canCreate = false,
 }: ScheduleViewModalProps) {
   const [schedules, setSchedules] = useState<CourseSchedule[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [switchingId, setSwitchingId] = useState<string | null>(null)
 
-  useEffect(() => {
+  // "Add schedule" editor dialog (tutor only).
+  const [addOpen, setAddOpen] = useState(false)
+  const [draftSlots, setDraftSlots] = useState<ScheduleItem[]>([])
+  const [draftWeeks, setDraftWeeks] = useState(8)
+  const [saving, setSaving] = useState(false)
+
+  const loadSchedules = useCallback(async () => {
     if (!courseId) return
-    let cancelled = false
     setLoading(true)
     setError(null)
-    fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
-      .then(async res => {
-        if (!res.ok) throw new Error('failed')
-        const data = await res.json()
-        if (!cancelled) setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
-      })
-      .catch(() => {
-        if (!cancelled) setError('Could not load schedules')
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
+    try {
+      const res = await fetch(`/api/courses/${courseId}/schedules`, { credentials: 'include' })
+      if (!res.ok) throw new Error('failed')
+      const data = await res.json()
+      setSchedules(Array.isArray(data?.schedules) ? data.schedules : [])
+    } catch {
+      setError('Could not load schedules')
+    } finally {
+      setLoading(false)
     }
   }, [courseId])
 
-  return (
-    <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
-      <DialogContent className="max-w-4xl">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <CalendarClock className="h-5 w-5" /> Class Schedules
-          </DialogTitle>
-          <DialogDescription>
-            {courseName ? `${courseName} — available class times` : 'Available class times'}
-          </DialogDescription>
-        </DialogHeader>
+  useEffect(() => {
+    if (!courseId) return
+    void loadSchedules()
+  }, [courseId, loadSchedules])
 
-        <div className="max-h-[65vh] overflow-y-auto p-1">
-          {loading ? (
-            <div className="flex items-center justify-center py-10">
-              <Loader2 className="h-6 w-6 animate-spin text-indigo-500" />
-            </div>
-          ) : error ? (
-            <p className="py-8 text-center text-sm text-red-500">{error}</p>
-          ) : schedules.length === 0 ? (
-            <p className="py-8 text-center text-sm text-gray-500">
-              No fixed schedules yet — class times are arranged with the tutor.
-            </p>
-          ) : (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {schedules.map(s => {
-                const isCurrent = !!selectedScheduleId && s.scheduleId === selectedScheduleId
-                return (
-                  <div
-                    key={s.scheduleId}
-                    className={`flex flex-col rounded-lg border p-4 ${
-                      isCurrent
-                        ? 'border-indigo-400 bg-indigo-50/60 ring-1 ring-indigo-300'
-                        : 'bg-gray-50'
-                    }`}
-                  >
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <h4 className="font-semibold text-gray-900">{s.name}</h4>
-                        {isCurrent && (
-                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700">
-                            Current
+  const openAdd = () => {
+    setDraftSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
+    setDraftWeeks(8)
+    setAddOpen(true)
+  }
+
+  const handleCreate = async () => {
+    if (!courseId || saving) return
+    const slots = draftSlots.filter(s => s?.dayOfWeek && s?.startTime)
+    if (slots.length === 0) {
+      toast.error('Add at least one time slot.')
+      return
+    }
+    setSaving(true)
+    try {
+      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token as string | undefined
+      const res = await fetch(`/api/tutor/courses/${courseId}/schedules`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
+        },
+        body: JSON.stringify({ schedule: slots, weeksToSchedule: draftWeeks }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data?.error || 'Failed to create schedule')
+      }
+      toast.success('Schedule created')
+      setAddOpen(false)
+      await loadSchedules()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create schedule')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={!!courseId} onOpenChange={open => !open && onClose()}>
+        <DialogContent className="max-w-4xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <CalendarClock className="h-5 w-5" /> Class Schedules
+            </DialogTitle>
+            <DialogDescription>
+              {courseName ? `${courseName} — available class times` : 'Available class times'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-[65vh] overflow-y-auto p-1">
+            {loading ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-indigo-500" />
+              </div>
+            ) : error ? (
+              <p className="py-8 text-center text-sm text-red-500">{error}</p>
+            ) : schedules.length === 0 ? (
+              <p className="py-8 text-center text-sm text-gray-500">
+                No fixed schedules yet — class times are arranged with the tutor.
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {schedules.map(s => {
+                  const isCurrent = !!selectedScheduleId && s.scheduleId === selectedScheduleId
+                  return (
+                    <div
+                      key={s.scheduleId}
+                      className={`flex flex-col rounded-lg border p-4 ${
+                        isCurrent
+                          ? 'border-indigo-400 bg-indigo-50/60 ring-1 ring-indigo-300'
+                          : 'bg-gray-50'
+                      }`}
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <h4 className="font-semibold text-gray-900">{s.name}</h4>
+                          {isCurrent && (
+                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700">
+                              Current
+                            </span>
+                          )}
+                        </div>
+                        {s.maxStudents != null && (
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                              s.isFull
+                                ? 'bg-red-100 text-red-700'
+                                : 'bg-emerald-100 text-emerald-700'
+                            }`}
+                          >
+                            {s.isFull
+                              ? 'Full'
+                              : `${s.spotsLeft} spot${s.spotsLeft === 1 ? '' : 's'} left`}
                           </span>
                         )}
                       </div>
-                      {s.maxStudents != null && (
-                        <span
-                          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                            s.isFull ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700'
-                          }`}
+                      {(() => {
+                        const { line, perWeek } = summarizeSlots(s.slots)
+                        const weeks = s.weeksToSchedule || 0
+                        return (
+                          <div className="space-y-1">
+                            <p className="text-sm text-gray-700">{line}</p>
+                            {perWeek > 0 && (
+                              <p className="text-xs text-gray-400">
+                                {weeks > 0
+                                  ? `${perWeek * weeks} sessions over ${weeks} weeks`
+                                  : `${perWeek} session${perWeek === 1 ? '' : 's'}/week`}
+                              </p>
+                            )}
+                          </div>
+                        )
+                      })()}
+                      {onSwitch && !isCurrent && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={s.isFull || switchingId !== null}
+                          className="mt-3"
+                          onClick={async () => {
+                            setSwitchingId(s.scheduleId)
+                            try {
+                              await onSwitch(s.scheduleId)
+                            } finally {
+                              setSwitchingId(null)
+                            }
+                          }}
                         >
-                          {s.isFull
-                            ? 'Full'
-                            : `${s.spotsLeft} spot${s.spotsLeft === 1 ? '' : 's'} left`}
-                        </span>
+                          {switchingId === s.scheduleId ? (
+                            <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                          ) : null}
+                          {s.isFull ? 'Full' : 'Switch to this schedule'}
+                        </Button>
                       )}
                     </div>
-                    {(() => {
-                      const { line, perWeek } = summarizeSlots(s.slots)
-                      const weeks = s.weeksToSchedule || 0
-                      return (
-                        <div className="space-y-1">
-                          <p className="text-sm text-gray-700">{line}</p>
-                          {perWeek > 0 && (
-                            <p className="text-xs text-gray-400">
-                              {weeks > 0
-                                ? `${perWeek * weeks} sessions over ${weeks} weeks`
-                                : `${perWeek} session${perWeek === 1 ? '' : 's'}/week`}
-                            </p>
-                          )}
-                        </div>
-                      )
-                    })()}
-                    {onSwitch && !isCurrent && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={s.isFull || switchingId !== null}
-                        className="mt-3"
-                        onClick={async () => {
-                          setSwitchingId(s.scheduleId)
-                          try {
-                            await onSwitch(s.scheduleId)
-                          } finally {
-                            setSwitchingId(null)
-                          }
-                        }}
-                      >
-                        {switchingId === s.scheduleId ? (
-                          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-                        ) : null}
-                        {s.isFull ? 'Full' : 'Switch to this schedule'}
-                      </Button>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
 
-        {createHref && (
-          <div className="border-t border-gray-100 pt-3">
-            <Button asChild variant="outline" size="sm" className="gap-1.5">
-              <Link href={createHref}>
+          {canCreate && (
+            <div className="border-t border-gray-100 pt-3">
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={openAdd}>
                 <Plus className="h-4 w-4" />
                 New schedule
-              </Link>
-            </Button>
-          </div>
-        )}
+              </Button>
+            </div>
+          )}
 
-        <DialogFooter align="end">
-          <Button
-            className="border border-[#1F2933] bg-white text-[#1F2933] hover:bg-[#1F2933] hover:text-white hover:outline hover:outline-1 hover:outline-white"
-            onClick={onClose}
+          <DialogFooter align="end">
+            <Button
+              className="border border-[#1F2933] bg-white text-[#1F2933] hover:bg-[#1F2933] hover:text-white hover:outline hover:outline-1 hover:outline-white"
+              onClick={onClose}
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* "Add schedule" — the same rich time-grid editor as the course scheduler,
+          opened in place over the Class Schedules modal so the tutor doesn't have
+          to leave for the full course-details page. Persists via the schedules API. */}
+      {canCreate && (
+        <Dialog open={addOpen} onOpenChange={open => !saving && setAddOpen(open)}>
+          <DialogContent
+            className="h-[90vh] max-h-[90vh] w-[95vw] max-w-[95vw] overflow-hidden sm:max-h-[800px] sm:max-w-[820px]"
+            rounded="lg"
           >
-            Close
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+            <div className="flex h-full flex-col">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <CalendarClock className="h-5 w-5" /> New schedule
+                </DialogTitle>
+                <DialogDescription>
+                  Click a time slot to add or remove a 1-hour session. It saves as &ldquo;Schedule{' '}
+                  {schedules.length + 1}&rdquo;.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="scrollbar-hide mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pr-1">
+                <VariantScheduleEditor
+                  schedule={draftSlots}
+                  onScheduleChange={updater => setDraftSlots(prev => updater(prev))}
+                  weeksToSchedule={draftWeeks}
+                  onWeeksChange={setDraftWeeks}
+                  siblingSchedules={schedules.map(s => s.slots)}
+                />
+              </div>
+
+              <DialogFooter align="end" className="mt-4">
+                <Button variant="outline" onClick={() => setAddOpen(false)} disabled={saving}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreate} disabled={saving}>
+                  {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+                  Create schedule
+                </Button>
+              </DialogFooter>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
Per your feedback: clicking **New schedule** should open the **schedule editor modal** in place — the same one behind **"+Add schedule"** on the course-details page — instead of navigating to the whole course page (which #579 did).

## Change
- **New schedule** now opens a **nested dialog** containing **`VariantScheduleEditor`** — the exact rich time-grid editor (click a slot to add/remove a 1-hour session, weeks selector) used by the course scheduler. No page navigation.
- **Save** POSTs to the existing `/api/tutor/courses/[courseId]/schedules` (with CSRF) and refreshes the Class Schedules list in place. Auto-named "Schedule N".
- `VariantScheduleEditor` is self-contained (it only fetches the tutor's availability), so it embeds cleanly over the dashboard.
- Reverts the `createHref` prop back to **`canCreate`**; the schedules list refetch is restored.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
Tutor dashboard → sessions tab → **Schedule** on a course card → **New schedule** → the schedule-editor dialog opens over the modal (time grid + weeks) → pick slots → **Create schedule** → it appears in the Class Schedules list without leaving the dashboard. Student enroll view unaffected (no button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)