### PR TITLE
test(e2e): guard the CSP allows the Daily video stack + Google Fonts

### DIFF
--- a/tutorme-app/e2e/security-headers.spec.ts
+++ b/tutorme-app/e2e/security-headers.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Guards the Content-Security-Policy against the regression that broke live
+ * video: production once stripped 'unsafe-eval' + the Daily hosts from
+ * script-src, so the Daily SDK (which evals its call-machine bundle) was blocked
+ * and no video call could join, and Google Fonts were blocked too. These
+ * assertions fail loudly if the CSP ever tightens back in a way that breaks the
+ * live-video stack or fonts.
+ */
+test.describe('Security headers — CSP allows the live-video stack', () => {
+  test('served CSP permits the Daily SDK, media, workers and Google Fonts', async ({ request }) => {
+    const res = await request.get('/login')
+    // The page itself should load (any 2xx/3xx is fine — request follows redirects).
+    expect(res.status()).toBeLessThan(400)
+
+    const csp = res.headers()['content-security-policy']
+    expect(csp, 'a Content-Security-Policy header must be present').toBeTruthy()
+
+    // Daily's call machine needs eval + its bundle host.
+    expect(csp).toContain("'unsafe-eval'")
+    expect(csp).toContain('https://*.daily.co')
+    // Camera/mic + Daily media tracks and its blob workers.
+    expect(csp).toContain('media-src')
+    expect(csp).toContain('worker-src')
+    expect(csp).toContain('blob:')
+    // Google Fonts stylesheet + font files.
+    expect(csp).toContain('https://fonts.googleapis.com')
+    expect(csp).toContain('https://fonts.gstatic.com')
+
+    // Core hardening must remain intact.
+    expect(csp).toContain("default-src 'self'")
+    expect(csp).toContain("object-src 'none'")
+    expect(csp).toContain("frame-ancestors 'self'")
+  })
+})


### PR DESCRIPTION
E2E regression guard (item 5) for the CSP bug that broke **all** live video this session.

## Why this one
Of the live-session flows, the CSP was the single highest-impact, hardest-to-catch regression — a header tweak silently blocked Daily's SDK and every video call. A header-level e2e is **reliable** (no auth, no sockets, no two-party video), and it directly guards that failure mode.

## What it checks
`GET /login` and asserts the served `Content-Security-Policy` still:
- permits the Daily SDK: `'unsafe-eval'`, `https://*.daily.co`, `blob:`, `media-src`, `worker-src`;
- permits Google Fonts: `fonts.googleapis.com`, `fonts.gstatic.com`;
- keeps the core hardening: `default-src 'self'`, `object-src 'none'`, `frame-ancestors 'self'`.

Verified the assertions against the real `getCspHeader()` output on `main` — every token is present. (The complementary unit test in `middleware-edge.test.ts`, added with the CSP fix, guards the builder directly; this guards the *served* header end-to-end.)

## Honest scope note
I could not execute Playwright in this environment (it needs the app running on :3003 + DB), so this spec is **verified by static analysis** (the CSP source it asserts against), not by a live run — it's a simple header assertion, low-risk. Broader live-session e2e (video join with two parties, socket poll/submission flows) needs dedicated auth + socket + Daily fixtures; I scoped to the reliable, high-value guard rather than ship flaky specs. Happy to build the fuller fixtures if you want them.

## Verification
`tsc`/eslint clean on the spec. Runs under `npm run test:e2e` (not the required Build/Typecheck/Unit checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)