### PR TITLE
fix(submissions): collapse all folders by default on initial load

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -158,9 +158,9 @@ export function SubmissionsPanel({
         // Only auto-expand on the first load — a refetch must not collapse or
         // re-expand folders the tutor has toggled.
         if (!preserveOpen) {
-          const nextOpen: Record<string, boolean> = { course: true }
+          const nextOpen: Record<string, boolean> = { course: false }
           ;(json?.lessons || []).forEach((l: any) => {
-            nextOpen[`lesson_${l.id}`] = true
+            nextOpen[`lesson_${l.id}`] = false
           })
           setOpen(nextOpen)
         }


### PR DESCRIPTION
Changed the default open state for course and lesson folders from true (expanded) to false (collapsed). This gives tutors a cleaner initial view and lets them expand folders as needed.