### PR TITLE
feat(pci): AI-prefilled structured PCI questionnaire

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -127,6 +127,7 @@ import { usePci } from './hooks/use-pci'
 import { getThread, type PciTarget } from './hooks/pci-reducer'
 import { parsePciTranscript, type PciMessage } from '@/lib/assessment/pci'
 import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
+import { PciQuestionnaire } from './PciQuestionnaire'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
@@ -987,6 +988,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Whether the "Current PCI" box is in edit mode (tutor typing the policy
     // directly instead of via the assistant chat).
     const [editingCurrentPci, setEditingCurrentPci] = useState(false)
+    // Which source's guided PCI questionnaire is open ('task' | 'assessment' | null).
+    const [pciFormSource, setPciFormSource] = useState<'task' | 'assessment' | null>(null)
     // Directly set the saved PCI (the marking policy used by grading) for the
     // active context — the active task extension, the base task, or the
     // assessment. Mirrors where applyTaskPciDraft / applyAssessmentPciDraft write.
@@ -6225,6 +6228,15 @@ FEEDBACK: [one or two short sentences explaining the score]`
             {canEdit && (
               <button
                 type="button"
+                onClick={() => setPciFormSource(prev => (prev === source ? null : source))}
+                className="font-semibold text-indigo-700 hover:underline"
+              >
+                {pciFormSource === source ? 'Hide form' : 'Guided form'}
+              </button>
+            )}
+            {canEdit && (
+              <button
+                type="button"
                 data-pci-anchor="edit-pci"
                 onClick={() => setEditingCurrentPci(v => !v)}
                 className="font-semibold text-blue-700 hover:underline"
@@ -6234,6 +6246,26 @@ FEEDBACK: [one or two short sentences explaining the score]`
             )}
           </div>
         </div>
