### PR TITLE
feat(pci): Board + Subject dropdowns on the Guided form, linked to Course details

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -117,6 +117,7 @@ import {
   type DmiQuestionType,
 } from '@/lib/assessment/question-types'
 import { deriveExamContext, EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
+import { getAllCourseCategoryOptions } from '@/lib/data/all-categories'
 import { reverifyAssessment } from '@/lib/assessment/assessment-gates'
 import { deriveSections, deriveTotalMarks } from '@/lib/assessment/sections'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
@@ -710,6 +711,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     useEffect(() => {
       setAssetViewFolder(designatedFolder !== 'Uncategorized' ? designatedFolder : 'All')
     }, [courseId, designatedFolder])
+
+    // Board & Subject for the PCI Guided form (Model A: the course category is
+    // the shared source of truth). `courseCategoryOverride` reflects a change the
+    // tutor makes here immediately, before the `courses` prop refetches; the
+    // change is also persisted back to the course so Course details picks it up.
+    const liveCourseCategories = useMemo(() => {
+      const lc = (insightsProps as any)?.courses?.find((c: any) => c.id === courseId)
+      return Array.isArray(lc?.categories) ? (lc.categories as string[]) : []
+    }, [(insightsProps as any)?.courses, courseId])
+    const [courseCategoryOverride, setCourseCategoryOverride] = useState<string | null>(null)
+    const [pciBoardOverride, setPciBoardOverride] = useState<string | null>(null)
+    const pciCategory =
+      courseCategoryOverride ?? (designatedFolder !== 'Uncategorized' ? designatedFolder : '')
+    const pciBoard =
+      pciBoardOverride ?? deriveExamContext(pciCategory || null, courseName).examBody ?? ''
+    const pciCategoryOptions = useMemo(() => getAllCourseCategoryOptions(), [])
 
     const [assetFoldersList, setAssetFoldersList] = useState<string[]>(() => {
       if (typeof window !== 'undefined') {
@@ -2932,6 +2949,52 @@ FEEDBACK: [one or two short sentences explaining the score]`
       courseName,
       setExamContext,
     })
+
+    // Persist the Guided-form Subject back to the course's categories so it
+    // reflects on the Course details page (Model A, item 5). Replaces the
+    // primary category, preserving any additional ones. Best-effort — the local
+    // override already reflects it in the form. The PATCH route is auth-only.
+    const persistCourseCategory = useCallback(
+      async (cat: string) => {
+        if (!courseId || !cat) return
+        const next =
+          liveCourseCategories.length > 0
+            ? [cat, ...liveCourseCategories.slice(1).filter(c => c !== cat)]
+            : [cat]
+        try {
+          await fetch(`/api/tutor/courses/${courseId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ categories: next }),
+          })
+        } catch {
+          // best-effort — the form already reflects it via the local override
+        }
+      },
+      [courseId, liveCourseCategories]
+    )
+
+    // Board/Subject changes from the PCI Guided form. Subject (a course category)
+    // drives the DMI exam context AND writes back to the course; Board overrides
+    // the derived examBody on the DMI.
+    const handlePciExamContextChange = useCallback(
+      (source: 'task' | 'assessment', patch: { category?: string; board?: string }) => {
+        if (patch.category !== undefined) {
+          const cat = patch.category
+          const derived = deriveExamContext(cat || null, courseName)
+          setCourseCategoryOverride(cat)
+          setPciBoardOverride(null) // re-derive the board from the new subject
+          setExamContext(source, { examBody: derived.examBody, subject: derived.subject ?? cat })
+          void persistCourseCategory(cat)
+        }
+        if (patch.board !== undefined) {
+          setPciBoardOverride(patch.board)
+          setExamContext(source, { examBody: patch.board })
+        }
+      },
+      [courseName, setExamContext, persistCourseCategory]
+    )
 
     // Generate DMI using AI from content or PDF images with versioning.
     // `questionSpec` is supplied (via the spec dialog) when the source is study
