### PR TITLE
fix(floating-zoom-pill): visual improvements, boundary constraints, f…

### DIFF
--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -51,10 +51,14 @@ export function FloatingZoomPill({
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       if (!isDragging) return
-      setPosition({
-        x: e.clientX - dragStartRef.current.x,
-        y: e.clientY - dragStartRef.current.y,
-      })
+      const pillWidth = pillRef.current?.offsetWidth ?? 56
+      const pillHeight = pillRef.current?.offsetHeight ?? 200
+      const margin = 8
+      const maxX = window.innerWidth - pillWidth - margin
+      const maxY = window.innerHeight - pillHeight - margin
+      const newX = Math.max(margin, Math.min(maxX, e.clientX - dragStartRef.current.x))
+      const newY = Math.max(margin, Math.min(maxY, e.clientY - dragStartRef.current.y))
+      setPosition({ x: newX, y: newY })
     },
     [isDragging]
   )
@@ -85,7 +89,7 @@ export function FloatingZoomPill({
     <div
       ref={pillRef}
       className={cn(
-        'absolute z-50 flex flex-col items-center gap-2 rounded-2xl border border-[#1F2933]/10 bg-white/10 p-3 shadow-lg backdrop-blur-md transition-shadow',
+        'fixed z-50 flex flex-col items-center gap-2 rounded-xl border border-white/20 bg-white/10 p-2.5 shadow-lg backdrop-blur-md transition-shadow',
         isDragging ? 'cursor-grabbing shadow-xl' : 'cursor-default',
         className
       )}
@@ -93,25 +97,25 @@ export function FloatingZoomPill({
         transform: `translate(${position.x}px, ${position.y}px)`,
         right: '16px',
         top: '50%',
-        marginTop: '-120px',
+        marginTop: '-100px',
       }}
     >
-      {/* Grab handle — six dots */}
+      {/* Grab handle — four dots */}
       <div
         className="flex cursor-grab flex-col items-center gap-1 py-1 active:cursor-grabbing"
         onMouseDown={handleMouseDown}
         title="Drag to move"
       >
         <div className="grid grid-cols-2 gap-0.5">
-          {[...Array(6)].map((_, i) => (
-            <div key={i} className="h-1 w-1 rounded-full bg-[#1F2933]/60" />
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-1 w-1 rounded-full bg-white/60" />
           ))}
         </div>
       </div>
 
       {/* Vertical zoom slider */}
       <div className="flex flex-col items-center gap-1">
-        <span className="text-[10px] font-medium text-[#1F2933]">{Math.round(scale * 100)}%</span>
+        <span className="text-[10px] font-medium text-white/80">{Math.round(scale * 100)}%</span>
         <div className="relative h-24 w-6">
           <input
             type="range"
@@ -120,7 +124,7 @@ export function FloatingZoomPill({
             step="1"
             value={sliderPercent}
             onChange={handleSliderChange}
-            className="absolute inset-0 h-24 w-6 cursor-pointer appearance-none rounded-full bg-[#1F2933]/20 outline-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#1F2933] [&::-webkit-slider-thumb]:shadow-md"
+            className="absolute inset-0 h-24 w-6 cursor-pointer appearance-none rounded-full bg-white/20 outline-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_2px_4px_rgba(0,0,0,0.3)]"
             style={{
               writingMode: 'vertical-lr',
               direction: 'rtl',
@@ -128,6 +132,29 @@ export function FloatingZoomPill({
           />
         </div>
       </div>
+
+      {/* Hide Preview arrow */}
+      {onHidePreview && (
+        <button
+          onClick={onHidePreview}
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-white/70 transition-colors hover:bg-white/20 hover:text-white"
+          title="Hide Preview"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
…ixed positioning

Edit 1 — Visual restyling:
- Reduce padding p-3 → p-2.5 for narrower panel (~10% width reduction)
- Replace charcoal colors with white: bg-[#1F2933] → bg-white, text-[#1F2933] → text-white/80
- Add white shadow ring to slider thumb for opaque white appearance
- Change grab handle from 6 dots to 4 dots (2×2 grid)
- Sharpen corners: rounded-2xl → rounded-xl

Edit 2 — Boundary constraints:
- Clamp drag position to viewport bounds with 8px margin
- Prevents user from dragging pill off-screen and losing access

Edit 3 — Fix scrolling in Assessment builder:
- Change position from absolute to fixed so pill stays in viewport
- Pill no longer scrolls away when scrolling through multi-page documents

Edit 4 — Sharper corners:
- rounded-2xl (16px) → rounded-xl (12px) for slightly sharper appearance