### PR TITLE
feat(pci): prefill the Guided form from the loaded marking scheme

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6264,6 +6264,18 @@ FEEDBACK: [one or two short sentences explaining the score]`
             title={source === 'task' ? taskBuilder.title : assessmentBuilder.title}
             content={source === 'task' ? taskBuilder.taskContent : assessmentBuilder.taskContent}
             currentPci={value}
+            // The official marking scheme (DMI) loaded in "Edit marks & answers",
+            // distilled to its policy-bearing bits (no answers) so the AI can
+            // infer award conventions from it.
+            markingScheme={(source === 'task' ? taskDmiItems : assessmentDmiItems)
+              .map(q => ({
+                label: q.questionLabel,
+                marks: typeof q.marks === 'number' ? q.marks : undefined,
+                rubric: q.rubric?.trim() || undefined,
+                responseType: q.responseType?.trim() || undefined,
+                hasVariants: (q.acceptableVariants?.length ?? 0) > 0,
+              }))
+              .filter(q => q.rubric || typeof q.marks === 'number' || q.hasVariants)}
             canEdit={canEdit}
             onSave={(specText, spec) => {
               setCurrentPci(source, specText, {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -28,11 +28,23 @@ const FIELD_HINTS: Partial<Record<keyof PciSpec, string>> = {
   instructionalTone: 'Tone to use',
 }
 
+/** A per-question digest of the official marking scheme (DMI) — the policy-
+ *  bearing bits only (no answers), used to inform the AI prefill. */
+export interface MarkingSchemeDigestRow {
+  label?: string
+  marks?: number
+  rubric?: string
+  responseType?: string
+  hasVariants?: boolean
+}
+
 interface PciQuestionnaireProps {
   source: 'task' | 'assessment'
   title?: string
   content?: string
   currentPci?: string
+  /** Distilled marking scheme from the "Edit marks & answers" modal, if any. */
+  markingScheme?: MarkingSchemeDigestRow[]
   canEdit: boolean
   onSave: (specText: string, spec: PciSpec) => void
   onClose: () => void
@@ -43,6 +55,7 @@ export function PciQuestionnaire({
   title,
   content,
   currentPci,
+  markingScheme,
   canEdit,
   onSave,
   onClose,
@@ -65,7 +78,13 @@ export function PciQuestionnaire({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ type: source, title, content, pci: currentPci }),
+        body: JSON.stringify({
+          type: source,
+          title,
+          content,
+          pci: currentPci,
+          markingScheme: markingScheme?.length ? markingScheme : undefined,
+        }),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
@@ -115,7 +134,7 @@ export function PciQuestionnaire({
               ) : (
                 <Sparkles className="h-3 w-3" />
               )}
-              Prefill from paper
+              {markingScheme?.length ? 'Prefill from marking scheme' : 'Prefill from paper'}
             </button>
           )}
           <button
@@ -132,6 +151,13 @@ export function PciQuestionnaire({
         Policy only — keep answers, marks, and per-question rubric in the{' '}
         {source === 'assessment' ? 'marking scheme' : 'rubric'}. Leave anything you don&rsquo;t want
         to specify blank.
+        {markingScheme?.length ? (
+          <>
+            {' '}
+            Prefill reads your loaded marking scheme ({markingScheme.length} question
+            {markingScheme.length === 1 ? '' : 's'}) and distils its award conventions into policy.
+          </>
+        ) : null}
       </p>
 
       <div className="space-y-2">

--- a/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
@@ -23,6 +23,21 @@ const RequestSchema = z.object({
   title: z.string().max(200).optional(),
   content: z.string().max(50000).optional(),
   pci: z.string().max(50000).optional(),
+  // The official marking scheme (DMI), distilled per question. The AI reads the
+  // rubrics/marks to infer cross-cutting POLICY — it must not copy per-question
+  // answers/rubric text (those live in the marking scheme, not the PCI).
+  markingScheme: z
+    .array(
+      z.object({
+        label: z.string().max(40).optional(),
+        marks: z.number().optional(),
+        rubric: z.string().max(2000).optional(),
+        responseType: z.string().max(60).optional(),
+        hasVariants: z.boolean().optional(),
+      })
+    )
+    .max(120)
+    .optional(),
 })
 
 function truncate(value: string | undefined, max: number): string {
@@ -51,12 +66,29 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
-    const { type, title, content, pci } = parsed.data
+    const { type, title, content, pci, markingScheme } = parsed.data
+
+    // Distil the marking scheme into a compact, policy-bearing digest: the
+    // per-question rubrics + marks + response types are where official marking
+    // conventions live (method marks, partial credit, accepted equivalents).
+    const schemeRows = (markingScheme ?? [])
+      .map(q => {
+        const parts = [
+          q.label && `Q${q.label}`,
+          typeof q.marks === 'number' && `${q.marks} mark(s)`,
+          q.responseType && `type: ${q.responseType}`,
+          q.hasVariants && 'accepts equivalent variants',
+          q.rubric && `rubric: ${truncate(q.rubric, 600)}`,
+        ].filter(Boolean)
+        return parts.length > 0 ? `- ${parts.join(' | ')}` : ''
+      })
+      .filter(Boolean)
+    const schemeBlock = schemeRows.length > 0 ? schemeRows.slice(0, 120).join('\n') : ''
 
     // No content to infer from → return an empty draft rather than fabricating.
     const safeContent = AISecurityManager.sanitizeAiInput(content ?? '')
     const safePci = AISecurityManager.sanitizeAiInput(pci ?? '')
-    if (!safeContent && !safePci && !title) {
+    if (!safeContent && !safePci && !title && !schemeBlock) {
       return NextResponse.json({ spec: {} })
     }
 
@@ -64,14 +96,20 @@ export async function POST(request: NextRequest) {
       title && `Title: ${title}`,
       safeContent && `Content:\n${truncate(safeContent, 12000)}`,
       safePci && `Existing marking policy (PCI):\n${truncate(safePci, 6000)}`,
+      schemeBlock &&
+        `Official marking scheme (per-question rubrics + marks — the tutor's source of truth for HOW marks are awarded):\n${truncate(schemeBlock, 16000)}`,
     ]
       .filter(Boolean)
       .join('\n\n')
 
