### PR TITLE
fix(task-builder): remove header bar from text panel

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9622,41 +9622,6 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               taskPdfVisible ? 'w-1/2 border-r' : 'w-full'
                                             )}
                                           >
-                                            <div className="flex h-11 shrink-0 items-center justify-between border-b border-[#E5E7EB] bg-white px-2">
-                                              <div className="flex w-full items-center justify-between gap-2">
-                                                <Button
-                                                  variant="ghost"
-                                                  size="sm"
-                                                  onClick={() => {
-                                                    if (!taskPdfVisible) setTaskPdfVisible(true)
-                                                    setTaskTextVisible(false)
-                                                  }}
-                                                  className={cn(
-                                                    'h-8 w-8 rounded-lg text-slate-400 hover:bg-slate-50 hover:text-slate-700',
-                                                    taskPdfVisible && taskTextVisible
-                                                      ? 'opacity-100'
-                                                      : 'pointer-events-none opacity-0'
-                                                  )}
-                                                  title="Hide Text"
-                                                >
-                                                  <ChevronLeft className="h-5 w-5" />
-                                                </Button>
-
-                                                {!taskPdfVisible ? (
-                                                  <Button
-                                                    variant="ghost"
-                                                    size="sm"
-                                                    onClick={() => setTaskPdfVisible(true)}
-                                                    className="h-8 w-8 rounded-lg text-slate-400 hover:bg-slate-50 hover:text-slate-700"
-                                                    title="Show Preview"
-                                                  >
-                                                    <ChevronRight className="h-5 w-5" />
-                                                  </Button>
-                                                ) : (
-                                                  <div className="w-8" />
-                                                )}
-                                              </div>
-                                            </div>
                                             <AutoTextarea
                                               placeholder={
                                                 taskBuilder.activeExtensionId


### PR DESCRIPTION
## Problem
The task text editor panel had a header bar (h-11) containing ChevronLeft and ChevronRight toggle buttons. This bar consumed vertical space in the display area without adding value since the arrow button functions are not needed.

## Changes
- Removed the entire header bar div from the task text panel in CourseBuilder.tsx
- The AutoTextarea now extends to the full height of the panel, increasing the viewable area

## Before
- Blank header bar with arrow button visible when no PDF was loaded
- Reduced vertical space for text content

## After
- No header bar — text area fills the full panel height
- More viewable area for task content

## Files Changed
- tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx