### PR TITLE
feat(feedback): tutor visibility into the AI layer (hints + follow-ups)

### DIFF
--- a/tutorme-app/drizzle/0067_tasksubmission_followups.sql
+++ b/tutorme-app/drizzle/0067_tasksubmission_followups.sql
@@ -1,0 +1,6 @@
+-- TaskSubmission.followUps: persisted follow-up Q&A between the student and the
+--   PCI-scoped assistant on a graded assessment, so the tutor can see what was
+--   asked and answered (and catch AI drift). Array of {questionId, question,
+--   answer, at}. Nullable; idempotent (also applied via startup-schema-fix so a
+--   revision that skips migrations still gets it before serving traffic).
+ALTER TABLE "TaskSubmission" ADD COLUMN IF NOT EXISTS "followUps" jsonb;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1781900000066,
       "tag": "0066_courselesson_source_lesson",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1781900000067,
+      "tag": "0067_tasksubmission_followups",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -48,6 +48,22 @@ interface Submission {
       needsReview?: boolean
     }
   >
+  /** AI study hints the student received (grounded per-question feedback). */
+  aiFeedback?: {
+    items?: Array<{
+      questionId: string
+      explanation: string
+      misconception?: string
+      nextStep?: string
+    }>
+  } | null
+  /** Follow-up Q&A the student had with the PCI-scoped assistant. */
+  followUps?: Array<{
+    questionId: string
+    question: string
+    answer: string
+    at?: string
+  }> | null
 }
 
 type StatusFilter = 'all' | 'submitted' | 'graded'
@@ -560,6 +576,60 @@ function SubmissionRow({
               </ul>
             )}
           </div>
