### PR TITLE
feat(course): stable sourceLessonId linkage + soft-delete-aware builder read

### DIFF
--- a/tutorme-app/drizzle/0066_courselesson_source_lesson.sql
+++ b/tutorme-app/drizzle/0066_courselesson_source_lesson.sql
@@ -1,0 +1,8 @@
+-- CourseLesson.sourceLessonId: the template lesson a published-variant lesson was
+--   copied from at publish time. Lets published lessons correlate back to their
+--   template lesson by a stable id instead of by `order` (which breaks when the
+--   tutor reorders lessons). Null on template rows and on pre-existing rows until
+--   backfilled (see startup-cleanup backfill, matched by order).
+-- Nullable, no FK (soft reference); idempotent (also applied via startup-schema-fix
+-- so a revision that skips migrations still gets it before serving traffic).
+ALTER TABLE "CourseLesson" ADD COLUMN IF NOT EXISTS "sourceLessonId" text;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1781900000065,
       "tag": "0065_live_lesson_linkage",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1781900000066,
+      "tag": "0066_courselesson_source_lesson",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/course/route.ts
@@ -109,11 +109,11 @@ export const PUT = withCsrf(
 
             for (const sibling of siblingVariants) {
               if (sibling.publishedCourseId === courseId) continue
-              // Correlate by `order` and update the sibling's OWN lesson rows in
-              // place. Feeding this course's lesson ids straight into
-              // updateCourseBuilderData deleted every sibling lesson (their ids
-              // never matched) and cascaded away their students' progress.
-              await CourseBuilderService.propagateLessonsByOrder(
+              // Correlate by shared sourceLessonId (fallback: order) and update the
+              // sibling's OWN lesson rows in place. Feeding this course's lesson ids
+              // straight into updateCourseBuilderData deleted every sibling lesson
+              // (their ids never matched) and cascaded away their students' progress.
+              await CourseBuilderService.propagateLessonsToVariant(
                 sibling.publishedCourseId,
                 userId,
                 lessons

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -440,15 +440,24 @@ export const POST = withCsrf(
                 // Propagate the template's lesson edits into this already-
                 // published variant. Publish previously copied lessons only when
                 // a variant was first created, so re-publishing never updated the
-                // live lessons. We correlate template↔published lessons by `order`
-                // (the only stable key — see lesson-usage.ts):
-                //   • same order  → update the published lesson IN PLACE, keeping
-                //     its id so DeployedMaterial / live-session links survive;
-                //   • new order   → insert a published copy of the added lesson;
-                //   • dropped order→ delete the published lesson only when nothing
-                //     has been deployed from it, so live classes keep working.
+                // live lessons. We correlate template↔published lessons by
+                // `sourceLessonId` (stamped at copy time), falling back to `order`
+                // for rows copied before that linkage existed:
+                //   • matched   → update the published lesson IN PLACE, keeping its
+                //     id so DeployedMaterial / live-session links survive, and
+                //     re-sync its `order` to the template;
+                //   • unmatched template lesson → insert a published copy;
+                //   • unmatched published lesson (dropped from template) → delete
+                //     only when nothing has been deployed from it.
+                // Correlating by id (not position) means reordering the template
+                // updates the RIGHT published lesson instead of whatever now sits
+                // at that slot.
                 const publishedLessonRows = await tx
-                  .select({ lessonId: courseLesson.lessonId, order: courseLesson.order })
+                  .select({
+                    lessonId: courseLesson.lessonId,
+                    order: courseLesson.order,
+                    sourceLessonId: courseLesson.sourceLessonId,
+                  })
                   .from(courseLesson)
                   .where(
                     and(
@@ -458,32 +467,41 @@ export const POST = withCsrf(
                   )
                   .orderBy(courseLesson.order)
 
-                const publishedIdByOrder = new Map<number, string>()
+                const publishedBySource = new Map<string, string>()
+                const publishedByOrder = new Map<number, string>()
                 for (const l of publishedLessonRows) {
+                  if (l.sourceLessonId && !publishedBySource.has(l.sourceLessonId)) {
+                    publishedBySource.set(l.sourceLessonId, l.lessonId)
+                  }
                   const ord = l.order ?? 0
-                  if (!publishedIdByOrder.has(ord)) publishedIdByOrder.set(ord, l.lessonId)
+                  if (!publishedByOrder.has(ord)) publishedByOrder.set(ord, l.lessonId)
                 }
 
-                const templateOrders = new Set<number>()
-                for (const lesson of templateLessons) {
-                  const ord = lesson.order ?? 0
-                  templateOrders.add(ord)
-                  const existingLessonId = publishedIdByOrder.get(ord)
-                  if (existingLessonId) {
+                const claimedPublishedIds = new Set<string>()
+                for (const [idx, lesson] of templateLessons.entries()) {
+                  const ord = lesson.order ?? idx
+                  const matchId =
+                    publishedBySource.get(lesson.lessonId) ?? publishedByOrder.get(ord)
+                  if (matchId && !claimedPublishedIds.has(matchId)) {
+                    claimedPublishedIds.add(matchId)
                     await tx
                       .update(courseLesson)
                       .set({
+                        // (Re)assert the linkage — backfills order-matched legacy rows.
+                        sourceLessonId: lesson.lessonId,
                         title: lesson.title,
                         description: lesson.description,
                         duration: lesson.duration ?? 60,
+                        order: ord,
                         builderData: lesson.builderData,
                         updatedAt: now,
                       })
-                      .where(eq(courseLesson.lessonId, existingLessonId))
+                      .where(eq(courseLesson.lessonId, matchId))
                   } else {
                     await tx.insert(courseLesson).values({
                       lessonId: crypto.randomUUID(),
                       courseId: publishedCourseId,
+                      sourceLessonId: lesson.lessonId,
                       title: lesson.title,
                       description: lesson.description,
                       duration: lesson.duration ?? 60,
@@ -496,7 +514,7 @@ export const POST = withCsrf(
                 }
 
                 const removedLessonIds = publishedLessonRows
-                  .filter(l => !templateOrders.has(l.order ?? 0))
+                  .filter(l => !claimedPublishedIds.has(l.lessonId))
                   .map(l => l.lessonId)
                 if (removedLessonIds.length > 0) {
                   const deployedRows = await tx
@@ -541,11 +559,13 @@ export const POST = withCsrf(
                 isFree,
               })
 
-              // Copy lessons
+              // Copy lessons — stamp sourceLessonId so each published copy can be
+              // correlated back to its template lesson by a stable id later.
               for (const lesson of templateLessons) {
                 await tx.insert(courseLesson).values({
                   lessonId: crypto.randomUUID(),
                   courseId: publishedCourseId,
+                  sourceLessonId: lesson.lessonId,
                   title: lesson.title,
                   description: lesson.description,
                   duration: lesson.duration ?? 60,

--- a/tutorme-app/src/lib/db/schema/tables/course.ts
+++ b/tutorme-app/src/lib/db/schema/tables/course.ts
@@ -96,6 +96,12 @@ export const courseLesson = pgTable(
     description: text('description'),
     duration: integer('duration').notNull().default(60),
     order: integer('order').notNull(),
+    // The template lesson this row was copied from at publish time. Lets published
+    // variants correlate back to their template lesson by a stable id instead of
+    // by `order` (which breaks when lessons are reordered). Null on template rows
+    // and on pre-existing rows until backfilled. Soft reference (no FK) — a
+    // dropped template lesson just leaves a dangling value, which callers ignore.
+    sourceLessonId: text('sourceLessonId'),
     // Builder data contains all lesson content (tasks, assessments, homework, media, etc.)
     builderData: jsonb('builderData').default({}),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),

--- a/tutorme-app/src/lib/db/startup-cleanup.ts
+++ b/tutorme-app/src/lib/db/startup-cleanup.ts
@@ -24,6 +24,26 @@ WHERE "courseId" IS NULL
   );
 `)
 
+/**
+ * Backfill CourseLesson.sourceLessonId for published-variant lessons that
+ * predate the linkage (drizzle/0066). We use the historical correlation —
+ * template↔published lessons at the same `order` — which is the best we have for
+ * existing rows; newly copied lessons are stamped at publish time. Idempotent:
+ * only touches rows whose sourceLessonId is still NULL.
+ */
+const BACKFILL_SOURCE_LESSON_SQL = sql.raw(`
+UPDATE "CourseLesson" AS pub
+SET "sourceLessonId" = tmpl."id"
+FROM "CourseVariant" cv
+JOIN "CourseLesson" tmpl
+  ON tmpl."courseId" = cv."templateCourseId"
+  AND tmpl."order" = pub."order"
+  AND tmpl."deletedAt" IS NULL
+WHERE pub."courseId" = cv."publishedCourseId"
+  AND pub."sourceLessonId" IS NULL
+  AND pub."deletedAt" IS NULL;
+`)
+
 export async function applyStartupDataCleanup(): Promise<void> {
   try {
     const result = await drizzleDb.execute(CLEANUP_SQL)
@@ -35,6 +55,19 @@ export async function applyStartupDataCleanup(): Promise<void> {
     // Never block boot on a cleanup — log and move on.
     console.error(
       '⚠️ [Server] Orphaned-session cleanup skipped:',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  try {
+    const result = await drizzleDb.execute(BACKFILL_SOURCE_LESSON_SQL)
+    const count = (result as { rowCount?: number })?.rowCount ?? 0
+    if (count > 0) {
+      console.log(`[Server] Data cleanup: backfilled sourceLessonId on ${count} lesson(s).`)
+    }
+  } catch (err) {
+    console.error(
+      '⚠️ [Server] sourceLessonId backfill skipped:',
       err instanceof Error ? err.message : err
     )
   }

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -146,6 +146,10 @@ ALTER TABLE "BuilderTask" ADD COLUMN IF NOT EXISTS "pciSpec" jsonb;
 ALTER TABLE "LiveSession" ADD COLUMN IF NOT EXISTS "lessonId" text;
 ALTER TABLE "DeployedMaterial" ADD COLUMN IF NOT EXISTS "lessonId" text;
 
+-- Source-lesson linkage (drizzle/0066): the template lesson a published-variant
+-- lesson was copied from, so correlation survives lesson reordering. Nullable.
+ALTER TABLE "CourseLesson" ADD COLUMN IF NOT EXISTS "sourceLessonId" text;
+
 -- TaskDeploymentStatus enum
 DO $$
 BEGIN

--- a/tutorme-app/src/lib/services/course-builder.service.ts
+++ b/tutorme-app/src/lib/services/course-builder.service.ts
@@ -183,11 +183,13 @@ export class CourseBuilderService {
       throw new Error('Course not found or access denied')
     }
 
-    // Load lessons
+    // Load lessons. Filter soft-deleted rows to match the other readers
+    // (progress, submissions, publish) — otherwise the builder would show and
+    // re-save a lesson those views already hide.
     const dbLessons = await drizzleDb
       .select()
       .from(courseLesson)
-      .where(eq(courseLesson.courseId, courseId))
+      .where(and(eq(courseLesson.courseId, courseId), isNull(courseLesson.deletedAt)))
       .orderBy(asc(courseLesson.order))
 
     // Transform to expected frontend structure
@@ -373,20 +375,21 @@ export class CourseBuilderService {
   }
 
   /**
-   * Propagate a source course's lessons into a TARGET course (a sibling
-   * published variant) by correlating lessons on `order` — the only stable
-   * template↔published key (see lesson-usage.ts). Matched positions are updated
-   * IN PLACE, preserving the target's own `lessonId`s so DeployedMaterial,
-   * live-session, and student-progress links survive; added positions are
-   * inserted; dropped positions are deleted only when nothing has been deployed
-   * from them.
+   * Propagate a source published variant's lessons into a TARGET sibling variant.
+   * Two variants' lessons correlate when they share a `sourceLessonId` (both were
+   * copied from the same template lesson); we fall back to `order` for rows that
+   * predate that linkage. Matched lessons are updated IN PLACE, preserving the
+   * target's own `lessonId` (so DeployedMaterial, live-session, and
+   * student-progress links survive); unmatched source lessons are inserted;
+   * target lessons no longer present in the source are deleted only when nothing
+   * has been deployed from them.
    *
    * This is the SAFE replacement for feeding a foreign course's lessons into
    * updateCourseBuilderData: because sibling variants carry distinct lessonIds,
    * that path deleted every target lesson and then no-op'd on the id conflicts,
    * leaving the sibling empty and cascading away its students' progress.
    */
-  static async propagateLessonsByOrder(
+  static async propagateLessonsToVariant(
     targetCourseId: string,
     userId: string,
     lessons: unknown
@@ -403,28 +406,54 @@ export class CourseBuilderService {
     }
     const sourceLessons = lessons as BuilderLessonInput[]
 
+    // Resolve each source lesson's template origin (sourceLessonId) so we can
+    // correlate to the sibling by a stable id instead of by position.
+    const sourceIds = sourceLessons.map(l => l.id).filter((id): id is string => Boolean(id))
+    const originBySourceId = new Map<string, string>()
+    if (sourceIds.length > 0) {
+      const rows = await drizzleDb
+        .select({ lessonId: courseLesson.lessonId, sourceLessonId: courseLesson.sourceLessonId })
+        .from(courseLesson)
+        .where(inArray(courseLesson.lessonId, sourceIds))
+      for (const r of rows) {
+        if (r.sourceLessonId) originBySourceId.set(r.lessonId, r.sourceLessonId)
+      }
+    }
+
     await drizzleDb.transaction(async tx => {
       const existing = await tx
-        .select({ lessonId: courseLesson.lessonId, order: courseLesson.order })
+        .select({
+          lessonId: courseLesson.lessonId,
+          order: courseLesson.order,
+          sourceLessonId: courseLesson.sourceLessonId,
+        })
         .from(courseLesson)
         .where(and(eq(courseLesson.courseId, targetCourseId), isNull(courseLesson.deletedAt)))
         .orderBy(asc(courseLesson.order))
 
-      const targetIdByOrder = new Map<number, string>()
+      const targetBySource = new Map<string, string>()
+      const targetByOrder = new Map<number, string>()
       for (const l of existing) {
+        if (l.sourceLessonId && !targetBySource.has(l.sourceLessonId)) {
+          targetBySource.set(l.sourceLessonId, l.lessonId)
+        }
         const ord = l.order ?? 0
-        if (!targetIdByOrder.has(ord)) targetIdByOrder.set(ord, l.lessonId)
+        if (!targetByOrder.has(ord)) targetByOrder.set(ord, l.lessonId)
       }
 
-      const sourceOrders = new Set<number>()
+      const claimed = new Set<string>()
       for (const [idx, les] of sourceLessons.entries()) {
-        sourceOrders.add(idx)
         const builderData = toLessonBuilderData(les)
-        const targetId = targetIdByOrder.get(idx)
-        if (targetId) {
+        const origin = les.id ? originBySourceId.get(les.id) : undefined
+        const targetId = (origin ? targetBySource.get(origin) : undefined) ?? targetByOrder.get(idx)
+        if (targetId && !claimed.has(targetId)) {
+          claimed.add(targetId)
           await tx
             .update(courseLesson)
             .set({
+              // Only (re)assert the linkage when we know the origin; never blank
+              // out a good sourceLessonId the target already has.
+              ...(origin ? { sourceLessonId: origin } : {}),
               title: les.title || 'Untitled Lesson',
               description: les.description || null,
               duration: les.duration ?? 60,
@@ -437,6 +466,7 @@ export class CourseBuilderService {
           await tx.insert(courseLesson).values({
             lessonId: crypto.randomUUID(),
             courseId: targetCourseId,
+            sourceLessonId: origin ?? null,
             title: les.title || 'Untitled Lesson',
             description: les.description || null,
             duration: les.duration ?? 60,
@@ -448,7 +478,7 @@ export class CourseBuilderService {
         }
       }
 
-      const removedIds = existing.filter(l => !sourceOrders.has(l.order ?? 0)).map(l => l.lessonId)
+      const removedIds = existing.filter(l => !claimed.has(l.lessonId)).map(l => l.lessonId)
       if (removedIds.length > 0) {
         const usage = await getLessonUsage(targetCourseId, removedIds)
         const deletable = removedIds.filter(id => !usage[id]?.hasDeployments)


### PR DESCRIPTION
Two robustness improvements to the template↔published lesson subsystem (the follow-ups flagged after the data-loss fixes).

## 1. Stable `sourceLessonId` linkage (replaces fragile positional correlation)
Template↔published lessons were correlated only by `order`, so reordering template lessons and re-publishing would map a lesson's content onto whatever published lesson now sat at that position — corrupting the deployed-material/session association.

Published-variant lessons now carry **`sourceLessonId`** (the template lesson they were copied from). Correlation matches by this stable id first, falling back to `order` for rows that predate the column:
- **schema:** `CourseLesson.sourceLessonId` (nullable, soft reference, no FK)
- **migration:** `drizzle/0066` + `startup-schema-fix` mirror (safe when migrations are skipped in prod)
- **stamped** on first-publish copy and on re-publish propagation inserts
- **re-publish propagation** (publish route) and **sibling propagation** (`propagateLessonsToVariant`, renamed from `propagateLessonsByOrder`) both match by `sourceLessonId` first; **removal is now driven by which published rows were actually claimed**, not by order — so reordered/dropped lessons are handled correctly and matched lessons keep their id (and their DeployedMaterial / live-session / progress links)
- **idempotent backfill** on boot sets `sourceLessonId` for existing published lessons via the historical order correlation (only NULL rows)

## 2. Soft-delete-aware builder read
`getCourseBuilderData` now filters `isNull(deletedAt)`, matching the progress/submissions/publish readers — so the builder can't show and re-save (resurrect) a lesson those views already hide.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

Note: `order` remains the display sequence and is re-synced to the template on propagation, so order-based readers (session auto-assignment, the delete-guard's lesson-usage) stay consistent; `sourceLessonId` is used purely for correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)