### PR TITLE
fix: eliminate dropdown focus flash completely

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -853,7 +853,7 @@ export default function TutorCoursePage() {
                             <SelectItem
                               key={region.id}
                               value={region.id}
-                              className="mx-1.5 rounded-md text-white hover:bg-white/20 focus:bg-white/20 focus:text-white focus:outline-none data-[highlighted]:bg-white/20 data-[highlighted]:text-white"
+                              className="mx-1.5 rounded-md text-white hover:bg-white/20"
                             >
                               {region.name}
                             </SelectItem>
@@ -890,7 +890,7 @@ export default function TutorCoursePage() {
                               <SelectItem
                                 key={country.code}
                                 value={country.code}
-                                className="mx-1.5 rounded-md text-white hover:bg-white/20 focus:bg-white/20 focus:text-white focus:outline-none data-[highlighted]:bg-white/20 data-[highlighted]:text-white"
+                                className="mx-1.5 rounded-md text-white hover:bg-white/20"
                               >
                                 {country.name}
                               </SelectItem>

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[highlighted]:text-white/[0.94] data-[disabled]:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION
PR #607 removed focus:bg-white from base SelectItem/DropdownMenuItem, but the white flash persisted due to two remaining causes:

1. Course Details page (tutor/courses/[id]/page.tsx) had inline className overrides on Region and Country SelectItem components that re-added focus:bg-white/20 and data-[highlighted]:bg-white/20. These overrides took precedence over the base component styles.

2. Radix UI Select internally sets data-[highlighted] on the active item during both keyboard and mouse navigation. Even without explicit styles, browser or Radix defaults could still apply a focus background.

Changes:
- Remove focus:bg-white/20, focus:text-white, data-[highlighted]:bg-white/20, and data-[highlighted]:text-white from both SelectItem instances on the Course Details page, keeping only hover:bg-white/20 for hover feedback.
- Add data-[highlighted]:bg-transparent and data-[highlighted]:text-white/[0.94] to the base SelectItem component to explicitly neutralize any Radix or browser default highlight styles.

Fixes #607-follow-up