### PR TITLE
fix(course): published-course builder loaded detached (empty course + save-wipe)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -934,7 +934,12 @@ function TutorDashboardContent() {
                                     // lessons live). `course.id` is the published
                                     // variant, which has no builder lessons — opening
                                     // it showed an empty course after publishing.
-                                    `/tutor/insights?tab=builder&courseId=${course.templateCourseId || course.id}&mode=edit`
+                                    // NOTE: no `mode=edit` — that flag forces the builder
+                                    // into detached/localStorage mode, which reads nothing
+                                    // from the DB (empty course) and can wipe the real
+                                    // lessons on save. A published course must load/save
+                                    // against the DB.
+                                    `/tutor/insights?tab=builder&courseId=${course.templateCourseId || course.id}`
                                   )
                                 )
                               }

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -134,14 +134,18 @@ function TutorInsightsPageInner() {
       setSaveMode('live')
       return
     }
-    // If mode=edit was explicitly passed, stay in draft (don't auto-detect)
-    if (searchParams.get('mode') === 'edit') {
-      setSaveMode('draft')
-      return
-    }
     // Otherwise detect from which list the course belongs to
     const isLive = courses.some(c => c.id === courseId)
     const isDraft = draftCourses.some(c => c.id === courseId)
+    // If mode=edit was explicitly passed, prefer draft — BUT never for a real DB
+    // course (present in the live list). Detached/draft mode reads from empty
+    // localStorage (blank builder) and, on save, can hard-delete the course's real
+    // lessons. mode=edit only makes sense for the local scratchpad, so honor it
+    // solely when the course isn't a known live DB course.
+    if (searchParams.get('mode') === 'edit' && !isLive) {
+      setSaveMode('draft')
+      return
+    }
     if (isLive && !isDraft) {
       setSaveMode('live')
     } else if (isDraft && !isLive) {


### PR DESCRIPTION
**Bug:** create a course, publish it, open it in the course builder → all content disappears.

**Root cause (my earlier #682 fix was necessary but insufficient):** the dashboard **Edit** link (and the my-page **Create Course** redirect) passed `&mode=edit`. That flag forces the insights builder into **detached** mode (`dataMode='detached'`), whose loader reads lessons from `localStorage` and **never queries the DB** — so a published, DB-backed course renders empty. Then a Save PUTs the empty node set, and `updateCourseBuilderData` **hard-deletes every lesson not in the payload**, silently wiping the real course (and siblings, with `propagateToVariants`).

**Fixes:**
1. Dashboard Edit link → drop `&mode=edit`. `/api/tutor/courses` hides the template when a published variant exists, so the template id is in no list → `saveMode` stays `'live'` → DB-backed load/save → the template's lessons show.
2. Insights `saveMode` auto-detect → honor `mode=edit` **only when the course isn't a known live DB course**. A real DB course (e.g. a just-created one from my-page, which also passes `mode=edit`) now stays live/DB-backed, so its lessons are written to the DB and survive publish instead of living only in localStorage.

Traced with a subagent across the open→load→save path; also rules out the auto-save-wipe and publish-deletes-template hypotheses (auto-save is disabled under `insightsProps`; publish only *reads*/copies template lessons).

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)