### PR TITLE
fix(curriculum-panel): hide scrollbar, green assets card, centered header

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5183,13 +5183,13 @@ FEEDBACK: [one or two short sentences explaining the score]`
     }, [courseAssets, assetViewFolder, assetViewSearch])
 
     const renderAssetsFolder = () => (
-      <div className="mb-3 mt-3 rounded-xl border bg-white shadow-sm">
+      <div className="mb-3 mt-3 rounded-xl border border-emerald-500 bg-white shadow-sm">
         {/* Header row matching image 1 */}
-        <div className="flex items-center justify-between px-3 py-2">
+        <div className="relative flex items-center justify-center px-3 py-2">
           <span className="text-sm font-semibold text-slate-700">Assets</span>
-          <div className="flex items-center gap-3">
+          <div className="absolute right-3 flex items-center gap-3">
             <button
-              className="text-sm font-medium text-blue-600 hover:text-blue-700"
+              className="text-sm font-medium text-emerald-600 hover:text-emerald-700"
               onClick={() => {
                 setAssetViewSearch('')
                 setAssetViewFolder('All')
@@ -5268,7 +5268,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   }}
                 />
                 <span
-                  className="flex items-center text-sm font-medium text-blue-600 hover:text-blue-700"
+                  className="flex items-center text-sm font-medium text-emerald-600 hover:text-emerald-700"
                   title="Upload Asset"
                 >
                   <Plus className="h-4 w-4" />
@@ -6711,7 +6711,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                       </div>
                     )}
 
-                    <ScrollArea className="min-h-0 flex-1 pr-1">
+                    <ScrollArea className="[&>[data-radix-scroll-area-viewport]]:scrollbar-none min-h-0 flex-1 pr-1">
                       <DndContext
                         sensors={sensors}
                         collisionDetection={closestCenter}


### PR DESCRIPTION
## Changes

### Curriculum Panel
- Hidden scrollbar while keeping scrollability using  utility on the ScrollArea viewport

### Assets Card
- Added  green outline to the card container
- Centered Assets text in the header using  with  positioned icons on the right
- Changed folder icon color from blue to 
- Changed plus (upload) icon color from blue to 

## Files Changed
- tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx