### PR TITLE
fix(scheduler): wire tutor availability correctly (blocked slots block)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor.tsx
@@ -14,7 +14,12 @@ import { DAYS, TIME_SLOT_OPTIONS } from '../constants'
 import { expandSchedule, extractTemplate } from './expand-schedule'
 
 interface AvailabilityData {
-  availability: Array<{ dayOfWeek: number; startTime: string; endTime: string }>
+  availability: Array<{
+    dayOfWeek: number
+    startTime: string
+    endTime: string
+    isAvailable?: boolean
+  }>
   exceptions: Array<{
     date: string
     isAvailable: boolean
@@ -192,13 +197,18 @@ export function VariantScheduleEditor({
         .toString()
         .padStart(2, '0')}:${(slotEndM % 60).toString().padStart(2, '0')}`
 
-      // 1. Check recurring availability
+      // 1. Check recurring availability. Tutors follow an "available unless
+      // blocked" model: every slot is available by default, and a row with
+      // isAvailable === false marks a BLOCKED time. So a slot is unavailable
+      // exactly when it overlaps a blocked row. (isAvailable=true rows and absent
+      // rows both mean available, so positive windows must NOT restrict — doing so
+      // is what let "all off" still read as available when the flag was dropped.)
       const dayAvailability = availabilityData.availability.filter(a => a.dayOfWeek === dayIndex)
-      const withinAvailability = dayAvailability.some(a =>
-        timesOverlap(slotStartStr, slotEndStr, a.startTime, a.endTime)
-      )
-      if (dayAvailability.length > 0 && !withinAvailability) {
-        return { available: false, reason: 'Outside your set availability' }
+      const blockedWindows = dayAvailability.filter(a => a.isAvailable === false)
+      if (
+        blockedWindows.some(a => timesOverlap(slotStartStr, slotEndStr, a.startTime, a.endTime))
+      ) {
+        return { available: false, reason: 'Blocked in your availability' }
       }
 
       // 2. Check exceptions

--- a/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
@@ -181,6 +181,10 @@ export const GET = withAuth(
             dayOfWeek: a.dayOfWeek,
             startTime: a.startTime,
             endTime: a.endTime,
+            // Tutors store BLOCKED times as isAvailable=false ("available unless
+            // blocked"). The scheduler must see this to grey blocked slots — the
+            // field was previously dropped, so blocked rows read as availability.
+            isAvailable: a.isAvailable,
           })),
           exceptions: exceptions.map(e => ({
             date: normalizeDate(e.date),

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -656,12 +656,15 @@ export const POST = withCsrf(
                     dayOfWeek: calendarAvailability.dayOfWeek,
                     startTime: calendarAvailability.startTime,
                     endTime: calendarAvailability.endTime,
+                    // Include the flag: tutors store BLOCKED times as
+                    // isAvailable=false. Filtering to true only left no windows,
+                    // so blocked slots were never enforced on publish.
+                    isAvailable: calendarAvailability.isAvailable,
                   })
                   .from(calendarAvailability)
                   .where(
                     and(
                       eq(calendarAvailability.tutorId, userId),
-                      eq(calendarAvailability.isAvailable, true),
                       or(
                         isNull(calendarAvailability.validUntil),
                         gte(calendarAvailability.validUntil, now)
@@ -706,10 +709,11 @@ export const POST = withCsrf(
                 const eStr = hhmm(end)
                 const dateKey = dateKeyOf(start)
                 const dayWindows = availabilityWindows.filter(a => a.dayOfWeek === dow)
-                if (
-                  dayWindows.length > 0 &&
-                  !dayWindows.some(a => timesOverlapStr(sStr, eStr, a.startTime, a.endTime))
-                ) {
+                // "Available unless blocked": a session overlapping a blocked
+                // (isAvailable=false) window is out of availability. isAvailable=true
+                // and absent rows both mean available, so they never restrict.
+                const blocked = dayWindows.filter(a => a.isAvailable === false)
+                if (blocked.some(a => timesOverlapStr(sStr, eStr, a.startTime, a.endTime))) {
                   return 'outside_availability'
                 }
                 for (const ex of dateExceptions) {


### PR DESCRIPTION
**Bug:** setting all availability off still leaves the scheduler showing available slots.

**Cause — a model mismatch.** The availability editor is *available unless blocked*: slots are available by default, and blocking one writes an `isAvailable=false` row. But the scheduler's `mode=schedule` endpoint **dropped the `isAvailable` flag** and returned every row as an availability *window*, and `getSlotStatus` treated any overlapping window as available. So the `isAvailable=false` (blocked) rows read as *available* → all-off looked fully available.

**Fix:**
- Endpoint now returns `isAvailable` per availability row.
- `getSlotStatus`: a slot is unavailable iff it overlaps a **blocked** (`isAvailable=false`) row. `true`/absent rows mean available and never restrict.
- Aligned the **publish route's** server-side enforcement the same way — it filtered to `isAvailable=true` windows (empty in this model), so blocked times were never enforced at publish either.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)