### PR TITLE
fix(availability): add the 11 PM (23:00) slot

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -179,6 +179,9 @@ const TIME_SLOTS = [
   '21:00',
   '22:00',
   '23:00',
+  // Pairing sentinel so 23:00 (11 PM) becomes a selectable start slot. Ends at
+  // 23:59 rather than 24:00 because the availability API validates HH:MM ≤ 23:59.
+  '23:59',
 ]
 
 const generateAvailability = (): AvailabilityBlock[] => {


### PR DESCRIPTION
The availability grid pairs consecutive `TIME_SLOTS`, and the array ended at `'23:00'`, so the last selectable start was **22:00 (10 PM)** — 11 PM was missing. Appended a `'23:59'` pairing sentinel so **23:00 (11 PM)** becomes a selectable start slot (ends `23:59`, not `24:00`, because the availability API validates `HH:MM ≤ 23:59`). Both tutor and student grids build from `generateAvailability()`, so both get the row.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)