### PR TITLE
feat(tutor): "where students ask for help" follow-up insights

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
+import { FollowUpInsightsCard } from '@/components/tutor/follow-up-insights-card'
 import { MathText, hasMath } from '@/components/answer/MathText'
 import { cn } from '@/lib/utils'
 
@@ -133,6 +134,10 @@ export default function TutorSubmissionsPage() {
           </div>
         </div>
       </section>
+
+      <div className="px-1">
+        <FollowUpInsightsCard />
+      </div>
 
       {/* Mode selector + tab content */}
       <div className="flex min-h-0 flex-1 flex-col pb-0.5">

--- a/tutorme-app/src/app/api/tutor/follow-up-insights/route.ts
+++ b/tutorme-app/src/app/api/tutor/follow-up-insights/route.ts
@@ -1,0 +1,103 @@
+/**
+ * GET /api/tutor/follow-up-insights
+ *
+ * Where students ask for help. Aggregates the persisted follow-up Q&A
+ * (TaskSubmission.followUps) across the tutor's own tasks and groups it by
+ * (task, question), so the tutor can see which questions generate the most
+ * follow-ups — a signal of where the class is struggling. Read-only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { handleApiError } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, taskSubmission } from '@/lib/db/schema'
+
+interface FollowUp {
+  questionId?: string
+  question?: string
+}
+
+interface HotspotItem {
+  taskId: string
+  taskTitle: string
+  questionId: string
+  count: number
+  /** A few distinct sample questions students asked here. */
+  samples: string[]
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const isAdmin = session.user.role === 'ADMIN'
+
+    const rows = await drizzleDb
+      .select({
+        taskId: taskSubmission.taskId,
+        taskTitle: builderTask.title,
+        followUps: taskSubmission.followUps,
+      })
+      .from(taskSubmission)
+      .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+      .where(isAdmin ? undefined : and(eq(builderTask.tutorId, session.user.id)))
+      .limit(1000)
+
+    // Group by (taskId, questionId).
+    const groups = new Map<
+      string,
+      { taskId: string; taskTitle: string; questionId: string; count: number; samples: Set<string> }
+    >()
+
+    let totalFollowUps = 0
+    for (const r of rows) {
+      const list = Array.isArray(r.followUps) ? (r.followUps as FollowUp[]) : []
+      for (const f of list) {
+        const questionId = String(f?.questionId ?? '').trim()
+        const question = String(f?.question ?? '').trim()
+        if (!questionId || !question) continue
+        totalFollowUps++
+        const key = `${r.taskId}::${questionId}`
+        let g = groups.get(key)
+        if (!g) {
+          g = {
+            taskId: r.taskId,
+            taskTitle: r.taskTitle ?? 'Untitled',
+            questionId,
+            count: 0,
+            samples: new Set(),
+          }
+          groups.set(key, g)
+        }
+        g.count++
+        if (g.samples.size < 3) g.samples.add(question.slice(0, 160))
+      }
+    }
+
+    const items: HotspotItem[] = Array.from(groups.values())
+      .map(g => ({
+        taskId: g.taskId,
+        taskTitle: g.taskTitle,
+        questionId: g.questionId,
+        count: g.count,
+        samples: Array.from(g.samples),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 20)
+
+    return NextResponse.json({ items, totalFollowUps })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to load follow-up insights',
+      'api/tutor/follow-up-insights/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/components/tutor/follow-up-insights-card.tsx
+++ b/tutorme-app/src/components/tutor/follow-up-insights-card.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+/**
+ * FollowUpInsightsCard — "where students ask for help". Reads
+ * /api/tutor/follow-up-insights and lists the (task, question) pairs that drew
+ * the most follow-up questions, with a few sample questions each. Renders
+ * nothing until there's at least one follow-up.
+ */
+
+import { useEffect, useState } from 'react'
+import { MessageCircleQuestion, ChevronDown, ChevronUp } from 'lucide-react'
+
+interface Hotspot {
+  taskId: string
+  taskTitle: string
+  questionId: string
+  count: number
+  samples: string[]
+}
+
+export function FollowUpInsightsCard() {
+  const [items, setItems] = useState<Hotspot[] | null>(null)
+  const [total, setTotal] = useState(0)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/tutor/follow-up-insights', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { items: [], totalFollowUps: 0 }))
+      .then(d => {
+        if (!active) return
+        setItems(Array.isArray(d?.items) ? d.items : [])
+        setTotal(typeof d?.totalFollowUps === 'number' ? d.totalFollowUps : 0)
+      })
+      .catch(() => active && setItems([]))
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!items || items.length === 0) return null
+
+  return (
+    <div className="mb-6 rounded-xl border border-violet-200 bg-violet-50/40 p-4">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        <span className="inline-flex items-center gap-2 text-sm font-semibold text-violet-900">
+          <MessageCircleQuestion className="h-4 w-4" />
+          Where students ask for help
+          <span className="rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700">
+            {total} follow-up{total === 1 ? '' : 's'}
+          </span>
+        </span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 text-violet-500" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-violet-500" />
+        )}
+      </button>
+
+      {open && (
+        <ul className="mt-3 space-y-2">
+          {items.map(it => (
+            <li
+              key={`${it.taskId}:${it.questionId}`}
+              className="rounded-lg border border-violet-100 bg-white/70 p-2.5"
+            >
+              <div className="flex items-center justify-between gap-2 text-sm">
+                <span className="min-w-0 truncate font-medium text-gray-800">
+                  {it.taskTitle} · Q{it.questionId}
+                </span>
+                <span className="shrink-0 rounded-full bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-700">
+                  {it.count} ask{it.count === 1 ? '' : 's'}
+                </span>
+              </div>
+              {it.samples.length > 0 && (
+                <ul className="mt-1 space-y-0.5">
+                  {it.samples.map((s, i) => (
+                    <li key={i} className="truncate text-xs text-gray-500">
+                      “{s}”
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Now that follow-up Q&A is persisted (`TaskSubmission.followUps`, from #717), aggregate it for the tutor.

- **`GET /api/tutor/follow-up-insights`** — groups follow-ups across the tutor's own tasks by `(task, question)` and returns hotspots with counts + a few distinct sample questions each, sorted by volume. Read-only; scoped to the tutor's tasks (admins see all).
- A collapsible **"Where students ask for help"** card atop the grading page shows the total and the top hotspots — a direct signal of where the class is struggling. Renders nothing until there's at least one follow-up.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.