### PR TITLE
fix(pdf-viewer): constrain zoom pill to PDF container bounds

### DIFF
--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -10,6 +10,7 @@ interface FloatingZoomPillProps {
   maxScale?: number
   onHidePreview?: () => void
   className?: string
+  containerRef?: React.RefObject<HTMLElement | null>
 }
 
 export function FloatingZoomPill({
@@ -19,6 +20,7 @@ export function FloatingZoomPill({
   maxScale = 1.5,
   onHidePreview,
   className,
+  containerRef,
 }: FloatingZoomPillProps) {
   const [position, setPosition] = useState({ x: 0, y: 0 })
   const [isDragging, setIsDragging] = useState(false)
@@ -54,13 +56,22 @@ export function FloatingZoomPill({
       const pillWidth = pillRef.current?.offsetWidth ?? 56
       const pillHeight = pillRef.current?.offsetHeight ?? 200
       const margin = 8
-      const maxX = window.innerWidth - pillWidth - margin
-      const maxY = window.innerHeight - pillHeight - margin
+      const container = containerRef?.current
+      let maxX: number
+      let maxY: number
+      if (container) {
+        const rect = container.getBoundingClientRect()
+        maxX = rect.width - pillWidth - margin
+        maxY = rect.height - pillHeight - margin
+      } else {
+        maxX = window.innerWidth - pillWidth - margin
+        maxY = window.innerHeight - pillHeight - margin
+      }
       const newX = Math.max(margin, Math.min(maxX, e.clientX - dragStartRef.current.x))
       const newY = Math.max(margin, Math.min(maxY, e.clientY - dragStartRef.current.y))
       setPosition({ x: newX, y: newY })
     },
-    [isDragging]
+    [isDragging, containerRef]
   )
 
   const handleMouseUp = useCallback(() => {
@@ -89,7 +100,7 @@ export function FloatingZoomPill({
     <div
       ref={pillRef}
       className={cn(
-        'fixed z-50 flex flex-col items-center gap-2 rounded-xl border border-white/20 bg-white/10 p-2.5 shadow-lg backdrop-blur-md transition-shadow',
+        'absolute z-50 flex flex-col items-center gap-2 rounded-xl border border-white/20 bg-white/10 p-2.5 shadow-lg backdrop-blur-md transition-shadow',
         isDragging ? 'cursor-grabbing shadow-xl' : 'cursor-default',
         className
       )}

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
@@ -47,6 +47,7 @@ export function PDFViewer({
   const [loading, setLoading] = useState<boolean>(true)
   const [useFallback, setUseFallback] = useState<boolean>(false)
   const [pdfData, setPdfData] = useState<string | ArrayBuffer | null>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   // Detect blob URLs immediately — they are client-side only and break after refresh
   const isBlobUrl = typeof fileUrl === 'string' && fileUrl.startsWith('blob:')
@@ -181,7 +182,10 @@ export function PDFViewer({
 
       {/* Document pages */}
       {!error && !isBlobUrl && pdfData && (
-        <div className={`relative flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}>
+        <div
+          ref={scrollContainerRef}
+          className={`relative flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}
+        >
           {/* Floating zoom pill */}
           {!loading && !error && numPages > 0 && (
             <FloatingZoomPill
@@ -190,6 +194,7 @@ export function PDFViewer({
               minScale={0.5}
               maxScale={1.5}
               onHidePreview={onHidePreview}
+              containerRef={scrollContainerRef}
             />
           )}
           <Document


### PR DESCRIPTION
## Problem
The FloatingZoomPill was using  and viewport-based drag constraints, allowing it to be dragged outside the Task Builder display area where it could become inaccessible.

## Changes
- Convert  from  to  positioning so it stays inside the PDF container
- Add  prop to measure parent container bounds
- Update drag constraints to clamp movement within the container's width/height instead of the full viewport
- Pass  from  to 

## Result
The zoom panel is now visually contained within the PDF display area and cannot be dragged outside it.

## Files Changed
- 
- 