### PR TITLE
fix(course): open builder on the template (lessons vanished after publish)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -930,7 +930,11 @@ function TutorDashboardContent() {
                               onClick={() =>
                                 router.push(
                                   withLocalePath(
-                                    `/tutor/insights?tab=builder&courseId=${course.id}&mode=edit`
+                                    // The builder edits the TEMPLATE course (where the
+                                    // lessons live). `course.id` is the published
+                                    // variant, which has no builder lessons — opening
+                                    // it showed an empty course after publishing.
+                                    `/tutor/insights?tab=builder&courseId=${course.templateCourseId || course.id}&mode=edit`
                                   )
                                 )
                               }


### PR DESCRIPTION
**Bug:** create a course, publish, then open it in the course builder → empty course, all lessons gone.

**Cause:** the dashboard **Edit** button opened the builder with `course.id`, but the enrolled API returns `id` as the **published variant** (it filters `isPublished = true`) and exposes the template separately as `templateCourseId`. The builder edits the **template** (where the lessons live), so opening the published variant showed no builder lessons.

**Fix:** open the builder with `course.templateCourseId || course.id` — matching the course-details link directly above it (line 918) which already does this. One line.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

Related (not in this PR, worth knowing): editing the template and **re-publishing does not re-copy lesson changes** to an existing published variant — publish only copies lessons when a variant is first created. If you want lesson edits to propagate to already-published variants, that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)