### PR TITLE
fix(assessment): stop misclassifying study material as a question paper

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1181,6 +1181,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [dmiSpecRows, setDmiSpecRows] = useState<Array<{ type: DmiQuestionType; count: number }>>(
       []
     )
+    // "Is this a question paper?" confirmation — shown when generate-dmi can't be
+    // confident of the document kind (model unsure, or its call conflicts with the
+    // text signals). `signal` is the code-level paper-signal strength, for a hint.
+    const [dmiKindDialog, setDmiKindDialog] = useState<{
+      type: 'task' | 'assessment'
+      signal: 'strong' | 'weak' | 'none' | null
+    } | null>(null)
     // "Edit marks & answers" review modal — lets the tutor set per-question marks
     // and vet/approve the AI-generated answers before deploying.
     const [dmiEditor, setDmiEditor] = useState<{ source: 'task' | 'assessment' } | null>(null)
@@ -3045,7 +3052,8 @@ FEEDBACK: [one or two short sentences explaining the score]`
     // material and the tutor has chosen which question types/counts to generate.
     const handleGenerateDMI = async (
       type: 'task' | 'assessment',
-      questionSpec?: Array<{ type: DmiQuestionType; count: number }>
+      questionSpec?: Array<{ type: DmiQuestionType; count: number }>,
+      documentKindOverride?: 'question_paper' | 'study_material'
     ) => {
       const isTask = type === 'task'
       const builder = isTask ? taskBuilder : assessmentBuilder
@@ -3095,6 +3103,7 @@ FEEDBACK: [one or two short sentences explaining the score]`
             content: pdfText ?? (!hasPdf && hasContent ? content : undefined),
             pdfPages,
             questionSpec,
+            documentKindOverride,
           }),
         })
 
@@ -3104,6 +3113,14 @@ FEEDBACK: [one or two short sentences explaining the score]`
         }
 
         const data = await response.json()
+
+        // Ambiguous document kind: ask the tutor to confirm "question paper vs
+        // study material" before proceeding, instead of silently treating it as a
+        // paper. On confirm we re-run with an explicit override.
+        if (data.needsKindConfirmation && !documentKindOverride) {
+          setDmiKindDialog({ type, signal: data.documentSignal ?? null })
+          return
+        }
 
         // Study material with no explicit questions: ask the tutor which question
         // types + counts to generate, then re-run with that spec.
@@ -11932,6 +11949,53 @@ FEEDBACK: [one or two short sentences explaining the score]`
                   </>
                 )
               })()}
+          </DialogContent>
+        </Dialog>
+
+        {/* Document-kind confirmation — shown when generate-dmi can't be confident
+            whether the upload is a question paper or study material, so we ask
+            rather than silently treating it as a paper. */}
+        <Dialog
+          open={!!dmiKindDialog}
+          onOpenChange={open => {
+            if (!open) setDmiKindDialog(null)
+          }}
+        >
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Is this a question paper?</DialogTitle>
+              <DialogDescription>
+                We couldn&rsquo;t tell whether this document is a question paper (a set of questions
+                for students to answer) or study material to learn from.
+                {dmiKindDialog?.signal === 'none'
+                  ? ' It reads mostly like explanatory material.'
+                  : dmiKindDialog?.signal === 'strong'
+                    ? ' It shows strong signs of a question paper.'
+                    : ''}{' '}
+                Which is it?
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-2 py-2">
+              <Button
+                onClick={() => {
+                  const t = dmiKindDialog?.type
+                  setDmiKindDialog(null)
+                  if (t) void handleGenerateDMI(t, undefined, 'question_paper')
+                }}
+              >
+                It&rsquo;s a question paper
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  const t = dmiKindDialog?.type
+                  setDmiKindDialog(null)
+                  if (t) void handleGenerateDMI(t, undefined, 'study_material')
+                }}
+              >
+                It&rsquo;s study material
+              </Button>
+            </div>
           </DialogContent>
         </Dialog>
 

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/assessment/question-types'
 import { extractQuestionRef } from '@/lib/assessment/marking-scheme'
 import { scoreDocumentConfidence } from '@/lib/assessment/confidence'
+import { analyzeDocumentSignals } from '@/lib/assessment/document-signals'
 import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
