### PR TITLE
fix(course-builder): course name unreadable (white) in top header under dark themes

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -825,7 +825,11 @@ function CourseBuilderInsightsRouteInner({
                       >
                         <SelectTrigger
                           className={cn(
-                            'h-9 min-w-[160px] max-w-[320px] border-none bg-transparent text-sm font-semibold shadow-none transition-colors focus:ring-0',
+                            // Header card is hardcoded light (bg-white) regardless of
+                            // theme, so use a hardcoded dark text colour — the theme
+                            // token text-foreground flips to white under dark themes
+                            // and made the course name unreadable here.
+                            'h-9 min-w-[160px] max-w-[320px] border-none bg-transparent text-sm font-semibold text-[#1F2933] shadow-none transition-colors focus:ring-0',
                             hasNoCourses ? 'cursor-not-allowed opacity-60' : 'hover:bg-slate-100'
                           )}
                         >
@@ -901,9 +905,9 @@ function CourseBuilderInsightsRouteInner({
                     )}
 
                   {activeMainTab === 'builder' && (
-                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight text-[#1F2933]">
                       {currentCourse?.name && (
-                        <span className="text-muted-foreground text-xl font-normal">
+                        <span className="text-xl font-normal text-slate-500">
                           {currentCourse.name}
                         </span>
                       )}
@@ -913,9 +917,9 @@ function CourseBuilderInsightsRouteInner({
                     // Centered across the full header via absolute positioning;
                     // pointer-events-none so the overlay never blocks the back
                     // button / header controls underneath it.
-                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight text-[#1F2933]">
                       {model.course?.name && (
-                        <span className="text-muted-foreground text-xl font-normal">
+                        <span className="text-xl font-normal text-slate-500">
                           {model.course.name}
                         </span>
                       )}
@@ -935,9 +939,9 @@ function CourseBuilderInsightsRouteInner({
                     </h1>
                   )}
                   {activeMainTab === 'test-pci' && (
-                    <h1 className="text-foreground pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight">
+                    <h1 className="pointer-events-none absolute left-0 right-0 mx-auto flex items-center justify-center gap-2 text-2xl font-bold tracking-tight text-[#1F2933]">
                       {(model.course?.name || currentCourse?.name) && (
-                        <span className="text-muted-foreground text-xl font-normal">
+                        <span className="text-xl font-normal text-slate-500">
                           {model.course?.name || currentCourse?.name}
                         </span>
                       )}


### PR DESCRIPTION
## Problem
On the course builder, the **course name** in the top header renders **white and unreadable**.

## Root cause
The top header card uses **hardcoded light backgrounds** (`bg-[#fafafc]`, `bg-white`), but rendered the course name with **theme tokens** (`text-foreground` / `text-muted-foreground`). The `aura` / `nimbus` / `sahara` **`.dark`** themes define `--foreground` and `--muted-foreground` as **near-white** (`#E8E6E3`, `#F8F9FA`, …). So for any tutor on a dark theme, the theme-relative text flips to white while the hardcoded-light header stays light → **white-on-white**.

It's the classic mismatch: theme-token *text* on a *non-theme* (hardcoded) background.

## Fix
Give the course-name texts **hardcoded dark colours** to match the header's hardcoded light background — the rest of this header already uses hardcoded colours (`text-[#1F2933]`, `border-[#E5E7EB]`, etc.):
- Course **Select trigger** (the name shown on the left): add `text-[#1F2933]`.
- The three centered course-name **`<h1>`** overlays (builder / live / test-pci): `text-foreground` → `text-[#1F2933]`.
- The three course-name **`<span>`**s: `text-muted-foreground` → `text-slate-500`.

The category chips (`bg-muted text-muted-foreground`) are a **matched theme pair** (both flip together), so they stay readable under any theme and are left unchanged. Readable in both light and dark themes now.

## Testing
- Lint clean (0 errors) on the file; change is className-only.
- Note: local `npm run typecheck` shows pre-existing errors in `.next/types/validator.ts` (stale local build cache, gitignored) — they appear with this change stashed too, so they're unrelated; CI rebuilds `.next` fresh.
- Not visually verified in-app here — but the fix is deterministic (hardcoded-light bg ⇒ hardcoded-dark text), independent of which theme is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)