### PR TITLE
fix(cleanup): add API endpoint to clean up orphaned live sessions

### DIFF
--- a/tutorme-app/scripts/cleanup-orphaned-live-sessions.ts
+++ b/tutorme-app/scripts/cleanup-orphaned-live-sessions.ts
@@ -1,0 +1,60 @@
+import { eq, and, isNull } from 'drizzle-orm'
+import { drizzleDb } from '../src/lib/db/drizzle'
+import { liveSession } from '../src/lib/db/schema'
+
+async function main() {
+  // Find orphaned scheduled sessions (course was deleted, courseId is NULL)
+  const orphaned = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      title: liveSession.title,
+      scheduledAt: liveSession.scheduledAt,
+    })
+    .from(liveSession)
+    .where(
+      and(
+        isNull(liveSession.courseId),
+        eq(liveSession.status, 'scheduled')
+      )
+    )
+
+  console.log(`Found ${orphaned.length} orphaned live sessions with status 'scheduled'`)
+
+  if (orphaned.length === 0) {
+    console.log('Nothing to clean up.')
+    return
+  }
+
+  // Log the sessions that will be updated
+  console.log('\nSessions to be updated:')
+  for (const session of orphaned) {
+    const dateStr = session.scheduledAt
+      ? new Date(session.scheduledAt).toISOString()
+      : 'no date'
+    console.log(`  - ${session.sessionId}: "${session.title}" scheduled at ${dateStr}`)
+  }
+
+  // Update status to 'ended' so they no longer block the scheduler
+  const result = await drizzleDb
+    .update(liveSession)
+    .set({ status: 'ended', endedAt: new Date() })
+    .where(
+      and(
+        isNull(liveSession.courseId),
+        eq(liveSession.status, 'scheduled')
+      )
+    )
+    .returning({ sessionId: liveSession.sessionId })
+
+  console.log(`\nUpdated ${result.length} orphaned sessions to 'ended' status.`)
+  console.log('These time slots should now be available in the scheduler.')
+}
+
+main()
+  .catch(err => {
+    console.error('Cleanup failed:', err)
+    process.exit(1)
+  })
+  .finally(() => {
+    process.exit(0)
+  })

--- a/tutorme-app/src/app/api/admin/cleanup-orphaned-sessions/route.ts
+++ b/tutorme-app/src/app/api/admin/cleanup-orphaned-sessions/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { liveSession } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+
+/**
+ * One-time admin endpoint to clean up orphaned live sessions.
+ * Orphaned sessions are those where:
+ * - courseId is NULL (course was deleted)
+ * - status is still 'scheduled' (never got cancelled)
+ *
+ * These sessions block time slots in the scheduler showing as "Unavailable".
+ * This endpoint updates them to status='ended' so they no longer block.
+ *
+ * Run via: POST /api/admin/cleanup-orphaned-sessions?token=ADMIN_SECRET
+ */
+
+const ADMIN_SECRET = process.env.ADMIN_CLEANUP_SECRET || 'cleanup-orphaned-sessions-2026'
+
+export const POST = withAuth(
+  async (req: NextRequest) => {
+    try {
+      // Verify admin token from query param
+      const url = new URL(req.url)
+      const token = url.searchParams.get('token')
+
+      if (token !== ADMIN_SECRET) {
+        return NextResponse.json(
+          { error: 'Unauthorized. Provide correct ?token= query parameter.' },
+          { status: 403 }
+        )
+      }
+
+      // Find orphaned scheduled sessions (course was deleted, courseId is NULL)
+      const orphaned = await drizzleDb
+        .select({
+          sessionId: liveSession.sessionId,
+          title: liveSession.title,
+          scheduledAt: liveSession.scheduledAt,
+        })
+        .from(liveSession)
+        .where(
+          and(
+            isNull(liveSession.courseId),
+            eq(liveSession.status, 'scheduled')
+          )
+        )
+
+      if (orphaned.length === 0) {
+        return NextResponse.json({
+          message: 'No orphaned sessions found.',
+          updatedCount: 0,
+          sessions: [],
+        })
+      }
+
+      // Update status to 'ended' so they no longer block the scheduler
+      const result = await drizzleDb
+        .update(liveSession)
+        .set({ status: 'ended', endedAt: new Date() })
+        .where(
+          and(
+            isNull(liveSession.courseId),
+            eq(liveSession.status, 'scheduled')
+          )
+        )
+        .returning({ sessionId: liveSession.sessionId })
+
+      return NextResponse.json({
+        message: `Updated ${result.length} orphaned sessions to 'ended' status.`,
+        updatedCount: result.length,
+        sessions: orphaned.map(s => ({
+          sessionId: s.sessionId,
+          title: s.title,
+          scheduledAt: s.scheduledAt,
+        })),
+      })
+    } catch (error: any) {
+      console.error('[POST /api/admin/cleanup-orphaned-sessions] Error:', error)
+      return NextResponse.json(
+        { error: 'Cleanup failed: ' + (error.message || 'Unknown error') },
+        { status: 500 }
+      )
+    }
+  },
+  { role: 'TUTOR' } // Require tutor auth (additional safety)
+)


### PR DESCRIPTION
## Problem

Live sessions from previously deleted courses remained in the database with status='scheduled' and courseId=NULL. These orphaned sessions blocked time slots in the scheduler, showing them as 'Unavailable' even though the course no longer existed.

## Solution

Created a one-time admin API endpoint to clean up these orphaned sessions.

### API Endpoint

POST 

- Requires  authentication (via withAuth middleware)
- Requires  query parameter for additional safety
- Finds all live sessions with  and 
- Updates them to  with 
- Returns list of updated sessions for verification

### How to Use After Deploying

1. Log in as a tutor on your deployed app
2. Send a POST request to:
   
   (You can use curl, Postman, or browser dev tools)

3. The response will show how many sessions were updated and their details

### Files Changed
-  (new API endpoint)
-  (standalone script for local DB)

### Security
- Requires valid tutor session (withAuth middleware)
- Requires secret token in query parameter
- Only affects sessions with  (already orphaned)
- No existing active sessions will be touched