### PR TITLE
feat(pci): persist the structured PCI spec for assessments too

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -951,6 +951,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       title: string
       taskContent: string
       taskPci: string
+      // Current approved structured PCI spec (TASK-6) — persisted at deploy to
+      // BuilderTask.pciSpec, mirroring tasks, so the grader gets it too.
+      pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
       details: string
       sourceDocument?: {
         fileName: string
@@ -1016,7 +1019,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             : base
         })
       } else {
-        setAssessmentBuilder(prev => ({ ...prev, taskPci: text }))
+        // TASK-6: persist the structured spec on a real "Apply to PCI" (audit
+        // present); a manual edit/clear passes no audit and leaves it as-is.
+        setAssessmentBuilder(prev =>
+          audit ? { ...prev, taskPci: text, pciSpec: audit.spec } : { ...prev, taskPci: text }
+        )
       }
     }
 
@@ -1830,6 +1837,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         title: assessment.title || '',
         taskContent: content,
         taskPci: assessment.instructions || '',
+        pciSpec: assessment.pciSpec,
         details: '',
         sourceDocument: assessment.sourceDocument,
         extensions: [],
@@ -2081,6 +2089,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   hw.title === assessmentBuilder.title &&
                   hw.description === assessmentBuilder.taskContent &&
                   hw.instructions === assessmentBuilder.taskPci &&
+                  hw.pciSpec === assessmentBuilder.pciSpec &&
                   hw.dmiItems === assessmentDmiItems &&
                   hw.dmiVersions === assessmentDmiVersions &&
                   hw.activeDmiVersionId === nextActiveDmiVersionId &&
@@ -2094,6 +2103,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   title: assessmentBuilder.title,
                   description: assessmentBuilder.taskContent,
                   instructions: assessmentBuilder.taskPci,
+                  pciSpec: assessmentBuilder.pciSpec,
                   dmiItems: assessmentDmiItems,
                   dmiVersions: assessmentDmiVersions,
                   activeDmiVersionId: nextActiveDmiVersionId,
@@ -2111,6 +2121,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       assessmentBuilder.title,
       assessmentBuilder.taskContent,
       assessmentBuilder.taskPci,
+      assessmentBuilder.pciSpec,
       assessmentBuilder.sourceDocument,
       assessmentDmiItems,
       assessmentDmiVersions,
@@ -3247,10 +3258,11 @@ FEEDBACK: [one or two short sentences explaining the score]`
             marks: item.marks,
           })),
           answerReveal: reveal,
-          // Tutor's PCI (free-text) for server-side use by the live tutor +
-          // grader. Deploy-only; never broadcast to students. (Assessments have
-          // no structured pciSpec — that's a task-builder concept.)
+          // Tutor's PCI (free-text + structured spec) for server-side use by the
+          // live tutor + grader. Deploy-only; never broadcast to students. The
+          // server persists pciSpec to BuilderTask.pciSpec, mirroring tasks.
           pci: assessmentBuilder.taskPci || undefined,
+          pciSpec: assessmentBuilder.pciSpec,
           // The lesson this assessment was deployed from (real lesson, not
           // "Lesson 1").
           lessonId: findLessonIdForItem(loadedAssessmentId),
@@ -6296,21 +6308,25 @@ FEEDBACK: [one or two short sentences explaining the score]`
           </p>
         )}
         {/* TASK-6: the structured specification mirror, when one was finalized. */}
-        {source === 'task' && taskBuilder.pciSpec && !editingCurrentPci && (
-          <div className="mt-2 border-t border-slate-200 pt-2">
-            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-              Structured specification
-            </p>
-            <dl className="space-y-1">
-              {PCI_SPEC_FIELDS.filter(f => taskBuilder.pciSpec?.[f.key]).map(f => (
-                <div key={f.key} className="grid grid-cols-[minmax(0,9rem)_1fr] gap-2">
-                  <dt className="text-slate-500">{f.label}</dt>
-                  <dd className="text-slate-700">{taskBuilder.pciSpec?.[f.key]}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-        )}
+        {(() => {
+          const activeSpec = source === 'task' ? taskBuilder.pciSpec : assessmentBuilder.pciSpec
+          if (!activeSpec || editingCurrentPci) return null
+          return (
+            <div className="mt-2 border-t border-slate-200 pt-2">
+              <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                Structured specification
+              </p>
+              <dl className="space-y-1">
+                {PCI_SPEC_FIELDS.filter(f => activeSpec[f.key]).map(f => (
+                  <div key={f.key} className="grid grid-cols-[minmax(0,9rem)_1fr] gap-2">
+                    <dt className="text-slate-500">{f.label}</dt>
+                    <dd className="text-slate-700">{activeSpec[f.key]}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )
+        })()}
       </div>
     )
     const activeTaskPciInput = activeTaskThread.input

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -181,6 +181,10 @@ export interface Assessment extends WithDifficultyVariants {
   title: string
   description: string
   instructions: string
+  /** Current approved structured PCI spec (TASK-6), when finalized. Persisted at
+   *  deploy to BuilderTask.pciSpec so the grader can use the same structured
+   *  marking policy tasks already get. */
+  pciSpec?: import('@/lib/assessment/pci-spec').PciSpec
   dmiItems?: DMIQuestion[]
   dmiVersions?: DMIVersion[]
   activeDmiVersionId?: string

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts
@@ -148,4 +148,37 @@ describe('usePci', () => {
       expect.objectContaining({ spec: { evaluationLogic: 'Exact match' } })
     )
   })
+
+  it('applyAssessmentPciDraft carries the structured spec into the audit record (parity)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        response: 'ok',
+        pciDraft: 'FINAL',
+        pciSpec: { evaluationLogic: 'Award method marks' },
+        guardrailWarnings: [],
+      }),
+    }) as unknown as typeof fetch
+    const setCurrentPci = vi.fn()
+    const assessmentTarget = { kind: 'assessment' as const, id: 'a1' }
+    const { result } = renderHook(() =>
+      usePci(
+        deps({
+          loadedAssessmentId: 'a1',
+          autoCreateAssessment: () => ({ id: 'a1' }),
+          setCurrentPci,
+        })
+      )
+    )
+    act(() => result.current.setPciInput(assessmentTarget, 'q'))
+    await act(async () => {
+      await result.current.handlePciSend('assessment')
+    })
+    act(() => result.current.applyAssessmentPciDraft('a1'))
+    expect(setCurrentPci).toHaveBeenCalledWith(
+      'assessment',
+      'FINAL',
+      expect.objectContaining({ spec: { evaluationLogic: 'Award method marks' } })
+    )
+  })
 })

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -85,9 +85,18 @@ export function usePci(deps: UsePciDeps) {
 
   const applyAssessmentPciDraft = (assessmentId: string) => {
     const target: PciTarget = { kind: 'assessment', id: assessmentId }
-    const draft = getThread(pci, target).draft
+    const thread = getThread(pci, target)
+    const draft = thread.draft
     if (!draft) return
-    deps.setCurrentPci('assessment', draft)
+    // Persist the structured spec + audit too (parity with tasks), so the
+    // finalized assessment PCI carries its machine-readable form to the grader.
+    const audit: PciAuditRecord = {
+      approvedPci: draft,
+      spec: thread.draftSpec,
+      transcript: thread.messages,
+      approvedAt: Date.now(),
+    }
+    deps.setCurrentPci('assessment', draft, audit)
     dispatch({ type: 'clearDraft', target })
     toast.success('Rubric applied to PCI')
   }


### PR DESCRIPTION
Follow-up to #632. Tasks already persist a structured `PciSpec` to `BuilderTask.pciSpec` at deploy (so the grader gets a machine-readable marking policy); assessments only saved the free-text PCI. This brings assessments to parity.

## Changes (client + types only — no server/DB change)
- `Assessment` type and the assessment builder state gain a `pciSpec` field.
- `setCurrentPci`'s assessment branch persists the spec on a real "Apply to PCI" (audit present), mirroring tasks. Both entry points now carry it: the #632 questionnaire's **Save to PCI** and the chat's `applyAssessmentPciDraft`.
- Assessment **auto-save** threads `pciSpec` into the lesson JSON and the **loader** restores it, so it survives reopening.
- The assessment **deploy payload** carries `pciSpec`. The deploy handler in `socket-server-enhanced.ts` is already **source-agnostic** — it writes `BuilderTask.pciSpec` for any `LiveTask` — so **no server change was needed**. The grader (`ai-grade`) then consumes it exactly as it does for tasks.
- The **"Structured specification"** panel now renders for assessments too.

## Verification
- `npm run typecheck` ✅
- `npx vitest run use-pci.test.ts pci-spec.test.ts` → 11 passed (incl. a new test asserting `applyAssessmentPciDraft` carries the spec) ✅
- `npm run build` ✅
- `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)