### PR TITLE
fix(dialogs): match Go Live and Create Course popups to Course Sessions design

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateCourseDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateCourseDialog.tsx
@@ -188,16 +188,16 @@ export function CreateCourseDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="sm:max-w-[500px]"
+        className="border border-slate-200 shadow-2xl sm:max-w-[500px]"
         aria-busy={creating}
         aria-describedby={apiError ? 'create-course-api-error' : undefined}
       >
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <BookOpen className="h-5 w-5 text-blue-500" />
+          <DialogTitle className="flex items-center gap-2 text-white">
+            <BookOpen className="text-primary h-5 w-5" />
             New session
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="text-white/80">
             Create a whole course (course) with modules and lessons. You can add more modules and
             lessons after creation.
           </DialogDescription>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/GoLiveDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/GoLiveDialog.tsx
@@ -68,9 +68,9 @@ export function GoLiveDialog({
         onOpenChange(isOpen)
       }}
     >
-      <DialogContent className="max-w-md" theme="metallic">
+      <DialogContent className="max-w-md border border-slate-200 shadow-2xl">
         <DialogHeader className="text-center">
-          <DialogTitle className="mx-auto text-center">Go Live</DialogTitle>
+          <DialogTitle className="mx-auto text-center text-white">Go Live</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4 px-6 py-4">


### PR DESCRIPTION
Makes the Go Live and Create New Course popups match the Course Sessions popup styling from the tutor dashboard.\n\n- Go Live Dialog: remove explicit `theme=metallic` (already the default), add `border border-slate-200 shadow-2xl` to className, make title `text-white`\n- Create Course Dialog: add `border border-slate-200 shadow-2xl` to className, make title `text-white` and description `text-white/80`\n\nAll three popups now share the same metallic glass background, border, shadow, and white text styling.