### PR TITLE
fix(communications): make panel headers flush with top edge

### DIFF
--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -41,7 +41,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   const ListIcon = list.icon
 
   return (
-    <Card className="flex h-full w-full flex-col overflow-hidden rounded-2xl border-0 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+    <Card className="flex h-full w-full flex-col overflow-hidden rounded-b-2xl border border-gray-200 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       {/* Full-width Chat header */}
       <div className="relative flex h-12 shrink-0 items-center justify-center bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
         Chat

--- a/tutorme-app/src/components/communications/notifications-panel.tsx
+++ b/tutorme-app/src/components/communications/notifications-panel.tsx
@@ -117,7 +117,7 @@ export default function NotificationsPanel({
   )
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+    <div className="flex h-full w-full flex-col overflow-hidden rounded-b-2xl border border-[#E5E7EB] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       <div className="flex items-center justify-between rounded-t-2xl bg-gradient-to-br from-[#1F2933] to-[#111827] px-4 py-3">
         <div className="flex items-center gap-2">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/10">


### PR DESCRIPTION
## Problem
The Chats panel header had a gap at the top because the Card wrapper used `rounded-2xl` which rounded all corners, clipping the header. The panel also blended into the white background.

## Changes
- **MessagingPanel**: Changed `rounded-2xl` to `rounded-b-2xl` so the blue 'Chat' header sits flush against the top edge. Added `border border-gray-200` to distinguish the panel from the background.
- **NotificationsPanel**: Changed `rounded-2xl` to `rounded-b-2xl` so the dark header sits flush against the top edge.
- Both panels retain the heavy `shadow-[0_14px_45px_rgba(0,0,0,0.14)]` for the floating effect.