### PR TITLE
feat(session-summary): redesign stats cards and page width

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
-import { ArrowLeft, Users, MessageSquare, Hand } from 'lucide-react'
+import { ArrowLeft, Users, CheckCircle, BookOpen, Clock } from 'lucide-react'
 import { toast } from 'sonner'
 
 interface SessionData {
@@ -58,6 +58,8 @@ interface SessionData {
     totalChatMessages: number
     classDuration: number
     classStartTime: string
+    homeworkAssigned: number
+    assetsDeployed: number
   }
 }
 
@@ -115,7 +117,6 @@ export default function TutorSessionInsightsPage() {
   }
 
   const { session, students, metrics } = data
-  const handRaises = students.filter(s => s.handRaised).length
   const scheduledDate = session.scheduledAt
     ? new Date(session.scheduledAt).toLocaleDateString(undefined, {
         weekday: 'long',
@@ -127,7 +128,7 @@ export default function TutorSessionInsightsPage() {
 
   return (
     <div className="min-h-screen w-full bg-[linear-gradient(145deg,#ECEFF3_0%,#D6DBE3_40%,#C9D0DA_60%,#EEF2F6_100%)] p-6 font-sans">
-      <div className="mx-auto max-w-6xl space-y-6">
+      <div className="w-full px-3 lg:px-4 space-y-6">
         <Card className="rounded-lg border border-[#E5E7EB] bg-[linear-gradient(145deg,#ECEFF3_0%,#D6DBE3_40%,#C9D0DA_60%,#EEF2F6_100%)] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.08)] ring-1 ring-white/40">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
@@ -186,27 +187,20 @@ export default function TutorSessionInsightsPage() {
           <Card className="rounded-lg border border-[#E5E7EB] bg-[rgba(255,255,255,0.75)] shadow-sm ring-1 ring-white/40 transition-all duration-200 hover:bg-[rgba(255,255,255,0.92)]">
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-2 text-sm font-semibold text-[#7F7C77]">
-                <MessageSquare className="h-4 w-4 text-[#2563EB]" />
-                Messages
+                <CheckCircle className="h-4 w-4 text-[#2DBE8A]" />
+                Task Completion Rate
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-2xl font-bold text-[#344054]">{metrics.totalChatMessages}</p>
-              <p className="mt-1 text-xs font-medium text-[#7F7C77]">Total chat messages</p>
-            </CardContent>
-          </Card>
-
-          <Card className="rounded-lg border border-[#E5E7EB] bg-[rgba(255,255,255,0.75)] shadow-sm ring-1 ring-white/40 transition-all duration-200 hover:bg-[rgba(255,255,255,0.92)]">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-sm font-semibold text-[#7F7C77]">
-                <Hand className="h-4 w-4 text-[#F17623]" />
-                Hand Raises
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-2xl font-bold text-[#344054]">{handRaises}</p>
+              <p className="text-2xl font-bold text-[#344054]">
+                {metrics.totalStudents > 0 && metrics.homeworkAssigned > 0
+                  ? `${Math.round(
+                      (metrics.assetsDeployed / metrics.homeworkAssigned) * 100
+                    )}%`
+                  : 'N/A'}
+              </p>
               <p className="mt-1 text-xs font-medium text-[#7F7C77]">
-                From {metrics.totalStudents} students
+                {metrics.assetsDeployed} of {metrics.homeworkAssigned} tasks completed
               </p>
             </CardContent>
           </Card>
@@ -214,6 +208,22 @@ export default function TutorSessionInsightsPage() {
           <Card className="rounded-lg border border-[#E5E7EB] bg-[rgba(255,255,255,0.75)] shadow-sm ring-1 ring-white/40 transition-all duration-200 hover:bg-[rgba(255,255,255,0.92)]">
             <CardHeader className="pb-2">
               <CardTitle className="flex items-center gap-2 text-sm font-semibold text-[#7F7C77]">
+                <BookOpen className="h-4 w-4 text-[#F17623]" />
+                Homework Assigned
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold text-[#344054]">{metrics.homeworkAssigned}</p>
+              <p className="mt-1 text-xs font-medium text-[#7F7C77]">
+                Tasks &amp; assessments deployed
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg border border-[#E5E7EB] bg-[rgba(255,255,255,0.75)] shadow-sm ring-1 ring-white/40 transition-all duration-200 hover:bg-[rgba(255,255,255,0.92)]">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-semibold text-[#7F7C77]">
+                <Clock className="h-4 w-4 text-[#2563EB]" />
                 Duration
               </CardTitle>
             </CardHeader>
@@ -297,11 +307,6 @@ export default function TutorSessionInsightsPage() {
                         <span className="rounded-md border border-[#E5E7EB] bg-white px-2 py-1 text-[#3F3D39]">
                           Msgs: {student.chatMessages}
                         </span>
-                        {student.handRaised && (
-                          <span className="rounded-md border border-[#F5D7B3] bg-[#FFF7ED] px-2 py-1 text-[#F17623]">
-                            Raised hand
-                          </span>
-                        )}
                       </div>
                     </li>
                   ))}

--- a/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/sessions/[sessionId]/page.tsx
@@ -128,7 +128,7 @@ export default function TutorSessionInsightsPage() {
 
   return (
     <div className="min-h-screen w-full bg-[linear-gradient(145deg,#ECEFF3_0%,#D6DBE3_40%,#C9D0DA_60%,#EEF2F6_100%)] p-6 font-sans">
-      <div className="w-full px-3 lg:px-4 space-y-6">
+      <div className="w-full space-y-6 px-3 lg:px-4">
         <Card className="rounded-lg border border-[#E5E7EB] bg-[linear-gradient(145deg,#ECEFF3_0%,#D6DBE3_40%,#C9D0DA_60%,#EEF2F6_100%)] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.08)] ring-1 ring-white/40">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
@@ -194,9 +194,7 @@ export default function TutorSessionInsightsPage() {
             <CardContent>
               <p className="text-2xl font-bold text-[#344054]">
                 {metrics.totalStudents > 0 && metrics.homeworkAssigned > 0
-                  ? `${Math.round(
-                      (metrics.assetsDeployed / metrics.homeworkAssigned) * 100
-                    )}%`
+                  ? `${Math.round((metrics.assetsDeployed / metrics.homeworkAssigned) * 100)}%`
                   : 'N/A'}
               </p>
               <p className="mt-1 text-xs font-medium text-[#7F7C77]">

--- a/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/classes/[id]/route.ts
@@ -19,6 +19,7 @@ import {
   courseVariant,
   sessionReplayArtifact,
   calendarEvent,
+  deployedMaterial,
 } from '@/lib/db/schema'
 import { eq, and, asc, desc, sql } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
@@ -163,6 +164,20 @@ export const GET = withAuth(
       0,
       Math.floor((Date.now() - new Date(classStart).getTime()) / 60000)
     )
+
+    const deployedMaterials = await drizzleDb
+      .select({
+        type: deployedMaterial.type,
+        itemId: deployedMaterial.itemId,
+        title: deployedMaterial.title,
+      })
+      .from(deployedMaterial)
+      .where(eq(deployedMaterial.sessionId, classId))
+
+    const homeworkCount = deployedMaterials.filter(
+      m => m.type === 'task' || m.type === 'assessment'
+    ).length
+    const assetCount = deployedMaterials.filter(m => m.type === 'asset').length
 
     const tutorCourses = await drizzleDb
       .select({ id: course.courseId, name: course.name, updatedAt: course.updatedAt })
@@ -320,8 +335,15 @@ export const GET = withAuth(
         passive: students.filter(s => s.engagementScore >= 30 && s.engagementScore < 60).length,
         disengaged: students.filter(s => s.engagementScore < 30).length,
         engagementTrend: 'stable',
+        homeworkAssigned: homeworkCount,
+        assetsDeployed: assetCount,
       },
       alerts: [],
+      deployedMaterials: deployedMaterials.map(m => ({
+        type: m.type,
+        itemId: m.itemId,
+        title: m.title,
+      })),
     })
   },
   { role: 'TUTOR' }

--- a/tutorme-app/src/components/categories/CategorySelector.tsx
+++ b/tutorme-app/src/components/categories/CategorySelector.tsx
@@ -172,7 +172,7 @@ export function CategorySelector({
                     <SelectItem
                       key={region.id}
                       value={region.id}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:bg-transparent focus:text-white/[0.94] data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:bg-transparent focus:text-white/[0.94] focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
                     >
                       {region.name}
                     </SelectItem>
@@ -202,7 +202,7 @@ export function CategorySelector({
                     <SelectItem
                       key={country.code}
                       value={country.code}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:bg-transparent focus:text-white/[0.94] data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:bg-transparent focus:text-white/[0.94] focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
                     >
                       {country.name}
                     </SelectItem>

--- a/tutorme-app/src/components/categories/CategorySelector.tsx
+++ b/tutorme-app/src/components/categories/CategorySelector.tsx
@@ -169,7 +169,11 @@ export function CategorySelector({
                 </SelectTrigger>
                 <SelectContent>
                   {REGIONS.map(region => (
-                    <SelectItem key={region.id} value={region.id}>
+                    <SelectItem
+                      key={region.id}
+                      value={region.id}
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:bg-transparent focus:text-white/[0.94] data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                    >
                       {region.name}
                     </SelectItem>
                   ))}
@@ -195,7 +199,11 @@ export function CategorySelector({
                 </SelectTrigger>
                 <SelectContent>
                   {availableCountries.map(country => (
-                    <SelectItem key={country.code} value={country.code}>
+                    <SelectItem
+                      key={country.code}
+                      value={country.code}
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus:bg-transparent focus:text-white/[0.94] data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                    >
                       {country.name}
                     </SelectItem>
                   ))}


### PR DESCRIPTION
- Remove max-w-6xl constraint, use w-full px-3 lg:px-4 to match standard tutor pages
- Replace Messages card with Task Completion Rate (assetsDeployed / homeworkAssigned)
- Replace Hand Raises card with Homework Assigned (task + assessment count)
- Add Clock icon to Duration card for visual consistency
- Extend GET /api/tutor/classes/:id to query deployedMaterial table
- Add homeworkAssigned and assetsDeployed to metrics response
- Include deployedMaterials array in API response for frontend use
- Remove unused handRaised badge from attendance list