### PR TITLE
fix(lessons): show published lessons in live view + group Desk by real lesson [2/5]

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -556,8 +556,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       return JSON.parse(JSON.stringify(value)) as CourseBuilderNode[]
     }, [])
 
+    // Live shows the synced snapshot (liveNodes). But a session opened directly
+    // in 'live' mode may never run the switch-triggered sync, leaving liveNodes
+    // empty and the lessons "missing" — fall back to builderNodes (the loaded
+    // course lessons) whenever the snapshot is empty.
     const nodes = useMemo(
-      () => (mainTab === 'live' ? liveNodes : builderNodes),
+      () => (mainTab === 'live' ? (liveNodes.length > 0 ? liveNodes : builderNodes) : builderNodes),
       [mainTab, liveNodes, builderNodes]
     )
 

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SubmissionsPanel.tsx
@@ -32,6 +32,7 @@ type SubmissionsTreeResponse = {
     itemId: string
     title: string
     sessionSequence: number
+    lessonId?: string | null
     deployedAt: string | Date | null
   }[]
   sessionParticipants: { sessionId: string; studentId: string; studentName: string | null }[]
@@ -202,17 +203,38 @@ export function SubmissionsPanel({
 
   const sessions = useMemo(() => (data?.sessions || []).filter(s => !!s.id), [data])
 
+  // Which lesson each session belongs to, derived from the REAL lesson its
+  // deployed material came from (deployedMaterial.lessonId) — not the old
+  // by-array-index guess that dumped everything under "Lesson 1". A session with
+  // material from several lessons is placed under whichever lesson it deployed
+  // most from. Sessions with no lesson-tagged material fall back to the index
+  // mapping so pre-existing data doesn't disappear.
+  const lessonIdBySessionId = useMemo(() => {
+    const validLesson = new Set(lessons.map(l => l.id))
+    const counts: Record<string, Record<string, number>> = {}
+    for (const d of data?.deployed || []) {
+      if (!d.lessonId || !validLesson.has(d.lessonId)) continue
+      counts[d.sessionId] = counts[d.sessionId] || {}
+      counts[d.sessionId][d.lessonId] = (counts[d.sessionId][d.lessonId] || 0) + 1
+    }
+    const out: Record<string, string> = {}
+    for (const [sid, byLesson] of Object.entries(counts)) {
+      out[sid] = Object.entries(byLesson).sort((a, b) => b[1] - a[1])[0][0]
+    }
+    return out
+  }, [data, lessons])
+
   const sessionsByLessonId = useMemo(() => {
     const map: Record<string, SubmissionsTreeResponse['sessions']> = {}
     if (sessions.length === 0) return map
     sessions.forEach((s, idx) => {
       const lessonIdx = Math.min(idx, Math.max(0, lessons.length - 1))
-      const lessonId = lessons[lessonIdx]?.id || 'lesson_unknown'
+      const lessonId = lessonIdBySessionId[s.id] || lessons[lessonIdx]?.id || 'lesson_unknown'
       if (!map[lessonId]) map[lessonId] = []
       map[lessonId].push({ ...s } as any)
     })
     return map
-  }, [sessions, lessons])
+  }, [sessions, lessons, lessonIdBySessionId])
 
   // Color-code sessions by lifecycle/chronology so the tutor can see status at a
   // glance: green = active now, yellow = the next-upcoming session (the one right

--- a/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
@@ -99,6 +99,7 @@ export const GET = withAuth(async (request, session, context) => {
             itemId: deployedMaterial.itemId,
             title: deployedMaterial.title,
             sessionSequence: deployedMaterial.sessionSequence,
+            lessonId: deployedMaterial.lessonId,
             deployedAt: deployedMaterial.deployedAt,
           })
           .from(deployedMaterial)


### PR DESCRIPTION
**PR 2 of 5** — Task 1, building on #617's lesson linkage.

## 1. Published lessons missing in the live session
The live tab renders `liveNodes` — a snapshot synced from `builderNodes` **only on a tab switch**. But a live session opens **directly** in 'live' mode (`initialMainTab='live'`), so the switch-triggered sync never fires → `liveNodes` stays empty → the lessons look missing.
**Fix:** when in the live view, fall back to `builderNodes` (the loaded course lessons) whenever `liveNodes` is empty. Never overrides a real snapshot.

## 2. Desk "Submissions" always showing "Lesson 1"
`SubmissionsPanel` mapped sessions to lessons **by array index** (`lessons[idx]`), so everything collapsed under Lesson 1.
**Fix:** each session is now placed under the **real lesson its deployed material came from** — `deployedMaterial.lessonId` (added to the `submissions-tree` route response, now populated by #617). A session that deployed from several lessons goes under the one it deployed from most. Sessions with no lesson-tagged material keep the index fallback, so pre-existing data doesn't vanish.

## Verification
`tsc` 0, build clean, eslint 0 errors.

## ⚠️ Smoke-test
- Open a published course's live session → the lessons appear in the builder tree (not empty).
- Deploy a task from **Lesson 3** → in the Desk → Submissions, that session/material appears under **Lesson 3**, not Lesson 1. (Applies to material deployed *after* #617 shipped — older deploys have no lesson tag and keep the index fallback.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)