### PR TITLE
feat(course): enforce lesson delete guard server-side

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { verifyCourseOwnership } from '@/lib/api/course-helpers'
-import { CourseBuilderService } from '@/lib/services/course-builder.service'
+import { CourseBuilderService, LESSON_DEPLOYED_ERROR } from '@/lib/services/course-builder.service'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseVariant } from '@/lib/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
@@ -105,10 +105,13 @@ export const PUT = withCsrf(
 
             for (const sibling of siblingVariants) {
               if (sibling.publishedCourseId === courseId) continue
+              // Propagation wholesale re-syncs the sibling's lessons; it isn't a
+              // user deletion, so it keeps its existing behavior (guard skipped).
               await CourseBuilderService.updateCourseBuilderData(
                 sibling.publishedCourseId,
                 userId,
-                lessons
+                lessons,
+                { guardDeletions: false }
               )
             }
           }
@@ -123,6 +126,12 @@ export const PUT = withCsrf(
         }
         if (error.message.includes('Invalid payload')) {
           return NextResponse.json({ error: '`lessons` must be an array' }, { status: 400 })
+        }
+        if (error.message.includes(LESSON_DEPLOYED_ERROR)) {
+          return NextResponse.json(
+            { error: error.message.replace(`${LESSON_DEPLOYED_ERROR}: `, '') },
+            { status: 409 }
+          )
         }
         return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
       }

--- a/tutorme-app/src/lib/services/course-builder.service.ts
+++ b/tutorme-app/src/lib/services/course-builder.service.ts
@@ -4,6 +4,10 @@ import { eq, and, inArray, asc } from 'drizzle-orm'
 import crypto from 'crypto'
 import { removeFile } from '@/lib/storage/service'
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
+import { getLessonUsage } from '@/lib/courses/lesson-usage'
+
+/** Thrown when a save would hard-delete a lesson that has deployed material. */
+export const LESSON_DEPLOYED_ERROR = 'LESSON_HAS_DEPLOYMENTS'
 
 export interface BuilderLessonMedia {
   videos: unknown[]
@@ -206,8 +210,17 @@ export class CourseBuilderService {
   static async updateCourseBuilderData(
     courseId: string,
     userId: string,
-    lessons: unknown
+    lessons: unknown,
+    options?: {
+      /**
+       * Reject the save if it would hard-delete a lesson that has deployed
+       * material. Defaults to true. Set false for variant-propagation, which
+       * wholesale re-syncs a sibling's lessons and is not a user deletion.
+       */
+      guardDeletions?: boolean
+    }
   ): Promise<void> {
+    const guardDeletions = options?.guardDeletions ?? true
     // Verify ownership
     const [courseRow] = await drizzleDb
       .select({ courseId: course.courseId })
@@ -255,6 +268,20 @@ export class CourseBuilderService {
       const idsToDelete = [...existingLessonIds].filter(id => !incomingLessonIds.has(id))
 
       if (idsToDelete.length > 0) {
+        // Server-side enforcement of the delete guard (the builder blocks this
+        // client-side, but a direct save must not slip a deployed lesson
+        // through). DeployedMaterial.lessonId has no FK cascade, so hard-
+        // deleting a deployed lesson would leave dangling references.
+        if (guardDeletions) {
+          const usage = await getLessonUsage(courseId, idsToDelete)
+          const blocked = idsToDelete.filter(id => usage[id]?.hasDeployments)
+          if (blocked.length > 0) {
+            throw new Error(
+              `${LESSON_DEPLOYED_ERROR}: cannot delete ${blocked.length} lesson(s) with material ` +
+                `deployed from them in a class. Remove or reassign the deployed tasks/assessments first.`
+            )
+          }
+        }
         await tx.delete(courseLesson).where(inArray(courseLesson.lessonId, idsToDelete))
       }
 


### PR DESCRIPTION
Defense-in-depth for Task 3. The builder blocks deleting a lesson with deployed material **client-side** (#623), but a direct save to the course-content API could still slip one through — and `DeployedMaterial.lessonId` has **no FK cascade**, so a hard delete leaves dangling references.

## Change
- `CourseBuilderService.updateCourseBuilderData` runs `getLessonUsage` on the lessons a save would delete and **throws** when any has deployments. The throw is inside the transaction, so the whole save rolls back — nothing is deleted or modified.
- The course `PUT` route surfaces it as **HTTP 409** with a clear message (the builder's save flow already renders `err.error`).
- Scoped to the primary save via a `guardDeletions` option. **Variant-propagation** (a wholesale sibling re-sync, not a user deletion) opts out, so its existing behavior is unchanged — no regression.

Reuses the same `getLessonUsage` / `order`-correlation core that's unit-tested in #627, so the client and server guards agree.

## Verification
- `npm run typecheck` ✅
- `npx vitest run src/lib/courses/lesson-usage.test.ts` → 9 passed ✅
- `npm run build` ✅
- `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)