### PR TITLE
fix(communications): make Chat header flush by overriding Card default rounding

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -636,7 +636,7 @@ export default function TutorSettings() {
   }
 
   return (
-    <div className="flex h-full min-h-full flex-col bg-[#fafafc] px-3 pb-0 pt-2 lg:px-4 lg:pt-0">
+    <div className="flex h-full min-h-full flex-col bg-white px-3 pb-0 pt-2 lg:px-4 lg:pt-0">
       {/* Hero */}
       <section className="relative mb-4 flex-shrink-0 overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] p-5 shadow-[0_24px_72px_rgba(0,0,0,0.20)] ring-1 ring-white/20">
         <div className="text-center">

--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -41,7 +41,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   const ListIcon = list.icon
 
   return (
-    <Card className="flex h-full w-full flex-col overflow-hidden rounded-b-2xl border border-gray-200 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+    <Card className="flex h-full w-full flex-col overflow-hidden rounded-none rounded-b-2xl border border-gray-200 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
       {/* Full-width Chat header */}
       <div className="relative flex h-12 shrink-0 items-center justify-center bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
         Chat


### PR DESCRIPTION
The Card component has `rounded-xl` as a base style that was being applied before `rounded-b-2xl`, causing the top corners to still be rounded. This created a gap between the blue header and the top edge of the panel.

Add `rounded-none` before `rounded-b-2xl` to explicitly remove the Card's default top rounding, making the header truly flush with the panel edge.