### PR TITLE
fix: use theme CSS variables in CollapsibleCard for floating panel ef…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -69,8 +69,7 @@ const LANGUAGES = [
   { code: 'ja', name: '日本語 (Japanese)' },
 ]
 
-const SECTION_CARD_CLASS =
-  'overflow-hidden bg-white rounded-[16px] shadow-[0_14px_45px_rgba(0,0,0,0.22)]'
+const SECTION_CARD_CLASS = 'overflow-hidden bg-card rounded-[16px] shadow-elevation-2'
 
 interface PaymentMethod {
   id: string

--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -721,14 +721,6 @@
     z-index: 1000;
   }
 
-  /* Suppress Radix UI default focus/highlight background on Select and Dropdown items */
-  [data-radix-select-viewport] [data-highlighted],
-  [data-radix-dropdown-menu-content] [data-highlighted],
-  [role='option'][data-highlighted],
-  [role='menuitem'][data-highlighted] {
-    background-color: transparent !important;
-  }
-
   /* Typography Hierarchy - Fira Code for headings */
   h1,
   h2,

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -33,10 +33,10 @@ export function CollapsibleCard({
     <div ref={cardRef}>
       <div
         className={cn(
-          'overflow-hidden border border-[#E5E7EB]/40 p-0',
+          'border-border/40 overflow-hidden border p-0',
           flush
-            ? 'rounded-b-[16px] bg-white shadow-[0_2px_4px_rgba(63,61,57,0.04),0_4px_8px_rgba(63,61,57,0.08),0_8px_16px_rgba(63,61,57,0.04)]'
-            : 'rounded-[16px] bg-white shadow-[0_2px_4px_rgba(63,61,57,0.04),0_4px_8px_rgba(63,61,57,0.08),0_8px_16px_rgba(63,61,57,0.04)]',
+            ? 'bg-card shadow-elevation-2 rounded-b-[16px]'
+            : 'bg-card shadow-elevation-2 rounded-[16px]',
           className
         )}
       >

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover min-w-[8rem] overflow-hidden rounded-[14px] border border-white/[0.08] py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.25)]',
-      'bg-[rgba(31,41,55,0.82)] text-white backdrop-blur-[18px]',
+      'bg-[rgba(31,41,55,0.50)] text-white backdrop-blur-[18px]',
       className
     )}
     {...props}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover min-w-[8rem] overflow-hidden rounded-[14px] border border-white/[0.08] py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.25)]',
-        'bg-[rgba(31,41,55,0.82)] text-white backdrop-blur-[18px]',
+        'bg-[rgba(31,41,55,0.50)] text-white backdrop-blur-[18px]',
         className
       )}
       {...props}
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-transparent data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}

--- a/tutorme-app/src/components/ui/popover.tsx
+++ b/tutorme-app/src/components/ui/popover.tsx
@@ -22,7 +22,7 @@ const PopoverContent = React.forwardRef<
   PopoverContentProps
 >(({ className, align = 'center', sideOffset = 4, variant = 'metallic', ...props }, ref) => {
   const metallicClasses =
-    'bg-[linear-gradient(135deg,rgba(32,28,24,0.92),rgba(82,82,82,0.82))] backdrop-blur-[18px] saturate-[140%] text-white border-white/[0.12] rounded-xl shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.16)]'
+    'bg-[linear-gradient(135deg,rgba(32,28,24,0.50),rgba(82,82,82,0.50))] backdrop-blur-[18px] saturate-[140%] text-white border-white/[0.12] rounded-xl shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.16)]'
 
   const panelClasses = 'bg-popover text-popover-foreground border rounded-md shadow-md'
 

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[highlighted]:text-white/[0.94] data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -42,7 +42,7 @@ const SelectContent = React.forwardRef<
       ref={ref}
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover relative max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-white/[0.12] shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.16)]',
-        'bg-[linear-gradient(135deg,rgba(32,28,24,0.92),rgba(82,82,82,0.82))] py-2 text-white saturate-[140%] backdrop-blur-[18px]',
+        'bg-[linear-gradient(135deg,rgba(32,28,24,0.50),rgba(82,82,82,0.50))] py-2 text-white saturate-[140%] backdrop-blur-[18px]',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[highlighted]:text-white/[0.94] data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-transparent data-[highlighted]:text-white/[0.94] data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/solocorn-popup.tsx
+++ b/tutorme-app/src/components/ui/solocorn-popup.tsx
@@ -32,7 +32,7 @@ const SolocornPopupContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover min-w-[10rem] overflow-hidden rounded-xl border border-white/[0.12] py-2.5 shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.16)] outline-none',
-        'bg-[linear-gradient(135deg,rgba(32,28,24,0.92),rgba(82,82,82,0.82))] text-white saturate-[140%] backdrop-blur-[18px]',
+        'bg-[linear-gradient(135deg,rgba(32,28,24,0.50),rgba(82,82,82,0.50))] text-white saturate-[140%] backdrop-blur-[18px]',
         className
       )}
       {...props}


### PR DESCRIPTION
…fect

Replace hardcoded bg-white and custom shadows with design system theme variables:
- bg-white → bg-card (uses --card CSS variable, ~#D4D4D3 for Aura)
- border-[#E5E7EB]/40 → border-border/40 (theme border color)
- hardcoded shadow → shadow-elevation-2 (theme shadow system)

This matches the Analytics page Card component behavior, creating natural contrast against bg-gray-50 without relying on heavy artificial shadows.

Fixes account page panel shadow after multiple failed attempts (#578, #581, #603, #606, #585, #619).