@@ -6281,6 +6344,10 @@ FEEDBACK: [one or two short sentences explaining the score]`
             // then the form auto-prefills the PCI from it.
             onUploadMarkingScheme={file => handleMarkingSchemeFile(file, source)}
             markingSchemeLoading={markingSchemeLoading}
+            board={pciBoard}
+            subject={pciCategory}
+            categoryOptions={pciCategoryOptions}
+            onExamContextChange={patch => handlePciExamContextChange(source, patch)}
             canEdit={canEdit}
             onSave={(specText, spec) => {
               setCurrentPci(source, specText, {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Loader2, Sparkles, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import { PCI_SPEC_FIELDS, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
+import { EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
 
 // Short helper hints per field so tutors know what belongs where.
 const FIELD_HINTS: Partial<Record<keyof PciSpec, string>> = {
@@ -50,6 +51,13 @@ interface PciQuestionnaireProps {
    *  shows an upload control and auto-prefills the PCI once the DMI is filled. */
   onUploadMarkingScheme?: (file: File) => Promise<void>
   markingSchemeLoading?: boolean
+  /** Board & Subject (Model A: category is the source of truth, shared with
+   *  Course details). Subject is a course category from the catalog; Board is
+   *  the examBody, auto-derived from the subject but overridable. */
+  board?: string
+  subject?: string
+  categoryOptions?: string[]
+  onExamContextChange?: (patch: { category?: string; board?: string }) => void
   canEdit: boolean
   onSave: (specText: string, spec: PciSpec) => void
   onClose: () => void
@@ -63,6 +71,10 @@ export function PciQuestionnaire({
   markingScheme,
   onUploadMarkingScheme,
   markingSchemeLoading,
+  board,
+  subject,
+  categoryOptions,
+  onExamContextChange,
   canEdit,
   onSave,
   onClose,
@@ -225,6 +237,59 @@ export function PciQuestionnaire({
           </>
         ) : null}
       </p>
+
+      {onExamContextChange && (
+        <div className="mb-3 grid grid-cols-2 gap-2 rounded-md border border-slate-200 bg-white/70 p-2">
+          <div>
+            <label
+              htmlFor={`pci-board-${source}`}
+              className="block text-[11px] font-medium text-slate-700"
+            >
+              Board
+            </label>
+            <select
+              id={`pci-board-${source}`}
+              value={board ?? ''}
+              disabled={!canEdit}
+              onChange={e => onExamContextChange({ board: e.target.value })}
+              className="mt-0.5 w-full rounded-md border border-gray-300 p-1.5 text-[11px] text-gray-900"
+            >
+              <option value="">—</option>
+              {EXAM_BOARDS.map(b => (
+                <option key={b} value={b}>
+                  {b}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor={`pci-subject-${source}`}
+              className="block text-[11px] font-medium text-slate-700"
+            >
+              Subject / category
+            </label>
+            <input
+              id={`pci-subject-${source}`}
+              list={`pci-subject-list-${source}`}
+              value={subject ?? ''}
+              disabled={!canEdit}
+              onChange={e => onExamContextChange({ category: e.target.value })}
+              placeholder="Search the catalog…"
+              className="mt-0.5 w-full rounded-md border border-gray-300 p-1.5 text-[11px] text-gray-900"
+            />
+            <datalist id={`pci-subject-list-${source}`}>
+              {(categoryOptions ?? []).map(c => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
+          </div>
+          <p className="col-span-2 text-[10px] leading-snug text-slate-400">
+            Shared with Course details — set it here for a new course, or it shows the published
+            course&rsquo;s category. Board auto-fills from the subject; override if needed.
+          </p>
+        </div>
+      )}
 
       <div className="space-y-2">
         {PCI_SPEC_FIELDS.map(({ key, label }) => (

--- a/tutorme-app/src/lib/data/all-categories.ts
+++ b/tutorme-app/src/lib/data/all-categories.ts
@@ -1,0 +1,50 @@
+/**
+ * Flattened catalog of every selectable course category (the "subjects" the
+ * Guided form's Subject dropdown offers). These are the same category strings
+ * the Course details page stores in `course.categories`, so the PCI Guided form
+ * and Course details share one vocabulary — Model A: category is the source of
+ * truth for Board/Subject.
+ */
+
+import {
+  NATIONAL_EXAMS_DATA,
+  GLOBAL_EXAMS_CATEGORIES,
+  AP_CATEGORIES,
+  A_LEVEL_CATEGORIES,
+  IB_CATEGORIES,
+  IGCSE_CATEGORIES,
+  type ExamCategory,
+} from './tutor-categories'
+import {
+  LANGUAGE_CATEGORIES,
+  PROFESSIONAL_CATEGORIES,
+  UNIVERSITY_CATEGORIES,
+  SPECIALTY_CATEGORIES,
+} from '@/lib/tutoring/specialty-categories'
+
+let cached: string[] | null = null
+
+/** Every distinct course-category string, sorted. Memoized (the source lists are static). */
+export function getAllCourseCategoryOptions(): string[] {
+  if (cached) return cached
+  const out = new Set<string>()
+  const groups: ExamCategory[][] = [
+    GLOBAL_EXAMS_CATEGORIES,
+    AP_CATEGORIES,
+    A_LEVEL_CATEGORIES,
+    IB_CATEGORIES,
+    IGCSE_CATEGORIES,
+    LANGUAGE_CATEGORIES,
+    PROFESSIONAL_CATEGORIES,
+    UNIVERSITY_CATEGORIES,
+    SPECIALTY_CATEGORIES,
+  ]
+  for (const group of groups) {
+    for (const cat of group) for (const exam of cat.exams) out.add(exam)
+  }
+  for (const list of Object.values(NATIONAL_EXAMS_DATA)) {
+    for (const cat of list) for (const exam of cat.exams) out.add(exam)
+  }
+  cached = Array.from(out).sort((a, b) => a.localeCompare(b))
+  return cached
+}


### PR DESCRIPTION
Items 3 & 5. Tutors set **Board & Subject on the PCI Guided form** via dropdowns, standardized from the reference data, and the value is **shared with the Course details page** — Model A (the recommended option): the course category is the single source of truth.

## What changed
- **`getAllCourseCategoryOptions()`** flattens the category catalog (AP, IB, A-Level, IGCSE, national exams, languages, professional, universities) into the Subject dropdown's options — the *same* strings Course details stores in `course.categories`.
- **`PciQuestionnaire`** gains **Board** (`<select>` from `EXAM_BOARDS`) + **Subject / category** (searchable `<datalist>` over the catalog). Board **auto-derives** from the subject (`deriveExamContext`) and is overridable.
- Changing the Subject:
  - sets the **DMI exam context** (`setExamContext`) so marking-scheme handling uses it, and
  - **writes the category back to the course** via `PATCH /api/tutor/courses/[id]` (auth-only route), replacing the primary category and preserving any extras. A local override reflects it instantly in the form.

## Bidirectional by construction (item 5)
- **Published-first course** → its category is in `course.categories`, surfaced via `designatedFolder` (`categories[0]`) → shows as the Subject in the Guided form.
- **New/unpublished course** → the Subject set here persists to `course.categories`, so **Course details picks it up** on load.
Both directions share the one course record, so there's no separate state to drift.

## Notes
- The old Board/Subject controls in "Edit marks & answers" are left in place (harmless — they write the same DMI exam context); the Guided form is now the richer, primary place to set them.
- Live cross-surface reflection is via the shared course record (a refetch/reload shows the other side's change); no direct component coupling.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors
- Note: verified via typecheck/build/lint. The Subject write-back mutates `course.categories`, so please sanity-check end-to-end once deployed: (a) new course → set Subject in Guided form → open Course details, category is prefilled; (b) published course → its category shows as the Subject in the Guided form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)