### PR TITLE
feat(student): per-topic assessment mastery card with trend + recurring slips

### DIFF
--- a/tutorme-app/src/app/[locale]/student/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/assignments/page.tsx
@@ -24,6 +24,7 @@ import {
   type AssessmentReviewData,
   type FollowUpTurn,
 } from '@/components/quiz/assessment-review-modal'
+import { AssessmentMasteryCard } from '@/components/student/assessment-mastery-card'
 import { toast } from 'sonner'
 
 interface AssignmentItem {
@@ -409,6 +410,8 @@ export default function StudentAssignmentsPage() {
         </h1>
         <p className="mt-1 text-gray-600">Track your homework, quizzes, and projects</p>
       </div>
+
+      <AssessmentMasteryCard />
 
       {/* Stats Cards */}
       <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">

--- a/tutorme-app/src/app/api/student/assessment-mastery/route.ts
+++ b/tutorme-app/src/app/api/student/assessment-mastery/route.ts
@@ -1,0 +1,111 @@
+/**
+ * GET /api/student/assessment-mastery
+ *
+ * Per-topic mastery from the student's graded assessments: groups their
+ * submissions by the lesson each task belongs to (the "topic"), and reports the
+ * average score, a chronological trend, and the misconception tags that recur
+ * across attempts (from the persisted AI study hints). Read-only aggregation —
+ * no new storage; it reuses builderTask.lessonId + TaskSubmission.aiFeedback.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, asc, eq, isNotNull } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { handleApiError } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, courseLesson, taskSubmission } from '@/lib/db/schema'
+
+interface TrendPoint {
+  at: string | null
+  score: number
+}
+
+interface TopicMastery {
+  topic: string
+  attempts: number
+  averageScore: number
+  latestScore: number
+  /** Positive = improving over the topic's attempts. */
+  delta: number
+  trend: TrendPoint[]
+  misconceptions: { label: string; count: number }[]
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const studentId = session.user.id
+
+    const rows = await drizzleDb
+      .select({
+        score: taskSubmission.score,
+        submittedAt: taskSubmission.submittedAt,
+        aiFeedback: taskSubmission.aiFeedback,
+        taskTitle: builderTask.title,
+        lessonTitle: courseLesson.title,
+      })
+      .from(taskSubmission)
+      .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+      .leftJoin(courseLesson, eq(builderTask.lessonId, courseLesson.lessonId))
+      .where(and(eq(taskSubmission.studentId, studentId), isNotNull(taskSubmission.score)))
+      .orderBy(asc(taskSubmission.submittedAt))
+      .limit(500)
+
+    // Group by topic = the task's lesson (fall back to the task title).
+    const groups = new Map<string, { scores: TrendPoint[]; misconceptions: Map<string, number> }>()
+
+    for (const r of rows) {
+      const topic = (r.lessonTitle ?? r.taskTitle ?? 'General').trim() || 'General'
+      const score = typeof r.score === 'number' ? Math.round(r.score) : null
+      if (score === null) continue
+
+      let g = groups.get(topic)
+      if (!g) {
+        g = { scores: [], misconceptions: new Map() }
+        groups.set(topic, g)
+      }
+      g.scores.push({ at: r.submittedAt ? r.submittedAt.toISOString() : null, score })
+
+      const items = (r.aiFeedback as { items?: Array<{ misconception?: string }> } | null)?.items
+      if (Array.isArray(items)) {
+        for (const it of items) {
+          const label = it?.misconception?.trim()
+          if (label) g.misconceptions.set(label, (g.misconceptions.get(label) ?? 0) + 1)
+        }
+      }
+    }
+
+    const topics: TopicMastery[] = Array.from(groups.entries()).map(([topic, g]) => {
+      const scores = g.scores
+      const avg = Math.round(scores.reduce((a, b) => a + b.score, 0) / scores.length)
+      const latest = scores[scores.length - 1].score
+      const first = scores[0].score
+      return {
+        topic,
+        attempts: scores.length,
+        averageScore: avg,
+        latestScore: latest,
+        delta: latest - first,
+        trend: scores.slice(-8),
+        misconceptions: Array.from(g.misconceptions.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([label, count]) => ({ label, count })),
+      }
+    })
+
+    // Weakest topics first — the most useful thing for a student to see.
+    topics.sort((a, b) => a.averageScore - b.averageScore)
+
+    return NextResponse.json({ topics })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to load mastery',
+      'api/student/assessment-mastery/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/components/student/assessment-mastery-card.tsx
+++ b/tutorme-app/src/components/student/assessment-mastery-card.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+/**
+ * AssessmentMasteryCard — per-topic mastery from a student's graded assessments,
+ * weakest first, with a small trend sparkline and the misconceptions that recur.
+ * Purely a read of /api/student/assessment-mastery; renders nothing until there
+ * is at least one graded submission.
+ */
+
+import { useEffect, useState } from 'react'
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
+
+interface TrendPoint {
+  at: string | null
+  score: number
+}
+interface TopicMastery {
+  topic: string
+  attempts: number
+  averageScore: number
+  latestScore: number
+  delta: number
+  trend: TrendPoint[]
+  misconceptions: { label: string; count: number }[]
+}
+
+function barColor(score: number): string {
+  if (score >= 80) return 'bg-emerald-500'
+  if (score >= 60) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+function Sparkline({ trend }: { trend: TrendPoint[] }) {
+  if (trend.length < 2) return null
+  const w = 64
+  const h = 20
+  const max = 100
+  const step = w / (trend.length - 1)
+  const pts = trend
+    .map((p, i) => `${(i * step).toFixed(1)},${(h - (p.score / max) * h).toFixed(1)}`)
+    .join(' ')
+  return (
+    <svg width={w} height={h} className="shrink-0" aria-hidden>
+      <polyline points={pts} fill="none" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  )
+}
+
+export function AssessmentMasteryCard() {
+  const [topics, setTopics] = useState<TopicMastery[] | null>(null)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/student/assessment-mastery', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { topics: [] }))
+      .then(d => {
+        if (active) setTopics(Array.isArray(d?.topics) ? d.topics : [])
+      })
+      .catch(() => active && setTopics([]))
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!topics || topics.length === 0) return null
+
+  return (
+    <div className="mb-8 rounded-xl border border-gray-200 bg-white p-5">
+      <h2 className="mb-3 text-sm font-semibold text-gray-900">Your topic mastery</h2>
+      <div className="space-y-3">
+        {topics.slice(0, 6).map(t => {
+          const trendUp = t.delta > 4
+          const trendDown = t.delta < -4
+          return (
+            <div key={t.topic}>
+              <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                <span className="min-w-0 truncate font-medium text-gray-800">{t.topic}</span>
+                <span className="flex shrink-0 items-center gap-2 text-gray-500">
+                  <span
+                    className={`inline-flex items-center gap-0.5 text-xs ${
+                      trendUp ? 'text-emerald-600' : trendDown ? 'text-red-500' : 'text-gray-400'
+                    }`}
+                  >
+                    {trendUp ? (
+                      <TrendingUp className="h-3.5 w-3.5" />
+                    ) : trendDown ? (
+                      <TrendingDown className="h-3.5 w-3.5" />
+                    ) : (
+                      <Minus className="h-3.5 w-3.5" />
+                    )}
+                    {t.delta > 0 ? `+${t.delta}` : t.delta}
+                  </span>
+                  <span className="font-semibold tabular-nums text-gray-700">
+                    {t.averageScore}%
+                  </span>
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className={`h-full rounded-full ${barColor(t.averageScore)}`}
+                    style={{ width: `${Math.max(2, t.averageScore)}%` }}
+                  />
+                </div>
+                <div className="text-gray-300">
+                  <Sparkline trend={t.trend} />
+                </div>
+              </div>
+              {t.misconceptions.length > 0 && (
+                <p className="mt-1 text-xs text-gray-500">
+                  Recurring slips: {t.misconceptions.map(m => m.label).join(', ')}
+                </p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Turns assessment history into a **mastery view** — the concept-trend piece from the Tier 3 plan, done as a read-only enhancement rather than a parallel store (the existing `/api/student/progress` keeps owning strengths/weaknesses).

- **`GET /api/student/assessment-mastery`** — groups the student's graded submissions by the lesson each task belongs to (the "topic", via `builderTask.lessonId → courseLesson.title`) and returns, weakest-first: attempts, average score, latest, **delta**, an 8-point **trend**, and the top **recurring misconceptions** (pulled from the misconception tags stored in `aiFeedback`). No new storage.
- **`AssessmentMasteryCard`** on the student assignments page — a bar per topic (colour-coded), a trend sparkline + up/down delta, and "recurring slips". Renders nothing until there's at least one graded submission.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)