+        {pciFormSource === source && (
+          <PciQuestionnaire
+            source={source}
+            title={source === 'task' ? taskBuilder.title : assessmentBuilder.title}
+            content={source === 'task' ? taskBuilder.taskContent : assessmentBuilder.taskContent}
+            currentPci={value}
+            canEdit={canEdit}
+            onSave={(specText, spec) => {
+              setCurrentPci(source, specText, {
+                approvedPci: specText,
+                spec,
+                transcript: [],
+                approvedAt: Date.now(),
+              })
+              setPciFormSource(null)
+              toast.success('Marking policy saved to PCI')
+            }}
+            onClose={() => setPciFormSource(null)}
+          />
+        )}
         {editingCurrentPci ? (
           <>
             <textarea

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+/**
+ * PciQuestionnaire — a guided, structured way to author a marking policy (PCI).
+ *
+ * Renders the fixed PciSpec fields as editable rows, can AI-prefill them from
+ * the paper/context (the tutor reviews & edits), and saves the result as the
+ * PCI. It writes the same free-text PCI the grader consumes (via pciSpecToText)
+ * plus the structured spec, so it complements the chat rather than replacing it.
+ */
+
+import { useState } from 'react'
+import { Loader2, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { PCI_SPEC_FIELDS, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
+
+// Short helper hints per field so tutors know what belongs where.
+const FIELD_HINTS: Partial<Record<keyof PciSpec, string>> = {
+  instructionalContentReference: 'Which lesson/material this refers to',
+  triggerEvent: 'When this applies, e.g. "on a submitted answer"',
+  evaluationLogic: 'How to judge — e.g. "award method marks even if the final answer is wrong"',
+  correctResponseBehavior: 'What to do on a correct answer',
+  incorrectResponseBehavior: 'What to do on a wrong answer — hint vs reveal',
+  partialUnderstandingBehavior: 'Partial-credit policy',
+  noResponseBehavior: 'What to do when the student leaves it blank',
+  explanationRules: 'Whether/how to explain reasoning',
+  retryPolicy: 'Retries allowed, if any',
+  instructionalTone: 'Tone to use',
+}
+
+interface PciQuestionnaireProps {
+  source: 'task' | 'assessment'
+  title?: string
+  content?: string
+  currentPci?: string
+  canEdit: boolean
+  onSave: (specText: string, spec: PciSpec) => void
+  onClose: () => void
+}
+
+export function PciQuestionnaire({
+  source,
+  title,
+  content,
+  currentPci,
+  canEdit,
+  onSave,
+  onClose,
+}: PciQuestionnaireProps) {
+  const [spec, setSpec] = useState<PciSpec>({})
+  const [prefilling, setPrefilling] = useState(false)
+
+  const setField = (key: keyof PciSpec, value: string) =>
+    setSpec(prev => {
+      const next = { ...prev }
+      if (value.trim()) next[key] = value
+      else delete next[key]
+      return next
+    })
+
+  const prefill = async () => {
+    setPrefilling(true)
+    try {
+      const res = await fetch('/api/ai/pci-spec-suggest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ type: source, title, content, pci: currentPci }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not prefill from the paper')
+        return
+      }
+      const suggested = (data?.spec ?? {}) as PciSpec
+      // Merge suggestions over anything the tutor already typed, but never blank
+      // out a field they filled that the model omitted.
+      setSpec(prev => ({ ...prev, ...suggested }))
+      const count = Object.keys(suggested).length
+      toast.success(
+        count > 0 ? `Prefilled ${count} field${count === 1 ? '' : 's'}` : 'Nothing to prefill yet'
+      )
+    } catch {
+      toast.error('Could not reach the AI. Please try again.')
+    } finally {
+      setPrefilling(false)
+    }
+  }
+
+  const handleSave = () => {
+    const text = pciSpecToText(spec)
+    if (!text.trim()) {
+      toast.error('Fill at least one field before saving')
+      return
+    }
+    onSave(text, spec)
+  }
+
+  const filledCount = Object.keys(spec).length
+
+  return (
+    <div className="mt-2 rounded-lg border border-indigo-200 bg-indigo-50/50 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold text-indigo-900">Guided marking policy</span>
+        <div className="flex items-center gap-2">
+          {canEdit && (
+            <button
+              type="button"
+              onClick={prefill}
+              disabled={prefilling}
+              className="inline-flex items-center gap-1 rounded-full border border-indigo-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-700 transition-colors hover:bg-indigo-100 disabled:opacity-60"
+            >
+              {prefilling ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Sparkles className="h-3 w-3" />
+              )}
+              Prefill from paper
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[11px] font-medium text-slate-500 hover:text-slate-700"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <p className="mb-2 text-[11px] leading-snug text-slate-500">
+        Policy only — keep answers, marks, and per-question rubric in the{' '}
+        {source === 'assessment' ? 'marking scheme' : 'rubric'}. Leave anything you don&rsquo;t want
+        to specify blank.
+      </p>
+
+      <div className="space-y-2">
+        {PCI_SPEC_FIELDS.map(({ key, label }) => (
+          <div key={key}>
+            <label
+              htmlFor={`pci-field-${source}-${key}`}
+              className="block text-[11px] font-medium text-slate-700"
+            >
+              {label}
+            </label>
+            <textarea
+              id={`pci-field-${source}-${key}`}
+              value={spec[key] ?? ''}
+              readOnly={!canEdit}
+              onChange={e => setField(key, e.target.value)}
+              placeholder={FIELD_HINTS[key] || 'unspecified'}
+              rows={1}
+              className="mt-0.5 min-h-[32px] w-full resize-y rounded-md border border-gray-300 p-1.5 text-[11px] text-gray-900 placeholder:text-slate-400"
+            />
+          </div>
+        ))}
+      </div>
+
+      {canEdit && (
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <span className="text-[11px] text-slate-500">
+            {filledCount} field{filledCount === 1 ? '' : 's'} set
+          </span>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-indigo-700"
+          >
+            Save to PCI
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
@@ -1,0 +1,114 @@
+/**
+ * PCI Spec Suggest API
+ * POST /api/ai/pci-spec-suggest
+ *
+ * Prefills the structured PCI questionnaire (a PciSpec) from the task/assessment
+ * context, so a tutor reviews/edits fields instead of authoring from scratch.
+ * Returns ONLY fields the model can reasonably infer — undefined fields are left
+ * out (never fabricated), matching the PciSpec normalization rules.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, getSessionForRealm, authOptions } from '@/lib/auth'
+import { withRateLimitPreset } from '@/lib/api/middleware'
+import { AISecurityManager } from '@/lib/security/ai-sanitization'
+import { generateWithFallback } from '@/lib/agents'
+import { parseLlmJson } from '@/lib/ai/llm-response'
+import { normalizePciSpec, PCI_SPEC_FIELDS, type PciSpec } from '@/lib/assessment/pci-spec'
+import { guardrailSystemPrompt, GUARDRAILED_TEMPERATURE } from '@/lib/ai/guardrails'
+import { z } from 'zod'
+
+const RequestSchema = z.object({
+  type: z.enum(['task', 'assessment']),
+  title: z.string().max(200).optional(),
+  content: z.string().max(50000).optional(),
+  pci: z.string().max(50000).optional(),
+})
+
+function truncate(value: string | undefined, max: number): string {
+  if (!value) return ''
+  return value.length <= max ? value : `${value.slice(0, max)}\n...[TRUNCATED]`
+}
+
+const SPEC_KEYS = PCI_SPEC_FIELDS.map(f => f.key).join(', ')
+
+export async function POST(request: NextRequest) {
+  try {
+    const session =
+      (await getSessionForRealm(request, 'tutor')) ?? (await getServerSession(authOptions, request))
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { response: rateLimitResponse } = await withRateLimitPreset(
+      request,
+      'aiGenerate',
+      `user:${session.user.id}`
+    )
+    if (rateLimitResponse) return rateLimitResponse
+
+    const parsed = RequestSchema.safeParse(await request.json().catch(() => null))
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    const { type, title, content, pci } = parsed.data
+
+    // No content to infer from → return an empty draft rather than fabricating.
+    const safeContent = AISecurityManager.sanitizeAiInput(content ?? '')
+    const safePci = AISecurityManager.sanitizeAiInput(pci ?? '')
+    if (!safeContent && !safePci && !title) {
+      return NextResponse.json({ spec: {} })
+    }
+
+    const contextBlock = [
+      title && `Title: ${title}`,
+      safeContent && `Content:\n${truncate(safeContent, 12000)}`,
+      safePci && `Existing marking policy (PCI):\n${truncate(safePci, 6000)}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+
+    const instruction = `Draft a structured marking-policy specification (PCI) for this ${type} for the tutor to REVIEW and edit.
+Return ONLY a JSON object whose keys are a subset of: ${SPEC_KEYS}.
+Populate a field ONLY when the context clearly implies it; OMIT any field you cannot reasonably infer — never fabricate policy (retries, grading weights, strictness, partial-credit, reveal timing) the context does not support. It is completely fine to return just one or two fields, or {}.
+Keep each value a short, plain-text instruction. Do NOT include answers, rubric criteria, or per-question scoring here — those belong in the marking scheme, not the PCI.
+Respond with ONLY the JSON object (no prose, no code fences).
+
+Context:
+${contextBlock}`
+
+    let raw: string
+    try {
+      const result = await generateWithFallback(
+        `System:\n${guardrailSystemPrompt(type)}\n\n${instruction}`,
+        {
+          temperature: GUARDRAILED_TEMPERATURE,
+          maxTokens: 1500,
+          skipCache: true,
+          timeoutMs: 45_000,
+          retries: 2,
+        }
+      )
+      raw = result.content
+    } catch (err) {
+      console.error('[pci-spec-suggest] provider error:', err)
+      return NextResponse.json(
+        { error: 'The AI model is briefly unavailable. Please try again.', retryable: true },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      )
+    }
+
+    // The model may wrap the spec directly or under a `spec` key — accept both.
+    const parsedJson = parseLlmJson<Record<string, unknown>>(raw)
+    const candidate =
+      parsedJson && typeof parsedJson === 'object' && 'spec' in parsedJson
+        ? (parsedJson as { spec?: unknown }).spec
+        : parsedJson
+    const spec: PciSpec = normalizePciSpec(candidate) ?? {}
+
+    return NextResponse.json({ spec })
+  } catch (error) {
+    console.error('PCI Spec Suggest error:', error)
+    return NextResponse.json({ error: 'Failed to suggest a PCI spec' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
Item 4 from the PCI feedback — a guided, structured way to author a marking policy, so tutors reliably capture every dimension instead of depending on freeform chat + an approval handshake.

## What it does
- **`PciQuestionnaire` component**: renders the fixed `PciSpec` fields (evaluation logic, correct/incorrect/partial/no-response behaviour, explanation rules, retry policy, tone, …) as editable rows with per-field hints. A **"Prefill from paper"** button asks the AI to draft the fields; the tutor edits/confirms; **"Save to PCI"** writes it.
- **`POST /api/ai/pci-spec-suggest`**: drafts a `PciSpec` from the task/assessment context (title, content, existing PCI). Populates only fields it can infer and **omits the rest — never fabricates** policy, reusing the guardrail system prompt + `normalizePciSpec`.
- **Wiring**: a **"Guided form"** toggle in the PCI panel (both task and assessment). Save goes through the existing `setCurrentPci` path, writing the clean free-text PCI the grader consumes (via `pciSpecToText`) plus the structured spec (for tasks).

## Why this shape
It **separates concerns by construction** (the earlier redundancy question): each field is policy-only, with a reminder that answers/marks/rubric belong in the marking scheme. It **guarantees capture** — every dimension gets an explicit prompt — and it **sidesteps the finalize-handshake fragility** that made assessment chat unreliable. The chat remains available; this complements it.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors
- Note: verified via typecheck/build/lint; the form lives deep in the course-builder PCI panel and wasn't driven end-to-end in a running app here. The prefill endpoint reuses the already-tested `normalizePciSpec` + guardrail prompt.

## Follow-up (not in this PR)
Persisting the structured spec for **assessments** too (tasks already persist `pciSpec`; assessments currently save the derived free-text PCI, which is what grading uses). Easy to add if you want structured-spec parity for assessment grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)