### PR TITLE
feat: Apply sliding pill tab animation to all mode selectors

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -131,6 +131,7 @@ import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { PanelErrorBoundary } from '@/components/ui/panel-error-boundary'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
@@ -8962,26 +8963,17 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                           }
                                           className="flex h-full min-h-0 flex-col"
                                         >
-                                          <TabsList className="mb-2 grid w-full grid-cols-3 gap-2 rounded-lg bg-white p-1 shadow-none">
-                                            <TabsTrigger
-                                              value="analytics"
-                                              className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                            >
-                                              Analytics
-                                            </TabsTrigger>
-                                            <TabsTrigger
-                                              value="poll"
-                                              className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                            >
-                                              Poll
-                                            </TabsTrigger>
-                                            <TabsTrigger
-                                              value="question"
-                                              className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                            >
-                                              Question
-                                            </TabsTrigger>
-                                          </TabsList>
+                                          <SlidingPillTabsList
+                                            value={insightsTab}
+                                            variant="white"
+                                            tabs={[
+                                              { value: 'analytics', label: 'Analytics' },
+                                              { value: 'poll', label: 'Poll' },
+                                              { value: 'question', label: 'Question' },
+                                            ]}
+                                            listClassName="mb-2 grid grid-cols-3 gap-2 shadow-none"
+                                            triggerClassName="h-7 rounded-md px-2 text-[11px]"
+                                          />
 
                                           <TabsContent
                                             value="analytics"
@@ -10705,21 +10697,19 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                   setLiveRightPanelTab(value as 'submissions' | 'insights')
                                 }}
                               >
-                                <TabsList className="grid w-full grid-cols-2 gap-2 rounded-lg border-0 bg-gray-100 p-1 shadow-none">
-                                  <TabsTrigger
-                                    value="submissions"
-                                    className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                                  >
-                                    Submissions
-                                  </TabsTrigger>
-                                  <TabsTrigger
-                                    value="insights"
-                                    disabled={mainTab !== 'live'}
-                                    className="h-8 rounded-md px-3 text-xs font-medium transition-all hover:bg-white hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 data-[state=active]:bg-gray-800 data-[state=inactive]:bg-white data-[state=active]:text-white data-[state=inactive]:text-gray-700"
-                                  >
-                                    Insights
-                                  </TabsTrigger>
-                                </TabsList>
+                                <SlidingPillTabsList
+                                  value={liveRightPanelTab}
+                                  variant="gray"
+                                  tabs={[
+                                    { value: 'submissions', label: 'Submissions' },
+                                    {
+                                      value: 'insights',
+                                      label: 'Insights',
+                                      disabled: mainTab !== 'live',
+                                    },
+                                  ]}
+                                  triggerClassName="h-8 rounded-md px-3"
+                                />
                               </Tabs>
                             </div>
                             <div className="min-h-0 flex-1 overflow-hidden p-4 pt-2">
@@ -10732,26 +10722,17 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                     }
                                     className="flex h-full min-h-0 flex-col"
                                   >
