### PR TITLE
fix(scheduler): compute availability, sessions & scheduler in the tutor's timezone

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/availability/route.ts
@@ -20,6 +20,7 @@ import {
   liveSession,
 } from '@/lib/db/schema'
 import { eq, and, or, gte, lte, gt, lt, asc, isNull, isNotNull, inArray } from 'drizzle-orm'
+import { formatInZone } from '@/lib/time/tz'
 import { z } from 'zod'
 import { nanoid } from 'nanoid'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
@@ -140,8 +141,13 @@ export const GET = withAuth(
             )
           )
 
-        const normalizeDate = (d: Date) => d.toISOString().split('T')[0]
-        const normalizeTime = (d: Date) => d.toISOString().split('T')[1].slice(0, 5)
+        // Event/session instants are read in the TUTOR's timezone so they line
+        // up with availability (also the tutor's local "HH:MM") and the scheduler
+        // cells — previously these used UTC (toISOString), which offset every
+        // event by the tutor's UTC offset.
+        const tutorTz = availability[0]?.timezone || 'UTC'
+        const normalizeDate = (d: Date) => formatInZone(d, tutorTz).date
+        const normalizeTime = (d: Date) => formatInZone(d, tutorTz).time
 
         // Merge calendar events and live sessions into a single events array
         const calendarEventItems = existingEvents.map(ev => ({

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -20,6 +20,7 @@ import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 import { eq, and, inArray, gte, lte, lt, gt, sql, or, isNull } from 'drizzle-orm'
 import crypto from 'crypto'
 import { findAlternativeSlots as sharedFindAlternativeSlots } from '@/lib/schedule/conflicts'
+import { zonedWallClockToUtc, zonedWeekday, zonedDateParts, formatInZone } from '@/lib/time/tz'
 
 // GET current variants for this template course
 export const GET = withAuth(
@@ -160,11 +161,17 @@ const DAY_MAP: Record<string, number> = {
  */
 function generateSessionDates(
   schedule: ScheduleItem[],
-  weeksAhead = 8
+  weeksAhead = 8,
+  timeZone = 'UTC'
 ): Array<{ scheduledAt: Date; title: string; durationMinutes: number }> {
   const sessions: Array<{ scheduledAt: Date; title: string; durationMinutes: number }> = []
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const cutoffMs = Date.now() + 60 * 60 * 1000 // skip sessions within the next hour
+
+  // Add `n` days to a wall-clock date (Y/1-based-M/D) → new Y/M/D, without tz drift.
+  const addDays = (year: number, month: number, day: number, n: number) => {
+    const t = new Date(Date.UTC(year, month - 1, day + n))
+    return { year: t.getUTCFullYear(), month: t.getUTCMonth() + 1, day: t.getUTCDate() }
+  }
 
   for (const slot of schedule) {
     const targetDay = DAY_MAP[slot.dayOfWeek]
@@ -186,14 +193,12 @@ function generateSessionDates(
       continue
 
     if (slot.date) {
-      // Manual specific date
-      const dateParts = slot.date.split('-').map(Number)
-      const [year, month, day] = dateParts
+      // Manual specific date — the "HH:MM" is the tutor's local wall clock.
+      const [year, month, day] = slot.date.split('-').map(Number)
       if (!year || !month || !day) continue
-      const sessionDate = new Date(year, month - 1, day, hours, minutes, 0, 0)
+      const sessionDate = zonedWallClockToUtc(year, month, day, hours, minutes, timeZone)
       if (isNaN(sessionDate.getTime())) continue
-      // Skip sessions already in the past (within the next hour cutoff)
-      if (sessionDate.getTime() < Date.now() + 60 * 60 * 1000) continue
+      if (sessionDate.getTime() < cutoffMs) continue
       sessions.push({
         scheduledAt: sessionDate,
         title: `Live Session — ${slot.date} ${slot.startTime}`,
@@ -202,21 +207,23 @@ function generateSessionDates(
       continue
     }
 
-    // Find the next occurrence of this day (relative to today, in server local time)
-    const cursor = new Date(today)
-    const daysUntil = (targetDay - cursor.getDay() + 7) % 7
-    cursor.setDate(cursor.getDate() + daysUntil)
-    cursor.setHours(hours, minutes, 0, 0)
-
-    // If the time already passed today or is less than 1 hour away, start from next week
-    if (cursor.getTime() < Date.now() + 60 * 60 * 1000) {
-      cursor.setDate(cursor.getDate() + 7)
+    // Find the next occurrence of this weekday in the TUTOR's timezone, so a
+    // "9 AM Monday" slot means 9 AM Monday for the tutor (not the server/UTC).
+    const now = new Date()
+    const todayZ = zonedDateParts(now, timeZone)
+    const todayWeekday = zonedWeekday(now, timeZone)
+    const daysUntil = (targetDay - todayWeekday + 7) % 7
+    let occ = addDays(todayZ.year, todayZ.month, todayZ.day, daysUntil)
+    let first = zonedWallClockToUtc(occ.year, occ.month, occ.day, hours, minutes, timeZone)
+    if (first.getTime() < cutoffMs) {
+      occ = addDays(occ.year, occ.month, occ.day, 7)
+      first = zonedWallClockToUtc(occ.year, occ.month, occ.day, hours, minutes, timeZone)
     }
 
     // Generate sessions for the next N weeks
     for (let w = 0; w < weeksAhead; w++) {
-      const sessionDate = new Date(cursor)
-      sessionDate.setDate(cursor.getDate() + w * 7)
+      const wk = addDays(occ.year, occ.month, occ.day, w * 7)
+      const sessionDate = zonedWallClockToUtc(wk.year, wk.month, wk.day, hours, minutes, timeZone)
       if (isNaN(sessionDate.getTime())) continue
       sessions.push({
         scheduledAt: sessionDate,
@@ -360,6 +367,16 @@ export const POST = withCsrf(
           conflictWith?: { start?: Date | null; end?: Date | null }
           recommendations: Array<{ date: string; startTime: string; endTime: string }>
         }> = []
+
+        // The tutor's timezone (all their availability rows share it). Session
+        // "HH:MM" slots are that tutor's wall clock, so everything — session
+        // creation and the availability check — is computed in this zone.
+        const [tutorTzRow] = await drizzleDb
+          .select({ timezone: calendarAvailability.timezone })
+          .from(calendarAvailability)
+          .where(eq(calendarAvailability.tutorId, userId))
+          .limit(1)
+        const tutorTimeZone = tutorTzRow?.timezone || 'UTC'
 
         await drizzleDb.transaction(async tx => {
           // Fetch existing variants with their course data
@@ -561,7 +578,11 @@ export const POST = withCsrf(
             for (const s of schedules) {
               const scheduleItems = Array.isArray(s.schedule) ? s.schedule : []
               if (scheduleItems.length === 0) continue
-              const sessionDates = generateSessionDates(scheduleItems, s.weeksToSchedule || 8)
+              const sessionDates = generateSessionDates(
+                scheduleItems,
+                s.weeksToSchedule || 8,
+                tutorTimeZone
+              )
 
               // Each schedule is an independent offering that walks the whole
               // course, so the lesson cursor restarts at Lesson 1 per schedule.
@@ -690,11 +711,11 @@ export const POST = withCsrf(
                   : Promise.resolve([]),
               ])
 
-              // Wall-clock helpers (sessions are built as server-local = UTC, the
-              // same wall clock the scheduler compares against).
-              const hhmm = (d: Date) =>
-                `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}`
-              const dateKeyOf = (d: Date) => d.toISOString().split('T')[0]
+              // Wall-clock helpers in the TUTOR's timezone — availability/exception
+              // times are stored as the tutor's local "HH:MM", so the session
+              // instant must be read in the same zone (not UTC) to compare.
+              const hhmm = (d: Date) => formatInZone(d, tutorTimeZone).time
+              const dateKeyOf = (d: Date) => formatInZone(d, tutorTimeZone).date
               const timesOverlapStr = (s1: string, e1: string, s2: string, e2: string) =>
                 s1 < e2 && e1 > s2
 
@@ -704,7 +725,7 @@ export const POST = withCsrf(
                 start: Date,
                 end: Date
               ): 'outside_availability' | 'exception' | null {
-                const dow = start.getUTCDay()
+                const dow = zonedWeekday(start, tutorTimeZone)
                 const sStr = hhmm(start)
                 const eStr = hhmm(end)
                 const dateKey = dateKeyOf(start)

--- a/tutorme-app/src/lib/time/tz.test.ts
+++ b/tutorme-app/src/lib/time/tz.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { zonedWallClockToUtc, formatInZone, zonedWeekday, zonedDateParts } from './tz'
+
+describe('tz helpers', () => {
+  it('builds the UTC instant for a wall-clock time in a fixed-offset zone', () => {
+    // 09:00 on 2026-03-10 in Shanghai (UTC+8, no DST) = 01:00 UTC.
+    const utc = zonedWallClockToUtc(2026, 3, 10, 9, 0, 'Asia/Shanghai')
+    expect(utc.toISOString()).toBe('2026-03-10T01:00:00.000Z')
+  })
+
+  it('round-trips wall clock → UTC → wall clock', () => {
+    const utc = zonedWallClockToUtc(2026, 6, 15, 23, 0, 'America/New_York') // 11 PM EDT
+    const back = formatInZone(utc, 'America/New_York')
+    expect(back).toEqual({ date: '2026-06-15', time: '23:00' })
+  })
+
+  it('formats a UTC instant in the target zone', () => {
+    // 01:00 UTC = 09:00 Shanghai the same day.
+    expect(formatInZone(new Date('2026-03-10T01:00:00Z'), 'Asia/Shanghai')).toEqual({
+      date: '2026-03-10',
+      time: '09:00',
+    })
+    // 23:00 UTC = 07:00 next day in Shanghai — date rolls over.
+    expect(formatInZone(new Date('2026-03-10T23:00:00Z'), 'Asia/Shanghai')).toEqual({
+      date: '2026-03-11',
+      time: '07:00',
+    })
+  })
+
+  it('reports the weekday/date in the target zone (handles day rollover)', () => {
+    // 2026-03-10 is a Tuesday. At 23:00 UTC it's already Wednesday in Shanghai.
+    const d = new Date('2026-03-10T23:00:00Z')
+    expect(zonedWeekday(d, 'UTC')).toBe(2) // Tue
+    expect(zonedWeekday(d, 'Asia/Shanghai')).toBe(3) // Wed
+    expect(zonedDateParts(d, 'Asia/Shanghai')).toEqual({ year: 2026, month: 3, day: 11 })
+  })
+
+  it('handles a US DST spring-forward boundary', () => {
+    // 2026-03-08 02:30 America/New_York does not exist (spring forward). The
+    // helper must still return a sane instant, not NaN.
+    const utc = zonedWallClockToUtc(2026, 3, 8, 2, 30, 'America/New_York')
+    expect(Number.isNaN(utc.getTime())).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/time/tz.ts
+++ b/tutorme-app/src/lib/time/tz.ts
@@ -1,0 +1,96 @@
+/**
+ * Dependency-free timezone helpers (no date libs in this repo).
+ *
+ * The scheduler/availability stack was mixing UTC and browser-local "HH:MM"
+ * strings. These let us pin everything to ONE frame — the tutor's timezone —
+ * by (a) reading a UTC instant's wall-clock in a zone, and (b) building the UTC
+ * instant for a wall-clock time in a zone.
+ */
+
+interface ZonedParts {
+  year: number
+  month: number // 1-12
+  day: number
+  hour: number // 0-23
+  minute: number
+  second: number
+}
+
+/** The wall-clock parts of a UTC `date` as seen in `timeZone`. */
+function partsInZone(date: Date, timeZone: string): ZonedParts {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+  const m: Record<string, string> = {}
+  for (const p of dtf.formatToParts(date)) {
+    if (p.type !== 'literal') m[p.type] = p.value
+  }
+  return {
+    year: Number(m.year),
+    month: Number(m.month),
+    day: Number(m.day),
+    // Some engines format midnight as '24'.
+    hour: m.hour === '24' ? 0 : Number(m.hour),
+    minute: Number(m.minute),
+    second: Number(m.second),
+  }
+}
+
+/** Offset (ms) that `timeZone` is AHEAD of UTC at the instant `date`. */
+function offsetMsAt(date: Date, timeZone: string): number {
+  const p = partsInZone(date, timeZone)
+  const asIfUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second)
+  return asIfUtc - date.getTime()
+}
+
+/**
+ * Build the UTC Date for a wall-clock time (`year`, 1-based `month`, `day`,
+ * `hour`, `minute`) in `timeZone`. DST-aware (re-checks the offset at the result).
+ */
+export function zonedWallClockToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timeZone: string
+): Date {
+  const guess = new Date(Date.UTC(year, month - 1, day, hour, minute))
+  const off = offsetMsAt(guess, timeZone)
+  let result = new Date(guess.getTime() - off)
+  const off2 = offsetMsAt(result, timeZone)
+  if (off2 !== off) result = new Date(guess.getTime() - off2)
+  return result
+}
+
+/** Format a UTC Date as { date: 'YYYY-MM-DD', time: 'HH:MM' } in `timeZone`. */
+export function formatInZone(date: Date, timeZone: string): { date: string; time: string } {
+  const p = partsInZone(date, timeZone)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return {
+    date: `${p.year}-${pad(p.month)}-${pad(p.day)}`,
+    time: `${pad(p.hour)}:${pad(p.minute)}`,
+  }
+}
+
+/** Day-of-week (0=Sun..6=Sat) of a UTC instant as seen in `timeZone`. */
+export function zonedWeekday(date: Date, timeZone: string): number {
+  const p = partsInZone(date, timeZone)
+  return new Date(Date.UTC(p.year, p.month - 1, p.day)).getUTCDay()
+}
+
+/** The wall-clock calendar date (Y/M/D) of a UTC instant in `timeZone`. */
+export function zonedDateParts(
+  date: Date,
+  timeZone: string
+): { year: number; month: number; day: number } {
+  const p = partsInZone(date, timeZone)
+  return { year: p.year, month: p.month, day: p.day }
+}


### PR DESCRIPTION
Root-cause fix for the calendar/availability/scheduler wiring: the three didn't share a timezone.

**Before:** availability saved as the tutor's local `HH:MM`; sessions built in the **server** zone (UTC); scheduler normalized events with `toISOString()` (**UTC**); publish enforcement compared `getUTCHours()` against local `HH:MM`. For any non-UTC tutor: sessions created at the wrong real hour, events greyed the wrong slots (wrong day near midnight), and blocked hours weren't enforced on publish.

**Now everything is pinned to the tutor's timezone** (read from `calendarAvailability.timezone`):
- New dependency-free `Intl`-based tz helpers (`src/lib/time/tz.ts`, DST-aware) with unit tests (5 passing, incl. day-rollover + spring-forward).
- `generateSessionDates` builds each session instant from the slot `HH:MM` as the tutor's wall clock (specific-date **and** recurring-weekday paths).
- Publish `availabilityBlock` reads the session instant in the tutor's zone → blocked hours are actually enforced.
- Scheduler endpoint (`mode=schedule`) normalizes event/session times in the tutor's zone → they line up with availability + cells.

Instant-based conflict checks (`getTime()`) are timezone-agnostic and unchanged.

**Behavior note (as agreed):** newly-created classes now land at the tutor's local time; any pre-existing UTC-built sessions display shifted by the tutor's offset.

npm run typecheck ✅ · vitest tz.test ✅ (5) · npm run build ✅ · eslint 0 errors. Timezone logic couldn't be driven end-to-end here — worth a live check: set availability, publish a schedule, confirm the session lands at the intended local hour and blocked hours are greyed/skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)