### PR TITLE
fix: suppress Radix UI default highlight background via global CSS

### DIFF
--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -712,6 +712,14 @@
     z-index: 1000;
   }
 
+  /* Suppress Radix UI default focus/highlight background on Select and Dropdown items */
+  [data-radix-select-viewport] [data-highlighted],
+  [data-radix-dropdown-menu-content] [data-highlighted],
+  [role='option'][data-highlighted],
+  [role='menuitem'][data-highlighted] {
+    background-color: transparent !important;
+  }
+
   /* Typography Hierarchy - Fira Code for headings */
   h1,
   h2,


### PR DESCRIPTION
Radix UI injects inline styles via JavaScript that set a background-color on [data-highlighted] items in Select and Dropdown menus. Our Tailwind classes (data-[highlighted]:bg-transparent) were being overridden by these dynamically injected styles.

Add global CSS rules targeting Radix's data attributes and ARIA roles with !important to force transparent background on all highlighted items:
- [data-radix-select-viewport] [data-highlighted]
- [data-radix-dropdown-menu-content] [data-highlighted]
- [role='option'][data-highlighted]
- [role='menuitem'][data-highlighted]

This ensures the white focus flash is completely eliminated across all Select and Dropdown components regardless of Radix's internal styling.

Fixes #614-follow-up