### PR TITLE
feat(pci): upload a marking scheme from the Guided form (fills DMI + PCI)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6276,6 +6276,11 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 hasVariants: (q.acceptableVariants?.length ?? 0) > 0,
               }))
               .filter(q => q.rubric || typeof q.marks === 'number' || q.hasVariants)}
+            // Upload a marking scheme straight from the Guided form: fills the
+            // DMI (marks & answers) via the same flow as "Edit marks & answers",
+            // then the form auto-prefills the PCI from it.
+            onUploadMarkingScheme={file => handleMarkingSchemeFile(file, source)}
+            markingSchemeLoading={markingSchemeLoading}
             canEdit={canEdit}
             onSave={(specText, spec) => {
               setCurrentPci(source, specText, {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -9,8 +9,8 @@
  * plus the structured spec, so it complements the chat rather than replacing it.
  */
 
-import { useState } from 'react'
-import { Loader2, Sparkles } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Loader2, Sparkles, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import { PCI_SPEC_FIELDS, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
 
@@ -45,6 +45,11 @@ interface PciQuestionnaireProps {
   currentPci?: string
   /** Distilled marking scheme from the "Edit marks & answers" modal, if any. */
   markingScheme?: MarkingSchemeDigestRow[]
+  /** Upload a marking-scheme file — populates the DMI (marks & answers) exactly
+   *  as the "Edit marks & answers" modal does. When provided, the Guided form
+   *  shows an upload control and auto-prefills the PCI once the DMI is filled. */
+  onUploadMarkingScheme?: (file: File) => Promise<void>
+  markingSchemeLoading?: boolean
   canEdit: boolean
   onSave: (specText: string, spec: PciSpec) => void
   onClose: () => void
@@ -56,12 +61,18 @@ export function PciQuestionnaire({
   content,
   currentPci,
   markingScheme,
+  onUploadMarkingScheme,
+  markingSchemeLoading,
   canEdit,
   onSave,
   onClose,
 }: PciQuestionnaireProps) {
   const [spec, setSpec] = useState<PciSpec>({})
   const [prefilling, setPrefilling] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  // Set right after an upload so the auto-prefill fires once the DMI (and thus
+  // the markingScheme prop) has repopulated from the parsed scheme.
+  const [awaitingSchemePrefill, setAwaitingSchemePrefill] = useState(false)
 
   const setField = (key: keyof PciSpec, value: string) =>
     setSpec(prev => {
@@ -71,7 +82,7 @@ export function PciQuestionnaire({
       return next
     })
 
-  const prefill = async () => {
+  const prefill = useCallback(async () => {
     setPrefilling(true)
     try {
       const res = await fetch('/api/ai/pci-spec-suggest', {
@@ -104,6 +115,26 @@ export function PciQuestionnaire({
     } finally {
       setPrefilling(false)
     }
+  }, [source, title, content, currentPci, markingScheme])
+
+  // After an upload, the parent repopulates the DMI → the markingScheme prop
+  // grows → auto-prefill the PCI from the freshly-parsed scheme.
+  useEffect(() => {
+    if (awaitingSchemePrefill && (markingScheme?.length ?? 0) > 0) {
+      setAwaitingSchemePrefill(false)
+      void prefill()
+    }
+  }, [awaitingSchemePrefill, markingScheme, prefill])
+
+  const handleUpload = async (file: File) => {
+    if (!onUploadMarkingScheme) return
+    try {
+      await onUploadMarkingScheme(file)
+      // Fill the DMI first, then let the effect prefill the PCI from it.
+      setAwaitingSchemePrefill(true)
+    } catch {
+      // The upload hook surfaces its own errors.
+    }
   }
 
   const handleSave = () => {
@@ -122,10 +153,39 @@ export function PciQuestionnaire({
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="text-xs font-semibold text-indigo-900">Guided marking policy</span>
         <div className="flex items-center gap-2">
+          {canEdit && onUploadMarkingScheme && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/pdf,.pdf,text/plain,.txt"
+                className="hidden"
+                onChange={e => {
+                  const file = e.target.files?.[0]
+                  e.target.value = ''
+                  if (file) void handleUpload(file)
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={markingSchemeLoading || prefilling}
+                className="inline-flex items-center gap-1 rounded-full border border-sky-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-sky-700 transition-colors hover:bg-sky-100 disabled:opacity-60"
+                title="Upload a marking scheme — fills marks & answers, then the policy"
+              >
+                {markingSchemeLoading ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Upload className="h-3 w-3" />
+                )}
+                Upload marking scheme
+              </button>
+            </>
+          )}
           {canEdit && (
             <button
               type="button"
-              onClick={prefill}
+              onClick={() => prefill()}
               disabled={prefilling}
               className="inline-flex items-center gap-1 rounded-full border border-indigo-300 bg-white px-2.5 py-1 text-[11px] font-semibold text-indigo-700 transition-colors hover:bg-indigo-100 disabled:opacity-60"
             >
@@ -156,6 +216,12 @@ export function PciQuestionnaire({
             {' '}
             Prefill reads your loaded marking scheme ({markingScheme.length} question
             {markingScheme.length === 1 ? '' : 's'}) and distils its award conventions into policy.
+          </>
+        ) : onUploadMarkingScheme ? (
+          <>
+            {' '}
+            Have the official marking scheme? <span className="font-medium">Upload</span> it — it
+            fills the marks &amp; answers, then prefills this policy automatically.
           </>
         ) : null}
       </p>


### PR DESCRIPTION
Item 2 of the request. Tutors can now upload the official marking scheme **directly in the PCI Guided form**, not only in "Edit marks & answers".

## Flow
1. Guided form → **Upload marking scheme** → runs the same parse flow as the DMI editor (`handleMarkingSchemeFile`), populating the **marks & answers** and detected board/subject.
2. Once the DMI repopulates, an effect fires the existing PCI prefill — so **one upload fills both** the answer key *and* the marking policy.

## Implementation
- `PciQuestionnaire` gains `onUploadMarkingScheme` + `markingSchemeLoading`; a sky-styled **Upload marking scheme** button with a hidden file input.
- After upload, `awaitingSchemePrefill` is set; an effect watches the `markingScheme` prop (which grows once the DMI is filled) and then runs prefill against the fresh scheme.
- `prefill` is memoized (`useCallback`) so the post-upload effect reads current data, not a stale closure.
- Reuses the builder's existing `useMarkingScheme` hook — no new parse logic.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors (my effect's deps are complete)
- Note: verified via typecheck/build/lint; couldn't drive the deep builder UI end-to-end here. When deployed: open a new assessment → Guided form → Upload marking scheme → confirm the marks/answers fill AND the policy fields prefill.

Items 3 (Board/Subject dropdowns on the Guided form) and 5 (bidirectional link to Course details) are a separate change with a data-model decision — coming in a follow-up with a short plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)