### PR TITLE
fix: center PDF vertically and horizontally in display area

### DIFF
--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -233,7 +233,7 @@ export function PDFViewer({
               ))
             ) : (
               // Single-page pagination view (for large PDFs or while loading)
-              <div className="flex justify-center px-4 py-4">
+              <div className="flex min-h-full items-center justify-center px-4 py-4">
                 <Page
                   pageNumber={pageNumber}
                   renderTextLayer


### PR DESCRIPTION
Centers the PDF page within the display area both vertically and horizontally.

## Problem
In the Course Builder Slide view (and other PDF displays), the PDF was positioned at the top of the container with empty space below. It was only horizontally centered, not vertically.

## Fix
Single-page view wrapper in PDFViewer.tsx:
- Before: flex justify-center px-4 py-4 (horizontal center only, top-aligned)
- After: flex min-h-full items-center justify-center px-4 py-4 (both axes centered)

## Files Changed
- src/components/pdf/PDFViewer.tsx

## Type Check & Format
- npx tsc --noEmit passes
- npx prettier --write applied