-                                    <TabsList className="mb-2 grid w-full shrink-0 grid-cols-3 gap-2 rounded-lg bg-white p-1 shadow-none">
-                                      <TabsTrigger
-                                        value="analytics"
-                                        className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                      >
-                                        Analytics
-                                      </TabsTrigger>
-                                      <TabsTrigger
-                                        value="poll"
-                                        className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                      >
-                                        Poll
-                                      </TabsTrigger>
-                                      <TabsTrigger
-                                        value="question"
-                                        className="h-7 rounded-md px-2 text-[11px] font-medium text-gray-700 transition-all hover:bg-gray-100 data-[state=inactive]:bg-transparent data-[state=active]:bg-gradient-to-br data-[state=active]:from-[#2563EB] data-[state=active]:to-[#1D4ED8] data-[state=active]:text-white data-[state=inactive]:text-gray-700 data-[state=active]:shadow-sm"
-                                      >
-                                        Question
-                                      </TabsTrigger>
-                                    </TabsList>
+                                    <SlidingPillTabsList
+                                      value={insightsTab}
+                                      variant="white"
+                                      tabs={[
+                                        { value: 'analytics', label: 'Analytics' },
+                                        { value: 'poll', label: 'Poll' },
+                                        { value: 'question', label: 'Question' },
+                                      ]}
+                                      listClassName="mb-2 grid shrink-0 grid-cols-3 gap-2 shadow-none"
+                                      triggerClassName="h-7 rounded-md px-2 text-[11px]"
+                                    />
                                     <TabsContent
                                       value="analytics"
                                       className="flex h-full flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -17,6 +17,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
 import {
   Dialog,
   DialogContent,
@@ -651,56 +652,20 @@ export default function TutorSettings() {
         <div className="flex h-full flex-col rounded-[16px] bg-white p-5 shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="flex h-full flex-col">
             <div className="flex-shrink-0">
-              <TabsList className="relative flex w-full gap-1.5 rounded-xl bg-[#1F2933] p-1.5">
-                <TabsTrigger
-                  value="profile"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Profile
-                </TabsTrigger>
-                <TabsTrigger
-                  value="1-on-1"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  1-on-1
-                </TabsTrigger>
-                <TabsTrigger
-                  value="billing"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Billing
-                </TabsTrigger>
-                <TabsTrigger
-                  value="refunds"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Refunds
-                </TabsTrigger>
-                <TabsTrigger
-                  value="notifications"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Notifications
-                </TabsTrigger>
-                <TabsTrigger
-                  value="security"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Security
-                </TabsTrigger>
-                <TabsTrigger
-                  value="controls"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Account
-                </TabsTrigger>
-                <TabsTrigger
-                  value="session-log"
-                  className="flex-1 rounded-lg text-xs text-white/80 transition-colors hover:text-white data-[state=active]:bg-white data-[state=active]:text-[#1F2933] data-[state=active]:shadow-sm"
-                >
-                  Session Log
-                </TabsTrigger>
-              </TabsList>
+              <SlidingPillTabsList
+                value={activeTab}
+                variant="charcoal"
+                tabs={[
+                  { value: 'profile', label: 'Profile' },
+                  { value: '1-on-1', label: '1-on-1' },
+                  { value: 'billing', label: 'Billing' },
+                  { value: 'refunds', label: 'Refunds' },
+                  { value: 'notifications', label: 'Notifications' },
+                  { value: 'security', label: 'Security' },
+                  { value: 'controls', label: 'Account' },
+                  { value: 'session-log', label: 'Session Log' },
+                ]}
+              />
             </div>
             <div className="flex min-h-0 flex-1 flex-col pt-3">
               {/* Profile & Identity */}

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -63,12 +63,12 @@ export function CollapsibleCard({
         </button>
         <div
           className={cn(
-            'grid transition-all duration-300 ease-in-out',
+            'grid h-full transition-all duration-300 ease-in-out',
             open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
           )}
         >
-          <div className="overflow-hidden">
-            <div className={contentClassName}>{children}</div>
+          <div className="h-full overflow-hidden">
+            <div className={cn('h-full', contentClassName)}>{children}</div>
           </div>
         </div>
       </div>

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -188,7 +188,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
       </section>
 
       {/* Mode selector + tab content */}
-      <div className="flex min-h-0 flex-1 flex-col pb-0.5">
+      <div className="flex min-h-0 flex-1 flex-col">
         <SessionCalendarPanel
           value={activeTab}
           onValueChange={setActiveTab}

--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -45,7 +45,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       {/* Content area */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex h-full min-h-0 flex-1 overflow-hidden">
         {/* Left menu rail - shorter */}
         <div className="flex w-40 flex-col items-center gap-2 border-r border-gray-200 py-2">
           {topItems.map(item => {
@@ -105,7 +105,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
         </div>
 
         {/* Detail / chat area */}
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
+        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-white">
           {/* Chat viewport */}
           <div className="scrollbar-hide flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto p-6 text-center">
             <Inbox className="mb-3 h-16 w-16 text-slate-300" />

--- a/tutorme-app/src/components/communications/notifications-panel.tsx
+++ b/tutorme-app/src/components/communications/notifications-panel.tsx
@@ -118,7 +118,7 @@ export default function NotificationsPanel({
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
-      <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+      <div className="scrollbar-hide flex h-full min-h-0 flex-1 overflow-y-auto px-4 pb-4">
         {loading ? (
           <div className="flex items-center justify-center py-10">
             <Loader2 className="h-6 w-6 animate-spin text-slate-400" />

--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -180,7 +180,7 @@ export function SessionCalendarPanel({
             )}
           </div>
         </div>
-        <div className="flex min-h-0 flex-1 flex-col pt-3">{children}</div>
+        <div className="flex min-h-0 flex-1 flex-col pt-3 pb-3">{children}</div>
       </Tabs>
     </Card>
   )

--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import * as React from 'react'
+import { useRef } from 'react'
+import { motion } from 'framer-motion'
+import { cn } from '@/lib/utils'
+import { useSlidingPillMetrics } from '@/hooks/use-sliding-pill'
+import { TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+export interface SlidingPillTab {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+interface SlidingPillTabsListProps {
+  value: string
+  tabs: SlidingPillTab[]
+  variant?: 'charcoal' | 'gray' | 'white'
+  className?: string
+  listClassName?: string
+  triggerClassName?: string
+  pillClassName?: string
+}
+
+const VARIANT_STYLES = {
+  charcoal: {
+    list: 'bg-[#1F2933]',
+    trigger:
+      'text-white/80 hover:text-white data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:!text-[#1F2933]',
+    pill: 'bg-white shadow-sm',
+  },
+  gray: {
+    list: 'bg-gray-100',
+    trigger:
+      'text-gray-700 hover:bg-white hover:text-gray-900 data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:!text-white',
+    pill: 'bg-gray-800',
+  },
+  white: {
+    list: 'bg-white',
+    trigger:
+      'text-gray-700 hover:bg-gray-100 data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:!text-white',
+    pill: 'bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] shadow-sm',
+  },
+}
+
+export function SlidingPillTabsList({
+  value,
+  tabs,
+  variant = 'charcoal',
+  className,
+  listClassName,
+  triggerClassName,
+  pillClassName,
+}: SlidingPillTabsListProps) {
+  const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const activeIndex = tabs.findIndex(tab => tab.value === value)
+  const { left, width } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const styles = VARIANT_STYLES[variant]
+
+  return (
+    <TabsList
+      className={cn('relative flex w-full gap-1.5 rounded-xl p-1.5', styles.list, listClassName)}
+    >
+      {tabs.map((tab, i) => (
+        <TabsTrigger
+          key={tab.value}
+          ref={el => {
+            triggerRefs.current[i] = el
+          }}
+          value={tab.value}
+          disabled={tab.disabled}
+          className={cn(
+            'relative z-10 flex-1 rounded-lg text-xs font-medium transition-colors',
+            styles.trigger,
+            triggerClassName
+          )}
+        >
+          {tab.label}
+        </TabsTrigger>
+      ))}
+      <motion.div
+        className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
+        initial={false}
+        animate={{ left, width }}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      />
+    </TabsList>
+  )
+}


### PR DESCRIPTION
Replaced static tab mode selectors with animated sliding pill indicator across three locations.

## Changes

### New Component: 
- Reusable component with three visual variants: \"charcoal\", \"gray\", \"white\"
- Uses framer-motion spring animation (stiffness 400, damping 30)
- Uses existing  hook for position tracking
- Supports disabled tabs

### 1. Account Page (settings/page.tsx)
- 8 tabs: Profile, 1-on-1, Billing, Refunds, Notifications, Security, Account, Session Log
- Charcoal background with white sliding pill (matches existing design)

### 2. Desk Panel — Submissions/Insights (CourseBuilder.tsx)
- 2 tabs with disabled state support for Insights (when not in live mode)
- Gray background with dark gray sliding pill

### 3. Insights Panel — Analytics/Poll/Question (CourseBuilder.tsx x2)
- 3 tabs in both test mode and live mode contexts
- White background with blue gradient sliding pill

## Verification
- TypeScript check passes
- Build passes
- Prettier formatting applied