@@ -43,6 +44,12 @@ const GenerateDmiRequestSchema = z.object({
     .array(z.object({ type: z.enum(DMI_QUESTION_TYPES), count: z.number().int().min(1).max(50) }))
     .max(10)
     .optional(),
+  /**
+   * Tutor's explicit answer to the "is this a question paper?" prompt. When set,
+   * the model is told the kind (so it extracts/authors accordingly) and the
+   * re-classification confirmation is skipped.
+   */
+  documentKindOverride: z.enum(['question_paper', 'study_material']).optional(),
 })
 
 const SYSTEM_PROMPT = `You build a DMI: a list of ANSWER INPUT FIELDS for a question paper. The student
@@ -51,7 +58,7 @@ the question wording or any answers — you only output a short reference LABEL 
 
 Return ONLY a JSON object (no prose, no markdown, no code fences) with EXACTLY this shape:
 {
-  "documentKind": "question_paper" | "study_material",
+  "documentKind": "question_paper" | "study_material" | "uncertain",
   "fields": [
     { "label": "Question 1(a)", "type": "short", "marks": 2 },
     { "label": "Question 2", "type": "mcq", "options": ["A", "B", "C", "D", "E"], "answer": "C", "marks": 1 }
@@ -59,23 +66,27 @@ Return ONLY a JSON object (no prose, no markdown, no code fences) with EXACTLY t
 }
 
 Rules:
-- documentKind (ALWAYS include it). Decide ONLY by whether the student is being asked to ANSWER
-  questions — NOT by how much prose the document contains:
-  - "question_paper" — the document contains questions/tasks the student must answer. Signals:
-    numbered questions or parts (1, 2, (a), (b), (i), (ii)); multiple-choice items with lettered
-    options (A–E); imperative task verbs aimed at the student (calculate, determine, find, compute,
-    show, prove, explain, justify, describe, state, estimate, sketch, construct, interpret); printed
-    mark allocations like "[5]"; or blank answer spaces. This INCLUDES exam / past papers that wrap
-    each question in heavy context — a scenario paragraph, a data set, a table, a chart, a formula
-    sheet, or a stimulus passage is NORMAL in a question paper and does NOT make it study material
-    (e.g. an AP Statistics free-response paper is a question_paper even though every question has a
-    long scenario).
-  - "study_material" — ONLY when the document is purely explanatory (a textbook section, lecture
-    notes, an article, a summary, revision slides) with NO questions for the student to answer.
-  - If the document has BOTH explanation AND questions to answer (worked examples followed by
-    exercises, or a past paper with scenario context), choose "question_paper".
-  - Tie-breaker: if it contains ANY numbered question, sub-part, or multiple-choice item, it is a
-    "question_paper".
+- documentKind (ALWAYS include it): "question_paper", "study_material", or "uncertain". Decide by the
+  document's PURPOSE — is the student meant to ANSWER a set of questions (a paper), or to LEARN from
+  it (material)? Judge by real answer-prompts aimed at the student, NOT by mere structure (numbering,
+  lists) or by how much prose it contains.
+  - "question_paper" — the document is a SET of questions/tasks for the student to answer, shown by a
+    CONSISTENT pattern of answerable items: numbered questions that each pose a task; printed mark
+    allocations like "[5]"; multiple-choice items with lettered options (A–E); blank answer spaces; or
+    task verbs directed at the student to produce an answer (calculate, determine, find, compute,
+    show, prove, explain, justify, describe, state, estimate, sketch, construct, interpret). This
+    INCLUDES exam / past papers that wrap each question in heavy context — a scenario paragraph, data
+    set, table, chart, formula sheet, or stimulus passage is NORMAL in a question paper and does NOT
+    make it study material (e.g. an AP Statistics free-response paper is a question_paper even though
+    every question has a long scenario).
+  - "study_material" — the document is mainly there to be READ and learned from: a textbook section,
+    lecture notes, an article, a summary, revision slides, or a worked-examples handout. Incidental
+    structure — numbered headings, bulleted or lettered lists, the odd rhetorical or embedded question,
+    or worked examples that use verbs like "calculate"/"explain" while TEACHING a method — does NOT
+    make it a question paper. If the bulk is explanation and there is no consistent set of
+    answer-prompts aimed at the student, it is study_material.
+  - "uncertain" — use this when you genuinely cannot tell (a mix with no clear intent). Do NOT fall
+    back to "question_paper" when unsure; returning "uncertain" lets the tutor confirm.
 - For a question_paper: output ONE field per answerable part — every question AND every sub-part
   (a),(b),(c) and sub-sub-part (i),(ii). "label" is the part's reference EXACTLY as printed, e.g.
   "Question 1(a)", "Question 1(b)(i)", "Question 3(a)(ii)". For a bare multiple-choice section,
@@ -446,7 +457,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
 
-    const { type, title, content, pdfPages, questionSpec } = parsed.data
+    const { type, title, content, pdfPages, questionSpec, documentKindOverride } = parsed.data
 
     if (!content?.trim() && (!pdfPages || pdfPages.length === 0)) {
       return NextResponse.json({ error: 'No content or PDF pages provided' }, { status: 400 })
@@ -461,6 +472,15 @@ export async function POST(request: NextRequest) {
             .join(', ')}. Use those exact types and counts.`
         : ''
 
