### PR TITLE
fix(directory): show live-session deployed materials/assets to students

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -985,6 +985,7 @@ function StudentFeedbackContent() {
     tasks: true,
     assessments: true,
     homework: true,
+    materials: true,
     reports: true,
     recordedSessions: true,
   })
@@ -1014,6 +1015,7 @@ function StudentFeedbackContent() {
             tasks: true,
             assessments: true,
             homework: true,
+            materials: true,
             reports: true,
             recordedSessions: true,
           }
@@ -1759,6 +1761,7 @@ function StudentFeedbackContent() {
         item.type === 'task' ||
         item.type === 'assessment' ||
         item.type === 'homework' ||
+        item.type === 'asset' ||
         item.type === 'recording'
       ) {
         try {
@@ -2793,6 +2796,61 @@ function StudentFeedbackContent() {
                                                         </span>
                                                       </button>
                                                     ))}
+                                              </div>
+                                            )}
+                                          </div>
+
+                                          {/* Materials — documents/resources the
+                                              tutor deployed in a live session. */}
+                                          <div>
+                                            <button
+                                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 hover:bg-slate-100"
+                                              onClick={() =>
+                                                setFoldersOpen(prev => ({
+                                                  ...prev,
+                                                  materials: !prev.materials,
+                                                }))
+                                              }
+                                            >
+                                              {foldersOpen.materials ? (
+                                                <ChevronDown className="h-4 w-4 shrink-0 text-slate-500" />
+                                              ) : (
+                                                <ChevronRight className="h-4 w-4 shrink-0 text-slate-500" />
+                                              )}
+                                              <Folder
+                                                className="h-4 w-4 shrink-0 text-amber-400"
+                                                fill="currentColor"
+                                              />
+                                              <span className="text-sm font-medium text-slate-700">
+                                                Materials
+                                              </span>
+                                            </button>
+                                            {foldersOpen.materials && (
+                                              <div className="mt-1 flex flex-col gap-0.5 pl-6">
+                                                {(!courseData.materials ||
+                                                  courseData.materials.length === 0) && (
+                                                  <span className="px-2 py-1 text-xs text-slate-500">
+                                                    Empty folder
+                                                  </span>
+                                                )}
+                                                {courseData.materials &&
+                                                  [...courseData.materials].reverse().map(task => (
+                                                    <button
+                                                      key={task.id}
+                                                      onClick={() =>
+                                                        handleSelectDirectoryItem(task)
+                                                      }
+                                                      className={cn(
+                                                        'group flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                                                        activeTaskId === (task.itemId || task.id)
+                                                          ? 'bg-amber-50 font-medium text-amber-700'
+                                                          : 'text-slate-600 hover:bg-white hover:text-slate-900 hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]'
+                                                      )}
+                                                    >
+                                                      <FileText className="h-3.5 w-3.5 shrink-0 text-amber-400" />
+                                                      <span className="truncate">{task.title}</span>
+                                                    </button>
+                                                  ))}
                                               </div>
                                             )}
                                           </div>

--- a/tutorme-app/src/app/api/student/directory/route.ts
+++ b/tutorme-app/src/app/api/student/directory/route.ts
@@ -152,6 +152,7 @@ export const GET = withAuth(
           tasks: [],
           assessments: [],
           homework: [],
+          materials: [],
           reports: [],
           recordedSessions: [],
         }
@@ -233,6 +234,11 @@ export const GET = withAuth(
           break
         case 'homework':
           directory[tutorKey][courseKey].homework.push(item)
+          break
+        case 'asset':
+          // Documents / resources the tutor deployed in a live session. Without
+          // this case they were silently dropped from the Directory.
+          directory[tutorKey][courseKey].materials.push(item)
           break
         case 'recording':
           directory[tutorKey][courseKey].recordedSessions.push(item)


### PR DESCRIPTION
**The gap:** when a tutor deploys **materials** (documents/resources — `DeployedMaterial.type === 'asset'`) during a live session, students couldn't access them in the Directory. The directory route's `switch` on material type had cases for `task`/`assessment`/`homework`/`recording`/`report` but **not `asset`**, so deployed assets were silently dropped. Even if listed, clicking one did nothing — `handleSelectDirectoryItem` didn't accept the `asset` type.

## Fix
- **Directory API** (`/api/student/directory`): add a `materials` folder to each course tree and a **`case 'asset'`** that files deployed assets into it (document URLs are already GCS-refreshed).
- **Student Directory UI** (feedback page): render a **"Materials"** folder (open by default), and let a student select an asset — `handleSelectDirectoryItem` now handles `'asset'`, so the asset snapshot (its text + `sourceDocument`) opens in the classroom viewer (PDF/image/etc.) like any other deployed item.

Everything else (tasks, assessments, homework, recordings, reports) was already wired — only the asset type was missing.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)