### PR TITLE
feat(registration): add preferred language dropdown to student profile step

### DIFF
--- a/tutorme-app/src/app/[locale]/register/student/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/student/page.tsx
@@ -589,18 +589,18 @@ export default function StudentRegistrationPage() {
                       </span>
                     </div>
                     {/* Preferred Language dropdown */}
-                    <div className="rounded-lg bg-white/10 px-2 py-1 text-sm">
+                    <div className="rounded-full border border-white/40 bg-white/10 px-3 py-1 text-sm transition-colors hover:bg-white/20">
                       <Select
                         value={formData.preferredLanguage}
                         onValueChange={value =>
                           setFormData(prev => ({ ...prev, preferredLanguage: value }))
                         }
                       >
-                        <SelectTrigger className="h-7 w-[140px] border-0 bg-transparent text-sm text-white focus:ring-0 focus:ring-offset-0">
+                        <SelectTrigger className="h-7 w-[200px] border-0 bg-transparent text-sm text-white focus:ring-0 focus:ring-offset-0">
                           <span className="mr-1 text-white/60">Language:</span>
                           <SelectValue placeholder="Select…" />
                         </SelectTrigger>
-                        <SelectContent className="max-h-48">
+                        <SelectContent className="max-h-48 w-[220px]">
                           {(() => {
                             const country = availableCountries.find(
                               c => c.code === formData.countryCode

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -649,7 +649,7 @@ export default function TutorSettings() {
       </section>
 
       {/* Mode selector + tab content */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
+      <div className="flex min-h-0 flex-1 flex-col pb-0.5">
         <Card className="flex h-full flex-col rounded-[16px] border border-[#E5E7EB] bg-slate-50 p-5 ring-1 ring-black/5">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
             <div className="flex-shrink-0">
@@ -704,12 +704,9 @@ export default function TutorSettings() {
                 </TabsTrigger>
               </TabsList>
             </div>
-            <div className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3">
+            <div className="flex min-h-0 flex-1 flex-col pt-3">
               {/* Profile & Identity */}
-              <TabsContent
-                value="profile"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="profile" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     className={SECTION_CARD_CLASS}
@@ -993,20 +990,14 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* 1-on-1 Booking */}
-              <TabsContent
-                value="1-on-1"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="1-on-1" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <OneOnOneSettingsCard />
                 </div>
               </TabsContent>
 
               {/* Billing & Payment */}
-              <TabsContent
-                value="billing"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="billing" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     flush
@@ -1218,10 +1209,7 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* Refunds */}
-              <TabsContent
-                value="refunds"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="refunds" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     flush
@@ -1239,10 +1227,7 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* Notifications */}
-              <TabsContent
-                value="notifications"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="notifications" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     flush
@@ -1359,10 +1344,7 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* Privacy & Security */}
-              <TabsContent
-                value="security"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="security" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     flush
@@ -1472,10 +1454,7 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* Live Session Mirroring */}
-              <TabsContent
-                value="controls"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="controls" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <div className="h-full space-y-6 overflow-y-auto pb-4 pr-2">
                   <CollapsibleCard
                     flush
@@ -1690,10 +1669,7 @@ export default function TutorSettings() {
               </TabsContent>
 
               {/* Session Log */}
-              <TabsContent
-                value="session-log"
-                className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
-              >
+              <TabsContent value="session-log" className="mt-0 flex min-h-0 flex-1 flex-col">
                 <SessionLog />
               </TabsContent>
             </div>


### PR DESCRIPTION
## Changes

Add a language selector dropdown in the student registration step 3 header, beside the Profile Name and Country badges.

### Data Changes
- Add 'languages' field to CountryData interface in tutor-categories.ts
- Add language data for all 53 countries in the REGIONS array
- Each country always includes English + relevant local languages

### UI Changes
- Add 'preferredLanguage' to student registration form state
- Add language Select dropdown in step 3 header (Profile step)
- Dropdown dynamically shows languages based on selected country of residence
- Defaults to English if no country selected

### Language Coverage
| Region | Languages |
|--------|-----------|
| Asia | English + Chinese, Korean, Japanese, Thai, Hindi, etc. |
| Middle East | English + Arabic |
| Europe | English + German, French, Spanish, Italian, etc. |
| Oceania | English (+ Maori for NZ) |
| North America | English + Spanish/French |
| South America | English + Spanish |
| Africa | English + Swahili, Arabic, Afrikaans, etc. |