### PR TITLE
fix: remove focus flash from all remaining dropdowns across the app

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -4126,7 +4126,7 @@ const CategorySearchModal = ({
                     <SelectItem
                       key={region.id}
                       value={region.id}
-                      className="mx-1.5 rounded-md text-white hover:bg-white/20 focus:bg-white/20 focus:text-white focus:outline-none"
+                      className="mx-1.5 rounded-md text-white hover:bg-white/20"
                     >
                       {region.name}
                     </SelectItem>

--- a/tutorme-app/src/app/[locale]/register/admin/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/admin/page.tsx
@@ -392,19 +392,19 @@ export default function AdminRegistrationPage() {
                       <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
                         <SelectItem
                           value="super"
-                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                         >
                           Super Admin
                         </SelectItem>
                         <SelectItem
                           value="standard"
-                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                         >
                           Standard Admin
                         </SelectItem>
                         <SelectItem
                           value="limited"
-                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                          className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                         >
                           Limited Admin
                         </SelectItem>

--- a/tutorme-app/src/app/[locale]/register/parent/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/parent/page.tsx
@@ -481,31 +481,31 @@ export default function ParentRegistrationPage() {
                         <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
                           <SelectItem
                             value="parent"
-                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                           >
                             Parent
                           </SelectItem>
                           <SelectItem
                             value="guardian"
-                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                           >
                             Guardian
                           </SelectItem>
                           <SelectItem
                             value="step-parent"
-                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                           >
                             Step-Parent
                           </SelectItem>
                           <SelectItem
                             value="grandparent"
-                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                           >
                             Grandparent
                           </SelectItem>
                           <SelectItem
                             value="other"
-                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                            className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                           >
                             Other
                           </SelectItem>
@@ -626,7 +626,7 @@ export default function ParentRegistrationPage() {
                               <SelectItem
                                 key={grade}
                                 value={grade}
-                                className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                                className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                               >
                                 {grade}
                               </SelectItem>

--- a/tutorme-app/src/app/[locale]/register/student/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/student/page.tsx
@@ -404,7 +404,7 @@ export default function StudentRegistrationPage() {
                               <SelectItem
                                 key={regionItem.id}
                                 value={regionItem.id}
-                                className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                                className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                               >
                                 {regionItem.name}
                               </SelectItem>
@@ -438,7 +438,7 @@ export default function StudentRegistrationPage() {
                                 <SelectItem
                                   key={country.code}
                                   value={country.code}
-                                  className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                                  className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                                 >
                                   {country.name}
                                 </SelectItem>

--- a/tutorme-app/src/app/[locale]/register/tutor/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/tutor/page.tsx
@@ -869,7 +869,7 @@ export default function TutorRegistrationPage() {
                                 <SelectItem
                                   key={regionItem.id}
                                   value={regionItem.id}
-                                  className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                                  className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                                 >
                                   {regionItem.name}
                                 </SelectItem>
@@ -903,7 +903,7 @@ export default function TutorRegistrationPage() {
                                   <SelectItem
                                     key={country.code}
                                     value={country.code}
-                                    className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15 focus:bg-white/20 focus:text-white"
+                                    className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
                                   >
                                     {country.name}
                                   </SelectItem>

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -2012,7 +2012,7 @@ export default function PublicTutorPage() {
                       <SelectItem
                         key={cat}
                         value={cat}
-                        className="mx-1.5 rounded-md text-white hover:bg-white/10 focus:bg-white/10 focus:text-white focus:outline-none"
+                        className="mx-1.5 rounded-md text-white hover:bg-white/10"
                       >
                         {cat}
                       </SelectItem>

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/solocorn-popup.tsx
+++ b/tutorme-app/src/components/ui/solocorn-popup.tsx
@@ -51,7 +51,7 @@ const SolocornPopupItem = React.forwardRef<HTMLDivElement, SolocornPopupItemProp
     <div
       ref={ref}
       className={cn(
-        'flex cursor-pointer select-none items-center gap-3.5 rounded-lg px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:bg-white/10 active:scale-[0.98]',
+        'flex cursor-pointer select-none items-center gap-3.5 rounded-lg px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 active:scale-[0.98]',
         destructive && 'text-red-400 hover:bg-red-500/10 focus:bg-red-500/10',
         className
       )}


### PR DESCRIPTION
PR #612 fixed the base SelectItem component and the Course Details page, but inline focus:bg-white and data-[highlighted]:bg-white styles were still present on SelectItem components across multiple pages and in the solocorn popup component. This caused the white focus flash to persist on hover in all of these dropdowns.

Files fixed:
- components/ui/solocorn-popup.tsx: Removed focus:bg-white/10 and focus:bg-red-500/10 from SolocornPopupItem
- app/[locale]/page.tsx: Landing page region SelectItem
- app/[locale]/register/admin/page.tsx: Admin role SelectItems (3x)
- app/[locale]/register/parent/page.tsx: Relationship SelectItems (5x)
- app/[locale]/register/student/page.tsx: Region and Country SelectItems (2x)
- app/[locale]/register/tutor/page.tsx: Region and Country SelectItems (2x)
- app/[locale]/u/[username]/page.tsx: Course category SelectItem

All instances now only use hover:bg-white for hover feedback, with no focus or data-[highlighted] background flash.

Fixes #612-follow-up