### PR TITLE
fix(live-poll): custom options parse + reusable saved sets + re-enable send buttons

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1405,6 +1405,31 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       Record<string, 'letters' | 'tf' | 'yn' | 'custom'>
     >({})
     const [pollCustomOptionsMap, setPollCustomOptionsMap] = useState<Record<string, string>>({})
+    // Reusable custom option sets, persisted so a tutor can pick a set they used
+    // before instead of retyping it. Loaded once from localStorage.
+    const [savedPollOptionSets, setSavedPollOptionSets] = useState<string[][]>([])
+    useEffect(() => {
+      try {
+        const raw = localStorage.getItem('tutor-poll-option-sets')
+        const parsed = raw ? JSON.parse(raw) : []
+        if (Array.isArray(parsed)) setSavedPollOptionSets(parsed.filter(Array.isArray).slice(0, 8))
+      } catch {
+        /* ignore */
+      }
+    }, [])
+    const rememberPollOptionSet = useCallback((opts: string[]) => {
+      if (opts.length < 2) return
+      setSavedPollOptionSets(prev => {
+        const key = opts.join('')
+        const next = [opts, ...prev.filter(s => s.join('') !== key)].slice(0, 8)
+        try {
+          localStorage.setItem('tutor-poll-option-sets', JSON.stringify(next))
+        } catch {
+          /* ignore */
+        }
+        return next
+      })
+    }, [])
     const [questionPromptMap, setQuestionPromptMap] = useState<Record<string, string>>({})
     const [showAIPollMap, setShowAIPollMap] = useState<Record<string, boolean>>({})
     const [showAIQuestionMap, setShowAIQuestionMap] = useState<Record<string, boolean>>({})
@@ -1496,15 +1521,25 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
     // Resolve the chosen preset to explicit labels. `letters` returns undefined
     // so the server applies its A–E default; custom is split on newlines/commas.
