### PR TITLE
feat(lessons): open assigned lesson on start, student lesson labels, tests

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -114,6 +114,8 @@ interface SessionItem {
   status: 'scheduled' | 'active' | 'ended' | 'upcoming' | 'opening_soon'
   durationMinutes?: number
   tutorName?: string
+  lessonTitle?: string | null
+  lessonNumber?: number | null
 }
 
 function getSessionStatus(scheduledAt: string, existingStatus?: string): SessionItem['status'] {
@@ -194,7 +196,7 @@ function SessionList({
             className="flex flex-col justify-between gap-3 rounded-xl border bg-white p-4 shadow-sm transition-shadow hover:shadow-md sm:flex-row sm:items-center"
           >
             <div className="min-w-0 flex-1 space-y-1">
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <h4 className="truncate font-semibold text-gray-900">{session.title}</h4>
                 <span
                   className={cn(
@@ -204,6 +206,13 @@ function SessionList({
                 >
                   {status.replace('_', ' ')}
                 </span>
+                {session.lessonTitle && (
+                  <span className="rounded-full border border-indigo-200 bg-indigo-50 px-1.5 py-0.5 text-[10px] font-medium text-indigo-700">
+                    {session.lessonNumber
+                      ? `Lesson ${session.lessonNumber}: ${session.lessonTitle}`
+                      : session.lessonTitle}
+                  </span>
+                )}
               </div>
               {session.scheduledAt && (
                 <div className="flex items-center text-sm text-gray-500">

--- a/tutorme-app/src/app/[locale]/tutor/classroom/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/classroom/page.tsx
@@ -33,14 +33,16 @@ export default async function TutorClassroomRedirect({
   // The insights classroom reads courseId from the URL; nav links that pass only a
   // sessionId would otherwise lose the course context. Derive it from the session.
   const sessionId = typeof sp.sessionId === 'string' ? sp.sessionId : undefined
-  if (sessionId && !qs.get('courseId')) {
+  if (sessionId && (!qs.get('courseId') || !qs.get('lessonId'))) {
     try {
       const [row] = await drizzleDb
-        .select({ courseId: liveSession.courseId })
+        .select({ courseId: liveSession.courseId, lessonId: liveSession.lessonId })
         .from(liveSession)
         .where(eq(liveSession.sessionId, sessionId))
         .limit(1)
-      if (row?.courseId) qs.set('courseId', row.courseId)
+      if (row?.courseId && !qs.get('courseId')) qs.set('courseId', row.courseId)
+      // Carry the session's assigned lesson so the classroom opens on it.
+      if (row?.lessonId && !qs.get('lessonId')) qs.set('lessonId', row.lessonId)
     } catch {
       // Fall through and redirect with whatever params we have.
     }

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1119,6 +1119,9 @@ function CourseBuilderInsightsRouteInner({
               onSaveModeChange={onSaveModeChange}
               onSyncToLiveSession={onSyncToLiveSession}
               onUnsyncedChangesChange={setHasUnsyncedChanges}
+              focusLessonId={
+                isClassroomMode ? (searchParams.get('lessonId') ?? undefined) : undefined
+              }
             />
           </PanelErrorBoundary>
         )}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -476,6 +476,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       isStudentView = false,
       onSyncToLiveSession,
       onUnsyncedChangesChange,
+      focusLessonId,
     },
     ref
   ) {
@@ -578,6 +579,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [expandedCourseBuilderNodes, setExpandedCourseBuilderNodes] = useState<Set<string>>(
       new Set()
     )
+
+    // When a live session is opened with an assigned lesson, expand + scroll to
+    // that lesson exactly once (the existing expand→scroll effect handles the
+    // scroll). Guarded by a ref so a tutor's later manual collapse isn't undone.
+    const didFocusLessonRef = useRef(false)
+    useEffect(() => {
+      if (didFocusLessonRef.current) return
+      if (!focusLessonId || mainTab !== 'live' || nodes.length === 0) return
+      const target = nodes.find(
+        n => n.id === focusLessonId || n.lessons.some(l => l.id === focusLessonId)
+      )
+      if (!target) return
+      didFocusLessonRef.current = true
+      setExpandedCourseBuilderNodes(prev => new Set(prev).add(target.id))
+    }, [focusLessonId, mainTab, nodes])
+
     const [searchQuery, setSearchQuery] = useState('')
     const [selectedItem, setSelectedItem] = useState<{ type: string; id: string } | null>(null)
     const [outlineModalOpen, setOutlineModalOpen] = useState(false)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -430,6 +430,11 @@ export interface CourseBuilderProps {
   isStudentView?: boolean
   onSyncToLiveSession?: (silent?: boolean) => void
   onUnsyncedChangesChange?: (hasUnsynced: boolean) => void
+  /**
+   * When a live session is opened with an assigned lesson, expand and scroll to
+   * that lesson once on mount. Value is the lesson id (courseLesson.lessonId).
+   */
+  focusLessonId?: string | null
 }
 
 export interface CourseBuilderRef {

--- a/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
@@ -3,7 +3,12 @@ import { eq, and, asc } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession as liveSessionTable, courseEnrollment, course } from '@/lib/db/schema'
+import {
+  liveSession as liveSessionTable,
+  courseEnrollment,
+  course,
+  courseLesson,
+} from '@/lib/db/schema'
 import { or, isNull } from 'drizzle-orm'
 import { generateUpcomingSessions, mergeSessions } from '@/lib/schedule-sessions'
 import { resolveCourseScheduleSlots } from '@/lib/sessions/course-schedule-slots'
@@ -46,6 +51,15 @@ export const GET = withAuth(
       // Fetch real live sessions, scoped to the student's chosen schedule when
       // they have one (a switch then cascades to which sessions they see).
       // One-time/ad-hoc sessions (scheduleId null) are shown to everyone.
+      // Lesson titles so each session can show which lesson it covers.
+      const lessonRows = await drizzleDb
+        .select({ id: courseLesson.lessonId, title: courseLesson.title, order: courseLesson.order })
+        .from(courseLesson)
+        .where(and(eq(courseLesson.courseId, courseId), isNull(courseLesson.deletedAt)))
+        .orderBy(asc(courseLesson.order))
+      const lessonTitleById = new Map(lessonRows.map(l => [l.id, l.title]))
+      const lessonNumberById = new Map(lessonRows.map((l, i) => [l.id, i + 1]))
+
       const enrolledScheduleId = (enrollment as { scheduleId?: string | null }).scheduleId ?? null
       const realSessions = await drizzleDb.query.liveSession.findMany({
         where: enrolledScheduleId
@@ -76,6 +90,9 @@ export const GET = withAuth(
         isVirtual: false,
         durationMinutes: s.durationMinutes ?? 120,
         maxStudents: s.maxStudents ?? 50,
+        lessonId: s.lessonId ?? null,
+        lessonTitle: s.lessonId ? (lessonTitleById.get(s.lessonId) ?? null) : null,
+        lessonNumber: s.lessonId ? (lessonNumberById.get(s.lessonId) ?? null) : null,
       }))
 
       // Generate virtual sessions from the schedule that publish actually

--- a/tutorme-app/src/lib/courses/lesson-usage.test.ts
+++ b/tutorme-app/src/lib/courses/lesson-usage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { computeLessonUsage } from './lesson-usage'
+
+/**
+ * These cover the subtle part of the delete guard: a lesson edited in the
+ * builder (a template lesson id) must be considered "in use" when material was
+ * deployed against a *published copy* of it. Published copies get fresh ids at
+ * publish time and correlate to the template lesson only by their `order`.
+ */
+describe('computeLessonUsage', () => {
+  // Template lesson t2 (order 1) has two published copies: p2a and p2b.
+  const family = [
+    { lessonId: 't1', order: 0 },
+    { lessonId: 't2', order: 1 },
+    { lessonId: 't3', order: 2 },
+    { lessonId: 'p2a', order: 1 }, // published copy of t2 (variant A)
+    { lessonId: 'p2b', order: 1 }, // published copy of t2 (variant B)
+    { lessonId: 'p1a', order: 0 }, // published copy of t1
+  ]
+
+  it('returns empty for no targets', () => {
+    expect(computeLessonUsage([], family, ['p2a'])).toEqual({})
+  })
+
+  it('marks a lesson with no deployments as deletable', () => {
+    const usage = computeLessonUsage(['t3'], family, ['p2a', 'p1a'])
+    expect(usage.t3).toEqual({ lessonId: 't3', deployedCount: 0, hasDeployments: false })
+  })
+
+  it('blocks when material is deployed against the template id directly', () => {
+    const usage = computeLessonUsage(['t2'], family, ['t2'])
+    expect(usage.t2.hasDeployments).toBe(true)
+    expect(usage.t2.deployedCount).toBe(1)
+  })
+
+  it('blocks when material is deployed against a published copy (order-correlated)', () => {
+    // Deploy stamped the variant-A published lesson id, not the template id.
+    const usage = computeLessonUsage(['t2'], family, ['p2a'])
+    expect(usage.t2.hasDeployments).toBe(true)
+    expect(usage.t2.deployedCount).toBe(1)
+  })
+
+  it('sums deployments across all correlated copies', () => {
+    const usage = computeLessonUsage(['t2'], family, ['p2a', 'p2a', 'p2b'])
+    expect(usage.t2.deployedCount).toBe(3)
+  })
+
+  it('does not count deployments from a different order', () => {
+    // p1a is order 0; asking about t2 (order 1) must not pick it up.
+    const usage = computeLessonUsage(['t2'], family, ['p1a'])
+    expect(usage.t2).toEqual({ lessonId: 't2', deployedCount: 0, hasDeployments: false })
+  })
+
+  it('handles multiple targets independently', () => {
+    const usage = computeLessonUsage(['t1', 't2', 't3'], family, ['p1a', 'p2b'])
+    expect(usage.t1.hasDeployments).toBe(true) // via p1a (order 0)
+    expect(usage.t2.hasDeployments).toBe(true) // via p2b (order 1)
+    expect(usage.t3.hasDeployments).toBe(false)
+  })
+
+  it('ignores null/undefined deployed ids', () => {
+    const usage = computeLessonUsage(['t2'], family, [null, undefined, 'p2a'])
+    expect(usage.t2.deployedCount).toBe(1)
+  })
+
+  it('counts a target not present in the family only by its own id', () => {
+    // A not-yet-persisted lesson id with no family order still matches direct deploys.
+    const usage = computeLessonUsage(['brand-new'], family, ['brand-new'])
+    expect(usage['brand-new'].hasDeployments).toBe(true)
+  })
+})

--- a/tutorme-app/src/lib/courses/lesson-usage.ts
+++ b/tutorme-app/src/lib/courses/lesson-usage.ts
@@ -53,6 +53,60 @@ async function resolveCourseFamily(courseId: string): Promise<string[]> {
  * Count deployed material for each of the given lessons, following the
  * template→published `order` correlation described above.
  */
+/**
+ * Pure core of the usage computation: given the target lesson ids, every lesson
+ * in the course family (with its `order`), and the lesson ids referenced by
+ * deployed material, compute per-target deployment counts using the
+ * `order`-based template↔published correlation.
+ *
+ * Kept DB-free so it can be unit-tested without a database.
+ */
+export function computeLessonUsage(
+  targetLessonIds: string[],
+  familyLessons: Array<{ lessonId: string; order: number }>,
+  deployedLessonIds: Array<string | null | undefined>
+): Record<string, LessonUsage> {
+  const uniqueIds = Array.from(new Set(targetLessonIds.filter(Boolean)))
+  if (uniqueIds.length === 0) return {}
+
+  const orderByLessonId = new Map(familyLessons.map(l => [l.lessonId, l.order]))
+  const lessonIdsByOrder = new Map<number, string[]>()
+  for (const l of familyLessons) {
+    const list = lessonIdsByOrder.get(l.order) ?? []
+    list.push(l.lessonId)
+    lessonIdsByOrder.set(l.order, list)
+  }
+
+  // For each target lesson, the correlated id set = every family lesson at the
+  // same order, plus the target id itself (covers a not-yet-persisted lesson).
+  const correlatedByTarget = new Map<string, string[]>()
+  for (const id of uniqueIds) {
+    const order = orderByLessonId.get(id)
+    const correlated = new Set<string>([id])
+    if (order !== undefined) {
+      for (const cid of lessonIdsByOrder.get(order) ?? []) correlated.add(cid)
+    }
+    correlatedByTarget.set(id, Array.from(correlated))
+  }
+
+  const deployCountByLessonId = new Map<string, number>()
+  for (const lessonId of deployedLessonIds) {
+    if (!lessonId) continue
+    deployCountByLessonId.set(lessonId, (deployCountByLessonId.get(lessonId) ?? 0) + 1)
+  }
+
+  const result: Record<string, LessonUsage> = {}
+  for (const id of uniqueIds) {
+    const correlated = correlatedByTarget.get(id) ?? [id]
+    const deployedCount = correlated.reduce(
+      (sum, cid) => sum + (deployCountByLessonId.get(cid) ?? 0),
+      0
+    )
+    result[id] = { lessonId: id, deployedCount, hasDeployments: deployedCount > 0 }
+  }
+  return result
+}
+
 export async function getLessonUsage(
   courseId: string,
   lessonIds: string[]
@@ -72,26 +126,23 @@ export async function getLessonUsage(
     .from(courseLesson)
     .where(and(inArray(courseLesson.courseId, familyIds), isNull(courseLesson.deletedAt)))
 
-  const orderByLessonId = new Map(familyLessons.map(l => [l.lessonId, l.order]))
-  const lessonIdsByOrder = new Map<number, string[]>()
-  for (const l of familyLessons) {
-    const list = lessonIdsByOrder.get(l.order) ?? []
-    list.push(l.lessonId)
-    lessonIdsByOrder.set(l.order, list)
-  }
-
-  // For each target lesson, the correlated id set = every family lesson at the
-  // same order, plus the target id itself (covers a not-yet-persisted lesson).
-  const correlatedByTarget = new Map<string, string[]>()
+  // Every id that could be referenced by deployed material.
   const allCorrelated = new Set<string>()
-  for (const id of uniqueIds) {
-    const order = orderByLessonId.get(id)
-    const correlated = new Set<string>([id])
-    if (order !== undefined) {
-      for (const cid of lessonIdsByOrder.get(order) ?? []) correlated.add(cid)
+  {
+    const orderByLessonId = new Map(familyLessons.map(l => [l.lessonId, l.order]))
+    const lessonIdsByOrder = new Map<number, string[]>()
+    for (const l of familyLessons) {
+      const list = lessonIdsByOrder.get(l.order) ?? []
+      list.push(l.lessonId)
+      lessonIdsByOrder.set(l.order, list)
     }
-    correlatedByTarget.set(id, Array.from(correlated))
-    correlated.forEach(cid => allCorrelated.add(cid))
+    for (const id of uniqueIds) {
+      allCorrelated.add(id)
+      const order = orderByLessonId.get(id)
+      if (order !== undefined) {
+        for (const cid of lessonIdsByOrder.get(order) ?? []) allCorrelated.add(cid)
+      }
+    }
   }
 
   // One query for every potentially-referenced lesson id.
@@ -103,20 +154,9 @@ export async function getLessonUsage(
           .from(deployedMaterial)
           .where(inArray(deployedMaterial.lessonId, Array.from(allCorrelated)))
 
-  const deployCountByLessonId = new Map<string, number>()
-  for (const row of deployRows) {
-    if (!row.lessonId) continue
-    deployCountByLessonId.set(row.lessonId, (deployCountByLessonId.get(row.lessonId) ?? 0) + 1)
-  }
-
-  const result: Record<string, LessonUsage> = {}
-  for (const id of uniqueIds) {
-    const correlated = correlatedByTarget.get(id) ?? [id]
-    const deployedCount = correlated.reduce(
-      (sum, cid) => sum + (deployCountByLessonId.get(cid) ?? 0),
-      0
-    )
-    result[id] = { lessonId: id, deployedCount, hasDeployments: deployedCount > 0 }
-  }
-  return result
+  return computeLessonUsage(
+    uniqueIds,
+    familyLessons,
+    deployRows.map(r => r.lessonId)
+  )
 }


### PR DESCRIPTION
Three follow-ups that finish the lesson-linkage work (foundation #617; Tasks 1–4 in #619/#620/#622/#623).

## 1. Auto-open the assigned lesson when a tutor starts a session
Closes the Task 2 loop: a tutor can assign "this session covers Lesson 3," and now starting the class actually opens on Lesson 3.
- The `/tutor/classroom` redirect carries the session's `lessonId` in the URL.
- `CourseBuilderInsightsRoute` passes it as `focusLessonId` (classroom mode only).
- `CourseBuilder` expands + scrolls to that lesson **once** on mount (reusing the existing expand→scroll effect), guarded by a ref so a tutor's later manual collapse isn't undone.
- Ids line up because the classroom loads the **published** course, whose lesson ids equal `LiveSession.lessonId`.

## 2. Students see which lesson each session covers
- `GET /api/student/courses/[id]/sessions` now returns `lessonId` / `lessonTitle` / `lessonNumber`.
- The student course page renders a `Lesson N: <title>` chip on each session.

## 3. Tests for the delete-guard correlation
- Extracted `computeLessonUsage()` as a **DB-free pure core** of the `order`-based template↔published correlation.
- 9 unit tests: no-deploy → deletable, direct-id deploy → blocked, **published-copy-by-order → blocked** (the subtle case), cross-order isolation, multi-target independence, null handling, and a not-yet-persisted id.

## Verification
- `npx vitest run src/lib/courses/lesson-usage.test.ts` → 9 passed ✅
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)