### PR TITLE
fix(db): one-time cleanup deleting orphaned live sessions on boot

### DIFF
--- a/tutorme-app/server.ts
+++ b/tutorme-app/server.ts
@@ -11,6 +11,7 @@ import { config as dotenvConfig } from 'dotenv'
 import { initEnhancedSocketServer } from './src/lib/socket-server-enhanced'
 import { validateEnv } from './src/lib/env'
 import { applyStartupSchemaFixes } from './src/lib/db/startup-schema-fix'
+import { applyStartupDataCleanup } from './src/lib/db/startup-cleanup'
 import { startSessionReminderScheduler } from './src/lib/notifications/session-reminder-scheduler'
 
 // Load environment variables from .env.local before validation
@@ -195,6 +196,9 @@ server
       const schemaFixPromise = applyStartupSchemaFixes()
         .then(() => {
           console.log(`[Server] Step 1b: Schema fixes completed in ${elapsed(schemaFixStart)}`)
+          // Idempotent data cleanup (orphaned sessions) — after schema fixes so
+          // the columns it reads are guaranteed present. Best-effort, non-blocking.
+          return applyStartupDataCleanup()
         })
         .catch((schemaErr: unknown) => {
           const error = schemaErr instanceof Error ? schemaErr : new Error('Schema fix failed')

--- a/tutorme-app/src/lib/db/startup-cleanup.ts
+++ b/tutorme-app/src/lib/db/startup-cleanup.ts
@@ -1,0 +1,41 @@
+/**
+ * One-time (idempotent) data cleanup run on server boot, alongside the schema
+ * fixes. Kept separate from schema drift because it mutates DATA, not structure.
+ *
+ * Removes ORPHANED live sessions: rows left behind when a course was deleted
+ * before the delete flow ended its sessions (the FK set their courseId to null
+ * but left them 'scheduled', so they lingered on the calendar and blocked
+ * scheduler slots forever).
+ *
+ * Precise + safe: an orphan is identified as courseId IS NULL + an open status +
+ * NO CalendarEvent referencing it. Genuine course-less sessions (ad-hoc) always
+ * have a CalendarEvent, so they are never touched. Re-running deletes nothing.
+ */
+
+import { drizzleDb } from './drizzle'
+import { sql } from 'drizzle-orm'
+
+const CLEANUP_SQL = sql.raw(`
+DELETE FROM "LiveSession"
+WHERE "courseId" IS NULL
+  AND "status" IN ('scheduled', 'active', 'preparing', 'live', 'paused')
+  AND NOT EXISTS (
+    SELECT 1 FROM "CalendarEvent" ce WHERE ce."externalId" = "LiveSession"."id"
+  );
+`)
+
+export async function applyStartupDataCleanup(): Promise<void> {
+  try {
+    const result = await drizzleDb.execute(CLEANUP_SQL)
+    const count = (result as { rowCount?: number })?.rowCount ?? 0
+    if (count > 0) {
+      console.log(`[Server] Data cleanup: removed ${count} orphaned live session(s).`)
+    }
+  } catch (err) {
+    // Never block boot on a cleanup — log and move on.
+    console.error(
+      '⚠️ [Server] Orphaned-session cleanup skipped:',
+      err instanceof Error ? err.message : err
+    )
+  }
+}


### PR DESCRIPTION
You asked to **actually delete** the orphaned sessions (not just hide them).

New `applyStartupDataCleanup()` runs on every boot right after the schema fixes (which run in prod regardless of `SKIP_MIGRATIONS`), and idempotently deletes orphaned live sessions:

```
courseId IS NULL AND status IN (open statuses) AND NOT EXISTS (a CalendarEvent whose externalId = session id)
```

That predicate precisely targets course-deleted orphans (their CalendarEvent was removed on course delete) and **spares genuine ad-hoc sessions** (which always have a CalendarEvent). Best-effort/non-blocking; re-running deletes nothing.

Combined with the already-live root fix (course delete ends its sessions), scheduler fix (#668) and calendar fix (#670), this removes the leftover rows entirely — the greyed 'Unavailable' slots on the scheduler should clear once this deploys and the server boots.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)