### PR TITLE
fix(course-header): remove duplicate course name and center in build mode

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -812,25 +812,6 @@ function CourseBuilderInsightsRouteInner({
                   {/* Course selector — locked to read-only when a session is active */}
                   {activeMainTab !== 'live' &&
                     activeMainTab !== 'test-pci' &&
-                    insightsProps.sessionId &&
-                    currentCourse && (
-                      <div className="flex h-9 min-w-[160px] max-w-[320px] items-center px-2 text-sm font-semibold text-slate-700">
-                        {currentCourse.nationality && currentCourse.nationality !== 'Global' ? (
-                          <span className="inline-flex items-center gap-1">
-                            {currentCourse.name} — {currentCourse.variantCategory || ''} —{' '}
-                            <CountryFlag
-                              countryName={currentCourse.nationality}
-                              size="xs"
-                              showLabel
-                            />
-                          </span>
-                        ) : (
-                          currentCourse.name
-                        )}
-                      </div>
-                    )}
-                  {activeMainTab !== 'live' &&
-                    activeMainTab !== 'test-pci' &&
                     insightsProps.onCourseChange && (
                       <Select
                         // Only feed a value that has a matching <SelectItem>. courseId can
@@ -919,28 +900,15 @@ function CourseBuilderInsightsRouteInner({
                       </Select>
                     )}
 
-                  {activeMainTab !== 'live' &&
-                    activeMainTab !== 'test-pci' &&
-                    onCourseNameChange &&
-                    courseId &&
-                    courseId !== 'insights-draft' && (
-                      <input
-                        className={cn(
-                          'h-9 min-w-[200px] rounded-md border-none bg-transparent px-2 text-sm font-semibold transition-colors placeholder:text-gray-400 focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0',
-                          isCoursePublished ? 'cursor-not-allowed opacity-70' : 'hover:bg-slate-100'
-                        )}
-                        value={courseName || ''}
-                        readOnly={isCoursePublished}
-                        onChange={e => {
-                          onCourseNameChange(e.target.value)
-                        }}
-                        placeholder="Course Name..."
-                        title={
-                          isCoursePublished ? 'Published variant names cannot be edited' : undefined
-                        }
-                      />
-                    )}
-
+                  {activeMainTab === 'builder' && (
+                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                      {currentCourse?.name && (
+                        <span className="text-muted-foreground text-xl font-normal">
+                          {currentCourse.name}
+                        </span>
+                      )}
+                    </h1>
+                  )}
                   {activeMainTab === 'live' && (
                     // Centered across the full header via absolute positioning;
                     // pointer-events-none so the overlay never blocks the back

--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -10,6 +10,7 @@ interface FloatingZoomPillProps {
   maxScale?: number
   onHidePreview?: () => void
   className?: string
+  containerRef?: React.RefObject<HTMLElement | null>
 }
 
 export function FloatingZoomPill({
@@ -19,6 +20,7 @@ export function FloatingZoomPill({
   maxScale = 1.5,
   onHidePreview,
   className,
+  containerRef,
 }: FloatingZoomPillProps) {
   const [position, setPosition] = useState({ x: 0, y: 0 })
   const [isDragging, setIsDragging] = useState(false)
@@ -54,13 +56,22 @@ export function FloatingZoomPill({
       const pillWidth = pillRef.current?.offsetWidth ?? 56
       const pillHeight = pillRef.current?.offsetHeight ?? 200
       const margin = 8
-      const maxX = window.innerWidth - pillWidth - margin
-      const maxY = window.innerHeight - pillHeight - margin
+      const container = containerRef?.current
+      let maxX: number
+      let maxY: number
+      if (container) {
+        const rect = container.getBoundingClientRect()
+        maxX = rect.width - pillWidth - margin
+        maxY = rect.height - pillHeight - margin
+      } else {
+        maxX = window.innerWidth - pillWidth - margin
+        maxY = window.innerHeight - pillHeight - margin
+      }
       const newX = Math.max(margin, Math.min(maxX, e.clientX - dragStartRef.current.x))
       const newY = Math.max(margin, Math.min(maxY, e.clientY - dragStartRef.current.y))
       setPosition({ x: newX, y: newY })
     },
-    [isDragging]
+    [isDragging, containerRef]
   )
 
   const handleMouseUp = useCallback(() => {
@@ -89,7 +100,7 @@ export function FloatingZoomPill({
     <div
       ref={pillRef}
       className={cn(
-        'fixed z-50 flex flex-col items-center gap-2 rounded-xl border border-white/20 bg-white/10 p-2.5 shadow-lg backdrop-blur-md transition-shadow',
+        'absolute z-50 flex flex-col items-center gap-2 rounded-xl border border-white/20 bg-white/10 p-2.5 shadow-lg backdrop-blur-md transition-shadow',
         isDragging ? 'cursor-grabbing shadow-xl' : 'cursor-default',
         className
       )}

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
@@ -47,6 +47,7 @@ export function PDFViewer({
   const [loading, setLoading] = useState<boolean>(true)
   const [useFallback, setUseFallback] = useState<boolean>(false)
   const [pdfData, setPdfData] = useState<string | ArrayBuffer | null>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   // Detect blob URLs immediately — they are client-side only and break after refresh
   const isBlobUrl = typeof fileUrl === 'string' && fileUrl.startsWith('blob:')
@@ -181,7 +182,10 @@ export function PDFViewer({
 
       {/* Document pages */}
       {!error && !isBlobUrl && pdfData && (
-        <div className={`relative flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}>
+        <div
+          ref={scrollContainerRef}
+          className={`relative flex-1 overflow-y-auto ${loading ? 'hidden' : 'block'}`}
+        >
           {/* Floating zoom pill */}
           {!loading && !error && numPages > 0 && (
             <FloatingZoomPill
@@ -190,6 +194,7 @@ export function PDFViewer({
               minScale={0.5}
               maxScale={1.5}
               onHidePreview={onHidePreview}
+              containerRef={scrollContainerRef}
             />
           )}
           <Document


### PR DESCRIPTION
## Changes

### Live Session Build Mode
- Removed the read-only course name div that appeared near the back arrow when a live session was active in builder mode. This was causing the course name to be displayed twice.

### Course Builder Build Mode  
- Removed the editable course name input from the builder mode header
- Added a centered course name display in builder mode matching the Test mode styling

### Test Mode (reference)
- Build mode now matches Test mode: course name is centered in the top panel with the same font (text-2xl font-bold) and font size (text-xl font-normal inner span), using absolute positioning and pointer-events-none

## Files Changed
- tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx