### PR TITLE
fix(course): stop two silent data-loss paths in save/propagation

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
@@ -163,6 +163,17 @@ export function useCourseBuilderContentModel({
     }
   ) => {
     const isDetached = dataMode === 'detached'
+
+    // Guard against wiping the course when its content never loaded. On a
+    // DB-backed course, loadedLessons stays null only when the load failed
+    // (a successfully-empty course loads as []). Saving an empty tree in that
+    // state would delete every lesson, so refuse it. (The server enforces the
+    // same floor; this just avoids firing the destructive request.)
+    if (!isDetached && !options?.isAutoSave && lessons.length === 0 && loadedLessons === null) {
+      toast.error('Lessons haven’t finished loading yet — reload the course before saving.')
+      return
+    }
+
     if (!options?.isAutoSave && !isDetached) setSaving(true)
 
     const result = await saveCourse({

--- a/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
@@ -9,7 +9,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { verifyCourseOwnership } from '@/lib/api/course-helpers'
-import { CourseBuilderService, LESSON_DEPLOYED_ERROR } from '@/lib/services/course-builder.service'
+import {
+  CourseBuilderService,
+  LESSON_DEPLOYED_ERROR,
+  EMPTY_SAVE_ERROR,
+} from '@/lib/services/course-builder.service'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseVariant } from '@/lib/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
@@ -105,13 +109,14 @@ export const PUT = withCsrf(
 
             for (const sibling of siblingVariants) {
               if (sibling.publishedCourseId === courseId) continue
-              // Propagation wholesale re-syncs the sibling's lessons; it isn't a
-              // user deletion, so it keeps its existing behavior (guard skipped).
-              await CourseBuilderService.updateCourseBuilderData(
+              // Correlate by `order` and update the sibling's OWN lesson rows in
+              // place. Feeding this course's lesson ids straight into
+              // updateCourseBuilderData deleted every sibling lesson (their ids
+              // never matched) and cascaded away their students' progress.
+              await CourseBuilderService.propagateLessonsByOrder(
                 sibling.publishedCourseId,
                 userId,
-                lessons,
-                { guardDeletions: false }
+                lessons
               )
             }
           }
@@ -130,6 +135,12 @@ export const PUT = withCsrf(
         if (error.message.includes(LESSON_DEPLOYED_ERROR)) {
           return NextResponse.json(
             { error: error.message.replace(`${LESSON_DEPLOYED_ERROR}: `, '') },
+            { status: 409 }
+          )
+        }
+        if (error.message.includes(EMPTY_SAVE_ERROR)) {
+          return NextResponse.json(
+            { error: error.message.replace(`${EMPTY_SAVE_ERROR}: `, '') },
             { status: 409 }
           )
         }

--- a/tutorme-app/src/lib/services/course-builder.service.ts
+++ b/tutorme-app/src/lib/services/course-builder.service.ts
@@ -1,6 +1,6 @@
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseLesson } from '@/lib/db/schema'
-import { eq, and, inArray, asc } from 'drizzle-orm'
+import { eq, and, inArray, asc, isNull } from 'drizzle-orm'
 import crypto from 'crypto'
 import { removeFile } from '@/lib/storage/service'
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
@@ -8,6 +8,14 @@ import { getLessonUsage } from '@/lib/courses/lesson-usage'
 
 /** Thrown when a save would hard-delete a lesson that has deployed material. */
 export const LESSON_DEPLOYED_ERROR = 'LESSON_HAS_DEPLOYMENTS'
+
+/**
+ * Thrown when a save would delete EVERY lesson on a course that currently has
+ * lessons — almost always a failed content-load (the editor serializes an empty
+ * tree) rather than a real "clear the whole course". Callers can pass
+ * `allowEmpty` to override for a genuine full clear.
+ */
+export const EMPTY_SAVE_ERROR = 'EMPTY_LESSON_SAVE'
 
 export interface BuilderLessonMedia {
   videos: unknown[]
@@ -117,6 +125,25 @@ export async function deleteGcsFiles(keys: string[]): Promise<void> {
   }
 }
 
+/** Build the `builderData` JSONB payload for a lesson row from builder input. */
+function toLessonBuilderData(les: BuilderLessonInput) {
+  const media = les.media ?? { videos: [], images: [] }
+  return {
+    isPublished: les.isPublished ?? false,
+    duration: les.duration ?? 45,
+    difficultyMode: les.difficultyMode ?? 'all',
+    variants: les.variants ?? {},
+    media,
+    docs: les.docs ?? [],
+    content: les.content ?? [],
+    tasks: les.tasks ?? [],
+    assessments: les.assessments ?? [],
+    homework: les.homework ?? [],
+    quizzes: les.quizzes ?? [],
+    worksheets: les.worksheets ?? [],
+  }
+}
+
 export class CourseBuilderService {
   /**
    * Scan all lessons in a course for fileKeys and delete the GCS objects.
@@ -218,9 +245,16 @@ export class CourseBuilderService {
        * wholesale re-syncs a sibling's lessons and is not a user deletion.
        */
       guardDeletions?: boolean
+      /**
+       * Allow a save that clears every lesson on a course that currently has
+       * lessons. Defaults to false — an empty payload against a non-empty course
+       * is almost always a failed content-load, not an intentional full clear.
+       */
+      allowEmpty?: boolean
     }
   ): Promise<void> {
     const guardDeletions = options?.guardDeletions ?? true
+    const allowEmpty = options?.allowEmpty ?? false
     // Verify ownership
     const [courseRow] = await drizzleDb
       .select({ courseId: course.courseId })
@@ -255,6 +289,17 @@ export class CourseBuilderService {
 
     const oldFileKeys = collectFileKeys(existingLessons.map(l => l.builderData))
 
+    // Floor guard: never let an empty payload wipe a course that has lessons.
+    // This is the signature of a failed content-load (the editor serializes an
+    // empty tree) — refuse it rather than silently deleting the whole course
+    // (and cascading student progress). A genuine full clear passes allowEmpty.
+    if (!allowEmpty && lessons.length === 0 && existingLessons.length > 0) {
+      throw new Error(
+        `${EMPTY_SAVE_ERROR}: refusing to delete all ${existingLessons.length} lesson(s) on an ` +
+          `empty save — the editor may not have finished loading. Reload the course and try again.`
+      )
+    }
+
     await drizzleDb.transaction(async tx => {
       const existingDbLessons = await tx
         .select({ id: courseLesson.lessonId })
@@ -288,21 +333,7 @@ export class CourseBuilderService {
       for (const [idx, les] of incomingLessons.entries()) {
         if (!les.id) les.id = crypto.randomUUID()
 
-        const media = les.media ?? { videos: [], images: [] }
-        const builderData = {
-          isPublished: les.isPublished ?? false,
-          duration: les.duration ?? 45,
-          difficultyMode: les.difficultyMode ?? 'all',
-          variants: les.variants ?? {},
-          media,
-          docs: les.docs ?? [],
-          content: les.content ?? [],
-          tasks: les.tasks ?? [],
-          assessments: les.assessments ?? [],
-          homework: les.homework ?? [],
-          quizzes: les.quizzes ?? [],
-          worksheets: les.worksheets ?? [],
-        }
+        const builderData = toLessonBuilderData(les)
 
         await tx
           .insert(courseLesson)
@@ -339,5 +370,92 @@ export class CourseBuilderService {
     if (orphanedKeys.length > 0) {
       await deleteGcsFiles(orphanedKeys)
     }
+  }
+
+  /**
+   * Propagate a source course's lessons into a TARGET course (a sibling
+   * published variant) by correlating lessons on `order` — the only stable
+   * template↔published key (see lesson-usage.ts). Matched positions are updated
+   * IN PLACE, preserving the target's own `lessonId`s so DeployedMaterial,
+   * live-session, and student-progress links survive; added positions are
+   * inserted; dropped positions are deleted only when nothing has been deployed
+   * from them.
+   *
+   * This is the SAFE replacement for feeding a foreign course's lessons into
+   * updateCourseBuilderData: because sibling variants carry distinct lessonIds,
+   * that path deleted every target lesson and then no-op'd on the id conflicts,
+   * leaving the sibling empty and cascading away its students' progress.
+   */
+  static async propagateLessonsByOrder(
+    targetCourseId: string,
+    userId: string,
+    lessons: unknown
+  ): Promise<void> {
+    const [courseRow] = await drizzleDb
+      .select({ courseId: course.courseId })
+      .from(course)
+      .where(and(eq(course.courseId, targetCourseId), eq(course.creatorId, userId)))
+    if (!courseRow) {
+      throw new Error('Course not found or access denied')
+    }
+    if (!Array.isArray(lessons)) {
+      throw new Error('Invalid payload: expected lessons array')
+    }
+    const sourceLessons = lessons as BuilderLessonInput[]
+
+    await drizzleDb.transaction(async tx => {
+      const existing = await tx
+        .select({ lessonId: courseLesson.lessonId, order: courseLesson.order })
+        .from(courseLesson)
+        .where(and(eq(courseLesson.courseId, targetCourseId), isNull(courseLesson.deletedAt)))
+        .orderBy(asc(courseLesson.order))
+
+      const targetIdByOrder = new Map<number, string>()
+      for (const l of existing) {
+        const ord = l.order ?? 0
+        if (!targetIdByOrder.has(ord)) targetIdByOrder.set(ord, l.lessonId)
+      }
+
+      const sourceOrders = new Set<number>()
+      for (const [idx, les] of sourceLessons.entries()) {
+        sourceOrders.add(idx)
+        const builderData = toLessonBuilderData(les)
+        const targetId = targetIdByOrder.get(idx)
+        if (targetId) {
+          await tx
+            .update(courseLesson)
+            .set({
+              title: les.title || 'Untitled Lesson',
+              description: les.description || null,
+              duration: les.duration ?? 60,
+              order: idx,
+              builderData,
+              updatedAt: new Date(),
+            })
+            .where(eq(courseLesson.lessonId, targetId))
+        } else {
+          await tx.insert(courseLesson).values({
+            lessonId: crypto.randomUUID(),
+            courseId: targetCourseId,
+            title: les.title || 'Untitled Lesson',
+            description: les.description || null,
+            duration: les.duration ?? 60,
+            order: idx,
+            builderData,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+        }
+      }
+
+      const removedIds = existing.filter(l => !sourceOrders.has(l.order ?? 0)).map(l => l.lessonId)
+      if (removedIds.length > 0) {
+        const usage = await getLessonUsage(targetCourseId, removedIds)
+        const deletable = removedIds.filter(id => !usage[id]?.hasDeployments)
+        if (deletable.length > 0) {
+          await tx.delete(courseLesson).where(inArray(courseLesson.lessonId, deletable))
+        }
+      }
+    })
   }
 }


### PR DESCRIPTION
Two verified silent data-loss bugs on the course save path (found during a review of the save→publish→propagate flow, re-verified against current `origin/main`).

## HIGH 1 — Saving a multi-variant published course wiped its sibling variants
Manually saving a published course with multiple variants auto-fires `propagateToVariants` (`insights/page.tsx` `handleSave`), which passed **this** course's lesson objects — carrying **this** course's `lessonId`s — into `updateCourseBuilderData` for each sibling. Because siblings have their own distinct ids:
1. every sibling lesson was deleted (guard was skipped), then
2. the re-inserts hit `onConflictDoUpdate` on the source's ids (`courseId` not in the update set), so they just re-updated the source rows.

Net: **the sibling ended up with zero lessons**, and enrolled students' progress cascaded away (`courseLessonProgress`/`lessonLearningSession` are `onDelete: cascade`).

**Fix:** new `CourseBuilderService.propagateLessonsByOrder` — correlates by `order`, updates each sibling's **own** rows in place (preserving their `lessonId`s), inserts added lessons, and deletes dropped ones only when nothing was deployed from them.

## HIGH 2 — An empty/failed-load Save could wipe the whole course
`updateCourseBuilderData` hard-deletes any lesson not in the payload; the only guard was for *deployed* lessons. An empty `lessons: []` (the signature of a failed content-load) deleted every non-deployed lesson.

**Fix:** server-side floor guard — refuse to delete **all** lessons on an empty save unless an explicit `allowEmpty` flag is passed (`EMPTY_SAVE_ERROR` → 409 with a clear message). Plus a client guard in the builder content model: don't fire the save when `lessons.length === 0 && loadedLessons === null`.

Also extracted `toLessonBuilderData()` shared by both write paths.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)