### PR TITLE
feat(course): propagate template lesson edits to published variants on re-publish

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -13,6 +13,7 @@ import {
   calendarAvailability,
   calendarException,
   oneOnOneBookingRequest,
+  deployedMaterial,
 } from '@/lib/db/schema'
 import { dailyProvider } from '@/lib/video/daily-provider'
 import { createSession } from '@/lib/sessions/create-session'
@@ -435,6 +436,81 @@ export const POST = withCsrf(
                     isFree,
                   })
                   .where(eq(course.courseId, publishedCourseId))
+
+                // Propagate the template's lesson edits into this already-
+                // published variant. Publish previously copied lessons only when
+                // a variant was first created, so re-publishing never updated the
+                // live lessons. We correlate template↔published lessons by `order`
+                // (the only stable key — see lesson-usage.ts):
+                //   • same order  → update the published lesson IN PLACE, keeping
+                //     its id so DeployedMaterial / live-session links survive;
+                //   • new order   → insert a published copy of the added lesson;
+                //   • dropped order→ delete the published lesson only when nothing
+                //     has been deployed from it, so live classes keep working.
+                const publishedLessonRows = await tx
+                  .select({ lessonId: courseLesson.lessonId, order: courseLesson.order })
+                  .from(courseLesson)
+                  .where(
+                    and(
+                      eq(courseLesson.courseId, publishedCourseId),
+                      isNull(courseLesson.deletedAt)
+                    )
+                  )
+                  .orderBy(courseLesson.order)
+
+                const publishedIdByOrder = new Map<number, string>()
+                for (const l of publishedLessonRows) {
+                  const ord = l.order ?? 0
+                  if (!publishedIdByOrder.has(ord)) publishedIdByOrder.set(ord, l.lessonId)
+                }
+
+                const templateOrders = new Set<number>()
+                for (const lesson of templateLessons) {
+                  const ord = lesson.order ?? 0
+                  templateOrders.add(ord)
+                  const existingLessonId = publishedIdByOrder.get(ord)
+                  if (existingLessonId) {
+                    await tx
+                      .update(courseLesson)
+                      .set({
+                        title: lesson.title,
+                        description: lesson.description,
+                        duration: lesson.duration ?? 60,
+                        builderData: lesson.builderData,
+                        updatedAt: now,
+                      })
+                      .where(eq(courseLesson.lessonId, existingLessonId))
+                  } else {
+                    await tx.insert(courseLesson).values({
+                      lessonId: crypto.randomUUID(),
+                      courseId: publishedCourseId,
+                      title: lesson.title,
+                      description: lesson.description,
+                      duration: lesson.duration ?? 60,
+                      order: ord,
+                      builderData: lesson.builderData,
+                      createdAt: now,
+                      updatedAt: now,
+                    })
+                  }
+                }
+
+                const removedLessonIds = publishedLessonRows
+                  .filter(l => !templateOrders.has(l.order ?? 0))
+                  .map(l => l.lessonId)
+                if (removedLessonIds.length > 0) {
+                  const deployedRows = await tx
+                    .select({ lessonId: deployedMaterial.lessonId })
+                    .from(deployedMaterial)
+                    .where(inArray(deployedMaterial.lessonId, removedLessonIds))
+                  const deployedIds = new Set(deployedRows.map(d => d.lessonId))
+                  const deletableIds = removedLessonIds.filter(id => !deployedIds.has(id))
+                  if (deletableIds.length > 0) {
+                    await tx
+                      .delete(courseLesson)
+                      .where(inArray(courseLesson.lessonId, deletableIds))
+                  }
+                }
               }
 
               result.push({


### PR DESCRIPTION
**Gap:** editing a template and re-publishing never updated an already-published variant's lessons — publish only copied lessons when a variant was *first created* (the new-variant branch). The re-publish (`existing`) branch updated the course row + schedules but left lessons frozen at first-publish.

**Change:** re-publishing an existing variant (non-`schedulesOnly`) now syncs the template's lessons into it, inside the same publish transaction. Correlation is by lesson `order` — the only stable template↔published key (per `lesson-usage.ts`):

| Case | Action |
|---|---|
| Same `order` on both | **Update in place**, keeping the published `lessonId` so `DeployedMaterial` / live-session links survive |
| New `order` on template | **Insert** a published copy of the added lesson |
| `order` gone from template | **Delete** the published lesson **only if nothing was deployed from it** (mirrors the builder's delete guard); otherwise keep it so live classes keep working |

**Safety:**
- Preserves published lesson ids on update → deployed materials, session assignments, and student progress that reference them stay intact.
- Never hard-deletes a lesson that has deployed material.
- `schedulesOnly` publishes skip content sync entirely.
- Save ≠ Publish is preserved: template edits reach students only when the tutor re-publishes.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

Note: correlation is positional (by `order`), consistent with the rest of the system. If a tutor reorders template lessons, content maps by the new position — same model the session auto-assignment and delete-guard already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)