### PR TITLE
fix: Communications panel layout and tab icons

### DIFF
--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -194,25 +194,27 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
           onValueChange={setActiveTab}
           variant="charcoal"
           tabs={[
-            { value: 'messaging', label: 'Messaging', icon: MessageSquare },
-            { value: 'notifications', label: 'Notifications', icon: Bell },
+            { value: 'messaging', label: 'Messaging' },
+            { value: 'notifications', label: 'Notifications' },
           ]}
         >
-          <TabsContent value="messaging" className="flex h-full flex-col gap-4 pb-4">
+          <TabsContent value="messaging" className="flex h-full flex-col">
             <CollapsibleCard
               title="Messaging"
               icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
               defaultOpen
+              className="flex-1"
             >
               <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
             </CollapsibleCard>
           </TabsContent>
 
-          <TabsContent value="notifications" className="flex h-full flex-col gap-4 pb-4">
+          <TabsContent value="notifications" className="flex h-full flex-col">
             <CollapsibleCard
               title="Notifications"
               icon={<Bell className="h-5 w-5 text-slate-900" />}
               defaultOpen
+              className="flex-1"
             >
               <NotificationsPanel
                 role={role}


### PR DESCRIPTION
Fixes the Communications page panel sizing and removes tab icons.

## Changes

### Tab icons removed
- Messaging tab: removed MessageSquare icon
- Notifications tab: removed Bell icon
- Text labels only ('Messaging', 'Notifications')

### Panel sizing fixed
- Added  to both CollapsibleCards so they fill available height
- Removed  from TabsContent wrappers
- Both panels now extend to bottom of mode selector with consistent padding

## Before
- Messaging panel: didn't extend to bottom, had pb-4 padding
- Notifications panel: overflowed beyond bottom
- Tabs had icons + text

## After
- Both panels fill the tab content area evenly
- No overflow beyond mode selector bounds
- Clean text-only tabs

## Files Changed
- src/components/communications/communications-page.tsx

## Type Check & Format
- npx tsc --noEmit passes
- npx prettier --write applied