### PR TITLE
fix(live-poll): enable Send by targeting the deployed live task

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1387,7 +1387,16 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const setExtractedTextFontSize = (val: number) => {
       if (activeItemId) setExtractedTextFontSizeMap(prev => ({ ...prev, [activeItemId]: val }))
     }
-    const activeInsightsTaskId = mainBuilderTab === 'assessment' ? loadedAssessmentId : loadedTaskId
+    // In the LIVE view the poll/question composer targets this task. When no
+    // task is loaded in the builder (the common case — the tutor is just running
+    // the live session), fall back to the most-recently-deployed live task so the
+    // composer has a real target and the Send button isn't permanently disabled.
+    const loadedInsightsTaskId = mainBuilderTab === 'assessment' ? loadedAssessmentId : loadedTaskId
+    const activeInsightsTaskId =
+      loadedInsightsTaskId ??
+      (mainTab === 'live'
+        ? (insightsProps?.liveTasks?.[insightsProps.liveTasks.length - 1]?.id ?? null)
+        : null)
     const activeInsightsTask = activeInsightsTaskId
       ? (nodes
           .flatMap(n => n.lessons.flatMap(l => [...l.tasks, ...(l.homework || [])]))


### PR DESCRIPTION
Follow-up: the poll/question **Send** button was still disabled even after entering text. #598 removed the over-strict object gate; this fixes the actual remaining cause.

## Cause
The composer targets `activeInsightsTaskId`, which = the **builder's** `loadedTaskId`. In a live session the tutor typically hasn't *loaded* a task into the builder — they've **deployed** tasks (`insightsProps.liveTasks`). So `loadedTaskId` (and thus `activeInsightsTaskId`) is `null`, and the Send gate `!activeInsightsTaskId || !sessionId || !prompt` stays true no matter what text is entered.

## Fix
In the **live** view, fall back `activeInsightsTaskId` to the **most-recently-deployed live task** when nothing is loaded:
```
activeInsightsTaskId = loadedTaskId ?? (live ? lastDeployedLiveTask.id : null)
```
This flows through `currentInsightsId → activeLiveTask`, so the composer's send target, the Send button's enabled state, and the poll/question **results** all point at the same real task — consistent. Builder/Test views are untouched (fallback only when `mainTab === 'live'`).

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
In a live session with a task deployed → open the Insights → Poll (or Question) tab → type a prompt → **Send is now enabled** and sends to the deployed task; results show for it. (If a task is loaded in the builder, that still takes precedence.)

## Note
If Send is *still* disabled after this, the remaining possibility is `insightsProps.sessionId` being null in that view — tell me and I'll chase that, but a deployed task + active session should now enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)