### PR TITLE
fix: move zoom slider to bottom-right and fix reset button

### DIFF
--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -8,6 +8,7 @@ interface FloatingZoomPillProps {
   onScaleChange: (scale: number) => void
   minScale?: number
   maxScale?: number
+  defaultScale?: number
   onHidePreview?: () => void
   className?: string
   containerRef?: React.RefObject<HTMLElement | null>
@@ -19,6 +20,7 @@ export function FloatingZoomPill({
   onScaleChange,
   minScale = 0.5,
   maxScale = 1.5,
+  defaultScale = 1.0,
   onHidePreview,
   className,
   containerRef,
@@ -135,7 +137,7 @@ export function FloatingZoomPill({
 
       {/* Reset zoom button */}
       <button
-        onClick={() => onScaleChange(1.0)}
+        onClick={() => onScaleChange(defaultScale)}
         className="flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-700"
         title="Reset Zoom"
       >

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -188,13 +188,14 @@ export function PDFViewer({
         >
           {/* Floating zoom pill - fixed position, does not scroll with content */}
           {!loading && !error && numPages > 0 && (
-            <div className="pointer-events-none absolute right-4 top-1/2 z-50 -translate-y-1/2">
+            <div className="pointer-events-none absolute bottom-4 right-4 z-50">
               <div className="pointer-events-auto">
                 <FloatingZoomPill
                   scale={scale}
                   onScaleChange={newScale => changeScale(newScale, true)}
                   minScale={0.5}
                   maxScale={1.5}
+                  defaultScale={defaultScale}
                   onHidePreview={onHidePreview}
                   containerRef={scrollContainerRef}
                   fixed


### PR DESCRIPTION
## Summary

Moves the zoom slider from the vertically-centered right side to the bottom-right corner of the slide display area, and fixes the reset button to return to the actual default zoom level.

## Changes

### Position (PDFViewer.tsx)
- **Before**:  — vertically centered on right edge
- **After**:  — bottom-right corner of the display area

### Reset Button Fix (FloatingZoomPill.tsx)
- **Before**: Hardcoded  — always reset to 100%
- **After**:  — resets to the actual default
  - Task/Assessment Builder: resets to **75%** (was passing )
  - PDF viewer: resets to **125%** (default )

### New Prop
- Added  to  interface
- Passed from  to 

## Files Changed
-  — add  prop, use it in reset
-  — change positioning, pass  prop

## Type Check & Format
- 
[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages passes
-  applied