### PR TITLE
feat: add floating glassmorphic zoom pill to PDF viewer

### DIFF
--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import React, { useState, useRef, useCallback, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+
+interface FloatingZoomPillProps {
+  scale: number
+  onScaleChange: (scale: number) => void
+  minScale?: number
+  maxScale?: number
+  onHidePreview?: () => void
+  className?: string
+}
+
+export function FloatingZoomPill({
+  scale,
+  onScaleChange,
+  minScale = 0.5,
+  maxScale = 1.5,
+  onHidePreview,
+  className,
+}: FloatingZoomPillProps) {
+  const [position, setPosition] = useState({ x: 0, y: 0 })
+  const [isDragging, setIsDragging] = useState(false)
+  const dragStartRef = useRef({ x: 0, y: 0 })
+  const pillRef = useRef<HTMLDivElement>(null)
+
+  // Convert scale (0.5-1.5) to slider percentage (0-100)
+  const scaleToPercent = useCallback(
+    (s: number) => ((s - minScale) / (maxScale - minScale)) * 100,
+    [minScale, maxScale]
+  )
+
+  // Convert slider percentage (0-100) to scale (0.5-1.5)
+  const percentToScale = useCallback(
+    (p: number) => minScale + (p / 100) * (maxScale - minScale),
+    [minScale, maxScale]
+  )
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsDragging(true)
+      dragStartRef.current = {
+        x: e.clientX - position.x,
+        y: e.clientY - position.y,
+      }
+    },
+    [position]
+  )
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging) return
+      setPosition({
+        x: e.clientX - dragStartRef.current.x,
+        y: e.clientY - dragStartRef.current.y,
+      })
+    },
+    [isDragging]
+  )
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  useEffect(() => {
+    if (isDragging) {
+      window.addEventListener('mousemove', handleMouseMove)
+      window.addEventListener('mouseup', handleMouseUp)
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('mouseup', handleMouseUp)
+      }
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp])
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const percent = parseFloat(e.target.value)
+    onScaleChange(percentToScale(percent))
+  }
+
+  const sliderPercent = scaleToPercent(scale)
+
+  return (
+    <div
+      ref={pillRef}
+      className={cn(
+        'absolute z-50 flex flex-col items-center gap-2 rounded-2xl border border-white/20 bg-white/10 p-3 shadow-lg backdrop-blur-md transition-shadow',
+        isDragging ? 'cursor-grabbing shadow-xl' : 'cursor-default',
+        className
+      )}
+      style={{
+        transform: `translate(${position.x}px, ${position.y}px)`,
+        right: '16px',
+        top: '50%',
+        marginTop: '-120px',
+      }}
+    >
+      {/* Grab handle — six dots */}
+      <div
+        className="flex cursor-grab flex-col items-center gap-1 py-1 active:cursor-grabbing"
+        onMouseDown={handleMouseDown}
+        title="Drag to move"
+      >
+        <div className="grid grid-cols-2 gap-0.5">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-1 w-1 rounded-full bg-white/60" />
+          ))}
+        </div>
+      </div>
+
+      {/* Vertical zoom slider */}
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-[10px] font-medium text-white/80">{Math.round(scale * 100)}%</span>
+        <div className="relative h-24 w-6">
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={sliderPercent}
+            onChange={handleSliderChange}
+            className="absolute inset-0 h-24 w-6 cursor-pointer appearance-none rounded-full bg-white/20 outline-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-md"
+            style={{
+              writingMode: 'vertical-lr',
+              direction: 'rtl',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Hide Preview arrow */}
+      {onHidePreview && (
+        <button
+          onClick={onHidePreview}
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-white/70 transition-colors hover:bg-white/20 hover:text-white"
+          title="Hide Preview"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
+import { FloatingZoomPill } from './FloatingZoomPill'
 
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs'
 
@@ -115,9 +116,12 @@ export function PDFViewer({
     setLoading(false)
   }, [])
 
-  const changeScale = useCallback((delta: number) => {
+  const changeScale = useCallback((deltaOrValue: number, absolute = false) => {
     setScale(prev => {
-      const next = Math.round((prev + delta) * 100) / 100
+      if (absolute) {
+        return Math.max(0.5, Math.min(3.0, Math.round(deltaOrValue * 100) / 100))
+      }
+      const next = Math.round((prev + deltaOrValue) * 100) / 100
       return Math.max(0.5, Math.min(3.0, next))
     })
   }, [])
@@ -233,7 +237,17 @@ export function PDFViewer({
 
       {/* Document pages */}
       {!error && !isBlobUrl && pdfData && (
-        <div className={`flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}>
+        <div className={`relative flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}>
+          {/* Floating zoom pill */}
+          {!loading && !error && numPages > 0 && (
+            <FloatingZoomPill
+              scale={scale}
+              onScaleChange={newScale => changeScale(newScale, true)}
+              minScale={0.5}
+              maxScale={1.5}
+              onHidePreview={onHidePreview}
+            />
+          )}
           <Document
             file={pdfData}
             onLoadSuccess={onDocumentLoadSuccess}


### PR DESCRIPTION
New FloatingZoomPill component for the PDF slide viewer in Course Builder:
- Glassmorphic transparent panel (bg-white/10, backdrop-blur-md, border-white/20)
- Draggable six-dot grab handle (⠿) with mouse drag support
- Vertical zoom slider controlling 50%-150% range (default 75%)
- Current zoom percentage display above slider
- Hide Preview arrow button below slider
- Positioned on right side of viewer, draggable anywhere

Existing toolbar left in place (not removed yet).