+    // Split custom options on any common separator — newline, comma, slash, pipe
+    // or semicolon — so the tutor can type "Agree / Disagree / Unsure" (as the
+    // placeholder shows), or one per line, or comma-separated, and it all works.
+    // Previously only \n and , were split, so slash-separated input (per the
+    // example) collapsed into ONE option and silently fell back to A–E.
+    const parsePollOptions = (raw: string): string[] =>
+      raw
+        .split(/[\n,/|;]/)
+        .map(s => s.trim())
+        .filter(Boolean)
+        .slice(0, 8)
+
+    const customPollValid = parsePollOptions(pollCustomOptions).length >= 2
+
     const resolvePollOptions = (): string[] | undefined => {
       if (pollOptionMode === 'tf') return ['True', 'False']
       if (pollOptionMode === 'yn') return ['Yes', 'No']
       if (pollOptionMode === 'custom') {
-        const opts = pollCustomOptions
-          .split(/[\n,]/)
-          .map(s => s.trim())
-          .filter(Boolean)
-          .slice(0, 8)
+        const opts = parsePollOptions(pollCustomOptions)
         return opts.length >= 2 ? opts : undefined
       }
       return undefined
@@ -1538,13 +1573,44 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           ))}
         </div>
         {pollOptionMode === 'custom' && (
-          <textarea
-            value={pollCustomOptions}
-            onChange={e => setPollCustomOptions(e.target.value)}
-            rows={2}
-            placeholder="One option per line — e.g. Agree / Disagree / Unsure"
-            className="mt-1.5 w-full resize-none rounded-lg border border-blue-100 bg-white p-2 text-xs text-gray-900 placeholder:text-gray-400 focus:outline-none focus-visible:border-blue-400"
-          />
+          <>
+            <textarea
+              value={pollCustomOptions}
+              onChange={e => setPollCustomOptions(e.target.value)}
+              rows={2}
+              placeholder="Options separated by commas, slashes, or new lines — e.g. Agree, Disagree, Unsure"
+              className={cn(
+                'mt-1.5 w-full resize-none rounded-lg border bg-white p-2 text-xs text-gray-900 placeholder:text-gray-400 focus:outline-none',
+                customPollValid || !pollCustomOptions.trim()
+                  ? 'border-blue-100 focus-visible:border-blue-400'
+                  : 'border-amber-300 focus-visible:border-amber-400'
+              )}
+            />
+            {pollCustomOptions.trim() && !customPollValid && (
+              <p className="mt-1 text-[11px] text-amber-600">Enter at least 2 options.</p>
+            )}
+            {/* Reuse a previously-used custom set. */}
+            {savedPollOptionSets.length > 0 && (
+              <div className="mt-1.5">
+                <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-gray-400">
+                  Saved sets
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {savedPollOptionSets.map((set, i) => (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setPollCustomOptions(set.join(', '))}
+                      title={set.join(', ')}
+                      className="max-w-[180px] truncate rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-[11px] text-slate-600 hover:border-blue-300 hover:bg-blue-50"
+                    >
+                      {set.join(' · ')}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     )
@@ -8369,11 +8435,17 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                         !insightsProps.sessionId
                                                       )
                                                         return
-                                                      insightsProps.onSendPoll({
-                                                        taskId: currentInsightsId,
-                                                        question: pollPrompt,
-                                                        options: resolvePollOptions(),
-                                                      })
+                                                      {
+                                                        const opts = resolvePollOptions()
+                                                        if (pollOptionMode === 'custom' && opts) {
+                                                          rememberPollOptionSet(opts)
+                                                        }
+                                                        insightsProps.onSendPoll({
+                                                          taskId: currentInsightsId,
+                                                          question: pollPrompt,
+                                                          options: opts,
+                                                        })
+                                                      }
                                                       setPollPrompt('')
                                                     }}
                                                   >
@@ -10455,11 +10527,17 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                   !insightsProps.sessionId
                                                 )
                                                   return
-                                                insightsProps.onSendPoll({
-                                                  taskId: currentInsightsId,
-                                                  question: pollPrompt,
-                                                  options: resolvePollOptions(),
-                                                })
+                                                {
+                                                  const opts = resolvePollOptions()
+                                                  if (pollOptionMode === 'custom' && opts) {
+                                                    rememberPollOptionSet(opts)
+                                                  }
+                                                  insightsProps.onSendPoll({
+                                                    taskId: currentInsightsId,
+                                                    question: pollPrompt,
+                                                    options: opts,
+                                                  })
+                                                }
                                                 setPollPrompt('')
                                               }}
                                             >

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8424,14 +8424,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                     className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
                                                     disabled={
                                                       !activeInsightsTaskId ||
-                                                      !activeInsightsTask ||
                                                       !insightsProps.sessionId ||
                                                       !pollPrompt.trim()
                                                     }
                                                     onClick={() => {
                                                       if (
                                                         !activeInsightsTaskId ||
-                                                        !activeInsightsTask ||
                                                         !insightsProps.sessionId
                                                       )
                                                         return
@@ -8524,14 +8522,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                     className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
                                                     disabled={
                                                       !activeInsightsTaskId ||
-                                                      !activeInsightsTask ||
                                                       !insightsProps.sessionId ||
                                                       !questionPrompt.trim()
                                                     }
                                                     onClick={() => {
                                                       if (
                                                         !activeInsightsTaskId ||
-                                                        !activeInsightsTask ||
                                                         !insightsProps.sessionId
                                                       )
                                                         return
@@ -10516,14 +10512,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
                                               disabled={
                                                 !activeInsightsTaskId ||
-                                                !activeInsightsTask ||
                                                 !insightsProps.sessionId ||
                                                 !pollPrompt.trim()
                                               }
                                               onClick={() => {
                                                 if (
                                                   !activeInsightsTaskId ||
-                                                  !activeInsightsTask ||
                                                   !insightsProps.sessionId
                                                 )
                                                   return
@@ -10597,14 +10591,12 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
                                               disabled={
                                                 !activeInsightsTaskId ||
-                                                !activeInsightsTask ||
                                                 !insightsProps.sessionId ||
                                                 !questionPrompt.trim()
                                               }
                                               onClick={() => {
                                                 if (
                                                   !activeInsightsTaskId ||
-                                                  !activeInsightsTask ||
                                                   !insightsProps.sessionId
                                                 )
                                                   return


### PR DESCRIPTION
Fixes custom poll options not working, and makes them reusable.

## The bug
Custom options silently fell back to A–E. The parser split the tutor's input only on **newline and comma** (`/[\n,]/`) — but the placeholder example used **slashes**: *"Agree / Disagree / Unsure"*. So a tutor following the example typed slash-separated options → the parser saw **one** option → `< 2` → `undefined` → server used its A–E default. Presets (A–E, True/False, Yes/No) worked because they return fixed arrays, not parsed input.

## Fix
- Parse on **any common separator** — newline, comma, slash, pipe, semicolon — so commas, slashes, or one-per-line all work.
- Clearer placeholder ("Options separated by commas, slashes, or new lines").
- Inline **"Enter at least 2 options"** hint (amber) when the input is present but invalid, so it's never a silent fallback.

## Reuse (as requested)
Every custom set that's sent is **saved** (localStorage, deduped, most-recent first, max 8) and shown as one-click **"Saved sets"** chips in the picker — click one to refill the field. So tutors don't retype sets like "Agree · Disagree · Unsure".

## Verification
`tsc` 0, build clean, eslint 0 errors. Both poll composer send-sites updated.

## ⚠️ Smoke-test
In a live session: poll composer → **Custom** → type `Agree / Disagree / Unsure` (slashes) → send → students see those 3 options (not A–E). Send another custom poll → the previous set appears under **Saved sets**; click it to reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)