### PR TITLE
fix(course-delete): cancel associated live sessions when deleting course

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/route.ts
@@ -10,12 +10,14 @@ import {
   refund,
   courseVariant,
   calendarEvent,
+  liveSession,
 } from '@/lib/db/schema'
 import { eq, and, isNull, sql, inArray } from 'drizzle-orm'
 import { CourseBuilderService } from '@/lib/services/course-builder.service'
 import { z } from 'zod'
 import { notifyMany } from '@/lib/notifications/notify'
 import { getPaymentGateway, type GatewayName } from '@/lib/payments'
+import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 const patchCourseSchema = z.strictObject({
   name: z.string().min(1).optional(),
@@ -393,6 +395,16 @@ export const DELETE = withAuth(
 
       // Delete all events directly linked to this course
       await drizzleDb.delete(calendarEvent).where(eq(calendarEvent.courseId, id))
+
+      // Cancel any open live sessions associated with this course so they no longer
+      // block time slots in the scheduler (orphaned sessions from deleted courses
+      // would otherwise remain as 'scheduled' and show as unavailable).
+      await drizzleDb
+        .update(liveSession)
+        .set({ status: 'ended', endedAt: new Date() })
+        .where(
+          and(eq(liveSession.courseId, id), inArray(liveSession.status, LIVE_SESSION_OPEN_STATUSES))
+        )
 
       // Clean up GCS files referenced in lesson builderData before deleting the course
       await CourseBuilderService.cleanupCourseFiles(id)


### PR DESCRIPTION
## Problem
When a course was deleted, the associated live sessions remained in the database with status 'scheduled'. These orphaned sessions blocked time slots in the scheduler, showing them as 'Unavailable' even though the course no longer existed.

## Root Cause
The course DELETE handler deleted calendar events but did not cancel the linked live sessions. The liveSession table has onDelete: 'set null' on courseId, so sessions became orphaned with their original scheduledAt times and 'scheduled' status.

## Fix
When deleting a course, also update all associated open live sessions (status in LIVE_SESSION_OPEN_STATUSES) to:
- status: 'ended'
- endedAt: new Date()

## Files Changed
- tutorme-app/src/app/api/tutor/courses/[id]/route.ts

## Database Impact
None — uses existing columns (status, endedAt) on existing liveSession table.