### PR TITLE
Revert #718 (Communications Edits — caused unexpected changes)

### DIFF
--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -13,10 +13,6 @@ export interface CollapsibleCardProps {
   className?: string
   contentClassName?: string
   flush?: boolean
-  /** When true, the card and its open content fill the parent's height (for use
-   *  inside a bounded flex column) instead of sizing to content. Opt-in so the
-   *  default content-sized behavior used across the app stays unchanged. */
-  fill?: boolean
   children: React.ReactNode
 }
 
@@ -28,26 +24,24 @@ export function CollapsibleCard({
   className,
   contentClassName,
   flush = false,
-  fill = false,
   children,
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen)
   const cardRef = useAutoScrollOnExpand(open, { delay: 400, margin: 16, block: 'start' })
 
   return (
-    <div ref={cardRef} className={cn(fill && 'flex min-h-0 flex-1 flex-col')}>
+    <div ref={cardRef}>
       {/* Outer wrapper with shadow - overflow visible so shadow shows */}
       <div
         className={cn(
           flush
             ? 'rounded-b-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]'
             : 'rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]',
-          fill && 'flex min-h-0 flex-1 flex-col',
           className
         )}
       >
         {/* Inner wrapper with overflow hidden for animation */}
-        <div className={cn('flex flex-col overflow-hidden p-0', fill && 'h-full min-h-0 flex-1')}>
+        <div className="flex flex-col overflow-hidden p-0">
           <button
             type="button"
             onClick={() => setOpen(o => !o)}
@@ -72,11 +66,7 @@ export function CollapsibleCard({
           <div
             className={cn(
               'overflow-hidden transition-all duration-300 ease-in-out',
-              open
-                ? fill
-                  ? 'flex min-h-0 flex-1 flex-col opacity-100'
-                  : 'flex-1 opacity-100'
-                : 'flex-0 h-0 opacity-0'
+              open ? 'flex-1 opacity-100' : 'flex-0 h-0 opacity-0'
             )}
           >
             <div className={cn('h-full overflow-hidden', contentClassName)}>{children}</div>

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -203,7 +203,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               title="Messaging"
               icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
               defaultOpen
-              fill
+              className="flex-1"
             >
               <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
             </CollapsibleCard>
@@ -214,7 +214,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               title="Notifications"
               icon={<Bell className="h-5 w-5 text-slate-900" />}
               defaultOpen
-              fill
+              className="flex-1"
             >
               <NotificationsPanel
                 role={role}

--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -44,9 +44,8 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
-      {/* Content area — top padding gives the panel header room to breathe above
-          the menu rail, chat list column and the main display area. */}
-      <div className="flex h-full min-h-0 flex-1 overflow-hidden pt-3 sm:pt-4">
+      {/* Content area */}
+      <div className="flex h-full min-h-0 flex-1 overflow-hidden">
         {/* Left menu rail - shorter */}
         <div className="flex w-40 flex-col items-center gap-2 border-r border-gray-200 py-2">
           {topItems.map(item => {


### PR DESCRIPTION
Reverts **#718** ("fix(communications): fill collapsibles to panel height + header padding"), the work from the *Communications Edits* document.

Per the request, those edits caused unexpected changes, so this restores the Communications page to exactly its pre-#718 state:
- `CollapsibleCard`: removes the `fill` prop (back to content-sized behavior).
- `communications-page`: Messaging/Notifications cards go back to `className="flex-1"`.
- `messaging-panel`: removes the added header padding (`pt-3 sm:pt-4`).

**Verified:** the three files are byte-identical to `fb79118c3^` (the commit immediately before #718). This is a clean `git revert` of the squash commit; no later commits touched these files, so it applied without conflicts.

## Testing
- Restores code that was already on `main` and passed CI before #718.
- Local `npm run typecheck` shows only pre-existing stale `.next` cache errors (unrelated; CI rebuilds fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)