### PR TITLE
fix(sliding-pill): fix reverse animation from right tab to left tab

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -83,7 +83,7 @@ export function SessionCalendarPanel({
   const listRef = useRef<HTMLDivElement>(null)
   const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
   const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
   const activeTextColor =
     variant === 'orange' ? '#EA580C' : variant === 'charcoal' ? '#1F2933' : '#2563EB'
 
@@ -132,7 +132,7 @@ export function SessionCalendarPanel({
               ))}
               <motion.div
                 className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm"
-                initial={false}
+                initial={{ left: initialLeft, width: initialWidth }}
                 animate={{ left, width }}
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
               />

--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -55,7 +55,7 @@ export function SlidingPillTabsList({
 }: SlidingPillTabsListProps) {
   const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
   const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
   const styles = VARIANT_STYLES[variant]
 
   return (
@@ -81,7 +81,7 @@ export function SlidingPillTabsList({
       ))}
       <motion.div
         className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
-        initial={false}
+        initial={{ left: initialLeft, width: initialWidth }}
         animate={{ left, width }}
         transition={{ type: 'spring', stiffness: 400, damping: 30 }}
       />

--- a/tutorme-app/src/hooks/use-sliding-pill.ts
+++ b/tutorme-app/src/hooks/use-sliding-pill.ts
@@ -1,25 +1,48 @@
-import { useLayoutEffect, useState, useEffect, type RefObject } from 'react'
+import { useLayoutEffect, useState, useEffect, useRef, type RefObject } from 'react'
 
 export function useSlidingPillMetrics(
   triggerRefs: RefObject<(HTMLElement | null)[]>,
   activeIndex: number
 ) {
   const [metrics, setMetrics] = useState({ left: 0, width: 0 })
+  const prevMetricsRef = useRef({ left: 0, width: 0 })
+  const isFirstRenderRef = useRef(true)
 
   // Calculate metrics based on current DOM state
   const calculateMetrics = () => {
     if (!triggerRefs.current) return
     const trigger = triggerRefs.current[activeIndex]
     if (!trigger) return
-    setMetrics({
+    const newMetrics = {
       left: trigger.offsetLeft,
       width: trigger.offsetWidth,
-    })
+    }
+    // Store previous metrics before updating
+    prevMetricsRef.current = { ...metrics }
+    setMetrics(newMetrics)
   }
 
   // Initial calculation + when activeIndex changes
   useLayoutEffect(() => {
-    calculateMetrics()
+    if (!triggerRefs.current) return
+    const trigger = triggerRefs.current[activeIndex]
+    if (!trigger) return
+
+    const newMetrics = {
+      left: trigger.offsetLeft,
+      width: trigger.offsetWidth,
+    }
+
+    if (isFirstRenderRef.current) {
+      // On first render, set without animation
+      isFirstRenderRef.current = false
+      prevMetricsRef.current = newMetrics
+      setMetrics(newMetrics)
+    } else {
+      // Store current metrics as previous before updating
+      prevMetricsRef.current = { ...metrics }
+      setMetrics(newMetrics)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeIndex])
 
@@ -60,5 +83,9 @@ export function useSlidingPillMetrics(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeIndex])
 
-  return metrics
+  return {
+    ...metrics,
+    initialLeft: prevMetricsRef.current.left,
+    initialWidth: prevMetricsRef.current.width,
+  }
 }


### PR DESCRIPTION
## Problem
The sliding pill animation was broken when switching from a right tab to a left tab (e.g., Insights -> Submissions in the Desk panel). The pill would appear from the left side and animate off-screen to the right instead of sliding smoothly from the right tab position to the left tab position.

## Root Cause
Using  on the Framer Motion  prevented it from tracking the correct starting position for reverse-direction animations. When switching tabs, the pill lost its previous position context and started the animation from an incorrect origin.

## Changes
- **useSlidingPillMetrics hook**: Track previous metrics in a ref and expose them as /. On first render, set initial to current position to skip animation. On subsequent tab changes, initial is the previous tab's position so Framer Motion animates from the correct starting point.
- **SlidingPillTabsList**: Use  instead of  so Framer Motion knows the correct starting position for reverse-direction animations.
- **SessionCalendarPanel**: Same fix applied consistently.

## Affected Components
- Desk panel Submissions/Insights mode selector
- SessionCalendarPanel tab selectors
- Any other component using SlidingPillTabsList or useSlidingPillMetrics