### PR TITLE
feat(lessons): foundation — lesson linkage on sessions + deployed material [1/5]

### DIFF
--- a/tutorme-app/drizzle/0065_live_lesson_linkage.sql
+++ b/tutorme-app/drizzle/0065_live_lesson_linkage.sql
@@ -1,0 +1,9 @@
+-- Lesson linkage for live sessions + deployed material.
+-- LiveSession.lessonId: which lesson a scheduled session covers (its lesson-plan
+--   slot) — lets the live view auto-load the right lesson and the Desk group by it.
+-- DeployedMaterial.lessonId: which lesson a deployed task/assessment came from, so
+--   submissions group under the real lesson instead of always "Lesson 1".
+-- Both nullable; idempotent (also applied via startup-schema-fix so a revision
+-- that skips migrations still gets them before serving traffic).
+ALTER TABLE "LiveSession" ADD COLUMN IF NOT EXISTS "lessonId" text;
+ALTER TABLE "DeployedMaterial" ADD COLUMN IF NOT EXISTS "lessonId" text;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1781900000000,
       "tag": "0064_buildertask_pcispec",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1781900000065,
+      "tag": "0065_live_lesson_linkage",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1138,21 +1138,34 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         // up from the source task when the caller didn't supply it. Deploy-only —
         // the server never broadcasts it to students.
         let src: Task | undefined