+    const schemeGuidance = schemeBlock
+      ? `\nThe official marking scheme above is your richest source. DISTIL its cross-cutting policy into the PCI: recurring award conventions (e.g. method/working marks, "accept equivalent forms", follow-through, unit or significant-figure handling), partial-credit patterns implied by the mark splits, and how open vs closed items are treated. Do NOT copy per-question answers or verbatim rubric text into the PCI — those already live in the marking scheme; capture only the GENERAL policy a grader should apply across questions.`
+      : ''
+
     const instruction = `Draft a structured marking-policy specification (PCI) for this ${type} for the tutor to REVIEW and edit.
 Return ONLY a JSON object whose keys are a subset of: ${SPEC_KEYS}.
 Populate a field ONLY when the context clearly implies it; OMIT any field you cannot reasonably infer — never fabricate policy (retries, grading weights, strictness, partial-credit, reveal timing) the context does not support. It is completely fine to return just one or two fields, or {}.
-Keep each value a short, plain-text instruction. Do NOT include answers, rubric criteria, or per-question scoring here — those belong in the marking scheme, not the PCI.
+Keep each value a short, plain-text instruction. Do NOT include answers, rubric criteria, or per-question scoring here — those belong in the marking scheme, not the PCI.${schemeGuidance}
 Respond with ONLY the JSON object (no prose, no code fences).
 
 Context:


### PR DESCRIPTION
The Guided PCI form's **Prefill** could only read the paper text. Official marking schemes — loaded in the **"Edit marks & answers"** modal as the DMI — carry detailed, authoritative rubrics, which are a far richer source for the marking *policy*.

## What changed
- **`/api/ai/pci-spec-suggest`** now accepts a distilled marking scheme (per question: `label`, `marks`, `rubric`, `responseType`, `hasVariants` — **no answers**) and instructs the model to **distil cross-cutting policy** from it (method/working marks, accept-equivalents, follow-through, unit/sig-fig handling, partial-credit patterns implied by the mark splits) **without copying per-question answers or verbatim rubric text**. This keeps the policy-vs-answer-key separation we established earlier — the scheme stays the source of truth for *what's correct*; the PCI captures *how to apply marks in general*.
- **`PciQuestionnaire`** sends the marking scheme; the button reads **"Prefill from marking scheme"** when one is loaded, with a note showing how many questions informed it.
- The builder feeds the current source's DMI items (`taskDmiItems` / `assessmentDmiItems`), keeping only rows that carry a rubric, marks, or variants.

## Why this is safe on the redundancy front
The model is explicitly told to extract *general* policy, not per-question rubric text — so the PCI doesn't become a duplicate of the marking scheme. It's the official conventions, generalised.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors
- Note: verified via typecheck/build/lint; the form lives deep in the builder and wasn't driven end-to-end here. The endpoint reuses the tested `normalizePciSpec` + guardrail prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)