### PR TITLE
fix(live-video): tutor Video button on all tabs + surface the real Daily join error

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1299,6 +1299,12 @@ function StudentFeedbackContent() {
           scheduledAt: data?.session?.scheduledAt ?? null,
           endedAt: data?.session?.endedAt ?? null,
         })
+        // The server issues a room URL even when it couldn't mint a video token
+        // (private rooms need one). Surface that reason up front instead of the
+        // cryptic Daily "Failed to join video call" the student hits on click.
+        if (data?.videoError) {
+          toast.error(data.videoError)
+        }
       } catch (err: any) {
         console.error('Join request failed:', err)
         toast.error(err?.message || 'Failed to load live session')

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -368,7 +368,11 @@ function TutorControlsPanel({
 
                     <button
                       type="button"
-                      disabled={panelDisabled || mode !== 'build' || !hasSession}
+                      // Video joins the live session — it must be usable while
+                      // live (mode === 'classroom'), not only in build mode. It
+                      // was wrongly gated on mode === 'build' (like the adjacent
+                      // build-only actions), so it was disabled during a session.
+                      disabled={panelDisabled || !hasSession}
                       onClick={onVideo}
                       className={cn(
                         actionButtonBase,

--- a/tutorme-app/src/hooks/use-daily-call.ts
+++ b/tutorme-app/src/hooks/use-daily-call.ts
@@ -229,9 +229,24 @@ export function useDailyCall(options: UseDailyCallOptions = {}) {
         }))
       } catch (error) {
         console.error('Daily join error:', error)
-        const message = error instanceof Error ? error.message : 'Failed to join video call'
+        // Daily rejects join() with a plain object ({ action, errorMsg, error }),
+        // NOT an Error — so `error.message` was empty and users only ever saw the
+        // generic fallback. Pull out Daily's real reason (e.g. "Meeting token is
+        // invalid", "not allowed", "does not exist") so the actual cause shows.
+        const daily = error as {
+          errorMsg?: string | { errorMsg?: string }
+          error?: { localizedMsg?: string; msg?: string; type?: string }
+        }
+        const dailyMsg =
+          (typeof daily?.errorMsg === 'string' && daily.errorMsg) ||
+          (typeof daily?.errorMsg === 'object' && daily.errorMsg?.errorMsg) ||
+          daily?.error?.localizedMsg ||
+          daily?.error?.msg ||
+          (error instanceof Error ? error.message : '')
+        const message = dailyMsg || 'Failed to join video call'
         Sentry.captureException(error instanceof Error ? error : new Error(message), {
           tags: { feature: 'live-video', phase: 'join' },
+          extra: { joinedUrl: url, hasToken: !!token },
         })
         // Tear the errored call object down so the next Retry rebuilds a clean
         // instance instead of re-joining a dead one (which always fails).


### PR DESCRIPTION
Two issues from the latest report.

## 1. Tutor Video button inactive in a live session ✅ (code fix)
The tutor **Video** button was disabled by `panelDisabled || mode !== 'build' || !hasSession`. But during a live session the controls mode is **`'classroom'`**, not `'build'` — so the button (whose whole job is to **join the live video**) was disabled exactly when live. The `mode !== 'build'` clause is correct for the adjacent *build-only* actions (Schedule / Delete / Go Live) but wrong for Video. Fixed to `panelDisabled || !hasSession` so Video is available whenever there's a session.

## 2. Student "Failed to join video call" — now surfaced (diagnostic)
The join route returns a **room URL even when it couldn't mint a Daily meeting token** (`token: null` + a `videoError`). Rooms are **private** (token required), so the student got an *active* button that then failed with the generic Daily "Failed to join video call". The client ignored `videoError`. Now it's surfaced on join, so the student sees the real reason ("Video is temporarily unavailable for this session").

**Important:** #575's fixes (student token permission + tutor room recreation) are still present on main — I verified. So a student getting `token: null` means **server-side token minting is failing**, which (with the permission bug already gone) almost certainly means an **invalid/rotated `DAILY_API_KEY`** in the Cloud Run env. The room exists (button was active) → the key was valid when it was created, but token creation now fails. Please verify the key; the server logs show `[Join] Daily.co token creation failed` with the Daily error. No code change can mint tokens against a bad key.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
- Tutor: in a live session, the **Video** button is now enabled → click → video opens (if the server has a valid room+token).
- Student: if the server can't mint a token, they now see a clear "Video is temporarily unavailable" toast instead of the cryptic failure — that message = check `DAILY_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)