### PR TITLE
feat(schedule): distribute lessons across sessions + per-session lesson picker

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -161,6 +161,15 @@ type CourseSession = {
   /** Display name of the linked schedule, e.g. "Schedule 1" (null for one-time). */
   scheduleName?: string | null
   durationMinutes?: number
+  /** The lesson this session covers (auto-assigned on publish, tutor-editable). */
+  lessonId?: string | null
+  lessonTitle?: string | null
+}
+
+type CourseLessonOption = {
+  id: string
+  title: string
+  order: number
 }
 
 type OneOnOneRequest = {
@@ -232,6 +241,8 @@ function TutorDashboardContent() {
     null
   )
   const [courseSessions, setCourseSessions] = useState<CourseSession[]>([])
+  const [courseLessonOptions, setCourseLessonOptions] = useState<CourseLessonOption[]>([])
+  const [savingLessonSessionId, setSavingLessonSessionId] = useState<string | null>(null)
   const [loadingSessions, setLoadingSessions] = useState(false)
   const loadingSessionsRef = useRef(false)
   const [sessionLoadError, setSessionLoadError] = useState<string | null>(null)
@@ -472,6 +483,7 @@ function TutorDashboardContent() {
     setSelectedCourseForCancel(course)
     setCancelModalOpen(true)
     setCourseSessions([])
+    setCourseLessonOptions([])
     setSessionLoadError(null)
     setLoadingSessions(true)
 
@@ -482,6 +494,7 @@ function TutorDashboardContent() {
       if (res.ok) {
         const data = await res.json()
         setCourseSessions(data.sessions || [])
+        setCourseLessonOptions(data.lessons || [])
         setSessionsCourseMeta(data.course || { name: course.name, variantName: '' })
       } else {
         const errData = await res.json().catch(() => ({}))
@@ -571,6 +584,56 @@ function TutorDashboardContent() {
       setCancellingSessionId(null)
     }
   }, [])
+
+  const handleAssignLesson = useCallback(
+    async (sessionId: string, lessonId: string) => {
+      const nextLessonId = lessonId || null
+      // Optimistic update so the picker feels instant.
+      const prevSessions = courseSessions
+      setSavingLessonSessionId(sessionId)
+      setCourseSessions(prev =>
+        prev.map(s =>
+          s.id === sessionId
+            ? {
+                ...s,
+                lessonId: nextLessonId,
+                lessonTitle: courseLessonOptions.find(l => l.id === nextLessonId)?.title ?? null,
+              }
+            : s
+        )
+      )
+
+      try {
+        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrfData = await csrfRes.json().catch(() => ({}))
+        const csrfToken = csrfData?.token ?? null
+
+        const res = await fetch(`/api/tutor/sessions/${sessionId}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+          },
+          credentials: 'include',
+          body: JSON.stringify({ action: 'set-lesson', lessonId: nextLessonId }),
+        })
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          setCourseSessions(prevSessions) // roll back
+          toast.error(data.error || 'Failed to update lesson')
+          return
+        }
+        toast.success(nextLessonId ? 'Lesson updated' : 'Lesson cleared')
+      } catch {
+        setCourseSessions(prevSessions) // roll back
+        toast.error('Failed to update lesson')
+      } finally {
+        setSavingLessonSessionId(null)
+      }
+    },
+    [courseSessions, courseLessonOptions]
+  )
 
   const withLocalePath = useCallback(
     (path: string) => {
@@ -1204,6 +1267,31 @@ function TutorDashboardContent() {
                               <p className="text-muted-foreground truncate text-xs">
                                 {session.description}
                               </p>
+                            )}
+                            {!isVirtual && courseLessonOptions.length > 0 && (
+                              <div className="flex items-center gap-2 pt-0.5">
+                                <BookOpen className="text-muted-foreground h-3 w-3 shrink-0" />
+                                <label className="sr-only" htmlFor={`lesson-${session.id}`}>
+                                  Lesson this session covers
+                                </label>
+                                <select
+                                  id={`lesson-${session.id}`}
+                                  value={session.lessonId ?? ''}
+                                  disabled={savingLessonSessionId === session.id}
+                                  onChange={e => handleAssignLesson(session.id, e.target.value)}
+                                  className="border-border/40 bg-background max-w-[220px] truncate rounded-md border px-2 py-1 text-xs text-gray-900 disabled:opacity-60"
+                                >
+                                  <option value="">No lesson assigned</option>
+                                  {courseLessonOptions.map((l, i) => (
+                                    <option key={l.id} value={l.id}>
+                                      {`Lesson ${i + 1}: ${l.title}`}
+                                    </option>
+                                  ))}
+                                </select>
+                                {savingLessonSessionId === session.id && (
+                                  <div className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                                )}
+                              </div>
                             )}
                           </div>
                           <div className="ml-4 flex items-center gap-2">

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -544,11 +544,30 @@ export const POST = withCsrf(
               }
             }
 
+            // Published lessons in course order — each schedule's sessions are
+            // auto-assigned a lesson sequentially (session 1 → Lesson 1, session 2
+            // → Lesson 2, …) so a schedule no longer collapses everything into
+            // Lesson 1. Sessions beyond the last lesson are left unassigned (null)
+            // for the tutor to fill in via the per-session lesson picker.
+            const publishedLessons = await tx
+              .select({ lessonId: courseLesson.lessonId, order: courseLesson.order })
+              .from(courseLesson)
+              .where(
+                and(eq(courseLesson.courseId, publishedCourseId), isNull(courseLesson.deletedAt))
+              )
+              .orderBy(courseLesson.order)
+
             // Generate live sessions from all schedules
             for (const s of schedules) {
               const scheduleItems = Array.isArray(s.schedule) ? s.schedule : []
               if (scheduleItems.length === 0) continue
               const sessionDates = generateSessionDates(scheduleItems, s.weeksToSchedule || 8)
+
+              // Each schedule is an independent offering that walks the whole
+              // course, so the lesson cursor restarts at Lesson 1 per schedule.
+              // It only advances when a session is actually materialized, so
+              // skipped (conflicting/out-of-availability) slots don't burn a lesson.
+              let lessonCursor = 0
 
               const scheduledAts = sessionDates.map(s => s.scheduledAt).filter(Boolean)
               const minScheduledAt =
@@ -578,6 +597,7 @@ export const POST = withCsrf(
                           durationMinutes: liveSession.durationMinutes,
                           courseId: liveSession.courseId,
                           roomUrl: liveSession.roomUrl,
+                          lessonId: liveSession.lessonId,
                         })
                         .from(liveSession)
                         .where(
@@ -843,6 +863,22 @@ export const POST = withCsrf(
                         externalId: conflictingLs.sessionId,
                       })
                     }
+                    // Backfill the lesson on a session created before lesson
+                    // linkage existed (or a re-publish), keeping the sequence
+                    // aligned. Only set it when currently empty so a tutor's
+                    // manual re-assignment is never overwritten.
+                    const backfillLessonId =
+                      lessonCursor < publishedLessons.length
+                        ? publishedLessons[lessonCursor].lessonId
+                        : null
+                    if (!conflictingLs.lessonId && backfillLessonId) {
+                      await tx
+                        .update(liveSession)
+                        .set({ lessonId: backfillLessonId })
+                        .where(eq(liveSession.sessionId, conflictingLs.sessionId))
+                    }
+                    // Existing same-course session occupies this slot → advance.
+                    lessonCursor++
                     continue
                   } else {
                     // Conflict with a different course — skip and recommend
@@ -862,6 +898,11 @@ export const POST = withCsrf(
                   }
                 }
 
+                const assignedLessonId =
+                  lessonCursor < publishedLessons.length
+                    ? publishedLessons[lessonCursor].lessonId
+                    : undefined
+
                 try {
                   await createSession(
                     {
@@ -873,6 +914,7 @@ export const POST = withCsrf(
                       type: 'COURSE',
                       courseId: publishedCourseId,
                       scheduleId: scheduleIdByPayload.get(s) ?? undefined,
+                      lessonId: assignedLessonId,
                       description: templateCourse.description ?? undefined,
                       status: 'scheduled',
                       maxStudents: s.maxStudents ?? 50,
@@ -880,6 +922,8 @@ export const POST = withCsrf(
                     },
                     tx
                   )
+                  // Session materialized → advance to the next lesson.
+                  lessonCursor++
                 } catch (insertError: any) {
                   const pgError = insertError?.cause || insertError
                   const msg = insertError?.message || String(insertError)

--- a/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/sessions/route.ts
@@ -7,11 +7,12 @@
 import { NextResponse } from 'next/server'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
-import { eq, and, asc, inArray } from 'drizzle-orm'
+import { eq, and, asc, inArray, isNull } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import {
   liveSession as liveSessionTable,
   course,
+  courseLesson,
   courseSchedule,
   courseVariant,
 } from '@/lib/db/schema'
@@ -70,6 +71,19 @@ export const GET = withAuth(
       )
       const variantName = formatCourseVariantName(variantRow?.category, variantRow?.nationality)
 
+      // The course's lessons, so the client can render a per-session lesson
+      // picker and label each session with the lesson it covers.
+      const lessonRows = await drizzleDb
+        .select({
+          id: courseLesson.lessonId,
+          title: courseLesson.title,
+          order: courseLesson.order,
+        })
+        .from(courseLesson)
+        .where(and(eq(courseLesson.courseId, courseId), isNull(courseLesson.deletedAt)))
+        .orderBy(asc(courseLesson.order))
+      const lessonTitleById = new Map(lessonRows.map(l => [l.id, l.title]))
+
       const conditions = [
         eq(liveSessionTable.tutorId, tutorId),
         eq(liveSessionTable.courseId, courseId),
@@ -109,6 +123,9 @@ export const GET = withAuth(
         scheduleId: s.scheduleId ?? null,
         scheduleName: s.scheduleId ? (scheduleNameById.get(s.scheduleId) ?? null) : null,
         durationMinutes: s.durationMinutes ?? 120,
+        // The lesson this session covers (auto-assigned on publish, tutor-editable).
+        lessonId: s.lessonId ?? null,
+        lessonTitle: s.lessonId ? (lessonTitleById.get(s.lessonId) ?? null) : null,
       }))
 
       // Generate virtual sessions from the schedule that publish actually
@@ -127,6 +144,7 @@ export const GET = withAuth(
 
       return NextResponse.json({
         sessions: merged,
+        lessons: lessonRows,
         course: { name: courseRow?.name ?? null, variantName },
       })
     } catch (err) {

--- a/tutorme-app/src/app/api/tutor/sessions/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/sessions/[id]/route.ts
@@ -1,14 +1,14 @@
 /**
  * PATCH /api/tutor/sessions/[id]
- * Cancel a specific session
+ * Cancel a specific session, or assign the lesson it covers.
  */
 
 import { NextResponse } from 'next/server'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession as liveSessionTable, courseEnrollment } from '@/lib/db/schema'
+import { liveSession as liveSessionTable, courseEnrollment, courseLesson } from '@/lib/db/schema'
 import { notifyMany } from '@/lib/notifications/notify'
 
 export const PATCH = withAuth(
@@ -24,7 +24,7 @@ export const PATCH = withAuth(
     const body = await req.json().catch(() => ({}))
     const { action, reason } = body
 
-    if (action !== 'cancel') {
+    if (action !== 'cancel' && action !== 'set-lesson') {
       return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
     }
 
@@ -35,6 +35,47 @@ export const PATCH = withAuth(
 
     if (!existingSession) {
       return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+    }
+
+    // Assign / clear the lesson this session covers.
+    if (action === 'set-lesson') {
+      const rawLessonId = body.lessonId
+      let lessonId: string | null = null
+      if (typeof rawLessonId === 'string' && rawLessonId) {
+        // The lesson must belong to this session's course, so a tutor can't
+        // point a session at an unrelated lesson.
+        if (!existingSession.courseId) {
+          return NextResponse.json(
+            { error: 'This session is not tied to a course' },
+            { status: 400 }
+          )
+        }
+        const [lesson] = await drizzleDb
+          .select({ lessonId: courseLesson.lessonId })
+          .from(courseLesson)
+          .where(
+            and(
+              eq(courseLesson.lessonId, rawLessonId),
+              eq(courseLesson.courseId, existingSession.courseId),
+              isNull(courseLesson.deletedAt)
+            )
+          )
+          .limit(1)
+        if (!lesson) {
+          return NextResponse.json({ error: 'Lesson not found in this course' }, { status: 400 })
+        }
+        lessonId = lesson.lessonId
+      }
+
+      const [updated] = await drizzleDb
+        .update(liveSessionTable)
+        .set({ lessonId })
+        .where(
+          and(eq(liveSessionTable.sessionId, sessionId), eq(liveSessionTable.tutorId, tutorId))
+        )
+        .returning()
+
+      return NextResponse.json({ message: 'Lesson updated', session: updated })
     }
 
     if (existingSession.status === 'ended') {

--- a/tutorme-app/src/lib/sessions/create-session.ts
+++ b/tutorme-app/src/lib/sessions/create-session.ts
@@ -28,6 +28,8 @@ export interface CreateSessionInput {
   courseId?: string
   /** CourseSchedule this session is materialized from (course sessions only). */
   scheduleId?: string
+  /** The lesson this session covers (its lesson-plan slot). Course sessions only. */
+  lessonId?: string
   studentId?: string
   maxStudents?: number
   description?: string
@@ -79,6 +81,7 @@ export async function createSession(input: CreateSessionInput, tx?: DbClient) {
       tutorId: input.tutorId,
       courseId: input.courseId ?? null,
       scheduleId: input.scheduleId ?? null,
+      lessonId: input.lessonId ?? null,
       title: input.title,
       category: input.category,
       description: input.description ?? null,


### PR DESCRIPTION
## Task 2 — the "genius" lesson-plan fix

Previously a course schedule spread its entire duration onto **Lesson 1**, and tutors had no way to decide which lesson each part of the schedule covers. This PR fixes both halves.

### Auto-distribution on publish
- Sessions materialized from a schedule are auto-assigned a lesson **sequentially** (session 1 → Lesson 1, session 2 → Lesson 2, …).
- The lesson cursor **restarts per schedule** (each schedule is an independent offering that walks the whole course) and only advances when a session is actually materialized — so skipped (conflicting / out-of-availability) slots don't burn a lesson.
- Sessions beyond the last lesson are left **unassigned** for the tutor to fill in.
- Re-publish **backfills** the lesson on pre-existing same-course sessions that have none, and **never overwrites** a tutor's manual choice.

### Tutor control (per-session lesson picker)
- `createSession` now accepts an optional `lessonId` (persisted on `LiveSession`, using the `#617` linkage).
- New `set-lesson` action on `PATCH /api/tutor/sessions/[id]` assigns/clears the lesson a session covers (validated to belong to the session's course).
- `GET /api/tutor/courses/[id]/sessions` returns each session's `lessonId`/`lessonTitle` plus the course's `lessons`.
- The sessions modal renders a per-session lesson `<select>` with optimistic update + rollback on failure.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)