### PR TITLE
fix: Communications panels fill full height

### DIFF
--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -199,36 +199,40 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
           ]}
         >
           <TabsContent value="messaging" className="flex h-full flex-col">
-            <CollapsibleCard
-              title="Messaging"
-              icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
-              defaultOpen
-              className="flex-1"
-            >
-              <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
-            </CollapsibleCard>
+            <div className="flex flex-1 flex-col">
+              <CollapsibleCard
+                title="Messaging"
+                icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
+                defaultOpen
+                className="flex-1"
+              >
+                <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
+              </CollapsibleCard>
+            </div>
           </TabsContent>
 
           <TabsContent value="notifications" className="flex h-full flex-col">
-            <CollapsibleCard
-              title="Notifications"
-              icon={<Bell className="h-5 w-5 text-slate-900" />}
-              defaultOpen
-              className="flex-1"
-            >
-              <NotificationsPanel
-                role={role}
-                notifications={notifications}
-                loading={notificationsLoading}
-                unreadCount={unreadCount}
-                onMarkAllRead={markAllAsRead}
-                onClearAll={clearAllNotifications}
-                onMarkRead={markAsRead}
-                onDelete={deleteNotification}
-                onRespondOneOnOne={role === 'tutor' ? respondToOneOnOne : undefined}
-                respondingIds={respondingIds}
-              />
-            </CollapsibleCard>
+            <div className="flex flex-1 flex-col">
+              <CollapsibleCard
+                title="Notifications"
+                icon={<Bell className="h-5 w-5 text-slate-900" />}
+                defaultOpen
+                className="flex-1"
+              >
+                <NotificationsPanel
+                  role={role}
+                  notifications={notifications}
+                  loading={notificationsLoading}
+                  unreadCount={unreadCount}
+                  onMarkAllRead={markAllAsRead}
+                  onClearAll={clearAllNotifications}
+                  onMarkRead={markAsRead}
+                  onDelete={deleteNotification}
+                  onRespondOneOnOne={role === 'tutor' ? respondToOneOnOne : undefined}
+                  respondingIds={respondingIds}
+                />
+              </CollapsibleCard>
+            </div>
           </TabsContent>
         </SessionCalendarPanel>
       </div>


### PR DESCRIPTION
Fixes the Messaging and Notifications panels on the Communications page so they properly fill the available tab content area height.

## Problem
- The `CollapsibleCard` component has an outer wrapper `<div>` that does NOT receive the `className` prop — it only applies to the inner card div.
- This meant `className="flex-1"` on `CollapsibleCard` had no effect on the outer wrapper, so the panels wouldn't stretch to fill the parent flex container.
- Messaging panel stopped short of full height, and Notifications panel could overflow its container.

## Fix
- Wrapped each `CollapsibleCard` in an intermediate `<div className="flex flex-1 flex-col">` so the outer wrapper stretches to fill the available height in the `TabsContent`.
- Messaging panel: now fills full height.
- Notifications panel: now constrained to tab content area.

## Verification
- TypeScript check passes.
- Prettier formatting passes.