### PR TITLE
fix(registration): restore 50% transparency to dropdown panels

### DIFF
--- a/tutorme-app/src/app/[locale]/register/admin/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/admin/page.tsx
@@ -389,7 +389,7 @@ export default function AdminRegistrationPage() {
                       <SelectTrigger className="h-8 w-full rounded-md border border-white/10 bg-white px-3 py-2 text-sm text-[#1F2933] shadow-sm transition-all duration-200 hover:border-slate-400/50 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-red-500/40">
                         <SelectValue />
                       </SelectTrigger>
-                      <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                      <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                         <SelectItem
                           value="super"
                           className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"

--- a/tutorme-app/src/app/[locale]/register/parent/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/parent/page.tsx
@@ -478,7 +478,7 @@ export default function ParentRegistrationPage() {
                         <SelectTrigger className="h-8 w-full rounded-md border border-white/10 bg-white px-3 py-2 text-sm text-[#1F2933] shadow-sm transition-all duration-200 hover:border-slate-400/50 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40">
                           <SelectValue />
                         </SelectTrigger>
-                        <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                        <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                           <SelectItem
                             value="parent"
                             className="rounded-md text-[13px] text-white/[0.94] hover:bg-white/15"
@@ -607,7 +607,7 @@ export default function ParentRegistrationPage() {
                           <SelectTrigger className="h-8 w-full rounded-md border border-white/10 bg-white px-3 py-2 text-sm text-[#1F2933] shadow-sm transition-all duration-200 hover:border-slate-400/50 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40">
                             <SelectValue placeholder="Select grade" />
                           </SelectTrigger>
-                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                             {[
                               'Grade 1',
                               'Grade 2',

--- a/tutorme-app/src/app/[locale]/register/student/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/student/page.tsx
@@ -399,7 +399,7 @@ export default function StudentRegistrationPage() {
                           <SelectTrigger className="h-8 w-full rounded-md border border-white/10 bg-white px-3 py-2 text-sm text-[#1F2933] shadow-sm transition-all duration-200 hover:border-slate-400/50 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-[#F97316]/40">
                             <SelectValue placeholder="Select Region..." />
                           </SelectTrigger>
-                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                             {REGIONS.filter(r => r.id !== 'global').map(regionItem => (
                               <SelectItem
                                 key={regionItem.id}
@@ -428,7 +428,7 @@ export default function StudentRegistrationPage() {
                           >
                             <SelectValue placeholder="Select Country" />
                           </SelectTrigger>
-                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                             {availableCountries.length === 0 ? (
                               <div className="py-3 text-center text-[13px] text-white/70">
                                 No countries available

--- a/tutorme-app/src/app/[locale]/register/tutor/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/tutor/page.tsx
@@ -864,7 +864,7 @@ export default function TutorRegistrationPage() {
                             <SelectTrigger className="h-8 w-full rounded-md border border-white/10 bg-white px-3 py-2 text-sm text-[#1F2933] shadow-sm transition-all duration-200 hover:border-slate-400/50 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-[#2563EB]/40">
                               <SelectValue placeholder="Select Region..." />
                             </SelectTrigger>
-                            <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                            <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                               {REGIONS.filter(r => r.id !== 'global').map(regionItem => (
                                 <SelectItem
                                   key={regionItem.id}
@@ -893,7 +893,7 @@ export default function TutorRegistrationPage() {
                             >
                               <SelectValue placeholder="Select Country" />
                             </SelectTrigger>
-                            <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 bg-[#1F2933] p-1.5 shadow-lg">
+                            <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-md border border-white/10 p-1.5 shadow-lg">
                               {availableCountries.length === 0 ? (
                                 <div className="py-3 text-center text-[13px] text-white/70">
                                   No countries available


### PR DESCRIPTION
Remove solid bg-[#1F2933] override from SelectContent components in all registration flows, allowing the default 50% transparent gradient with backdrop-blur to take effect.

Files changed:
- register/tutor/page.tsx (2 dropdowns)
- register/student/page.tsx (2 dropdowns)
- register/parent/page.tsx (2 dropdowns)
- register/admin/page.tsx (1 dropdown)