### PR TITLE
fix: make Chat panel header flush with Card edges

### DIFF
--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -43,7 +43,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   return (
     <Card className="flex h-full w-full flex-col overflow-hidden rounded-2xl border-0 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       {/* Full-width Chat header */}
-      <div className="flex h-12 shrink-0 items-center justify-center rounded-t-2xl bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
+      <div className="relative flex h-12 shrink-0 items-center justify-center bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
         Chat
       </div>
 


### PR DESCRIPTION
Remove rounded-t-2xl from the Chat header div. The Card component already has rounded-2xl and overflow-hidden, which clips the header corners to match perfectly. The explicit border-radius on the header was causing a subpixel gap between the header and the Card edges due to anti-aliasing/rendering.

Fixes #617-follow-up