### PR TITLE
fix(zoom-panel): replace hide with reset, slim panel, move to bottom-right

### DIFF
--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -110,14 +110,13 @@ export function FloatingZoomPill({
       style={{
         transform: fixed ? undefined : `translate(${position.x}px, ${position.y}px)`,
         right: '16px',
-        top: '50%',
-        marginTop: '-90px',
+        bottom: '16px',
       }}
     >
-      {/* Vertical zoom slider */}
-      <div className="flex flex-col items-center gap-1">
+      {/* Zoom percentage with space above */}
+      <div className="mt-1 flex flex-col items-center gap-1">
         <span className="text-[10px] font-medium text-gray-700">{Math.round(scale * 100)}%</span>
-        <div className="relative h-24 w-5">
+        <div className="relative h-24 w-4">
           <input
             type="range"
             min="0"
@@ -125,7 +124,7 @@ export function FloatingZoomPill({
             step="1"
             value={sliderPercent}
             onChange={handleSliderChange}
-            className="absolute inset-0 h-24 w-5 cursor-pointer appearance-none rounded-full bg-gray-500/30 outline-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_2px_4px_rgba(0,0,0,0.3)]"
+            className="absolute inset-0 h-24 w-4 cursor-pointer appearance-none rounded-full bg-gray-500/30 outline-none [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_0_0_2px_rgba(255,255,255,0.8),0_2px_4px_rgba(0,0,0,0.3)]"
             style={{
               writingMode: 'vertical-lr',
               direction: 'rtl',
@@ -134,28 +133,27 @@ export function FloatingZoomPill({
         </div>
       </div>
 
-      {/* Hide Preview arrow */}
-      {onHidePreview && (
-        <button
-          onClick={onHidePreview}
-          className="flex h-8 w-8 items-center justify-center rounded-lg text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-          title="Hide Preview"
+      {/* Reset zoom button */}
+      <button
+        onClick={() => onScaleChange(1.0)}
+        className="flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-700"
+        title="Reset Zoom"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="m9 18 6-6-6-6" />
-          </svg>
-        </button>
-      )}
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Changes

- **Replace Hide Preview button** with **Reset Zoom button** — circular white button with gray border and refresh/rotate icon (matching image 2 style). Clicking resets zoom to 100%.
- **Add margin-top** () above the zoom percentage indicator for spacing.
- **Reduce panel width by 20%**: slider track  → , thumb  → .
- **Move panel position** from center-right () to **bottom-right corner** ().