### PR TITLE
fix(pci): rename to 'Guided PCI form'; unblock chat Send button

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6306,7 +6306,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 onClick={() => setPciFormSource(prev => (prev === source ? null : source))}
                 className="font-semibold text-indigo-700 hover:underline"
               >
-                {pciFormSource === source ? 'Hide form' : 'Guided form'}
+                {pciFormSource === source ? 'Hide PCI form' : 'Guided PCI form'}
               </button>
             )}
             {canEdit && (

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/PciWalkthrough.tsx
@@ -176,7 +176,7 @@ export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
       <button
         type="button"
         onClick={() => persistCollapsed(false)}
-        className="absolute bottom-4 right-4 z-30 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 shadow-lg transition-colors hover:bg-blue-50"
+        className="absolute bottom-4 left-4 z-30 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-white px-3 py-1.5 text-xs font-semibold text-blue-700 shadow-lg transition-colors hover:bg-blue-50"
         title="Open the PCI walkthrough"
       >
         <Compass className="h-3.5 w-3.5" />
@@ -192,7 +192,7 @@ export function PciWalkthrough({ kind }: { kind: 'task' | 'assessment' }) {
   return (
     <div
       ref={cardRef}
-      className="absolute bottom-4 right-4 z-30 w-[300px] overflow-hidden rounded-2xl border border-blue-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.18)]"
+      className="absolute bottom-4 left-4 z-30 w-[300px] overflow-hidden rounded-2xl border border-blue-200 bg-white shadow-[0_18px_45px_rgba(0,0,0,0.18)]"
     >
       <div className="flex items-center gap-2 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-3 py-2 text-white">
         <Compass className="h-4 w-4" />


### PR DESCRIPTION
Two small PCI UI fixes.

## 2. Rename "Guided form" → "Guided PCI form"
The PCI panel toggle now reads **Guided PCI form** / **Hide PCI form**.

## 4. "PCI guide" button was blocking the chat Send button
The floating **PCI guide** walkthrough (`PciWalkthrough`) was pinned `absolute bottom-4 right-4` — directly over the chat composer's Send button. Moved both the collapsed pill and the expanded card to **bottom-left** (`bottom-4 left-4`), so Send is clickable. No positioning/drag logic depended on the right anchor.

(Item 3 — whether "Prefill from paper" is still needed — is answered in chat; no code change.)

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)