### PR TITLE
feat(student): deliver graded assessment feedback for review (close the loop)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -19,6 +19,10 @@ import {
   BookOpen,
 } from 'lucide-react'
 import { QuizModal, type QuestionResultItem } from '@/components/quiz/quiz-modal'
+import {
+  AssessmentReviewModal,
+  type AssessmentReviewData,
+} from '@/components/quiz/assessment-review-modal'
 import { toast } from 'sonner'
 
 interface AssignmentItem {
@@ -74,6 +78,8 @@ export default function StudentAssignmentsPage() {
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [startTime, setStartTime] = useState<number>(0)
+  // Review of an already-submitted assessment (score + feedback + per-question).
+  const [reviewData, setReviewData] = useState<AssessmentReviewData | null>(null)
 
   const loadAssignments = useCallback(async () => {
     setLoading(true)
@@ -122,12 +128,20 @@ export default function StudentAssignmentsPage() {
       }
       const data = await res.json()
       if (data.alreadySubmitted) {
-        const scoreTxt = data.existingScore != null ? `${Math.round(data.existingScore)}%` : 'N/A'
-        toast.info(
-          data.existingGraded
-            ? `Graded by your tutor: ${scoreTxt}${data.existingFeedback ? ` — ${data.existingFeedback}` : ''}`
-            : `Submitted — provisional score ${scoreTxt} (auto-graded; awaiting your tutor).`
-        )
+        // Re-open the graded assessment for review: score + tutor feedback +
+        // per-question breakdown, instead of a one-line toast.
+        setReviewData({
+          title: data.task.title,
+          score: data.existingScore ?? null,
+          maxScore: data.existingMaxScore ?? null,
+          graded: data.existingGraded === true,
+          feedback: data.existingFeedback ?? null,
+          submittedAt: data.existingSubmittedAt ?? null,
+          gradedAt: data.existingGradedAt ?? null,
+          questions: data.task.questions ?? [],
+          answers: data.existingAnswers ?? null,
+          questionResults: data.existingQuestionResults ?? null,
+        })
         return
       }
       // Map to QuizModal question format
@@ -327,6 +341,9 @@ export default function StudentAssignmentsPage() {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      {reviewData && (
+        <AssessmentReviewModal data={reviewData} onClose={() => setReviewData(null)} />
+      )}
       <div className="mb-8">
         <h1 className="flex items-center gap-2 text-2xl font-bold text-gray-900">
           <ClipboardList className="h-6 w-6" />

--- a/tutorme-app/src/app/[locale]/student/work/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/work/page.tsx
@@ -11,6 +11,10 @@ import { Progress } from '@/components/ui/progress'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toast } from 'sonner'
 import { QuizModal, type QuestionResultItem } from '@/components/quiz/quiz-modal'
+import {
+  AssessmentReviewModal,
+  type AssessmentReviewData,
+} from '@/components/quiz/assessment-review-modal'
 import { StudentQuiz } from '@/types/quiz'
 import {
   ClipboardList,
@@ -109,6 +113,7 @@ function AssignmentsTab() {
   const [takingQuiz, setTakingQuiz] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [startTime, setStartTime] = useState<number>(0)
+  const [reviewData, setReviewData] = useState<AssessmentReviewData | null>(null)
 
   const loadAssignments = useCallback(async () => {
     setLoading(true)
@@ -132,12 +137,18 @@ function AssignmentsTab() {
       }
       const data = await res.json()
       if (data.alreadySubmitted) {
-        const scoreTxt = data.existingScore != null ? `${Math.round(data.existingScore)}%` : 'N/A'
-        toast.info(
-          data.existingGraded
-            ? `Graded by your tutor: ${scoreTxt}${data.existingFeedback ? ` — ${data.existingFeedback}` : ''}`
-            : `Submitted — provisional score ${scoreTxt} (auto-graded; awaiting your tutor).`
-        )
+        setReviewData({
+          title: data.task.title,
+          score: data.existingScore ?? null,
+          maxScore: data.existingMaxScore ?? null,
+          graded: data.existingGraded === true,
+          feedback: data.existingFeedback ?? null,
+          submittedAt: data.existingSubmittedAt ?? null,
+          gradedAt: data.existingGradedAt ?? null,
+          questions: data.task.questions ?? [],
+          answers: data.existingAnswers ?? null,
+          questionResults: data.existingQuestionResults ?? null,
+        })
         return
       }
       setActiveTask({
@@ -324,6 +335,9 @@ function AssignmentsTab() {
 
   return (
     <div className="space-y-6">
+      {reviewData && (
+        <AssessmentReviewModal data={reviewData} onClose={() => setReviewData(null)} />
+      )}
       {/* Stats Cards */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <Card>

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -107,6 +107,11 @@ export async function GET(
         status: taskSubmission.status,
         tutorApproved: taskSubmission.tutorApproved,
         tutorFeedback: taskSubmission.tutorFeedback,
+        answers: taskSubmission.answers,
+        questionResults: taskSubmission.questionResults,
+        maxScore: taskSubmission.maxScore,
+        submittedAt: taskSubmission.submittedAt,
+        gradedAt: taskSubmission.gradedAt,
       })
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
@@ -136,19 +141,31 @@ export async function GET(
             : 'instant'
     // correctAnswer is exposed for 'instant' and 'student_choice' (the student
     // may opt into practice mode); stripped for after_submit/hidden so it can't
-    // be peeked before submitting.
-    const exposeAnswers = answerReveal === 'instant' || answerReveal === 'student_choice'
+    // be peeked before submitting. BUT once the student has submitted, reveal the
+    // key for every mode except 'hidden' so they can review what they got wrong.
+    const alreadySubmitted = existing != null
+    const exposeAnswers =
+      answerReveal === 'instant' ||
+      answerReveal === 'student_choice' ||
+      (alreadySubmitted && answerReveal !== 'hidden')
     const safeQuestions = exposeAnswers
       ? questions
       : questions.map(({ correctAnswer: _c, ...q }) => q)
 
     return NextResponse.json({
-      alreadySubmitted: existing != null,
+      alreadySubmitted,
       existingScore: existing?.score ?? null,
       // Whether the tutor has finalized the grade (vs the automatic provisional
       // score). Lets the student see "graded by your tutor" + any feedback.
       existingGraded: existing?.status === 'graded' || existing?.tutorApproved === true,
       existingFeedback: existing?.tutorFeedback ?? null,
+      // Full graded review so a student can re-open a completed assessment and see
+      // their per-question breakdown + the tutor's feedback (not just a score).
+      existingAnswers: existing?.answers ?? null,
+      existingQuestionResults: existing?.questionResults ?? null,
+      existingMaxScore: existing?.maxScore ?? null,
+      existingSubmittedAt: existing?.submittedAt ?? null,
+      existingGradedAt: existing?.gradedAt ?? null,
       task: {
         id: task.taskId,
         title: task.title,

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -18,7 +18,6 @@ import { getParamAsync } from '@/lib/api/params'
 import { handleApiError, requireCsrf } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { builderTask, builderTaskDmi, courseEnrollment, taskSubmission } from '@/lib/db/schema'
-import { generateFeedback, submitFeedbackForReview } from '@/lib/feedback/workflow'
 import { autoGradeDmi, type DmiAnswerItem } from '@/lib/grading/auto-grade'
 
 const MAX_SCORE = 100
@@ -160,24 +159,13 @@ export async function POST(
       submittedAt: new Date(),
     })
 
-    // Best-effort: generate AI feedback into the tutor's review queue. Submission
-    // already persisted, so any failure here must not fail the request.
-    try {
-      const request_ = {
-        studentId,
-        submissionId,
-        courseId: task.courseId,
-        type: 'task_feedback' as const,
-        context: { taskId, recentPerformance: score ?? undefined },
-        priority: 'medium' as const,
-      }
-      const generated = await generateFeedback(request_)
-      if (generated.success && generated.feedback) {
-        await submitFeedbackForReview(generated.feedback, request_)
-      }
-    } catch (feedbackError) {
-      console.warn('[submit] AI feedback generation failed (non-critical):', feedbackError)
-    }
+    // (Removed) The old best-effort call to generateFeedback/submitFeedbackForReview
+    // wrote to the orphaned FeedbackWorkflow table — a review panel mounted nowhere
+    // and read by no student route — while adding a synchronous Kimi call to every
+    // submit. The feedback students actually see is the auto-graded per-question
+    // breakdown plus the tutor's own feedback (delivered via the task GET). If a
+    // real AI-feedback queue is wired later, it should consume the marking basis
+    // (answers + rubric + model answer + PCI), not the generic recent-score prompt.
 
     // Reveal correct answers in the response when the tutor chose 'after_submit'
     // or 'student_choice' — now that the student has submitted it's safe to show

--- a/tutorme-app/src/components/quiz/assessment-review-modal.tsx
+++ b/tutorme-app/src/components/quiz/assessment-review-modal.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+/**
+ * AssessmentReviewModal — read-only review of a submitted assessment.
+ *
+ * Closes the feedback loop: a student who already submitted can re-open a task
+ * and see their score, the tutor's written feedback, and a per-question
+ * breakdown (their answer vs the correct answer, points earned) — instead of the
+ * one-shot results screen that vanished after the QuizModal closed.
+ */
+
+import { Button } from '@/components/ui/button'
+import { CheckCircle, XCircle, Clock, X } from 'lucide-react'
+import type { QuestionResultItem } from './quiz-modal'
+
+export interface AssessmentReviewQuestion {
+  id: string
+  question: string
+  options?: string[]
+  correctAnswer?: string
+  points?: number
+}
+
+export interface AssessmentReviewData {
+  title: string
+  score: number | null
+  maxScore?: number | null
+  /** True once the tutor has finalized the grade (vs the provisional auto-grade). */
+  graded: boolean
+  feedback?: string | null
+  submittedAt?: string | null
+  gradedAt?: string | null
+  questions: AssessmentReviewQuestion[]
+  answers: Record<string, unknown> | null
+  questionResults: QuestionResultItem[] | null
+}
+
+function formatAnswer(value: unknown): string {
+  if (value == null || value === '') return '—'
+  if (Array.isArray(value)) return value.map(v => String(v)).join(', ')
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+export function AssessmentReviewModal({
+  data,
+  onClose,
+}: {
+  data: AssessmentReviewData
+  onClose: () => void
+}) {
+  const resultById = new Map<string, QuestionResultItem>()
+  for (const r of data.questionResults ?? []) resultById.set(String(r.questionId), r)
+
+  const scoreTxt = data.score != null ? `${Math.round(data.score)}%` : 'N/A'
+  const gradedDate = data.gradedAt ?? data.submittedAt
+  const dateTxt = gradedDate ? new Date(gradedDate).toLocaleDateString() : null
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Review of ${data.title}`}
+    >
+      <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 border-b border-gray-100 p-5">
+          <div className="min-w-0">
+            <h2 className="truncate text-lg font-semibold text-gray-900">{data.title}</h2>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm">
+              <span className="text-2xl font-bold text-indigo-600">{scoreTxt}</span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  data.graded ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-50 text-amber-700'
+                }`}
+              >
+                {data.graded ? 'Graded by your tutor' : 'Provisional — awaiting your tutor'}
+              </span>
+              {dateTxt && (
+                <span className="inline-flex items-center gap-1 text-xs text-gray-400">
+                  <Clock className="h-3 w-3" />
+                  {dateTxt}
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close review"
+            className="shrink-0 rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5">
+          {/* Tutor feedback — the headline of the review when present */}
+          {data.feedback && (
+            <div className="mb-5 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4">
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+                Feedback from your tutor
+              </p>
+              <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-800">
+                {data.feedback}
+              </p>
+            </div>
+          )}
+
+          {/* Per-question breakdown */}
+          <div className="space-y-3">
+            {data.questions.map((q, i) => {
+              const result = resultById.get(String(q.id))
+              const yourAnswer = data.answers?.[q.id]
+              const needsReview = result?.needsReview === true
+              const correct = result?.correct === true
+              return (
+                <div key={q.id} className="rounded-xl border border-gray-200 p-3.5">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="text-sm font-medium text-gray-900">
+                      <span className="mr-1 text-gray-400">Q{i + 1}.</span>
+                      {q.question}
+                    </p>
+                    {result &&
+                      (needsReview ? (
+                        <span className="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                          Tutor review
+                        </span>
+                      ) : correct ? (
+                        <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-emerald-600">
+                          <CheckCircle className="h-3.5 w-3.5" /> Correct
+                        </span>
+                      ) : (
+                        <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-red-500">
+                          <XCircle className="h-3.5 w-3.5" /> Incorrect
+                        </span>
+                      ))}
+                  </div>
+
+                  <div className="mt-2 space-y-1 text-sm">
+                    <p className="text-gray-700">
+                      <span className="text-gray-400">Your answer: </span>
+                      {formatAnswer(yourAnswer)}
+                    </p>
+                    {q.correctAnswer != null && q.correctAnswer !== '' && !correct && (
+                      <p className="text-emerald-700">
+                        <span className="text-gray-400">Correct answer: </span>
+                        {q.correctAnswer}
+                      </p>
+                    )}
+                    {result && !needsReview && (
+                      <p className="text-xs text-gray-400">
+                        {result.pointsEarned}/{result.pointsMax} points
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-gray-100 p-4">
+          <Button onClick={onClose} className="w-full">
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/components/quiz/quiz-modal.tsx
+++ b/tutorme-app/src/components/quiz/quiz-modal.tsx
@@ -24,6 +24,8 @@ export interface QuestionResultItem {
   pointsMax: number
   selectedAnswer?: unknown
   timeSpentSec?: number
+  /** Open-ended/drawn answers the auto-grader can't score — a tutor grades these. */
+  needsReview?: boolean
 }
 
 /** What the parent's submit returns so the modal can show the authoritative


### PR DESCRIPTION
First step of the assessment-feedback work: **make the feedback students already earn actually reach them.** Today a student sees per-question results only on the one-shot post-submit screen; re-opening a completed task shows a bare score toast, and the tutor's written feedback / per-question breakdown are saved but never re-surfaced.

## Changes
- **GET `/api/student/assignments/[taskId]`** returns the full graded review — the student's `answers`, `questionResults`, `maxScore`, submitted/graded timestamps — and reveals the correct-answer key **once submitted** for every reveal mode except `hidden` (fresh, not-yet-submitted loads stay stripped).
- **New `AssessmentReviewModal`** — re-opening a submitted assessment now shows the score + status (tutor-graded vs provisional), the tutor's feedback headlined, and a per-question breakdown: *your answer vs the correct answer*, points earned, and a **"tutor review"** flag for open-ended answers the auto-grader can't score. Replaces the old toast on both the student assignments and work pages.
- **Pruned the orphaned AI-feedback generation** from the submit path. It wrote to the `FeedbackWorkflow` table — whose review panel is mounted nowhere and which no student route reads — while adding a **synchronous Kimi call to every submission**. Removing it cuts cost + submit latency with zero user-facing change. (A real AI-feedback queue, if wired later, should consume the marking basis — answers + rubric + model answer + PCI — not the generic recent-score prompt.)

## Not in this PR (the proposed next tiers)
- Feed the true marking basis to an AI-feedback generator + persist per-question rationale/misconception tags into the unused `aiFeedback` slot.
- Concept-tagged mastery map + cross-assessment trend, and a PCI-scoped student follow-up question.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)