### PR TITLE
fix(live-video): definitive join-failure message (token presence + real Daily error)

### DIFF
--- a/tutorme-app/src/hooks/use-daily-call.ts
+++ b/tutorme-app/src/hooks/use-daily-call.ts
@@ -237,13 +237,27 @@ export function useDailyCall(options: UseDailyCallOptions = {}) {
           errorMsg?: string | { errorMsg?: string }
           error?: { localizedMsg?: string; msg?: string; type?: string }
         }
+        const stringified = (() => {
+          try {
+            const s = JSON.stringify(error)
+            return s && s !== '{}' && s !== 'null' ? s : ''
+          } catch {
+            return ''
+          }
+        })()
         const dailyMsg =
           (typeof daily?.errorMsg === 'string' && daily.errorMsg) ||
           (typeof daily?.errorMsg === 'object' && daily.errorMsg?.errorMsg) ||
           daily?.error?.localizedMsg ||
           daily?.error?.msg ||
-          (error instanceof Error ? error.message : '')
-        const message = dailyMsg || 'Failed to join video call'
+          (error instanceof Error ? error.message : '') ||
+          stringified
+        // Rooms are private, so joining WITHOUT a token (the server failed to mint
+        // one) always fails — that's the single most common cause, so name it
+        // plainly instead of the generic message.
+        const message = !token
+          ? 'No video access token — the server could not create one for this session (check the Daily API key / account).'
+          : dailyMsg || 'Failed to join video call'
         Sentry.captureException(error instanceof Error ? error : new Error(message), {
           tags: { feature: 'live-video', phase: 'join' },
           extra: { joinedUrl: url, hasToken: !!token },


### PR DESCRIPTION
Follow-up: joins still showed the generic "Failed to join video call" even after #587's error extraction. Reason: rooms are **private**, and the client was joining with **no token** — Daily rejects that, but the rejection object didn't carry the fields #587 checked, so it fell through to the fallback.

## Change
- If there's **no token**, the message now says plainly: **"No video access token — the server could not create one for this session (check the Daily API key / account)."** That's the smoking gun — a private-room join with no token = server-side token minting failed.
- Otherwise, a `JSON.stringify(error)` fallback guarantees Daily's real rejection contents are shown (not the generic text).

## Why this matters
Both tutor and student failing + no token = the server's `createMeetingToken` is failing. With #575's permission bug already gone, that means the **`DAILY_API_KEY` is invalid/rotated** (or the Daily account/plan). No code can mint tokens against a bad key.

## Also likely: stale PWA cache
The app has a service worker. If it served the pre-#587 bundle, the old generic message would persist regardless of deploys — a **hard refresh** (or clearing site data) ensures the new code runs.

## Verification
`tsc` 0, build clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)