### PR TITLE
fix(calendar): hide orphaned (course-deleted) sessions from the tutor calendar

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/route.ts
@@ -15,7 +15,7 @@ import {
   sessionParticipant,
   courseVariant,
 } from '@/lib/db/schema'
-import { eq, and, gte, lte, inArray, isNull, sql } from 'drizzle-orm'
+import { eq, and, gte, lte, inArray, isNull, isNotNull, sql } from 'drizzle-orm'
 
 export const GET = withAuth(
   async (req: NextRequest, session) => {
@@ -70,6 +70,11 @@ export const GET = withAuth(
     const lsFilters = [
       eq(liveSession.tutorId, tutorId),
       inArray(liveSession.status, ['scheduled', 'active', 'preparing', 'live', 'paused']),
+      // Skip orphaned sessions: a course deleted before sessions were ended on
+      // delete leaves rows with courseId nulled (FK) but still 'scheduled', which
+      // otherwise linger on the calendar forever. Genuine course-less sessions
+      // (ad-hoc) surface via their CalendarEvent, so nothing real is hidden.
+      isNotNull(liveSession.courseId),
     ]
 
     if (startParam) {


### PR DESCRIPTION
Follow-up to the orphaned-sessions issue.

The **root fix** you asked for — ending a course's live sessions when the course is deleted — **already landed on main** (commit `446efe287d`, added 2026-07-04). So new deletions no longer orphan their sessions.

This PR handles the **leftover** orphans (sessions deleted *before* that fix): they still have `courseId` nulled + status `scheduled`, and the calendar's live-session fallback (filtered only by tutor + status) kept showing them. Mirrors the scheduler fix (#668) — require `courseId` in that fallback. Ad-hoc sessions surface via their CalendarEvent, so nothing real is hidden.

Net: orphaned sessions are now gone from **both** the scheduler and the calendar; future deletions are clean at the source.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)