### PR TITLE
fix(csp): allow the Daily video SDK so live video works (real cause of "Failed to join")

### DIFF
--- a/tutorme-app/src/lib/middleware-edge/csp.ts
+++ b/tutorme-app/src/lib/middleware-edge/csp.ts
@@ -22,15 +22,23 @@ export function getCspHeader(): string {
 
   const directives = [
     "default-src 'self'",
-    // In production: remove 'unsafe-eval' once verified Next.js doesn't need it
-    // Next.js 16 with App Router requires 'unsafe-eval' for some dynamic imports
-    isDev ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'" : "script-src 'self' 'unsafe-inline'",
-    // 'unsafe-inline' for styles is acceptable and widely used
-    // Removing it would require hashing all inline styles which is impractical
-    "style-src 'self' 'unsafe-inline'",
+    // 'unsafe-eval' is REQUIRED in production too: the Daily.co video SDK loads
+    // its call-machine bundle and evaluates it (EvalError otherwise → video never
+    // joins), and Daily serves that bundle from *.daily.co via a blob. Without
+    // these, live video is fully broken. (Next.js dynamic imports also use eval.)
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.daily.co blob:",
+    // 'unsafe-inline' for styles is widely used; allow Google Fonts stylesheets.
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: blob: https:",
-    "font-src 'self' data:",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    // https:/wss: already cover Daily's API + signalling websockets.
     "connect-src 'self' https: wss:",
+    // Camera/mic + screen-share tracks and Daily media arrive as blob: and
+    // mediastream:; without media-src they'd fall back to default-src 'self'.
+    "media-src 'self' blob: mediastream: https://*.daily.co",
+    // Daily runs its call machine in blob-backed web workers.
+    "worker-src 'self' blob:",
+    "child-src 'self' blob:",
     "frame-src 'self' https://*.daily.co https://*.dailyhq.com",
     "frame-ancestors 'self'",
     "base-uri 'self'",

--- a/tutorme-app/src/lib/middleware-edge/middleware-edge.test.ts
+++ b/tutorme-app/src/lib/middleware-edge/middleware-edge.test.ts
@@ -39,11 +39,13 @@ describe('middleware-edge helpers', () => {
     expect(csp).toContain("object-src 'none'")
   })
 
-  it('getCspHeader removes unsafe-eval in production', () => {
+  it('getCspHeader keeps unsafe-eval in production (required by the Daily video SDK)', () => {
     const originalEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'production'
     const csp = getCspHeader()
-    expect(csp).not.toContain("'unsafe-eval'")
+    // Daily's call-machine bundle evaluates code; without unsafe-eval, live video
+    // never joins. Previously stripped in prod, which broke video entirely.
+    expect(csp).toContain("'unsafe-eval'")
     process.env.NODE_ENV = originalEnv
   })
 
@@ -53,6 +55,15 @@ describe('middleware-edge helpers', () => {
     const csp = getCspHeader()
     expect(csp).toContain("'unsafe-eval'")
     process.env.NODE_ENV = originalEnv
+  })
+
+  it('getCspHeader allows the Daily video SDK + Google Fonts', () => {
+    const csp = getCspHeader()
+    expect(csp).toContain('https://*.daily.co')
+    expect(csp).toContain('media-src')
+    expect(csp).toContain('worker-src')
+    expect(csp).toContain('https://fonts.googleapis.com')
+    expect(csp).toContain('https://fonts.gstatic.com')
   })
 
   it('getCspHeader includes report-uri', () => {


### PR DESCRIPTION
## The real root cause (not the API key)
Your console output pinpointed it:
```
Daily join error: Failed to load call object bundle https://c.daily.co/.../call-machine-object-bundle.js:
EvalError: Evaluating a string as JavaScript violates ... 'unsafe-eval' is not an allowed source of script:
script-src 'self' 'unsafe-inline'
```
The production **CSP stripped `'unsafe-eval'`** from `script-src` (`csp.ts` kept it in dev only). Daily's call-machine bundle **evaluates code**, so the browser blocked Daily from initializing → **every join failed, tutor and student**. This was never the `DAILY_API_KEY` — I was wrong about that earlier, and I'm sorry for the runaround; the console log is what finally showed the true cause.

## Fix (`src/lib/middleware-edge/csp.ts`)
Allow what the Daily SDK requires (and fix the Google-Fonts violations seen in the same console):
- **`script-src`**: keep `'unsafe-eval'` in **production** too, and add `https://*.daily.co blob:` (Daily loads/evals its bundle from there).
- **`media-src blob: mediastream: https://*.daily.co`** — camera/mic + screen-share + Daily media tracks (there was no `media-src`, so it fell back to `default-src 'self'` and would block streams after the eval fix).
- **`worker-src`/`child-src blob:`** — Daily runs its call machine in blob-backed web workers.
- **`style-src` += `https://fonts.googleapis.com`**, **`font-src` += `https://fonts.gstatic.com`** — the Google Fonts stylesheet/fonts were being blocked.

Updated the CSP test that asserted prod *removes* `'unsafe-eval'` (that assertion codified the bug) and added a Daily/fonts allow-list assertion.

## Security note
`'unsafe-eval'` is a real relaxation, but it's an unavoidable requirement of the Daily SDK (documented) and was already present in dev + intended in prod per the code comments. The host allow-lists (`*.daily.co`, fonts) are tightly scoped.

## Verification
`tsc` 0, build clean, eslint 0 errors, **8/8 CSP tests pass**.

## ⚠️ Smoke-test (hard-refresh first — PWA cache!)
After deploy, **hard-refresh / clear site data** (the service worker may serve the old bundle), then open **Video** in a live session as tutor and student → it should connect, and the Google Fonts CSP errors should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)