### PR TITLE
fix(tutor/settings): remove scrollable wrappers from TabsContent to m…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -665,262 +665,146 @@ export default function TutorSettings() {
           ]}
         >
           {/* Profile & Identity */}
-          <TabsContent value="profile" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Your Profile"
-                icon={<User className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="space-y-6 p-6">
-                  {/* Avatar */}
-                  <div className="flex items-center gap-4">
-                    <AvatarUploader
-                      avatarUrl={formData.avatarUrl}
-                      uploadUrl="/api/tutor/public-profile/avatar"
-                      deleteUrl="/api/tutor/public-profile/avatar"
-                      size={80}
-                      fallbackText={formData.name.charAt(0).toUpperCase() || '?'}
-                      onUploadSuccess={url => {
-                        const busted = `${url}${url.includes('?') ? '&' : '?'}t=${Date.now()}`
-                        setFormData(prev => ({ ...prev, avatarUrl: busted }))
-                        updateSession({ image: busted }).catch(() => {})
-                      }}
-                      onDeleteSuccess={() => {
-                        setFormData(prev => ({ ...prev, avatarUrl: '' }))
-                        updateSession({ image: null }).catch(() => {})
-                      }}
-                    />
-                    <div className="flex-1">
-                      <Label>Profile Photo</Label>
-                      <p className="mt-1 text-xs text-gray-500">Upload a profile photo</p>
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  {/* Name & Email */}
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="name">Full Name</Label>
-                      <Input id="name" value={formData.name} disabled className="bg-white" />
-                      <p className="text-xs text-gray-500">
-                        Contact{' '}
-                        <a
-                          href="mailto:support@solocorn.co"
-                          className="text-blue-600 hover:underline"
-                        >
-                          support@solocorn.co
-                        </a>{' '}
-                        to change your name
-                      </p>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="email">Email Address</Label>
-                      <Input id="email" value={formData.email} disabled className="bg-white" />
-                      <p className="text-xs text-gray-500">
-                        Contact{' '}
-                        <a
-                          href="mailto:support@solocorn.co"
-                          className="text-blue-600 hover:underline"
-                        >
-                          support@solocorn.co
-                        </a>{' '}
-                        to change your email
-                      </p>
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  {/* Language & Timezone */}
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="language">Preferred Language</Label>
-                      <select
-                        id="language"
-                        value={formData.language}
-                        onChange={e => setFormData({ ...formData, language: e.target.value })}
-                        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
-                      >
-                        {LANGUAGES.map(lang => (
-                          <option key={lang.code} value={lang.code}>
-                            {lang.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="timezone">Timezone</Label>
-                      <Input
-                        id="timezone"
-                        value={formData.timezone}
-                        disabled
-                        className="bg-white"
-                      />
-                      <p className="text-xs text-gray-500">Automatically detected</p>
-                    </div>
-                  </div>
-
-                  <Separator />
-
-                  {/* Bio Preview */}
-                  <div className="space-y-4">
-                    <div className="min-w-0 flex-1">
-                      <p className="font-medium text-slate-900">{formData.name || 'Your Name'}</p>
-                      <p className="mt-1 line-clamp-3 text-sm text-slate-500">
-                        {formData.bio ||
-                          'No bio added yet. Your bio helps students learn more about you.'}
-                      </p>
-                    </div>
-
-                    {Object.entries(formData.socialLinks).filter(([, v]) => v).length > 0 && (
-                      <div className="flex flex-wrap gap-2">
-                        {Object.entries(formData.socialLinks)
-                          .filter(([, v]) => v)
-                          .map(([platform, url]) => (
-                            <a
-                              key={platform}
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-200"
-                            >
-                              {platform.charAt(0).toUpperCase() + platform.slice(1)}
-                            </a>
-                          ))}
-                      </div>
-                    )}
-                  </div>
-
-                  <Separator />
-
-                  {/* Nationality */}
-                  <div className="space-y-2">
-                    <Label className="inline-flex items-center gap-1.5">
-                      <CountryFlag countryName={formData.nationality} size="xs" />
-                      Nationality
-                    </Label>
-                    <Input
-                      value={formData.nationality || 'Not specified'}
-                      disabled
-                      className="bg-white"
-                    />
-                    <div className="flex justify-end">
-                      <Button
-                        className="bg-[#2563EB] text-white hover:border-[#2563EB] hover:bg-white hover:text-[#2563EB]"
-                        onClick={handleSaveProfile}
-                        disabled={saving}
-                      >
-                        {saving ? (
-                          <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            Saving...
-                          </>
-                        ) : (
-                          <>
-                            <Save className="mr-2 h-4 w-4" />
-                            Save
-                          </>
-                        )}
-                      </Button>
-                    </div>
+          <TabsContent value="profile" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Your Profile"
+              icon={<User className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="space-y-6 p-6">
+                {/* Avatar */}
+                <div className="flex items-center gap-4">
+                  <AvatarUploader
+                    avatarUrl={formData.avatarUrl}
+                    uploadUrl="/api/tutor/public-profile/avatar"
+                    deleteUrl="/api/tutor/public-profile/avatar"
+                    size={80}
+                    fallbackText={formData.name.charAt(0).toUpperCase() || '?'}
+                    onUploadSuccess={url => {
+                      const busted = `${url}${url.includes('?') ? '&' : '?'}t=${Date.now()}`
+                      setFormData(prev => ({ ...prev, avatarUrl: busted }))
+                      updateSession({ image: busted }).catch(() => {})
+                    }}
+                    onDeleteSuccess={() => {
+                      setFormData(prev => ({ ...prev, avatarUrl: '' }))
+                      updateSession({ image: null }).catch(() => {})
+                    }}
+                  />
+                  <div className="flex-1">
+                    <Label>Profile Photo</Label>
+                    <p className="mt-1 text-xs text-gray-500">Upload a profile photo</p>
                   </div>
                 </div>
-              </CollapsibleCard>
 
-              {/* Tax Information */}
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Tax Information"
-                description="Required for payout and tax reporting"
-                icon={<FileText className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label>Region</Label>
-                      <Select
-                        value={taxRegion}
-                        onValueChange={value => {
-                          setTaxRegion(value)
-                          setTaxCountry('')
-                        }}
+                <Separator />
+
+                {/* Name & Email */}
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Full Name</Label>
+                    <Input id="name" value={formData.name} disabled className="bg-white" />
+                    <p className="text-xs text-gray-500">
+                      Contact{' '}
+                      <a
+                        href="mailto:support@solocorn.co"
+                        className="text-blue-600 hover:underline"
                       >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select region" />
-                        </SelectTrigger>
-                        <SelectContent className="max-h-72">
-                          {REGIONS.map(region => (
-                            <SelectItem key={region.id} value={region.id}>
-                              {region.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Country</Label>
-                      <Select
-                        value={taxCountry}
-                        onValueChange={setTaxCountry}
-                        disabled={!taxRegion}
-                      >
-                        <SelectTrigger>
-                          <SelectValue
-                            placeholder={taxRegion ? 'Select country' : 'Select region first'}
-                          />
-                        </SelectTrigger>
-                        <SelectContent className="max-h-72">
-                          {taxCountryOptions.map(country => (
-                            <SelectItem key={country.code} value={country.code}>
-                              {country.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Legal Name</Label>
-                      <Input
-                        value={taxLegalName}
-                        onChange={e => setTaxLegalName(e.target.value)}
-                        placeholder="Legal name"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Address</Label>
-                      <Input
-                        value={taxAddress}
-                        onChange={e => setTaxAddress(e.target.value)}
-                        placeholder="Registered address"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Tax ID (optional)</Label>
-                      <Input
-                        value={taxId}
-                        onChange={e => setTaxId(e.target.value)}
-                        placeholder="Tax ID"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Business / Individual</Label>
-                      <Select value={taxEntityType} onValueChange={setTaxEntityType}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select type" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="Individual">Individual</SelectItem>
-                          <SelectItem value="Business">Business</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
+                        support@solocorn.co
+                      </a>{' '}
+                      to change your name
+                    </p>
                   </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Email Address</Label>
+                    <Input id="email" value={formData.email} disabled className="bg-white" />
+                    <p className="text-xs text-gray-500">
+                      Contact{' '}
+                      <a
+                        href="mailto:support@solocorn.co"
+                        className="text-blue-600 hover:underline"
+                      >
+                        support@solocorn.co
+                      </a>{' '}
+                      to change your email
+                    </p>
+                  </div>
+                </div>
+
+                <Separator />
+
+                {/* Language & Timezone */}
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="language">Preferred Language</Label>
+                    <select
+                      id="language"
+                      value={formData.language}
+                      onChange={e => setFormData({ ...formData, language: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    >
+                      {LANGUAGES.map(lang => (
+                        <option key={lang.code} value={lang.code}>
+                          {lang.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="timezone">Timezone</Label>
+                    <Input id="timezone" value={formData.timezone} disabled className="bg-white" />
+                    <p className="text-xs text-gray-500">Automatically detected</p>
+                  </div>
+                </div>
+
+                <Separator />
+
+                {/* Bio Preview */}
+                <div className="space-y-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="font-medium text-slate-900">{formData.name || 'Your Name'}</p>
+                    <p className="mt-1 line-clamp-3 text-sm text-slate-500">
+                      {formData.bio ||
+                        'No bio added yet. Your bio helps students learn more about you.'}
+                    </p>
+                  </div>
+
+                  {Object.entries(formData.socialLinks).filter(([, v]) => v).length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {Object.entries(formData.socialLinks)
+                        .filter(([, v]) => v)
+                        .map(([platform, url]) => (
+                          <a
+                            key={platform}
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-200"
+                          >
+                            {platform.charAt(0).toUpperCase() + platform.slice(1)}
+                          </a>
+                        ))}
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                {/* Nationality */}
+                <div className="space-y-2">
+                  <Label className="inline-flex items-center gap-1.5">
+                    <CountryFlag countryName={formData.nationality} size="xs" />
+                    Nationality
+                  </Label>
+                  <Input
+                    value={formData.nationality || 'Not specified'}
+                    disabled
+                    className="bg-white"
+                  />
                   <div className="flex justify-end">
                     <Button
-                      onClick={() => toast.success('Tax information saved')}
+                      className="bg-[#2563EB] text-white hover:border-[#2563EB] hover:bg-white hover:text-[#2563EB]"
+                      onClick={handleSaveProfile}
                       disabled={saving}
                     >
                       {saving ? (
@@ -931,675 +815,763 @@ export default function TutorSettings() {
                       ) : (
                         <>
                           <Save className="mr-2 h-4 w-4" />
-                          Save Tax Info
+                          Save
                         </>
                       )}
                     </Button>
                   </div>
                 </div>
-              </CollapsibleCard>
-            </div>
+              </div>
+            </CollapsibleCard>
+
+            {/* Tax Information */}
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Tax Information"
+              description="Required for payout and tax reporting"
+              icon={<FileText className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Region</Label>
+                    <Select
+                      value={taxRegion}
+                      onValueChange={value => {
+                        setTaxRegion(value)
+                        setTaxCountry('')
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select region" />
+                      </SelectTrigger>
+                      <SelectContent className="max-h-72">
+                        {REGIONS.map(region => (
+                          <SelectItem key={region.id} value={region.id}>
+                            {region.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Country</Label>
+                    <Select value={taxCountry} onValueChange={setTaxCountry} disabled={!taxRegion}>
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={taxRegion ? 'Select country' : 'Select region first'}
+                        />
+                      </SelectTrigger>
+                      <SelectContent className="max-h-72">
+                        {taxCountryOptions.map(country => (
+                          <SelectItem key={country.code} value={country.code}>
+                            {country.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Legal Name</Label>
+                    <Input
+                      value={taxLegalName}
+                      onChange={e => setTaxLegalName(e.target.value)}
+                      placeholder="Legal name"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Address</Label>
+                    <Input
+                      value={taxAddress}
+                      onChange={e => setTaxAddress(e.target.value)}
+                      placeholder="Registered address"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Tax ID (optional)</Label>
+                    <Input
+                      value={taxId}
+                      onChange={e => setTaxId(e.target.value)}
+                      placeholder="Tax ID"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Business / Individual</Label>
+                    <Select value={taxEntityType} onValueChange={setTaxEntityType}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Individual">Individual</SelectItem>
+                        <SelectItem value="Business">Business</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button onClick={() => toast.success('Tax information saved')} disabled={saving}>
+                    {saving ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Save className="mr-2 h-4 w-4" />
+                        Save Tax Info
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* 1-on-1 Booking */}
-          <TabsContent value="1-on-1" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <OneOnOneSettingsCard />
-            </div>
+          <TabsContent value="1-on-1" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <OneOnOneSettingsCard />
           </TabsContent>
 
           {/* Billing & Payment */}
-          <TabsContent value="billing" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Payment Methods"
-                description="Manage your payment methods for subscription"
-                icon={<CreditCard className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="space-y-6 p-6">
-                  {paymentMethods.map(method => (
-                    <div
-                      key={method.id}
-                      className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50">
-                          <CreditCard className="h-5 w-5 text-blue-600" />
-                        </div>
-                        <div>
-                          <p className="font-medium">
-                            {method.brand} •••• {method.last4}{' '}
-                            {method.isDefault && (
-                              <span className="ml-2 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
-                                Default
-                              </span>
-                            )}
-                          </p>
-                          <p className="text-sm text-gray-500">
-                            Expires {method.expiryMonth}/{method.expiryYear}
-                          </p>
-                        </div>
+          <TabsContent value="billing" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Payment Methods"
+              description="Manage your payment methods for subscription"
+              icon={<CreditCard className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="space-y-6 p-6">
+                {paymentMethods.map(method => (
+                  <div
+                    key={method.id}
+                    className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50">
+                        <CreditCard className="h-5 w-5 text-blue-600" />
                       </div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-red-600 hover:text-red-700"
-                        onClick={() => removePaymentMethod(method.id)}
-                      >
-                        Remove
-                      </Button>
+                      <div>
+                        <p className="font-medium">
+                          {method.brand} •••• {method.last4}{' '}
+                          {method.isDefault && (
+                            <span className="ml-2 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                              Default
+                            </span>
+                          )}
+                        </p>
+                        <p className="text-sm text-gray-500">
+                          Expires {method.expiryMonth}/{method.expiryYear}
+                        </p>
+                      </div>
                     </div>
-                  ))}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-red-600 hover:text-red-700"
+                      onClick={() => removePaymentMethod(method.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
 
-                  <Button variant="outline" className="w-full">
-                    <CreditCard className="mr-2 h-4 w-4" />
-                    Add Payment Method
+                <Button variant="outline" className="w-full">
+                  <CreditCard className="mr-2 h-4 w-4" />
+                  Add Payment Method
+                </Button>
+              </div>
+            </CollapsibleCard>
+
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Subscription Plan"
+              description="Manage your tutor subscription"
+              icon={<DollarSign className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="space-y-2">
+                    <Label>Renew Subscription</Label>
+                    <Select value={renewTerm} onValueChange={setRenewTerm}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select term" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="1">1 month</SelectItem>
+                        <SelectItem value="2">2 months</SelectItem>
+                        <SelectItem value="12">1 year</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Subscription Cost</Label>
+                    <div className="h-10 rounded-md border bg-white px-3 py-2 text-sm">$15</div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Action</Label>
+                    <Button
+                      className="w-full bg-[#1D4ED8] text-white hover:bg-[#1E40AF]"
+                      onClick={() => toast.message('Subscription renewal queued')}
+                    >
+                      Renew
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button
+                    variant="outline"
+                    className="border-[#F59E0B] text-[#92400E] hover:bg-[#FDE68A]"
+                    onClick={() => {
+                      if (confirm('Are you sure you want to cancel your subscription?')) {
+                        toast.message(
+                          'Thank you for being with us. We hope you return another time.'
+                        )
+                      }
+                    }}
+                  >
+                    Cancel subscription
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => toast.message('Payment history loading')}
+                  >
+                    Payment history
+                  </Button>
+                  <Button variant="outline" onClick={() => toast.message('Billing details')}>
+                    Billing
                   </Button>
                 </div>
-              </CollapsibleCard>
+              </div>
+            </CollapsibleCard>
 
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Subscription Plan"
-                description="Manage your tutor subscription"
-                icon={<DollarSign className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  <div className="grid gap-4 md:grid-cols-3">
-                    <div className="space-y-2">
-                      <Label>Renew Subscription</Label>
-                      <Select value={renewTerm} onValueChange={setRenewTerm}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select term" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="1">1 month</SelectItem>
-                          <SelectItem value="2">2 months</SelectItem>
-                          <SelectItem value="12">1 year</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Subscription Cost</Label>
-                      <div className="h-10 rounded-md border bg-white px-3 py-2 text-sm">$15</div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Action</Label>
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Payout Settings"
+              description="Manage your earnings and withdrawals"
+              icon={<DollarSign className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Payout Available Balance</Label>
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 rounded-md border bg-white px-3 py-2 text-sm">
+                        {payoutBalance}
+                      </div>
                       <Button
-                        className="w-full bg-[#1D4ED8] text-white hover:bg-[#1E40AF]"
-                        onClick={() => toast.message('Subscription renewal queued')}
+                        variant="modal-primary"
+                        onClick={() => toast.message('Withdrawal request sent')}
                       >
-                        Renew
+                        Withdraw
                       </Button>
                     </div>
                   </div>
-                  <div className="flex flex-wrap gap-3">
-                    <Button
-                      variant="outline"
-                      className="border-[#F59E0B] text-[#92400E] hover:bg-[#FDE68A]"
-                      onClick={() => {
-                        if (confirm('Are you sure you want to cancel your subscription?')) {
-                          toast.message(
-                            'Thank you for being with us. We hope you return another time.'
-                          )
-                        }
-                      }}
-                    >
-                      Cancel subscription
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() => toast.message('Payment history loading')}
-                    >
-                      Payment history
-                    </Button>
-                    <Button variant="outline" onClick={() => toast.message('Billing details')}>
-                      Billing
-                    </Button>
-                  </div>
-                </div>
-              </CollapsibleCard>
-
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Payout Settings"
-                description="Manage your earnings and withdrawals"
-                icon={<DollarSign className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label>Payout Available Balance</Label>
-                      <div className="flex items-center gap-3">
-                        <div className="flex-1 rounded-md border bg-white px-3 py-2 text-sm">
-                          {payoutBalance}
-                        </div>
-                        <Button
-                          variant="modal-primary"
-                          onClick={() => toast.message('Withdrawal request sent')}
-                        >
-                          Withdraw
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Download earnings report</Label>
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          variant="outline"
-                          onClick={() => toast.message('CSV report generated')}
-                        >
-                          CSV
-                        </Button>
-                        <Button
-                          variant="outline"
-                          onClick={() => toast.message('PDF report generated')}
-                        >
-                          PDF
-                        </Button>
-                      </div>
+                  <div className="space-y-2">
+                    <Label>Download earnings report</Label>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="outline"
+                        onClick={() => toast.message('CSV report generated')}
+                      >
+                        CSV
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => toast.message('PDF report generated')}
+                      >
+                        PDF
+                      </Button>
                     </div>
                   </div>
                 </div>
-              </CollapsibleCard>
+              </div>
+            </CollapsibleCard>
 
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Billing History"
-                description="View and download your invoices and receipts"
-                icon={<FileText className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-4 p-6">
-                  {billingHistory.map(invoice => (
-                    <div
-                      key={invoice.id}
-                      className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
-                    >
-                      <div>
-                        <p className="font-medium">{invoice.description}</p>
-                        <p className="text-sm text-gray-500">{invoice.date}</p>
-                      </div>
-                      <div className="flex items-center gap-4">
-                        <div className="text-right">
-                          <p className="font-medium">${invoice.amount.toFixed(2)}</p>
-                          <span
-                            className={`text-xs ${
-                              invoice.status === 'paid'
-                                ? 'text-green-600'
-                                : invoice.status === 'pending'
-                                  ? 'text-yellow-600'
-                                  : 'text-red-600'
-                            }`}
-                          >
-                            {invoice.status.charAt(0).toUpperCase() + invoice.status.slice(1)}
-                          </span>
-                        </div>
-                        <Button variant="ghost" size="icon">
-                          <Download className="h-4 w-4" />
-                        </Button>
-                      </div>
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Billing History"
+              description="View and download your invoices and receipts"
+              icon={<FileText className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-4 p-6">
+                {billingHistory.map(invoice => (
+                  <div
+                    key={invoice.id}
+                    className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm"
+                  >
+                    <div>
+                      <p className="font-medium">{invoice.description}</p>
+                      <p className="text-sm text-gray-500">{invoice.date}</p>
                     </div>
-                  ))}
+                    <div className="flex items-center gap-4">
+                      <div className="text-right">
+                        <p className="font-medium">${invoice.amount.toFixed(2)}</p>
+                        <span
+                          className={`text-xs ${
+                            invoice.status === 'paid'
+                              ? 'text-green-600'
+                              : invoice.status === 'pending'
+                                ? 'text-yellow-600'
+                                : 'text-red-600'
+                          }`}
+                        >
+                          {invoice.status.charAt(0).toUpperCase() + invoice.status.slice(1)}
+                        </span>
+                      </div>
+                      <Button variant="ghost" size="icon">
+                        <Download className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
 
-                  {billingHistory.length === 0 && (
-                    <div className="py-8 text-center text-gray-500">
-                      <FileText className="mx-auto mb-2 h-8 w-8" />
-                      <p>No billing history available</p>
-                    </div>
-                  )}
-                </div>
-              </CollapsibleCard>
-            </div>
+                {billingHistory.length === 0 && (
+                  <div className="py-8 text-center text-gray-500">
+                    <FileText className="mx-auto mb-2 h-8 w-8" />
+                    <p>No billing history available</p>
+                  </div>
+                )}
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* Refunds */}
-          <TabsContent value="refunds" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Refunds"
-                description="Pending refund requests across all your courses — approve to process via the payment gateway, or decline."
-                icon={<DollarSign className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="p-6">
-                  <PendingRefundsPanel showCourse hideWhenEmpty={false} />
-                </div>
-              </CollapsibleCard>
-            </div>
+          <TabsContent value="refunds" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Refunds"
+              description="Pending refund requests across all your courses — approve to process via the payment gateway, or decline."
+              icon={<DollarSign className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="p-6">
+                <PendingRefundsPanel showCourse hideWhenEmpty={false} />
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* Notifications */}
-          <TabsContent value="notifications" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Notification Preferences"
-                description="Control how and when we contact you"
-                icon={<Bell className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="space-y-6 p-6">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Marketing Emails</p>
-                        <p className="text-sm text-gray-500">
-                          Receive updates about new features and offers
-                        </p>
-                      </div>
-                      <Switch
-                        checked={notifications.emailMarketing}
-                        onCheckedChange={checked =>
-                          setNotifications(prev => ({ ...prev, emailMarketing: checked }))
-                        }
-                      />
+          <TabsContent value="notifications" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Notification Preferences"
+              description="Control how and when we contact you"
+              icon={<Bell className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="space-y-6 p-6">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">Marketing Emails</p>
+                      <p className="text-sm text-gray-500">
+                        Receive updates about new features and offers
+                      </p>
                     </div>
-
-                    <Separator />
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Lesson Reminders</p>
-                        <p className="text-sm text-gray-500">Get notified about upcoming lessons</p>
-                      </div>
-                      <Switch
-                        checked={notifications.emailLessons}
-                        onCheckedChange={checked =>
-                          setNotifications(prev => ({ ...prev, emailLessons: checked }))
-                        }
-                      />
-                    </div>
-
-                    <Separator />
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Billing Notifications</p>
-                        <p className="text-sm text-gray-500">Receipts and payment confirmations</p>
-                      </div>
-                      <Switch
-                        checked={notifications.emailBilling}
-                        onCheckedChange={checked =>
-                          setNotifications(prev => ({ ...prev, emailBilling: checked }))
-                        }
-                      />
-                    </div>
-
-                    <Separator />
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">Push Notifications</p>
-                        <p className="text-sm text-gray-500">
-                          Browser and mobile push notifications
-                        </p>
-                      </div>
-                      <Switch
-                        checked={notifications.pushNotifications}
-                        onCheckedChange={checked =>
-                          setNotifications(prev => ({ ...prev, pushNotifications: checked }))
-                        }
-                      />
-                    </div>
-
-                    <Separator />
-
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="font-medium">SMS Reminders</p>
-                        <p className="text-sm text-gray-500">Text message reminders for lessons</p>
-                      </div>
-                      <Switch
-                        checked={notifications.smsReminders}
-                        onCheckedChange={checked =>
-                          setNotifications(prev => ({ ...prev, smsReminders: checked }))
-                        }
-                      />
-                    </div>
+                    <Switch
+                      checked={notifications.emailMarketing}
+                      onCheckedChange={checked =>
+                        setNotifications(prev => ({ ...prev, emailMarketing: checked }))
+                      }
+                    />
                   </div>
 
-                  <div className="flex justify-end">
-                    <Button onClick={handleSaveNotifications} disabled={saving}>
-                      {saving ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Saving...
-                        </>
-                      ) : (
-                        <>
-                          <Save className="mr-2 h-4 w-4" />
-                          Save Preferences
-                        </>
-                      )}
-                    </Button>
+                  <Separator />
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">Lesson Reminders</p>
+                      <p className="text-sm text-gray-500">Get notified about upcoming lessons</p>
+                    </div>
+                    <Switch
+                      checked={notifications.emailLessons}
+                      onCheckedChange={checked =>
+                        setNotifications(prev => ({ ...prev, emailLessons: checked }))
+                      }
+                    />
+                  </div>
+
+                  <Separator />
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">Billing Notifications</p>
+                      <p className="text-sm text-gray-500">Receipts and payment confirmations</p>
+                    </div>
+                    <Switch
+                      checked={notifications.emailBilling}
+                      onCheckedChange={checked =>
+                        setNotifications(prev => ({ ...prev, emailBilling: checked }))
+                      }
+                    />
+                  </div>
+
+                  <Separator />
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">Push Notifications</p>
+                      <p className="text-sm text-gray-500">Browser and mobile push notifications</p>
+                    </div>
+                    <Switch
+                      checked={notifications.pushNotifications}
+                      onCheckedChange={checked =>
+                        setNotifications(prev => ({ ...prev, pushNotifications: checked }))
+                      }
+                    />
+                  </div>
+
+                  <Separator />
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium">SMS Reminders</p>
+                      <p className="text-sm text-gray-500">Text message reminders for lessons</p>
+                    </div>
+                    <Switch
+                      checked={notifications.smsReminders}
+                      onCheckedChange={checked =>
+                        setNotifications(prev => ({ ...prev, smsReminders: checked }))
+                      }
+                    />
                   </div>
                 </div>
-              </CollapsibleCard>
-            </div>
+
+                <div className="flex justify-end">
+                  <Button onClick={handleSaveNotifications} disabled={saving}>
+                    {saving ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Save className="mr-2 h-4 w-4" />
+                        Save Preferences
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* Privacy & Security */}
-          <TabsContent value="security" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Privacy & Security"
-                description="Manage your password and account security"
-                icon={<Shield className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="space-y-6 p-6">
-                  {/* Password Change */}
-                  <div className="space-y-4">
-                    <h3 className="font-medium">Change Password</h3>
-                    <div className="grid gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="currentPassword">Current Password</Label>
-                        <Input id="currentPassword" type="password" />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="newPassword">New Password</Label>
-                        <Input id="newPassword" type="password" />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="confirmPassword">Confirm New Password</Label>
-                        <Input id="confirmPassword" type="password" />
-                      </div>
+          <TabsContent value="security" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Privacy & Security"
+              description="Manage your password and account security"
+              icon={<Shield className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="space-y-6 p-6">
+                {/* Password Change */}
+                <div className="space-y-4">
+                  <h3 className="font-medium">Change Password</h3>
+                  <div className="grid gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="currentPassword">Current Password</Label>
+                      <Input id="currentPassword" type="password" />
                     </div>
-                    <Button variant="outline">
-                      <Lock className="mr-2 h-4 w-4" />
-                      Update Password
-                    </Button>
+                    <div className="space-y-2">
+                      <Label htmlFor="newPassword">New Password</Label>
+                      <Input id="newPassword" type="password" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="confirmPassword">Confirm New Password</Label>
+                      <Input id="confirmPassword" type="password" />
+                    </div>
                   </div>
+                  <Button variant="outline">
+                    <Lock className="mr-2 h-4 w-4" />
+                    Update Password
+                  </Button>
+                </div>
 
-                  <Separator />
+                <Separator />
 
-                  {/* Two-Factor Authentication */}
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h3 className="font-medium">Two-Factor Authentication</h3>
-                        <p className="text-sm text-gray-500">
-                          Add an extra layer of security to your account
-                        </p>
-                      </div>
-                      <Switch checked={twoFactorEnabled} onCheckedChange={setTwoFactorEnabled} />
+                {/* Two-Factor Authentication */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="font-medium">Two-Factor Authentication</h3>
+                      <p className="text-sm text-gray-500">
+                        Add an extra layer of security to your account
+                      </p>
                     </div>
-                    {twoFactorEnabled && (
-                      <div className="rounded-lg bg-blue-50 p-4">
-                        <div className="flex items-start gap-2">
-                          <Check className="mt-0.5 h-4 w-4 text-blue-600" />
+                    <Switch checked={twoFactorEnabled} onCheckedChange={setTwoFactorEnabled} />
+                  </div>
+                  {twoFactorEnabled && (
+                    <div className="rounded-lg bg-blue-50 p-4">
+                      <div className="flex items-start gap-2">
+                        <Check className="mt-0.5 h-4 w-4 text-blue-600" />
+                        <div>
+                          <p className="text-sm font-medium text-blue-800">2FA Enabled</p>
+                          <p className="text-xs text-blue-600">
+                            Your account is protected with two-factor authentication
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                {/* Connected Devices */}
+                <div className="space-y-4">
+                  <h3 className="font-medium">Connected Devices</h3>
+                  <div className="space-y-3">
+                    {connectedDevices.map(device => (
+                      <div
+                        key={device.id}
+                        className="flex items-center justify-between rounded-[12px] border p-3 transition-all hover:bg-slate-50 hover:shadow-sm"
+                      >
+                        <div className="flex items-center gap-3">
+                          <Smartphone className="h-5 w-5 text-gray-400" />
                           <div>
-                            <p className="text-sm font-medium text-blue-800">2FA Enabled</p>
-                            <p className="text-xs text-blue-600">
-                              Your account is protected with two-factor authentication
+                            <p className="font-medium">
+                              {device.name}
+                              {device.isCurrent && (
+                                <span className="ml-2 text-xs text-green-600">(Current)</span>
+                              )}
+                            </p>
+                            <p className="text-xs text-gray-500">
+                              {device.location} • {device.lastActive}
                             </p>
                           </div>
                         </div>
+                        {!device.isCurrent && (
+                          <Button variant="ghost" size="sm" className="text-red-600">
+                            <LogOut className="mr-1 h-4 w-4" />
+                            Logout
+                          </Button>
+                        )}
                       </div>
-                    )}
+                    ))}
                   </div>
-
-                  <Separator />
-
-                  {/* Connected Devices */}
-                  <div className="space-y-4">
-                    <h3 className="font-medium">Connected Devices</h3>
-                    <div className="space-y-3">
-                      {connectedDevices.map(device => (
-                        <div
-                          key={device.id}
-                          className="flex items-center justify-between rounded-[12px] border p-3 transition-all hover:bg-slate-50 hover:shadow-sm"
-                        >
-                          <div className="flex items-center gap-3">
-                            <Smartphone className="h-5 w-5 text-gray-400" />
-                            <div>
-                              <p className="font-medium">
-                                {device.name}
-                                {device.isCurrent && (
-                                  <span className="ml-2 text-xs text-green-600">(Current)</span>
-                                )}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {device.location} • {device.lastActive}
-                              </p>
-                            </div>
-                          </div>
-                          {!device.isCurrent && (
-                            <Button variant="ghost" size="sm" className="text-red-600">
-                              <LogOut className="mr-1 h-4 w-4" />
-                              Logout
-                            </Button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                    <Button variant="outline" onClick={handleLogoutAllDevices}>
-                      <LogOut className="mr-2 h-4 w-4" />
-                      Logout from All Devices
-                    </Button>
-                  </div>
+                  <Button variant="outline" onClick={handleLogoutAllDevices}>
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Logout from All Devices
+                  </Button>
                 </div>
-              </CollapsibleCard>
-            </div>
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* Live Session Mirroring */}
-          <TabsContent value="controls" className="mt-0 flex min-h-0 flex-1 flex-col">
-            <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8">
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Live Session Mirroring"
-                description="Control what students see by default during live sessions"
-                icon={<Smartphone className="h-5 w-5 text-slate-900" />}
-                defaultOpen
-              >
-                <div className="space-y-6 p-6">
-                  {/* Mirror Classroom Toggle */}
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-start gap-3">
-                      <LayoutPanelTop className="mt-0.5 h-5 w-5 text-indigo-500" />
-                      <div>
-                        <p className="font-medium">Mirror Classroom by Default</p>
-                        <p className="text-sm text-gray-500">
-                          When a session starts, automatically broadcast your classroom view to all
-                          students
-                        </p>
-                      </div>
+          <TabsContent value="controls" className="mt-0 flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Live Session Mirroring"
+              description="Control what students see by default during live sessions"
+              icon={<Smartphone className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+            >
+              <div className="space-y-6 p-6">
+                {/* Mirror Classroom Toggle */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-start gap-3">
+                    <LayoutPanelTop className="mt-0.5 h-5 w-5 text-indigo-500" />
+                    <div>
+                      <p className="font-medium">Mirror Classroom by Default</p>
+                      <p className="text-sm text-gray-500">
+                        When a session starts, automatically broadcast your classroom view to all
+                        students
+                      </p>
                     </div>
-                    <Switch
-                      checked={mirrorPreferences.defaultMirrorClass}
-                      onCheckedChange={checked =>
-                        setMirrorPreferences(prev => ({ ...prev, defaultMirrorClass: checked }))
-                      }
-                    />
                   </div>
-
-                  <Separator />
-
-                  {/* Mirror Whiteboard Toggle */}
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-start gap-3">
-                      <PenTool className="mt-0.5 h-5 w-5 text-indigo-500" />
-                      <div>
-                        <p className="font-medium">Mirror Whiteboard by Default</p>
-                        <p className="text-sm text-gray-500">
-                          When a session starts, automatically broadcast your whiteboard to all
-                          students
-                        </p>
-                      </div>
-                    </div>
-                    <Switch
-                      checked={mirrorPreferences.defaultMirrorBoard}
-                      onCheckedChange={checked =>
-                        setMirrorPreferences(prev => ({ ...prev, defaultMirrorBoard: checked }))
-                      }
-                    />
-                  </div>
-
-                  <div className="flex justify-end">
-                    <Button onClick={saveMirrorPreferences}>
-                      <Save className="mr-2 h-4 w-4" />
-                      Save Preferences
-                    </Button>
-                  </div>
+                  <Switch
+                    checked={mirrorPreferences.defaultMirrorClass}
+                    onCheckedChange={checked =>
+                      setMirrorPreferences(prev => ({ ...prev, defaultMirrorClass: checked }))
+                    }
+                  />
                 </div>
-              </CollapsibleCard>
 
-              {/* Course Sync Mode */}
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Course Sync Mode"
-                description="Control how course edits are shared with students during live sessions"
-                icon={<LayoutPanelTop className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  <div className="space-y-3">
-                    {[
-                      {
-                        value: 'auto' as const,
-                        label: 'Automatic',
-                        description:
-                          'Edits sync automatically after you stop editing for 3 seconds. Students always see the latest content.',
-                      },
-                      {
-                        value: 'manual' as const,
-                        label: 'Manual',
-                        description:
-                          'You must click the Sync button to share changes. Best for preparing content privately.',
-                      },
-                      {
-                        value: 'ask' as const,
-                        label: 'Ask Before Syncing',
-                        description:
-                          'A prompt asks you to confirm before syncing. Good for awareness of what students see.',
-                      },
-                    ].map(option => (
-                      <label
-                        key={option.value}
-                        className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors ${
-                          syncMode === option.value
-                            ? 'border-indigo-300 bg-indigo-50'
-                            : 'border-slate-200 bg-white hover:bg-slate-50'
-                        }`}
+                <Separator />
+
+                {/* Mirror Whiteboard Toggle */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-start gap-3">
+                    <PenTool className="mt-0.5 h-5 w-5 text-indigo-500" />
+                    <div>
+                      <p className="font-medium">Mirror Whiteboard by Default</p>
+                      <p className="text-sm text-gray-500">
+                        When a session starts, automatically broadcast your whiteboard to all
+                        students
+                      </p>
+                    </div>
+                  </div>
+                  <Switch
+                    checked={mirrorPreferences.defaultMirrorBoard}
+                    onCheckedChange={checked =>
+                      setMirrorPreferences(prev => ({ ...prev, defaultMirrorBoard: checked }))
+                    }
+                  />
+                </div>
+
+                <div className="flex justify-end">
+                  <Button onClick={saveMirrorPreferences}>
+                    <Save className="mr-2 h-4 w-4" />
+                    Save Preferences
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleCard>
+
+            {/* Course Sync Mode */}
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Course Sync Mode"
+              description="Control how course edits are shared with students during live sessions"
+              icon={<LayoutPanelTop className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                <div className="space-y-3">
+                  {[
+                    {
+                      value: 'auto' as const,
+                      label: 'Automatic',
+                      description:
+                        'Edits sync automatically after you stop editing for 3 seconds. Students always see the latest content.',
+                    },
+                    {
+                      value: 'manual' as const,
+                      label: 'Manual',
+                      description:
+                        'You must click the Sync button to share changes. Best for preparing content privately.',
+                    },
+                    {
+                      value: 'ask' as const,
+                      label: 'Ask Before Syncing',
+                      description:
+                        'A prompt asks you to confirm before syncing. Good for awareness of what students see.',
+                    },
+                  ].map(option => (
+                    <label
+                      key={option.value}
+                      className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors ${
+                        syncMode === option.value
+                          ? 'border-indigo-300 bg-indigo-50'
+                          : 'border-slate-200 bg-white hover:bg-slate-50'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="syncMode"
+                        value={option.value}
+                        checked={syncMode === option.value}
+                        onChange={() => setSyncMode(option.value)}
+                        className="mt-1"
+                      />
+                      <div>
+                        <p className="font-medium text-slate-800">{option.label}</p>
+                        <p className="text-sm text-slate-500">{option.description}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+
+                <div className="flex justify-end">
+                  <Button onClick={saveSyncMode}>
+                    <Save className="mr-2 h-4 w-4" />
+                    Save Sync Mode
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleCard>
+
+            {/* Document Parsing */}
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Document Import"
+              description="Control how documents are handled when importing into tasks and assessments"
+              icon={<FileText className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-start gap-3">
+                    <FileText className="mt-0.5 h-5 w-5 text-indigo-500" />
+                    <div>
+                      <p className="font-medium">Parse Documents on Import</p>
+                      <p className="text-sm text-gray-500">
+                        Automatically extract text from PDFs, Word docs, and other files when
+                        importing into tasks and assessments
+                      </p>
+                    </div>
+                  </div>
+                  <Switch
+                    checked={parseDocuments}
+                    onCheckedChange={checked => setParseDocuments(checked)}
+                  />
+                </div>
+
+                <div className="flex justify-end">
+                  <Button onClick={saveParseDocuments}>
+                    <Save className="mr-2 h-4 w-4" />
+                    Save Preference
+                  </Button>
+                </div>
+              </div>
+            </CollapsibleCard>
+
+            <CollapsibleCard
+              className={SECTION_CARD_CLASS}
+              title="Account Controls"
+              description="Temporarily deactivate or permanently delete your account"
+              icon={<UserCircle className="h-5 w-5 text-slate-900" />}
+            >
+              <div className="space-y-6 p-6">
+                {/* Deactivate Account */}
+                <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+                  <div className="flex items-start gap-4">
+                    <Power className="mt-1 h-5 w-5 text-yellow-600" />
+                    <div className="flex-1">
+                      <h3 className="font-medium text-yellow-800">Deactivate Account</h3>
+                      <p className="text-sm text-yellow-700">
+                        Temporarily disable your account. You can reactivate it at any time by
+                        logging in. Your data will be preserved.
+                      </p>
+                      <Button
+                        variant="outline"
+                        className="mt-3 border-yellow-300 text-yellow-700 hover:bg-yellow-100"
+                        onClick={() => setShowDeactivateDialog(true)}
                       >
-                        <input
-                          type="radio"
-                          name="syncMode"
-                          value={option.value}
-                          checked={syncMode === option.value}
-                          onChange={() => setSyncMode(option.value)}
-                          className="mt-1"
-                        />
-                        <div>
-                          <p className="font-medium text-slate-800">{option.label}</p>
-                          <p className="text-sm text-slate-500">{option.description}</p>
-                        </div>
-                      </label>
-                    ))}
-                  </div>
-
-                  <div className="flex justify-end">
-                    <Button onClick={saveSyncMode}>
-                      <Save className="mr-2 h-4 w-4" />
-                      Save Sync Mode
-                    </Button>
-                  </div>
-                </div>
-              </CollapsibleCard>
-
-              {/* Document Parsing */}
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Document Import"
-                description="Control how documents are handled when importing into tasks and assessments"
-                icon={<FileText className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-start gap-3">
-                      <FileText className="mt-0.5 h-5 w-5 text-indigo-500" />
-                      <div>
-                        <p className="font-medium">Parse Documents on Import</p>
-                        <p className="text-sm text-gray-500">
-                          Automatically extract text from PDFs, Word docs, and other files when
-                          importing into tasks and assessments
-                        </p>
-                      </div>
-                    </div>
-                    <Switch
-                      checked={parseDocuments}
-                      onCheckedChange={checked => setParseDocuments(checked)}
-                    />
-                  </div>
-
-                  <div className="flex justify-end">
-                    <Button onClick={saveParseDocuments}>
-                      <Save className="mr-2 h-4 w-4" />
-                      Save Preference
-                    </Button>
-                  </div>
-                </div>
-              </CollapsibleCard>
-
-              <CollapsibleCard
-                className={SECTION_CARD_CLASS}
-                title="Account Controls"
-                description="Temporarily deactivate or permanently delete your account"
-                icon={<UserCircle className="h-5 w-5 text-slate-900" />}
-              >
-                <div className="space-y-6 p-6">
-                  {/* Deactivate Account */}
-                  <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
-                    <div className="flex items-start gap-4">
-                      <Power className="mt-1 h-5 w-5 text-yellow-600" />
-                      <div className="flex-1">
-                        <h3 className="font-medium text-yellow-800">Deactivate Account</h3>
-                        <p className="text-sm text-yellow-700">
-                          Temporarily disable your account. You can reactivate it at any time by
-                          logging in. Your data will be preserved.
-                        </p>
-                        <Button
-                          variant="outline"
-                          className="mt-3 border-yellow-300 text-yellow-700 hover:bg-yellow-100"
-                          onClick={() => setShowDeactivateDialog(true)}
-                        >
-                          Deactivate Account
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Delete Account */}
-                  <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-                    <div className="flex items-start gap-4">
-                      <Trash2 className="mt-1 h-5 w-5 text-red-600" />
-                      <div className="flex-1">
-                        <h3 className="font-medium text-red-800">Delete Account</h3>
-                        <p className="text-sm text-red-700">
-                          Permanently delete your account and all associated data. This action
-                          cannot be undone.
-                        </p>
-                        <Button
-                          variant="outline"
-                          className="mt-3 border-red-300 text-red-700 hover:bg-red-100"
-                          onClick={() => setShowDeleteDialog(true)}
-                        >
-                          Delete Account
-                        </Button>
-                      </div>
+                        Deactivate Account
+                      </Button>
                     </div>
                   </div>
                 </div>
-              </CollapsibleCard>
-            </div>
+
+                {/* Delete Account */}
+                <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                  <div className="flex items-start gap-4">
+                    <Trash2 className="mt-1 h-5 w-5 text-red-600" />
+                    <div className="flex-1">
+                      <h3 className="font-medium text-red-800">Delete Account</h3>
+                      <p className="text-sm text-red-700">
+                        Permanently delete your account and all associated data. This action cannot
+                        be undone.
+                      </p>
+                      <Button
+                        variant="outline"
+                        className="mt-3 border-red-300 text-red-700 hover:bg-red-100"
+                        onClick={() => setShowDeleteDialog(true)}
+                      >
+                        Delete Account
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CollapsibleCard>
           </TabsContent>
 
           {/* Session Log */}
-          <TabsContent value="session-log" className="mt-0 flex min-h-0 flex-1 flex-col">
+          <TabsContent value="session-log" className="mt-0 flex h-full flex-col gap-4 pb-4">
             <SessionLog />
           </TabsContent>
         </SessionCalendarPanel>


### PR DESCRIPTION
…atch Analytics design

Remove the no-scrollbar overflow-y-auto wrapper divs from all TabsContent containers in the Account page. This matches the Analytics page design where panels (CollapsibleCards) are placed directly inside TabsContent without an intermediate scrollable container, allowing proper flex height filling.

Changes:
- All 8 TabsContent tabs: removed <div className="no-scrollbar h-full space-y-6 overflow-y-auto pb-8"> wrapper
- Changed TabsContent className from min-h-0 flex-1 to h-full flex-col gap-4 pb-4
- Panels now fill available height like Analytics page