+
+          {/* AI layer: what the student was shown/asked by the assistant, so the
+              tutor can vet it and see where the student struggled. */}
+          {((submission.aiFeedback?.items?.length ?? 0) > 0 ||
+            (submission.followUps?.length ?? 0) > 0) && (
+            <div className="mb-4 rounded-lg border border-violet-200 bg-violet-50/50 p-3">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-violet-700">
+                AI assistant activity
+              </p>
+
+              {(submission.aiFeedback?.items?.length ?? 0) > 0 && (
+                <div className="mb-3">
+                  <p className="mb-1 text-xs font-medium text-gray-600">
+                    Study hints shown to the student
+                  </p>
+                  <ul className="space-y-1.5">
+                    {submission.aiFeedback!.items!.map((h, i) => (
+                      <li key={i} className="rounded-md bg-white/70 p-2 text-xs text-gray-700">
+                        <span className="font-medium text-gray-500">Q{h.questionId}: </span>
+                        {h.explanation}
+                        {h.misconception && (
+                          <span className="text-gray-400"> (slip: {h.misconception})</span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {(submission.followUps?.length ?? 0) > 0 && (
+                <div>
+                  <p className="mb-1 text-xs font-medium text-gray-600">
+                    Follow-up questions the student asked
+                  </p>
+                  <ul className="space-y-1.5">
+                    {submission.followUps!.map((f, i) => (
+                      <li key={i} className="rounded-md bg-white/70 p-2 text-xs">
+                        <p className="text-gray-800">
+                          <span className="font-medium text-violet-700">
+                            Q{f.questionId} · asked:{' '}
+                          </span>
+                          {f.question}
+                        </p>
+                        <p className="mt-0.5 text-gray-600">
+                          <span className="text-gray-400">assistant: </span>
+                          {f.answer}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
 
           <div className="grid gap-3 sm:grid-cols-[140px_1fr] sm:items-start">
             <div>

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/ask/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/ask/route.ts
@@ -80,7 +80,11 @@ export async function POST(
     // The student's own submission for this task (proves ownership + provides
     // the answer being discussed).
     const [submission] = await drizzleDb
-      .select({ answers: taskSubmission.answers })
+      .select({
+        submissionId: taskSubmission.submissionId,
+        answers: taskSubmission.answers,
+        followUps: taskSubmission.followUps,
+      })
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
       .limit(1)
@@ -192,6 +196,24 @@ export async function POST(
         '[ask] task guardrail warnings:',
         guardrail.violations.map(v => `${v.ruleId} ${v.severity}`).join(', ')
       )
+    }
+
+    // Persist the Q&A so the tutor can see what the student asked and how the
+    // assistant answered (best-effort — never fail the response on a write error).
+    try {
+      const existing = Array.isArray(submission.followUps)
+        ? (submission.followUps as unknown[])
+        : []
+      const next = [
+        ...existing,
+        { questionId, question, answer, at: new Date().toISOString() },
+      ].slice(-50)
+      await drizzleDb
+        .update(taskSubmission)
+        .set({ followUps: next })
+        .where(eq(taskSubmission.submissionId, submission.submissionId))
+    } catch (persistErr) {
+      console.warn('[ask] failed to persist follow-up:', persistErr)
     }
 
     return NextResponse.json({ answer })

--- a/tutorme-app/src/app/api/tutor/submissions/route.ts
+++ b/tutorme-app/src/app/api/tutor/submissions/route.ts
@@ -56,6 +56,10 @@ export async function GET(request: NextRequest) {
         answers: taskSubmission.answers,
         questionResults: taskSubmission.questionResults,
         tutorFeedback: taskSubmission.tutorFeedback,
+        // The AI study hints the student received + any follow-up Q&A they had,
+        // so the tutor can see the AI layer and catch drift.
+        aiFeedback: taskSubmission.aiFeedback,
+        followUps: taskSubmission.followUps,
         timeSpent: taskSubmission.timeSpent,
         submittedAt: taskSubmission.submittedAt,
         gradedAt: taskSubmission.gradedAt,

--- a/tutorme-app/src/lib/db/schema/tables/course.ts
+++ b/tutorme-app/src/lib/db/schema/tables/course.ts
@@ -325,6 +325,10 @@ export const taskSubmission = pgTable(
     maxScore: integer('maxScore').notNull(),
     status: text('status').notNull(),
     aiFeedback: jsonb('aiFeedback'),
+    // Persisted follow-up Q&A the student had with the PCI-scoped assistant, so
+    // the tutor can see what was asked/answered (and catch AI drift). Array of
+    // { questionId, question, answer, at }.
+    followUps: jsonb('followUps'),
     tutorFeedback: text('tutorFeedback'),
     tutorApproved: boolean('tutorApproved').notNull(),
     submittedAt: timestamp('submittedAt', { withTimezone: true }).notNull().defaultNow(),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -150,6 +150,10 @@ ALTER TABLE "DeployedMaterial" ADD COLUMN IF NOT EXISTS "lessonId" text;
 -- lesson was copied from, so correlation survives lesson reordering. Nullable.
 ALTER TABLE "CourseLesson" ADD COLUMN IF NOT EXISTS "sourceLessonId" text;
 
+-- Follow-up Q&A (drizzle/0067): persisted student<->assistant follow-ups on a
+-- graded assessment, so tutors can see what was asked/answered. Nullable jsonb.
+ALTER TABLE "TaskSubmission" ADD COLUMN IF NOT EXISTS "followUps" jsonb;
+
 -- TaskDeploymentStatus enum
 DO $$
 BEGIN


### PR DESCRIPTION
The AI study hints (Tier 2) and PCI-scoped follow-up Q&A (Tier 3) were **student-only** — a tutor couldn't see what the assistant told their students or what students asked, so AI drift and struggle points were invisible. This closes that half of the loop.

- **Persist follow-ups** — new `TaskSubmission.followUps` jsonb (`drizzle/0067` + startup-schema-fix mirror). The `ask` endpoint now appends each `{questionId, question, answer, at}` best-effort (capped at 50, never fails the response).
- **Tutor submissions API** returns `aiFeedback` + `followUps` per submission.
- **Tutor grading page** shows an **"AI assistant activity"** panel per submission: the study hints the student was shown, and the follow-up questions they asked with the assistant's answers — so the tutor can vet the AI and see where the student struggled.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)