+        let srcLessonId: string | undefined
         for (const mod of nodes) {
           for (const lesson of mod.lessons) {
             const found = lesson.tasks?.find(t => t.id === payload.id)
             if (found) {
               src = found
+              srcLessonId = lesson.id
+              break
+            }
+            // Also match assessments/homework so their deploys carry the lesson.
+            if (
+              lesson.assessments?.some(a => a.id === payload.id) ||
+              lesson.homework?.some(h => h.id === payload.id)
+            ) {
+              srcLessonId = lesson.id
               break
             }
           }
-          if (src) break
+          if (srcLessonId) break
         }
         const enriched: LiveTask = {
           ...payload,
           pci:
             payload.pci ?? (typeof src?.instructions === 'string' ? src.instructions : undefined),
           pciSpec: payload.pciSpec ?? src?.pciSpec,
+          // The lesson this material was deployed from, so the server tags it with
+          // the real lesson (not "Lesson 1").
+          lessonId: payload.lessonId ?? srcLessonId,
         }
         setDeployDialog({
           run: reveal => insightsProps?.onDeployTask?.({ ...enriched, answerReveal: reveal }),
@@ -2422,6 +2435,26 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       [nodes]
     )
 
+    // The lesson id that contains a given task/assessment/homework item, so a
+    // deploy can be tagged with the real lesson (not "Lesson 1").
+    const findLessonIdForItem = useCallback(
+      (id: string): string | undefined => {
+        for (const mod of nodes) {
+          for (const lesson of mod.lessons) {
+            if (
+              lesson.tasks?.some(t => t.id === id) ||
+              lesson.assessments?.some(a => a.id === id) ||
+              lesson.homework?.some(h => h.id === id)
+            ) {
+              return lesson.id
+            }
+          }
+        }
+        return undefined
+      },
+      [nodes]
+    )
+
     const findAssessmentById = useCallback(
       (id: string): Assessment | null => {
         for (const mod of nodes) {
@@ -3194,6 +3227,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
           // grader. Deploy-only; never broadcast to students. (Assessments have
           // no structured pciSpec — that's a task-builder concept.)
           pci: assessmentBuilder.taskPci || undefined,
+          // The lesson this assessment was deployed from (real lesson, not
+          // "Lesson 1").
+          lessonId: findLessonIdForItem(loadedAssessmentId),
           deployedAt: Date.now(),
           polls: [],
           questions: [],
@@ -9107,6 +9143,9 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                         title: task.title || 'Task',
                                                         content: task.description || '',
                                                         source: 'task',
+                                                        // Real source lesson (not
+                                                        // "Lesson 1").
+                                                        lessonId: findLessonIdForItem(task.id),
                                                         // Student-safe projection
                                                         // (strips answer key incl.
                                                         // matching pairs / hotspot

--- a/tutorme-app/src/lib/db/schema/tables/live.ts
+++ b/tutorme-app/src/lib/db/schema/tables/live.ts
@@ -16,7 +16,7 @@ import {
 } from 'drizzle-orm/pg-core'
 import * as enums from '../enums'
 import { user } from './auth'
-import { course, courseSchedule } from './course'
+import { course, courseSchedule, courseLesson } from './course'
 
 export const liveSession = pgTable(
   'LiveSession',
@@ -29,6 +29,12 @@ export const liveSession = pgTable(
     // The CourseSchedule this session was materialized from (null for ad-hoc / 1:1).
     // Lets a session trace back to its schedule and makes re-publish idempotent.
     scheduleId: text('scheduleId').references(() => courseSchedule.scheduleId, {
+      onDelete: 'set null',
+    }),
+    // The lesson this session covers (its "lesson plan" slot). Assigned when a
+    // schedule materializes into sessions; nullable for ad-hoc/1:1. Lets the live
+    // view auto-load the right lesson and the Desk group by it.
+    lessonId: text('lessonId').references(() => courseLesson.lessonId, {
       onDelete: 'set null',
     }),
     title: text('title').notNull(),
@@ -166,6 +172,9 @@ export const deployedMaterial = pgTable(
     title: text('title').notNull(),
     content: jsonb('content').$type<Record<string, unknown>>(), // Snapshot of the item's content at deployment time
     sessionSequence: integer('sessionSequence').notNull(), // e.g. 1 for 's1', 2 for 's2'
+    // The lesson this material was deployed from, so the Desk can group
+    // submissions under the real lesson (not always "Lesson 1"). Nullable.
+    lessonId: text('lessonId'),
     deployedAt: timestamp('deployedAt', { withTimezone: true }).notNull().defaultNow(),
   },
   table => ({

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -141,6 +141,11 @@ END $$;
 -- that skips migrations still has the column before it serves traffic.
 ALTER TABLE "BuilderTask" ADD COLUMN IF NOT EXISTS "pciSpec" jsonb;
 
+-- Lesson linkage (drizzle/0065): which lesson a session covers + which lesson a
+-- deployed item came from. Nullable; mirrors the migration for skip-migrations.
+ALTER TABLE "LiveSession" ADD COLUMN IF NOT EXISTS "lessonId" text;
+ALTER TABLE "DeployedMaterial" ADD COLUMN IF NOT EXISTS "lessonId" text;
+
 -- TaskDeploymentStatus enum
 DO $$
 BEGIN

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -167,6 +167,9 @@ export interface LiveTask {
    *  layer, same handling as answerKey. */
   pci?: string
   pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
+  /** The lesson this task/assessment was deployed from — tags BuilderTask +
+   *  DeployedMaterial with the real lesson so submissions group correctly. */
+  lessonId?: string
   /** Tutor's answer-reveal policy: 'instant' | 'after_submit' | 'hidden' | 'student_choice'. */
   answerReveal?: 'instant' | 'after_submit' | 'hidden' | 'student_choice'
   deployedAt: number
@@ -1239,6 +1242,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
             title: normalizedTask.title,
             content: normalizedTask as unknown as Record<string, unknown>,
             sessionSequence,
+            // Source lesson (deploy-only), so the Desk groups this under the real
+            // lesson instead of always "Lesson 1".
+            lessonId: typeof task.lessonId === 'string' && task.lessonId ? task.lessonId : null,
             deployedAt: new Date(normalizedTask.deployedAt || Date.now()),
           })
 
@@ -1257,15 +1263,34 @@ export async function initEnhancedSocketServer(server: NetServer) {
           try {
             const tutorId = socket.data.userId
             if (tutorId) {
-              // builderTask.lessonId is a NOT NULL FK. Most courses have a
-              // lesson, but one published with only a schedule (no built
-              // content) has none — create a placeholder so the deployed task
-              // can still be persisted and graded.
-              let [lesson] = await drizzleDb
-                .select({ lessonId: courseLesson.lessonId })
-                .from(courseLesson)
-                .where(eq(courseLesson.courseId, sessionRec.courseId))
-                .limit(1)
+              // builderTask.lessonId is a NOT NULL FK. Prefer the lesson the task
+              // was actually deployed FROM (task.lessonId, sent on the deploy
+              // payload) so submissions group under the real lesson instead of
+              // always "Lesson 1". Fall back to the course's first lesson, then a
+              // placeholder (a course published with only a schedule has none).
+              let lesson: { lessonId: string } | undefined
+              if (typeof task.lessonId === 'string' && task.lessonId) {
+                const [preferred] = await drizzleDb
+                  .select({ lessonId: courseLesson.lessonId })
+                  .from(courseLesson)
+                  .where(
+                    and(
+                      eq(courseLesson.lessonId, task.lessonId),
+                      eq(courseLesson.courseId, sessionRec.courseId)
+                    )
+                  )
+                  .limit(1)
+                if (preferred?.lessonId) lesson = preferred
+              }
+              if (!lesson) {
+                const [first] = await drizzleDb
+                  .select({ lessonId: courseLesson.lessonId })
+                  .from(courseLesson)
+                  .where(eq(courseLesson.courseId, sessionRec.courseId))
+                  .orderBy(courseLesson.order)
+                  .limit(1)
+                lesson = first
+              }
               // NOTE: set createdAt/updatedAt explicitly. These columns are
               // declared notNull().defaultNow() in the schema, but the prod DB
               // has drifted and lacks the column DEFAULT, so relying on the
@@ -1620,12 +1645,29 @@ export async function initEnhancedSocketServer(server: NetServer) {
             // every persist in this chain. Explicit values are drift-proof.
             const now = new Date()
 
-            // 1) Lesson (builderTask.lessonId is NOT NULL).
-            let [lesson] = await drizzleDb
-              .select({ lessonId: courseLesson.lessonId })
-              .from(courseLesson)
-              .where(eq(courseLesson.courseId, courseId))
-              .limit(1)
+            // 1) Lesson (builderTask.lessonId is NOT NULL). Prefer the lesson the
+            //    task was deployed from; fall back to the first lesson, then a
+            //    placeholder.
+            let lesson: { lessonId: string } | undefined
+            if (typeof task.lessonId === 'string' && task.lessonId) {
+              const [preferred] = await drizzleDb
+                .select({ lessonId: courseLesson.lessonId })
+                .from(courseLesson)
+                .where(
+                  and(eq(courseLesson.lessonId, task.lessonId), eq(courseLesson.courseId, courseId))
+                )
+                .limit(1)
+              if (preferred?.lessonId) lesson = preferred
+            }
+            if (!lesson) {
+              const [first] = await drizzleDb
+                .select({ lessonId: courseLesson.lessonId })
+                .from(courseLesson)
+                .where(eq(courseLesson.courseId, courseId))
+                .orderBy(courseLesson.order)
+                .limit(1)
+              lesson = first
+            }
             if (!lesson?.lessonId) {
               const newLessonId = crypto.randomUUID()
               await drizzleDb.insert(courseLesson).values({
@@ -1684,6 +1726,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 itemId: taskId,
                 title: task.title || 'Untitled',
                 sessionSequence: 1,
+                lessonId: lesson.lessonId,
                 deployedAt: now,
               })
             }

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -125,6 +125,10 @@ export interface LiveTask {
    *  NEVER broadcast to students — hidden evaluation layer, like answerKey. */
   pci?: string
   pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
+  /** The lesson this task/assessment was deployed from, so the server can tag the
+   *  persisted BuilderTask + DeployedMaterial with the real lesson (not "Lesson
+   *  1"). Sent tutor→server on deploy. */
+  lessonId?: string
   deployedAt: number
   polls: LiveTaskPoll[]
   questions: LiveTaskQuestion[]


### PR DESCRIPTION
**PR 1 of 5** for the lesson/schedule/live fixes (foundation first, per plan). This adds the missing lesson linkage that every later fix depends on — with no user-facing behaviour change beyond deploys being tagged with their real lesson.

## The gap this closes
- `LiveSession` had **no `lessonId`** → sessions are lesson-agnostic (blocks per-session lesson plans, Task 2).
- `DeployedMaterial` had **no `lessonId`**, and deployed tasks were assigned `builderTask.lessonId = the FIRST lesson` (`.limit(1)`) → everything collapsed to "Lesson 1" (Task 1) and there was no way to know a lesson had deployed material (Task 3).

## Changes
- **Schema:** nullable `lessonId` on **`LiveSession`** (the lesson a session covers — its lesson-plan slot) and **`DeployedMaterial`** (source lesson of a deployed item). `drizzle/0065` + `startup-schema-fix.ts` (idempotent, skip-migrations safe).
- **Deploy (server):** the socket server now tags `builderTask.lessonId` and `DeployedMaterial.lessonId` with the **real** lesson — preferring the deploy payload's `lessonId` (validated against the course), falling back to the first lesson, then a placeholder. Both `task:deploy` and `task:complete` paths.
- **Deploy (client):** `LiveTask` gains a deploy-only `lessonId`; `deployTaskWithDialog` and the direct assessment/task deploys attach the source lesson (new `findLessonIdForItem` helper).

## What later PRs build on this
- PR2 (Task 1): Desk groups submissions by the real `lessonId`; live view loads the right lesson.
- PR3 (Task 4): stable numbering / gaps.
- PR4 (Task 2): per-session lesson-plan editor using `LiveSession.lessonId`.
- PR5 (Task 3): block deleting a lesson that has deployed material / assigned sessions.

## Verification
`tsc` 0, build clean, eslint 0 errors. Migration + journal validated.

## ⚠️ Note
Ships a **DB migration** (two nullable columns). Additive/idempotent. Existing rows get `NULL` (unchanged behaviour); new deploys carry the real lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)