+    // When the tutor has explicitly confirmed the document kind, tell the model
+    // so it classifies + extracts accordingly (and we skip re-confirmation).
+    const overrideInstruction =
+      documentKindOverride === 'question_paper'
+        ? `\n\nThe tutor has confirmed this document IS a question paper. Set documentKind to "question_paper" and extract one answer-input field per answerable part — do NOT author new questions or answers.`
+        : documentKindOverride === 'study_material'
+          ? `\n\nThe tutor has confirmed this document is study material (not a question paper). Set documentKind to "study_material".`
+          : ''
+
     let aiResponse: string
 
     if (pdfPages && pdfPages.length > 0) {
@@ -469,7 +489,7 @@ export async function POST(request: NextRequest) {
       > = [
         {
           type: 'text',
-          text: `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}.${specInstruction}`,
+          text: `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}.${specInstruction}${overrideInstruction}`,
         },
         ...pdfPages.map(page => ({
           type: 'image_url' as const,
@@ -484,7 +504,7 @@ export async function POST(request: NextRequest) {
         timeoutMs: 60000,
       })
     } else {
-      const prompt = `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}:${specInstruction}\n\n${content}`
+      const prompt = `Build a DMI (answer input fields) for the following ${type}${title ? ` titled "${title}"` : ''}:${specInstruction}${overrideInstruction}\n\n${content}`
       aiResponse = await generateWithKimi(prompt, {
         systemPrompt: SYSTEM_PROMPT,
         temperature: GUARDRAILED_TEMPERATURE,
@@ -504,8 +524,30 @@ export async function POST(request: NextRequest) {
 
     // Prefer the strict-JSON output; fall back to the legacy line parser if the
     // model didn't return usable JSON.
-    const { documentKind, questions } =
+    const { documentKind: modelKind, questions } =
       parseDmiJson(aiResponse) ?? parseDmiResponse(stripCodeFences(aiResponse))
+
+    // A tutor override wins; otherwise use the model's classification.
+    const documentKind = documentKindOverride ?? modelKind
+
+    // Code-level cross-check on the classification (ASMT). We do NOT let the
+    // heuristic decide the kind — only flag a LIKELY misclassification so the
+    // tutor confirms, instead of silently defaulting an ambiguous document to
+    // "question paper". Text-only, so skipped for image-only PDFs.
+    const signals = content && content.trim() ? analyzeDocumentSignals(content) : null
+    const needsKindConfirmation =
+      !questionSpec &&
+      !documentKindOverride &&
+      // The model was unsure / didn't classify — ask rather than assume a paper.
+      (modelKind === null ||
+        // The model called it a paper, but the text shows no paper markers at all
+        // and reads like prose — a likely false "question paper".
+        (modelKind === 'question_paper' &&
+          signals != null &&
+          signals.paperSignal === 'none' &&
+          signals.proseChars > 400) ||
+        // The model called it study material, but the text has strong paper markers.
+        (modelKind === 'study_material' && signals != null && signals.paperSignal === 'strong'))
 
     // Warn-only assessment guardrails. Checks wording fidelity against the
     // source (ASMT-4) and other structural rules where data is available.
@@ -534,10 +576,18 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       response: aiResponse,
-      // null when the model didn't classify; the tutor UI treats null as
-      // "question paper" (the common case) and only prompts for types/counts
-      // when it's explicitly study_material with no questionSpec supplied.
+      // The resolved kind (tutor override, else the model's classification; null
+      // when the model was uncertain). The UI no longer assumes "question paper"
+      // for null — see needsKindConfirmation.
       documentKind,
+      // True when we can't be confident of the kind (model uncertain, or its call
+      // conflicts with the text signals). The builder should ask the tutor to
+      // confirm "question paper vs study material" before proceeding, instead of
+      // silently treating an ambiguous document as a question paper.
+      needsKindConfirmation,
+      // The code-level paper-signal strength, for an optional "we think this is …"
+      // note on the confirm prompt.
+      documentSignal: signals?.paperSignal ?? null,
       // True when the source is study material and the tutor hasn't yet chosen
       // the question types/counts — the builder should prompt before deploying.
       needsQuestionSpec: documentKind === 'study_material' && !questionSpec,

--- a/tutorme-app/src/lib/assessment/document-signals.test.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { analyzeDocumentSignals } from './document-signals'
+
+describe('analyzeDocumentSignals', () => {
+  it('flags a real question paper as a strong paper signal', () => {
+    const paper = `Section A
+1. Calculate the mean of the data set. [3]
+2. Determine the standard deviation. [4]
+3. Explain why the median is more robust. [5]
+(a) State one advantage.
+(b) State one disadvantage.`
+    const s = analyzeDocumentSignals(paper)
+    expect(s.paperSignal).toBe('strong')
+    expect(s.markAllocations).toBeGreaterThanOrEqual(2)
+  })
+
+  it('flags an MCQ paper as strong via lettered options', () => {
+    const mcq = `1. What is 2 + 2?
+A. 3
+B. 4
+C. 5
+D. 6
+2. Which is prime?
+A. 4
+B. 9
+C. 7
+D. 8`
+    const s = analyzeDocumentSignals(mcq)
+    expect(s.mcqOptionLines).toBeGreaterThanOrEqual(4)
+    expect(s.paperSignal).toBe('strong')
+  })
+
+  it('reports NO paper signal for explanatory study notes', () => {
+    const notes = `Photosynthesis is the process by which green plants convert light energy into chemical energy stored in glucose, using carbon dioxide and water.
+The process occurs mainly in the chloroplasts, which contain the pigment chlorophyll that absorbs light most strongly in the blue and red parts of the spectrum.
+There are two main stages: the light-dependent reactions and the light-independent reactions, which together sustain almost all life on Earth.`
+    const s = analyzeDocumentSignals(notes)
+    expect(s.paperSignal).toBe('none')
+    expect(s.markAllocations).toBe(0)
+    expect(s.proseChars).toBeGreaterThan(0)
+  })
+
+  it('does not call a numbered outline a strong paper on its own', () => {
+    const outline = `1. Introduction to cells
+2. The cell membrane
+3. Organelles and their functions
+4. Cell division`
+    const s = analyzeDocumentSignals(outline)
+    // Numbered headings alone (no marks, no options, no answer blanks, no task
+    // verbs) must not read as a strong question paper.
+    expect(s.paperSignal).not.toBe('strong')
+  })
+})

--- a/tutorme-app/src/lib/assessment/document-signals.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.ts
@@ -1,0 +1,90 @@
+/**
+ * Lightweight, code-level signals for "is this a question paper?" — a cheap
+ * cross-check on the AI's documentKind classification (ASMT). It does NOT decide
+ * the kind on its own; it only measures how strongly the raw text *looks like* a
+ * question paper, so the route can flag a likely misclassification and ask the
+ * tutor instead of silently defaulting to "question paper".
+ *
+ * Pure + text-only (works on extracted PDF text; skipped when no text is
+ * available, e.g. image-only PDFs).
+ */
+
+export interface DocumentSignals {
+  /** Printed mark allocations, e.g. "[5]" or "(3 marks)". */
+  markAllocations: number
+  /** Lines that begin like a numbered question or sub-part (1., (a), (ii)). */
+  questionLines: number
+  /** Lines that begin like a lettered multiple-choice option (A., b)). */
+  mcqOptionLines: number
+  /** Blank answer spaces / "Answer:" prompts. */
+  answerBlanks: number
+  /** Imperative task verbs at a line/sentence start (calculate, explain, …). */
+  imperativeCues: number
+  /** Characters sitting in paragraph-like (long) lines — a rough prose measure. */
+  proseChars: number
+  /**
+   * Strength of QUESTION-PAPER signals:
+   *  - 'strong': hard structural markers of a paper (marks, MCQ options, answer
+   *    blanks, or dense numbered questions + task verbs);
+   *  - 'none': essentially no paper markers (looks like plain material);
+   *  - 'weak': some structure but nothing decisive.
+   */
+  paperSignal: 'strong' | 'weak' | 'none'
+}
+
+const MARK_ALLOCATION_RE = /\[\s*\d{1,3}\s*\]|\(\s*\d{1,3}\s*marks?\s*\)/gi
+const QUESTION_LINE_RE = /^\s*(?:Q(?:uestion)?\s*)?\d{1,3}\s*[.)]\s+\S/
+const SUBPART_LINE_RE = /^\s*\(?(?:[a-z]|i{1,3}|iv|v|vi{0,3}|ix|x)\)\s+\S/i
+const MCQ_OPTION_LINE_RE = /^\s*[A-Ea-e]\s*[.)]\s+\S/
+const ANSWER_BLANK_RE = /_{3,}|\bAnswers?\s*[:.]/gi
+const IMPERATIVE_RE =
+  /(?:^|[.\n])\s*(?:calculate|determine|find|compute|show|prove|explain|justify|describe|state|estimate|sketch|construct|interpret|evaluate|solve|define|outline|discuss|identify|label|complete|derive|list)\b/gi
+
+function countMatches(text: string, re: RegExp): number {
+  const m = text.match(re)
+  return m ? m.length : 0
+}
+
+export function analyzeDocumentSignals(content: string): DocumentSignals {
+  const text = content ?? ''
+  const lines = text.split('\n')
+
+  let questionLines = 0
+  let mcqOptionLines = 0
+  let proseChars = 0
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    if (QUESTION_LINE_RE.test(line) || SUBPART_LINE_RE.test(line)) questionLines++
+    if (MCQ_OPTION_LINE_RE.test(line)) mcqOptionLines++
+    // Paragraph-like lines (long, unstructured) are the hallmark of prose.
+    if (line.length > 120) proseChars += line.length
+  }
+
+  const markAllocations = countMatches(text, MARK_ALLOCATION_RE)
+  const answerBlanks = countMatches(text, ANSWER_BLANK_RE)
+  const imperativeCues = countMatches(text, IMPERATIVE_RE)
+
+  // Hard markers of a real question paper.
+  const strong =
+    markAllocations >= 2 ||
+    mcqOptionLines >= 4 ||
+    answerBlanks >= 2 ||
+    (questionLines >= 4 && imperativeCues >= 2)
+
+  // Essentially nothing that says "answer these questions".
+  const none =
+    markAllocations === 0 && answerBlanks === 0 && mcqOptionLines < 2 && questionLines < 2
+
+  const paperSignal: DocumentSignals['paperSignal'] = strong ? 'strong' : none ? 'none' : 'weak'
+
+  return {
+    markAllocations,
+    questionLines,
+    mcqOptionLines,
+    answerBlanks,
+    imperativeCues,
+    proseChars,
+    paperSignal,
+  }
+}


### PR DESCRIPTION
**The bug you hit:** a document that isn't a question paper was extracted as one. Root cause was a detection pipeline biased toward "question paper" at every step (see the investigation) — an aggressive *"ANY numbered item → question_paper"* tie-breaker, a too-narrow *"study material = purely explanatory with NO questions"* definition, and a code path that silently treated an **unclassified (`null`)** document as a paper.

## Fixes
1. **Prompt** (`generate-dmi`): classify by **purpose** (is the student meant to *answer a set of questions* vs *learn from it*), not mere structure or prose length. Broadened `study_material` to cover mostly-explanatory docs with incidental numbering, lists, worked examples, or the odd embedded question. **Removed** the aggressive tie-breaker. Added an explicit **`uncertain`** kind so the model stops guessing "paper".
2. **Code-level cross-check** — new `analyzeDocumentSignals` measures *real* paper markers (mark allocations like `[5]`, MCQ options, answer blanks, dense numbered questions + task verbs) vs prose. It **does not decide the kind** — it only flags a *likely misclassification*. Pure + unit-tested (4 cases).
3. **Ambiguity now asks** instead of assuming: when the model is `uncertain`, or its classification conflicts with the signals, the builder shows an **"Is this a question paper?"** confirmation. The tutor's choice re-runs generation with an explicit `documentKindOverride` so extraction matches the real kind.

Net: study material with incidental structure is no longer force-extracted as an exam; genuine papers still classify straight through; and the only-real-ambiguity case defers to the tutor.

npm run typecheck ✅ · npm run build ✅ · unit tests ✅ (4/4) · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)