### PR TITLE
fix(session-calendar-panel): make hover shadow the default, remove hover effect

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -89,8 +89,9 @@ export function SessionCalendarPanel({
 
   return (
     <Card
+      hoverable={false}
       className={cn(
-        'flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5',
+        'shadow-hover-lift flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5',
         className
       )}
     >


### PR DESCRIPTION
Changes the SessionCalendarPanel component so the default shadow matches the previous hover intensity, and removes the hover effect altogether.

- Add `hoverable={false}` to Card to remove the hover shadow lift
- Add `shadow-hover-lift` to className so the default shadow is stronger
- This affects all panels using SessionCalendarPanel (Grading, Analytics tabs, etc.)