### PR TITLE
feat(live): tutor close polls/questions; answered responses locked

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -2438,6 +2438,10 @@ function StudentFeedbackContent() {
                             const selectedValue = poll.responses.find(
                               response => response.studentId === session?.user?.id
                             )?.value
+                            // Once answered (or the tutor closed it) the vote is
+                            // locked — you can't change your answer.
+                            const answered = selectedValue !== undefined
+                            const locked = poll.status === 'closed' || answered
                             return (
                               <div key={poll.id} className="rounded-lg border bg-white p-4">
                                 <p className="text-sm font-medium text-gray-900">{poll.question}</p>
@@ -2450,15 +2454,17 @@ function StudentFeedbackContent() {
                                       key={`${poll.id}-${i}`}
                                       variant={selectedValue === i ? 'default' : 'outline'}
                                       size="sm"
-                                      disabled={poll.status === 'closed'}
+                                      disabled={locked}
                                       onClick={() => handlePollVote(poll, i)}
                                     >
                                       {label}
                                     </Button>
                                   ))}
                                 </div>
-                                {poll.status === 'closed' && (
-                                  <p className="mt-2 text-xs text-gray-500">Poll closed</p>
+                                {locked && (
+                                  <p className="mt-2 text-xs text-gray-500">
+                                    {answered ? 'Answer submitted — locked' : 'Poll closed'}
+                                  </p>
                                 )}
                               </div>
                             )
@@ -2468,33 +2474,56 @@ function StudentFeedbackContent() {
 
                       {feedbackQuestions.length > 0 && (
                         <div className="space-y-3">
-                          {feedbackQuestions.map(question => (
-                            <div key={question.id} className="rounded-lg border bg-white p-4">
-                              <p className="text-sm font-medium text-gray-900">{question.prompt}</p>
-                              <div className="mt-3">
-                                <AutoTextarea
-                                  placeholder="Type your answer..."
-                                  className="min-h-[72px]"
-                                  value={questionDrafts[question.id] || ''}
-                                  onChange={event =>
-                                    setQuestionDrafts(prev => ({
-                                      ...prev,
-                                      [question.id]: event.target.value,
-                                    }))
-                                  }
-                                />
-                                <div className="mt-2 flex justify-end">
-                                  <Button
-                                    size="sm"
-                                    onClick={() => handleQuestionSend(question)}
-                                    disabled={!questionDrafts[question.id]?.trim()}
-                                  >
-                                    Send
-                                  </Button>
-                                </div>
+                          {feedbackQuestions.map(question => {
+                            const myAnswer = question.responses.find(
+                              r => r.studentId === session?.user?.id
+                            )?.answer
+                            const answered = myAnswer !== undefined
+                            const closed = (question as { status?: string }).status === 'closed'
+                            return (
+                              <div key={question.id} className="rounded-lg border bg-white p-4">
+                                <p className="text-sm font-medium text-gray-900">
+                                  {question.prompt}
+                                </p>
+                                {answered ? (
+                                  // Your answer is locked once submitted.
+                                  <div className="mt-3">
+                                    <div className="rounded-md border bg-gray-50 p-2 text-sm text-gray-700">
+                                      {myAnswer}
+                                    </div>
+                                    <p className="mt-1 text-xs text-gray-500">
+                                      Answer submitted — locked
+                                    </p>
+                                  </div>
+                                ) : closed ? (
+                                  <p className="mt-3 text-xs text-gray-500">Question closed</p>
+                                ) : (
+                                  <div className="mt-3">
+                                    <AutoTextarea
+                                      placeholder="Type your answer..."
+                                      className="min-h-[72px]"
+                                      value={questionDrafts[question.id] || ''}
+                                      onChange={event =>
+                                        setQuestionDrafts(prev => ({
+                                          ...prev,
+                                          [question.id]: event.target.value,
+                                        }))
+                                      }
+                                    />
+                                    <div className="mt-2 flex justify-end">
+                                      <Button
+                                        size="sm"
+                                        onClick={() => handleQuestionSend(question)}
+                                        disabled={!questionDrafts[question.id]?.trim()}
+                                      >
+                                        Send
+                                      </Button>
+                                    </div>
+                                  </div>
+                                )}
                               </div>
-                            </div>
-                          ))}
+                            )
+                          })}
                         </div>
                       )}
 

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1524,6 +1524,18 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       [insightsProps?.liveTasks, currentInsightsId]
     )
 
+    // Tutor closes a poll/question: server locks it and no more answers land.
+    const handleCloseInsight = useCallback(
+      (kind: 'poll' | 'question', insightId: string) => {
+        const socket = insightsProps?.socket
+        const roomId = insightsProps?.sessionId
+        const taskId = activeLiveTask?.id
+        if (!socket || !roomId || !taskId) return
+        socket.emit('insight:close', { roomId, taskId, type: kind, insightId })
+      },
+      [insightsProps?.socket, insightsProps?.sessionId, activeLiveTask?.id]
+    )
+
     // ALL polls for the active task (newest first) so sending a new poll no
     // longer hides the previous ones. Each option's tally is by 0-based index,
     // labelled from the poll's optionLabels (True/False, Yes/No, custom) with an
@@ -1538,6 +1550,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             id: poll.id,
             question: poll.question,
             totalResponses: total,
+            closed: poll.status === 'closed',
             options: Array.from({ length: optionCount }, (_, i) => {
               const responders = poll.responses.filter(r => r.value === i)
               return {
@@ -1559,6 +1572,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         .map(q => ({
           id: q.id,
           prompt: q.prompt,
+          closed: (q as { status?: string }).status === 'closed',
           answers: q.responses.map(r => ({
             studentName: studentNameById.get(r.studentId) || 'Student',
             answer: r.answer,
@@ -8800,6 +8814,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               <InsightsReportView
                                                 type="poll"
                                                 pollResults={pollResults}
+                                                onClose={handleCloseInsight}
                                                 onMentionStudent={name =>
                                                   setPollPrompt(
                                                     pollPrompt
@@ -8896,6 +8911,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                               <InsightsReportView
                                                 type="question"
                                                 questionResults={questionResults}
+                                                onClose={handleCloseInsight}
                                                 onMentionStudent={name =>
                                                   setQuestionPrompt(
                                                     questionPrompt
@@ -10556,6 +10572,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                         <InsightsReportView
                                           type="poll"
                                           pollResults={pollResults}
+                                          onClose={handleCloseInsight}
                                           onMentionStudent={name =>
                                             setPollPrompt(
                                               pollPrompt
@@ -10633,6 +10650,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                         <InsightsReportView
                                           type="question"
                                           questionResults={questionResults}
+                                          onClose={handleCloseInsight}
                                           onMentionStudent={name =>
                                             setQuestionPrompt(
                                               questionPrompt

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-parts/InsightsReportView.tsx
@@ -18,6 +18,7 @@ export interface PollResultBlock {
   question: string
   totalResponses: number
   options: PollResultOption[]
+  closed?: boolean
 }
 
 /** One sent question + its answers. */
@@ -25,6 +26,7 @@ export interface QuestionResultBlock {
   id: string
   prompt: string
   answers: QuestionAnswerEntry[]
+  closed?: boolean
 }
 
 /**
@@ -38,11 +40,14 @@ export function InsightsReportView({
   pollResults = [],
   questionResults = [],
   onMentionStudent,
+  onClose,
 }: {
   type: 'poll' | 'question'
   pollResults?: PollResultBlock[]
   questionResults?: QuestionResultBlock[]
   onMentionStudent: (studentName: string) => void
+  /** Close a poll/question so no more answers can be submitted. */
+  onClose?: (type: 'poll' | 'question', id: string) => void
 }) {
   const isPoll = type === 'poll'
   const hasData = isPoll ? pollResults.length > 0 : questionResults.length > 0
@@ -75,9 +80,26 @@ export function InsightsReportView({
             >
               <div className="mb-2 flex items-start justify-between gap-2">
                 <p className="text-xs font-semibold text-slate-800">{poll.question}</p>
-                <span className="shrink-0 text-[11px] text-slate-400">
-                  {poll.totalResponses} {poll.totalResponses === 1 ? 'vote' : 'votes'}
-                </span>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="text-[11px] text-slate-400">
+                    {poll.totalResponses} {poll.totalResponses === 1 ? 'vote' : 'votes'}
+                  </span>
+                  {poll.closed ? (
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-500">
+                      Closed
+                    </span>
+                  ) : (
+                    onClose && (
+                      <button
+                        type="button"
+                        onClick={() => onClose('poll', poll.id)}
+                        className="rounded-full border border-blue-200 bg-white px-2 py-0.5 text-[10px] font-semibold text-blue-700 hover:bg-blue-50"
+                      >
+                        Close
+                      </button>
+                    )
+                  )}
+                </div>
               </div>
               <div className="space-y-2.5">
                 {poll.options.map((item, i) => (
@@ -122,7 +144,24 @@ export function InsightsReportView({
               key={q.id}
               className="rounded-2xl border border-blue-100 bg-white/70 p-2.5 shadow-sm"
             >
-              <p className="mb-2 text-xs font-semibold text-slate-800">{q.prompt}</p>
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <p className="text-xs font-semibold text-slate-800">{q.prompt}</p>
+                {q.closed ? (
+                  <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-500">
+                    Closed
+                  </span>
+                ) : (
+                  onClose && (
+                    <button
+                      type="button"
+                      onClick={() => onClose('question', q.id)}
+                      className="shrink-0 rounded-full border border-blue-200 bg-white px-2 py-0.5 text-[10px] font-semibold text-blue-700 hover:bg-blue-50"
+                    >
+                      Close
+                    </button>
+                  )
+                )}
+              </div>
               {q.answers.length === 0 ? (
                 <p className="text-[11px] text-slate-400">No answers yet.</p>
               ) : (

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -109,6 +109,9 @@ export interface LiveTaskQuestion {
   id: string
   taskId: string
   prompt: string
+  /** Mirrors LiveTaskPoll: a closed question accepts no more answers. Optional
+   *  for back-compat with snapshots created before questions had a status. */
+  status?: 'open' | 'closed'
   responses: LiveTaskQuestionResponse[]
   createdAt: number
 }
@@ -2289,6 +2292,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
           id: `question-${taskId}-${Date.now()}`,
           taskId,
           prompt: prompt || 'Do you have a question about this task?',
+          status: 'open',
           responses: [],
           createdAt: Date.now(),
         }
@@ -2324,16 +2328,14 @@ export async function initEnhancedSocketServer(server: NetServer) {
           const studentId = socket.data.userId
           if (!studentId) return
           const existingIndex = poll.responses.findIndex(r => r.studentId === studentId)
+          // Once answered, a response is immutable — ignore any change attempt.
+          if (existingIndex >= 0) return
           const response: LiveTaskPollResponse = {
             studentId,
             value,
             submittedAt: Date.now(),
           }
-          if (existingIndex >= 0) {
-            poll.responses[existingIndex] = response
-          } else {
-            poll.responses.push(response)
-          }
+          poll.responses.push(response)
           room.lastActivity = Date.now()
           void persistRoomToRedis(roomId, room)
           io.to(roomId).emit('insight:response', { taskId, type: 'poll', item: poll })
@@ -2342,23 +2344,50 @@ export async function initEnhancedSocketServer(server: NetServer) {
         }
 
         const question = task.questions.find(item => item.id === insightId)
-        if (!question) return
+        if (!question || question.status === 'closed') return
         const studentId = socket.data.userId
         if (!studentId || !answer?.trim()) return
         const existingIndex = question.responses.findIndex(r => r.studentId === studentId)
+        // Once answered, a response is immutable — ignore any change attempt.
+        if (existingIndex >= 0) return
         const response: LiveTaskQuestionResponse = {
           studentId,
           answer: answer.trim(),
           submittedAt: Date.now(),
         }
-        if (existingIndex >= 0) {
-          question.responses[existingIndex] = response
-        } else {
-          question.responses.push(response)
-        }
+        question.responses.push(response)
         room.lastActivity = Date.now()
         void persistRoomToRedis(roomId, room)
         io.to(roomId).emit('insight:response', { taskId, type: 'question', item: question })
+        io.to(roomId).emit('task:updated', { task })
+      }
+    )
+
+    // Tutor closes a poll/question: no further responses are accepted and the
+    // already-collected answers are locked. Broadcast so both sides update.
+    socket.on(
+      'insight:close',
+      (data: { roomId: string; taskId: string; type: 'poll' | 'question'; insightId: string }) => {
+        const { roomId, taskId, type, insightId } = data
+        if (!roomId || !taskId || !insightId) return
+        const room = activeRooms.get(roomId)
+        if (!room) return
+        const task = room.tasks.find(item => item.id === taskId)
+        if (!task) return
+
+        if (type === 'poll') {
+          const poll = task.polls.find(item => item.id === insightId)
+          if (!poll) return
+          poll.status = 'closed'
+          io.to(roomId).emit('insight:response', { taskId, type: 'poll', item: poll })
+        } else {
+          const question = task.questions.find(item => item.id === insightId)
+          if (!question) return
+          question.status = 'closed'
+          io.to(roomId).emit('insight:response', { taskId, type: 'question', item: question })
+        }
+        room.lastActivity = Date.now()
+        void persistRoomToRedis(roomId, room)
         io.to(roomId).emit('task:updated', { task })
       }
     )

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -56,6 +56,8 @@ export interface LiveTaskQuestion {
   id: string
   taskId: string
   prompt: string
+  /** A closed question accepts no more answers (mirrors LiveTaskPoll.status). */
+  status?: 'open' | 'closed'
   responses: LiveTaskQuestionResponse[]
   createdAt: number
 }


### PR DESCRIPTION
Task 2. Two parts:

**Immutable once answered** — the `insight:respond` server handler now ignores a repeat response from the same student (it used to overwrite), for polls and questions. The student UI locks a voted poll / answered question and shows *Answer submitted — locked*.

**Tutor Close button** — new `insight:close` socket event + a **Close** button on each poll/question result card (tutor side, `InsightsReportView`). Closing sets `status='closed'`; the server then rejects further answers (added a `status` field to `LiveTaskQuestion`; polls already had one). Students see *Poll/Question closed* and the inputs disable.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors. Socket/live UI — not driven end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)