### PR TITLE
feat(feedback): persist worked solutions (no regeneration per view)

### DIFF
--- a/tutorme-app/drizzle/0068_tasksubmission_worked_solutions.sql
+++ b/tutorme-app/drizzle/0068_tasksubmission_worked_solutions.sql
@@ -1,0 +1,5 @@
+-- TaskSubmission.workedSolutions: cached AI worked solutions keyed by questionId
+--   ({ [questionId]: string }), so a solution the student already viewed is reused
+--   instead of re-running the model. Nullable; idempotent (also applied via
+--   startup-schema-fix so a revision that skips migrations still gets it).
+ALTER TABLE "TaskSubmission" ADD COLUMN IF NOT EXISTS "workedSolutions" jsonb;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1781900000067,
       "tag": "0067_tasksubmission_followups",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1781900000068,
+      "tag": "0068_tasksubmission_worked_solutions",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/worked-solution/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/worked-solution/route.ts
@@ -62,12 +62,22 @@ export async function POST(
 
     // Ownership: the student must have submitted this task.
     const [submission] = await drizzleDb
-      .select({ submissionId: taskSubmission.submissionId })
+      .select({
+        submissionId: taskSubmission.submissionId,
+        workedSolutions: taskSubmission.workedSolutions,
+      })
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
       .limit(1)
     if (!submission) {
       return NextResponse.json({ error: 'No submission for this task' }, { status: 404 })
+    }
+
+    // Return a previously-generated solution as-is — never re-run the model for a
+    // question the student already worked through.
+    const cached = (submission.workedSolutions ?? {}) as Record<string, string>
+    if (typeof cached[questionId] === 'string' && cached[questionId].trim()) {
+      return NextResponse.json({ solution: cached[questionId] })
     }
 
     const [task] = await drizzleDb
@@ -168,6 +178,16 @@ export async function POST(
         '[worked-solution] task guardrail warnings:',
         guardrail.violations.map(v => `${v.ruleId} ${v.severity}`).join(', ')
       )
+    }
+
+    // Cache it on the submission so future views reuse it (best-effort).
+    try {
+      await drizzleDb
+        .update(taskSubmission)
+        .set({ workedSolutions: { ...cached, [questionId]: solution } })
+        .where(eq(taskSubmission.submissionId, submission.submissionId))
+    } catch (persistErr) {
+      console.warn('[worked-solution] failed to cache solution:', persistErr)
     }
 
     return NextResponse.json({ solution })

--- a/tutorme-app/src/lib/db/schema/tables/course.ts
+++ b/tutorme-app/src/lib/db/schema/tables/course.ts
@@ -329,6 +329,10 @@ export const taskSubmission = pgTable(
     // the tutor can see what was asked/answered (and catch AI drift). Array of
     // { questionId, question, answer, at }.
     followUps: jsonb('followUps'),
+    // Cached AI worked solutions, keyed by questionId: { [questionId]: string }.
+    // Generated on demand and reused so we never re-run the model for a solution
+    // the student already viewed.
+    workedSolutions: jsonb('workedSolutions'),
     tutorFeedback: text('tutorFeedback'),
     tutorApproved: boolean('tutorApproved').notNull(),
     submittedAt: timestamp('submittedAt', { withTimezone: true }).notNull().defaultNow(),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -154,6 +154,10 @@ ALTER TABLE "CourseLesson" ADD COLUMN IF NOT EXISTS "sourceLessonId" text;
 -- graded assessment, so tutors can see what was asked/answered. Nullable jsonb.
 ALTER TABLE "TaskSubmission" ADD COLUMN IF NOT EXISTS "followUps" jsonb;
 
+-- Worked solutions (drizzle/0068): cached AI worked solutions keyed by
+-- questionId, reused instead of re-running the model. Nullable jsonb.
+ALTER TABLE "TaskSubmission" ADD COLUMN IF NOT EXISTS "workedSolutions" jsonb;
+
 -- TaskDeploymentStatus enum
 DO $$
 BEGIN


### PR DESCRIPTION
Worked solutions were generated on demand and cached only client-side, so re-opening a graded assessment in a new session **re-ran the model**. Now they're cached on the submission.

- New `TaskSubmission.workedSolutions` jsonb keyed by `questionId` (`drizzle/0068` + startup-schema-fix mirror).
- The `worked-solution` route returns a stored solution as-is and only calls Kimi the **first** time a question's solution is requested, then merge-persists it (best-effort).

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.