### PR TITLE
feat(builder): move tasks/assessments between lessons (drag + kebab)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -3366,6 +3366,15 @@ FEEDBACK: [one or two short sentences explaining the score]`
 
     const [editingData, setEditingData] = useState<any>(null)
     const [activeDragId, setActiveDragId] = useState<string | null>(null)
+    // "Move to lesson…" dialog (kebab flow). sourceNodeId is excluded from the
+    // target list so the item isn't "moved" to the lesson it already lives in.
+    const [moveDialog, setMoveDialog] = useState<{
+      itemType: 'task' | 'assessment'
+      itemId: string
+      itemTitle: string
+      sourceNodeId: string
+    } | null>(null)
+    const [moveTarget, setMoveTarget] = useState<string>('')
 
     useEffect(() => {
       if (lastInitialCourseBuilderNodesKeyRef.current === initialCourseBuilderNodesKey) return
@@ -3797,6 +3806,19 @@ FEEDBACK: [one or two short sentences explaining the score]`
         const sep = rest.indexOf('::')
         const targetCourseBuilderNodeId = sep >= 0 ? rest.slice(0, sep) : rest
         const targetLessonId = sep >= 0 ? rest.slice(sep + 2) : ''
+        // Dragging a TASK onto another lesson's task section → move it there
+        // (keeps it a task; carries extensions; renames on name collision).
+        const taskLoc = findTaskLocation(activeId)
+        if (taskLoc && targetCourseBuilderNodeId && targetLessonId) {
+          const srcLessonId = nodes[taskLoc.nIdx].lessons[taskLoc.lIdx].id
+          if (srcLessonId !== targetLessonId) {
+            void moveItemToLesson('task', activeId, {
+              kind: 'existing',
+              nodeId: targetCourseBuilderNodeId,
+            })
+            return
+          }
+        }
         const hwLoc = findHomeworkLocation(activeId)
         if (hwLoc && targetCourseBuilderNodeId && targetLessonId) {
           const hw = nodes[hwLoc.nIdx].lessons[hwLoc.lIdx].homework[hwLoc.hwIndex]
@@ -4301,6 +4323,120 @@ FEEDBACK: [one or two short sentences explaining the score]`
       if (mainTab !== 'live') await saveNodesIfPossible(nextNodes)
       setSelectedItem(null)
       toast.success('Assessment removed')
+    }
+
+    // Move a task/assessment from its lesson to another lesson (or a brand-new
+    // one). Tasks carry their extensions (they live inline on the Task object).
+    // If the target lesson already has an item of the same name, the moved item
+    // gets a "new" suffix. Used by both the kebab "Move to lesson…" flow and the
+    // cross-lesson drag-and-drop.
+    const moveItemToLesson = async (
+      itemType: 'task' | 'assessment',
+      itemId: string,
+      target: { kind: 'existing'; nodeId: string } | { kind: 'new' }
+    ) => {
+      const arrKey = itemType === 'task' ? 'tasks' : 'homework'
+      // Locate the item in its source node/lesson.
+      let srcN = -1
+      let srcL = -1
+      let item: any = null
+      for (let n = 0; n < nodes.length && !item; n++) {
+        for (let l = 0; l < nodes[n].lessons.length; l++) {
+          const list = (nodes[n].lessons[l] as any)[arrKey] || []
+          const idx = list.findIndex((x: any) => x.id === itemId)
+          if (idx !== -1) {
+            srcN = n
+            srcL = l
+            item = list[idx]
+            break
+          }
+        }
+      }
+      if (!item) {
+        toast.error('Could not find that item to move')
+        return
+      }
+
+      // Resolve the target node (creating a new "Lesson N" when requested).
+      let working = nodes
+      let tgtN = -1
+      if (target.kind === 'new') {
+        const newNode = DEFAULT_NODE(nodes.length)
+        let maxNum = 0
+        for (const mod of nodes) {
+          const m = /^Lesson\s+(\d+)/i.exec(mod.title || '')
+          if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10))
+        }
+        newNode.title = `Lesson ${maxNum + 1}`
+        newNode.lessons[0].title = `Lesson ${maxNum + 1}`
+        working = [...nodes, newNode]
+        tgtN = working.length - 1
+      } else {
+        tgtN = nodes.findIndex(m => m.id === target.nodeId)
+      }
+      if (tgtN === -1) {
+        toast.error('Could not find the target lesson')
+        return
+      }
+
+      const tgtL = 0 // each node maps to a single lesson in the UI
+      if (working[srcN].lessons[srcL].id === working[tgtN].lessons[tgtL].id) {
+        toast('Already in that lesson')
+        return
+      }
+
+      // Name-collision handling: append " new" until unique in the target lesson.
+      const targetList = (working[tgtN].lessons[tgtL] as any)[arrKey] || []
+      const existingTitles = new Set(targetList.map((x: any) => (x.title || '').trim()))
+      let title = (item.title || (itemType === 'task' ? 'Task' : 'Assessment')).trim()
+      while (existingTitles.has(title)) title = `${title} new`
+      const movedItem = { ...item, title }
+      const targetLessonTitle = working[tgtN].title
+
+      const next = working.map((mod, n) => {
+        if (n !== srcN && n !== tgtN) return mod
+        const lessons = mod.lessons.map((les, l) => {
+          let cur: any = les
+          if (n === srcN && l === srcL) {
+            cur = { ...cur, [arrKey]: (cur[arrKey] || []).filter((x: any) => x.id !== itemId) }
+          }
+          if (n === tgtN && l === tgtL) {
+            cur = { ...cur, [arrKey]: [...(cur[arrKey] || []), movedItem] }
+          }
+          return cur
+        })
+        return { ...mod, lessons }
+      })
+
+      setCourseBuilderNodes(next)
+      if (mainTab !== 'live') await saveNodesIfPossible(next)
+      setSelectedItem(null)
+      toast.success(
+        title === (item.title || '').trim()
+          ? `Moved to ${targetLessonTitle}`
+          : `Moved to ${targetLessonTitle} as “${title}”`
+      )
+    }
+
+    const openMoveDialog = (
+      itemType: 'task' | 'assessment',
+      itemId: string,
+      itemTitle: string,
+      sourceNodeId: string
+    ) => {
+      setMoveTarget('')
+      setMoveDialog({ itemType, itemId, itemTitle, sourceNodeId })
+    }
+
+    const confirmMoveDialog = async () => {
+      if (!moveDialog || !moveTarget) return
+      const target =
+        moveTarget === '__new__'
+          ? ({ kind: 'new' } as const)
+          : ({ kind: 'existing', nodeId: moveTarget } as const)
+      await moveItemToLesson(moveDialog.itemType, moveDialog.itemId, target)
+      setMoveDialog(null)
+      setMoveTarget('')
     }
 
     const deleteCourseBuilderNodeQuiz = async (nodeId: string, quizId: string) => {
@@ -7151,6 +7287,21 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                             </Button>
                                                           </DropdownMenuTrigger>
                                                           <DropdownMenuContent align="end">
+                                                            {canEdit && (
+                                                              <DropdownMenuItem
+                                                                onClick={e => {
+                                                                  e.stopPropagation()
+                                                                  openMoveDialog(
+                                                                    'task',
+                                                                    task.id,
+                                                                    task.title || 'Task',
+                                                                    node.id
+                                                                  )
+                                                                }}
+                                                              >
+                                                                Move to lesson…
+                                                              </DropdownMenuItem>
+                                                            )}
                                                             {mainTab === 'live' &&
                                                               insightsProps?.onDeployTask && (
                                                                 <DropdownMenuItem
@@ -7902,6 +8053,21 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                           </Button>
                                                         </DropdownMenuTrigger>
                                                         <DropdownMenuContent align="end">
+                                                          {canEdit && (
+                                                            <DropdownMenuItem
+                                                              onClick={e => {
+                                                                e.stopPropagation()
+                                                                openMoveDialog(
+                                                                  'assessment',
+                                                                  hw.id,
+                                                                  hw.title || 'Assessment',
+                                                                  node.id
+                                                                )
+                                                              }}
+                                                            >
+                                                              Move to lesson…
+                                                            </DropdownMenuItem>
+                                                          )}
                                                           {mainTab === 'live' &&
                                                             insightsProps?.onDeployTask && (
                                                               <DropdownMenuItem
@@ -11018,6 +11184,57 @@ FEEDBACK: [one or two short sentences explaining the score]`
                 </Button>
               </div>
             </div>
+          </DialogContent>
+        </Dialog>
+
+        {/* Move task/assessment to another lesson */}
+        <Dialog open={!!moveDialog} onOpenChange={open => !open && setMoveDialog(null)}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>
+                Move {moveDialog?.itemType === 'task' ? 'task' : 'assessment'} to lesson
+              </DialogTitle>
+              <DialogDescription>
+                Choose a lesson to move “{moveDialog?.itemTitle}” to, or create a new one. If the
+                lesson already has an item with the same name, this one gets a “new” suffix.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-2">
+              <label
+                htmlFor="move-to-lesson-select"
+                className="mb-1 block text-xs font-medium text-gray-700"
+              >
+                Destination lesson
+              </label>
+              <select
+                id="move-to-lesson-select"
+                value={moveTarget}
+                onChange={e => setMoveTarget(e.target.value)}
+                className="w-full rounded-md border border-gray-300 p-2 text-sm text-gray-900"
+              >
+                <option value="">Select a lesson…</option>
+                {nodes
+                  .filter(n => n.id !== moveDialog?.sourceNodeId)
+                  .map(n => (
+                    <option key={n.id} value={n.id}>
+                      {n.title}
+                    </option>
+                  ))}
+                <option value="__new__">＋ Create a new lesson</option>
+              </select>
+            </div>
+            <DialogFooter>
+              <Button variant="modal-secondary-dark" onClick={() => setMoveDialog(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="modal-primary-dark"
+                disabled={!moveTarget}
+                onClick={confirmMoveDialog}
+              >
+                Move
+              </Button>
+            </DialogFooter>
           </DialogContent>
         </Dialog>
 


### PR DESCRIPTION
Task 1 — move a task or assessment from one lesson to another.

## Kebab "Move to lesson…"
Added to the **task** and **assessment** kebab menus, in **both the Build and Classroom tabs**. Opens a modal to pick an existing lesson (source lesson excluded) or **＋ Create a new lesson** to move to.

## Drag-and-drop
Dragging a **task** onto another lesson's task section moves it there (this was the one missing case; assessments already cross lessons via the existing `drop-assessment`/`drop-hw` zones). Routed through the same helper so behaviour is consistent.

## The move helper
`moveItemToLesson()`:
- Pulls the item from its source lesson, appends to the target (or a fresh `Lesson N`).
- **Extensions travel with a task** — they live inline on the `Task` object, so moving the object moves them.
- **Name collision** → the moved item gets a `" new"` suffix (repeated until unique in the target lesson).
- Persists via `saveNodesIfPossible`; in the **Classroom/live** tab it updates the live snapshot without persisting, matching how the builder already treats live edits.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- `eslint` — 0 errors
- Note: verified via typecheck/build/lint; this is deep builder UI I couldn't drive end-to-end here. Worth a click-test once deployed: move a task with extensions to another lesson (extensions follow; duplicate-name gets "new"), the "Create a new lesson" option, and the drag path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)