### PR TITLE
fix(security): rate-limit the student-facing AI feedback endpoints

### DIFF
--- a/tutorme-app/src/app/api/student/assignments/[taskId]/ai-feedback/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/ai-feedback/route.ts
@@ -15,7 +15,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { and, desc, eq } from 'drizzle-orm'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
-import { handleApiError, requireCsrf } from '@/lib/api/middleware'
+import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { builderTask, builderTaskDmi, taskSubmission } from '@/lib/db/schema'
 import { normalizePciSpec, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
@@ -44,6 +44,9 @@ export async function POST(
   context: { params: Promise<Record<string, string | string[]>> }
 ) {
   try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
     const session = await getServerSession(authOptions, request)
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/ask/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/ask/route.ts
@@ -15,7 +15,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { and, desc, eq } from 'drizzle-orm'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
-import { handleApiError, requireCsrf } from '@/lib/api/middleware'
+import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { builderTask, builderTaskDmi, taskSubmission } from '@/lib/db/schema'
 import { generateWithKimi } from '@/lib/ai/kimi'
@@ -50,6 +50,9 @@ export async function POST(
   context: { params: Promise<Record<string, string | string[]>> }
 ) {
   try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
     const session = await getServerSession(authOptions, request)
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/worked-solution/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/worked-solution/route.ts
@@ -11,7 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { and, desc, eq } from 'drizzle-orm'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
-import { handleApiError, requireCsrf } from '@/lib/api/middleware'
+import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { builderTask, builderTaskDmi, taskSubmission } from '@/lib/db/schema'
 import { generateWithKimi } from '@/lib/ai/kimi'
@@ -37,6 +37,9 @@ export async function POST(
   context: { params: Promise<Record<string, string | string[]>> }
 ) {
   try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
     const session = await getServerSession(authOptions, request)
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })


### PR DESCRIPTION
Follow-up hardening on the assessment-feedback endpoints I added. Each makes a Kimi call, but none had rate limiting — unlike the reference `generate-dmi` route (`withRateLimitPreset(request, 'aiGenerate')`).

- **`ask`** and **`worked-solution`** are repeatable server-side (the 6-turn cap is client-only; worked solutions aren't persisted), so a scripted client could run up model cost.
- **`ai-feedback`** is idempotent (cached in `aiFeedback`) so lower-risk, but still unguarded.

Applies the shared **`aiGenerate`** preset (30 req/min) to all three, before auth, matching `generate-dmi`. The mastery endpoint is a pure DB read (no LLM) and needs none.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)