### PR TITLE
feat(course): block deleting a lesson with deployed material

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4104,8 +4104,38 @@ FEEDBACK: [one or two short sentences explaining the score]`
       )
     }
 
+    // Block deleting a lesson that has had material deployed from it in a live
+    // class. Returns true when deletion is allowed (or the check can't run).
+    const ensureLessonsDeletable = async (lessonIds: string[]): Promise<boolean> => {
+      const ids = lessonIds.filter(Boolean)
+      if (!courseId || ids.length === 0) return true
+      try {
+        const res = await fetch(`/api/tutor/courses/${courseId}/lessons/usage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ lessonIds: ids }),
+        })
+        if (!res.ok) return true // never block on a failed check
+        const data = await res.json().catch(() => ({}))
+        const usage = (data?.usage ?? {}) as Record<string, { deployedCount?: number }>
+        const blocked = ids.some(id => (usage[id]?.deployedCount ?? 0) > 0)
+        if (blocked) {
+          toast.error(
+            'This lesson has material deployed from it in a class and can’t be deleted. Remove or reassign its deployed tasks/assessments first.'
+          )
+          return false
+        }
+        return true
+      } catch {
+        return true
+      }
+    }
+
     const deleteCourseBuilderNode = async (nodeId: string) => {
       const nodeToDelete = nodes.find(m => m.id === nodeId)
+      const lessonIds = nodeToDelete?.lessons.map(l => l.id) ?? []
+      if (!(await ensureLessonsDeletable(lessonIds))) return
       if (nodeToDelete) {
         const keys = nodeToDelete.lessons.flatMap(l => collectLessonFileKeys(l))
         if (keys.length > 0) await cleanupGcsFiles(keys)
@@ -4117,6 +4147,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
     }
 
     const deleteLesson = async (nodeId: string, lessonId: string) => {
+      if (!(await ensureLessonsDeletable([lessonId]))) return
       const lessonToDelete = nodes.find(m => m.id === nodeId)?.lessons.find(l => l.id === lessonId)
       if (lessonToDelete) {
         const keys = collectLessonFileKeys(lessonToDelete)

--- a/tutorme-app/src/app/api/tutor/courses/[id]/lessons/usage/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/lessons/usage/route.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/tutor/courses/[id]/lessons/usage
+ *
+ * Body: { lessonIds: string[] }
+ * Returns per-lesson deployment usage so the builder can block deleting a
+ * lesson that has had material deployed from it in a live class.
+ */
+
+import { NextResponse } from 'next/server'
+import { withAuth } from '@/lib/api/middleware'
+import { getParamAsync } from '@/lib/api/params'
+import { verifyCourseOwnership } from '@/lib/api/course-helpers'
+import { getLessonUsage } from '@/lib/courses/lesson-usage'
+
+export const POST = withAuth(
+  async (req, session, context) => {
+    const courseId = await getParamAsync(context.params, 'id')
+    const userId = session.user.id
+
+    if (!courseId || courseId === 'undefined' || courseId === 'null') {
+      return NextResponse.json({ error: 'Course ID is required' }, { status: 400 })
+    }
+
+    const isOwner = await verifyCourseOwnership(courseId, userId)
+    if (!isOwner) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    const body = await req.json().catch(() => ({}))
+    const lessonIds = Array.isArray(body?.lessonIds)
+      ? body.lessonIds.filter((x: unknown): x is string => typeof x === 'string')
+      : []
+
+    if (lessonIds.length === 0) {
+      return NextResponse.json({ usage: {} })
+    }
+
+    const usage = await getLessonUsage(courseId, lessonIds)
+    return NextResponse.json({ usage })
+  },
+  { role: 'TUTOR' }
+)

--- a/tutorme-app/src/lib/courses/lesson-usage.ts
+++ b/tutorme-app/src/lib/courses/lesson-usage.ts
@@ -1,0 +1,122 @@
+/**
+ * Lesson usage lookup for the delete guard.
+ *
+ * A lesson can be deleted freely until something has been *deployed* from it in
+ * a live class. The wrinkle: the course builder edits the **template** course,
+ * but deployments stamp `DeployedMaterial.lessonId` with the **published**
+ * lesson id — a fresh id created at publish time. Publish copies lessons
+ * preserving their `order`, so `order` is the only stable correlation between a
+ * template lesson and its published copies.
+ *
+ * Given a (courseId, lessonId) as seen in the builder — where courseId may be
+ * either the template or a published variant — this resolves the whole course
+ * family (template + every published variant), finds every lesson that shares
+ * the target lesson's `order`, and counts deployed material against that set.
+ */
+
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseLesson, courseVariant, deployedMaterial } from '@/lib/db/schema'
+
+export interface LessonUsage {
+  lessonId: string
+  /** Number of DeployedMaterial rows tied to this lesson (or its published copies). */
+  deployedCount: number
+  /** True when the lesson has ever had material deployed and so must not be deleted. */
+  hasDeployments: boolean
+}
+
+/**
+ * Resolve the family of course ids (template + all published variants) that the
+ * given course id belongs to, regardless of whether the id is the template or a
+ * published variant.
+ */
+async function resolveCourseFamily(courseId: string): Promise<string[]> {
+  // Is this a published variant? If so, hop to its template.
+  const [asVariant] = await drizzleDb
+    .select({ templateCourseId: courseVariant.templateCourseId })
+    .from(courseVariant)
+    .where(eq(courseVariant.publishedCourseId, courseId))
+    .limit(1)
+
+  const templateId = asVariant?.templateCourseId ?? courseId
+
+  const variants = await drizzleDb
+    .select({ publishedCourseId: courseVariant.publishedCourseId })
+    .from(courseVariant)
+    .where(eq(courseVariant.templateCourseId, templateId))
+
+  return Array.from(new Set([templateId, ...variants.map(v => v.publishedCourseId)]))
+}
+
+/**
+ * Count deployed material for each of the given lessons, following the
+ * template→published `order` correlation described above.
+ */
+export async function getLessonUsage(
+  courseId: string,
+  lessonIds: string[]
+): Promise<Record<string, LessonUsage>> {
+  const uniqueIds = Array.from(new Set(lessonIds.filter(Boolean)))
+  if (uniqueIds.length === 0) return {}
+
+  const familyIds = await resolveCourseFamily(courseId)
+
+  // All lessons across the family, so we can (a) read each target lesson's order
+  // and (b) find every lesson sharing that order.
+  const familyLessons = await drizzleDb
+    .select({
+      lessonId: courseLesson.lessonId,
+      order: courseLesson.order,
+    })
+    .from(courseLesson)
+    .where(and(inArray(courseLesson.courseId, familyIds), isNull(courseLesson.deletedAt)))
+
+  const orderByLessonId = new Map(familyLessons.map(l => [l.lessonId, l.order]))
+  const lessonIdsByOrder = new Map<number, string[]>()
+  for (const l of familyLessons) {
+    const list = lessonIdsByOrder.get(l.order) ?? []
+    list.push(l.lessonId)
+    lessonIdsByOrder.set(l.order, list)
+  }
+
+  // For each target lesson, the correlated id set = every family lesson at the
+  // same order, plus the target id itself (covers a not-yet-persisted lesson).
+  const correlatedByTarget = new Map<string, string[]>()
+  const allCorrelated = new Set<string>()
+  for (const id of uniqueIds) {
+    const order = orderByLessonId.get(id)
+    const correlated = new Set<string>([id])
+    if (order !== undefined) {
+      for (const cid of lessonIdsByOrder.get(order) ?? []) correlated.add(cid)
+    }
+    correlatedByTarget.set(id, Array.from(correlated))
+    correlated.forEach(cid => allCorrelated.add(cid))
+  }
+
+  // One query for every potentially-referenced lesson id.
+  const deployRows =
+    allCorrelated.size === 0
+      ? []
+      : await drizzleDb
+          .select({ lessonId: deployedMaterial.lessonId })
+          .from(deployedMaterial)
+          .where(inArray(deployedMaterial.lessonId, Array.from(allCorrelated)))
+
+  const deployCountByLessonId = new Map<string, number>()
+  for (const row of deployRows) {
+    if (!row.lessonId) continue
+    deployCountByLessonId.set(row.lessonId, (deployCountByLessonId.get(row.lessonId) ?? 0) + 1)
+  }
+
+  const result: Record<string, LessonUsage> = {}
+  for (const id of uniqueIds) {
+    const correlated = correlatedByTarget.get(id) ?? [id]
+    const deployedCount = correlated.reduce(
+      (sum, cid) => sum + (deployCountByLessonId.get(cid) ?? 0),
+      0
+    )
+    result[id] = { lessonId: id, deployedCount, hasDeployments: deployedCount > 0 }
+  }
+  return result
+}


### PR DESCRIPTION
## Task 3 — protect lessons that have been deployed from

A lesson could be deleted even after tasks/assessments had been deployed from it in a live class. This guards deletion in the course builder.

### The mapping wrinkle
The builder edits the **template** course, but deployments stamp `DeployedMaterial.lessonId` with the **published** lesson id — a fresh id minted at publish time. Publish copies lessons preserving `order`, so `order` is the only stable correlation between a template lesson and its published copies.

`getLessonUsage()` resolves the whole course family (template + every published variant), finds every lesson sharing the target's `order`, and counts `DeployedMaterial` against that set.

### Behaviour
- New `POST /api/tutor/courses/[id]/lessons/usage` → per-lesson deployment counts (owner-checked; works whether the id is the template or a published variant).
- `deleteCourseBuilderNode` / `deleteLesson` call it first and abort with a clear toast when any target lesson has deployments.
- The check **never blocks on its own failure** — a network error won't trap a tutor.

This composes with the `#617` lesson-linkage foundation and the `#622` per-session lesson assignment.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)