### PR TITLE
fix(calendar): add abbreviated weekday to day view header

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -746,7 +746,7 @@ export function InteractiveCalendar({
       return `${format(weekStart, 'MMM d')} – ${format(weekEnd, 'MMM d')}`
     }
     if (view === 'day') {
-      return format(currentDate, 'MMMM d')
+      return format(currentDate, 'EEE MMMM d')
     }
     return `${monthNames[currentDate.getMonth()]} ${currentDate.getFullYear()}`
   }, [currentDate, view])


### PR DESCRIPTION
Changes the calendar day view date format from `MMMM d` (e.g. 'July 5') to `EEE MMMM d` (e.g. 'Mon July 5') so the abbreviated day of week is visible in the header.