### PR TITLE
fix(live): poll/question Send active; bg picker z-index; orphaned-session scheduler slots

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1467,11 +1467,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // the live session), fall back to the most-recently-deployed live task so the
     // composer has a real target and the Send button isn't permanently disabled.
     const loadedInsightsTaskId = mainBuilderTab === 'assessment' ? loadedAssessmentId : loadedTaskId
+    // Fall back to the most-recently-deployed live task whenever one exists, so
+    // the poll/question composer has a target and its Send button is active —
+    // the composer only shows in a live session, so gating on the exact mainTab
+    // value was too strict and left Send permanently disabled.
     const activeInsightsTaskId =
       loadedInsightsTaskId ??
-      (mainTab === 'live'
-        ? (insightsProps?.liveTasks?.[insightsProps.liveTasks.length - 1]?.id ?? null)
-        : null)
+      insightsProps?.liveTasks?.[(insightsProps.liveTasks?.length ?? 0) - 1]?.id ??
+      null
     const activeInsightsTask = activeInsightsTaskId
       ? (nodes
           .flatMap(n => n.lessons.flatMap(l => [...l.tasks, ...(l.homework || [])]))

--- a/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
@@ -19,7 +19,7 @@ import {
   oneOnOneBookingRequest,
   liveSession,
 } from '@/lib/db/schema'
-import { eq, and, or, gte, lte, gt, lt, asc, isNull, inArray } from 'drizzle-orm'
+import { eq, and, or, gte, lte, gt, lt, asc, isNull, isNotNull, inArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { nanoid } from 'nanoid'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
@@ -111,6 +111,12 @@ export const GET = withAuth(
             and(
               eq(liveSession.tutorId, tutorId),
               inArray(liveSession.status, LIVE_SESSION_OPEN_STATUSES),
+              // Ignore orphaned sessions: deleting a course sets liveSession.courseId
+              // to null (FK on delete) but leaves the row scheduled, which then
+              // blocked scheduler slots forever. Only count sessions still tied to a
+              // course here; genuinely course-less sessions (ad-hoc) already surface
+              // via their CalendarEvent above, so nothing real is lost.
+              isNotNull(liveSession.courseId),
               // A live session overlaps if: scheduledAt < endDate AND (scheduledAt + duration) > startDate
               // We approximate with scheduledAt within a window that could overlap
               gte(liveSession.scheduledAt, new Date(startDate.getTime() - 24 * 60 * 60 * 1000)),

--- a/tutorme-app/src/components/class/daily-video-frame.tsx
+++ b/tutorme-app/src/components/class/daily-video-frame.tsx
@@ -700,7 +700,10 @@ export function DailyVideoFrame({
                 </PopoverTrigger>
                 <PopoverContent
                   align="center"
-                  className="max-h-[70vh] w-[340px] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4"
+                  // The floating video overlay is z-[9999]; the picker portals to
+                  // body with the lower z-popover, so it rendered behind the
+                  // video. Lift it above the overlay.
+                  className="z-[10000] max-h-[70vh] w-[340px] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4"
                 >
                   <div className="mb-2 text-sm font-semibold text-slate-900">
                     Virtual background


### PR DESCRIPTION
Three surgical fixes.

**2 — Poll/question Send inactive.** `activeInsightsTaskId` only fell back to the latest deployed live task when `mainTab === 'live'` exactly; the composer only renders in a live session, so that gate left Send permanently disabled in some states. Fall back whenever a live task exists.

**3 — Video Background menu behind the video.** The floating video overlay is `z-[9999]`; the Radix Popover portals to body with the lower `z-popover`, so it rendered behind. Lifted this PopoverContent to `z-[10000]`.

**4 — Orphaned sessions occupying scheduler slots.** Deleting a course sets `liveSession.courseId` to null (FK) but leaves the row scheduled; the availability endpoint's schedule-mode live-session query filtered only by tutor+status, so those orphans blocked slots forever. Now requires `courseId` to be set — genuine ad-hoc sessions still surface via their CalendarEvent, so no real conflict is lost. (Root cause — course-delete leaving sessions — could also be fixed to end them; this is the surgical scheduler fix you asked for.)

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)