### PR TITLE
fix: sliding pill animation direction when switching tabs

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -1,11 +1,10 @@
 'use client'
 
 import * as React from 'react'
-import { useRef } from 'react'
+import { useRef, useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useSlidingPillMetrics } from '@/hooks/use-sliding-pill'
 import { Card } from '@/components/ui/card'
 import {
   Select,
@@ -78,21 +77,56 @@ export function SessionCalendarPanel({
   timezone,
   onTimezoneChange,
   variant = 'blue',
-  className,
+  className: _className,
 }: SessionCalendarPanelProps) {
   const listRef = useRef<HTMLDivElement>(null)
-  const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
-  const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const [pillStyle, setPillStyle] = useState({ left: 0, width: 0 })
+  const _activeIndex = tabs.findIndex(tab => tab.value === value)
   const activeTextColor =
     variant === 'orange' ? '#EA580C' : variant === 'charcoal' ? '#1F2933' : '#2563EB'
+
+  const updatePillPosition = useCallback(() => {
+    const list = listRef.current
+    if (!list) return
+    const triggers = Array.from(list.querySelectorAll('[role="tab"]'))
+    const active = triggers.find(t => t.getAttribute('data-state') === 'active')
+    if (!active) return
+    const rect = active.getBoundingClientRect()
+    const listRect = list.getBoundingClientRect()
+    setPillStyle({
+      left: rect.left - listRect.left,
+      width: rect.width,
+    })
+  }, [])
+  React.useLayoutEffect(() => {
+    updatePillPosition()
+  }, [updatePillPosition])
+
+  React.useEffect(() => {
+    const id = setTimeout(updatePillPosition, 100)
+    return () => clearTimeout(id)
+  }, [updatePillPosition])
+
+  React.useEffect(() => {
+    const handleResize = () => updatePillPosition()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [updatePillPosition])
+
+  React.useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const ro = new ResizeObserver(() => updatePillPosition())
+    ro.observe(list)
+    return () => ro.disconnect()
+  }, [updatePillPosition])
 
   return (
     <Card
       hoverable={false}
       className={cn(
         'shadow-hover-lift flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5',
-        className
+        _className
       )}
     >
       <Tabs value={value} onValueChange={onValueChange} className="flex h-full w-full flex-col">
@@ -109,12 +143,9 @@ export function SessionCalendarPanel({
                     : 'bg-gradient-to-r from-[#2563EB] to-[#1D4ED8]'
               )}
             >
-              {tabs.map((tab, i) => (
+              {tabs.map(tab => (
                 <TabsTrigger
                   key={tab.value}
-                  ref={el => {
-                    triggerRefs.current[i] = el
-                  }}
                   value={tab.value}
                   className={cn(
                     'relative z-10 flex-1 rounded-lg text-white/80 transition-colors hover:text-white data-[state=active]:bg-transparent data-[state=active]:shadow-none',
@@ -132,8 +163,7 @@ export function SessionCalendarPanel({
               ))}
               <motion.div
                 className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm"
-                initial={{ left: initialLeft, width: initialWidth }}
-                animate={{ left, width }}
+                animate={{ left: pillStyle.left, width: pillStyle.width }}
                 transition={{ type: 'spring', stiffness: 400, damping: 30 }}
               />
             </TabsList>

--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import * as React from 'react'
-import { useRef } from 'react'
+import { useRef, useState, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
-import { useSlidingPillMetrics } from '@/hooks/use-sliding-pill'
 import { TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export interface SlidingPillTab {
@@ -48,26 +47,82 @@ export function SlidingPillTabsList({
   value,
   tabs,
   variant = 'charcoal',
-  className,
+  className: _className,
   listClassName,
   triggerClassName,
   pillClassName,
 }: SlidingPillTabsListProps) {
-  const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
-  const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const listRef = useRef<HTMLDivElement>(null)
+  const [pillStyle, setPillStyle] = useState({ left: 0, width: 0 })
+  const _activeIndex = tabs.findIndex(tab => tab.value === value)
   const styles = VARIANT_STYLES[variant]
+
+  const updatePillPosition = useCallback(() => {
+    const list = listRef.current
+    if (!list) return
+
+    const activeTrigger = list.children[_activeIndex] as HTMLElement | undefined
+    if (!activeTrigger || activeTrigger.getAttribute('role') !== 'tab') {
+      // Fallback: find by data-state="active"
+      const triggers = Array.from(list.querySelectorAll('[role="tab"]'))
+      const active = triggers.find(t => t.getAttribute('data-state') === 'active')
+      if (!active) return
+      const rect = active.getBoundingClientRect()
+      const listRect = list.getBoundingClientRect()
+      setPillStyle({
+        left: rect.left - listRect.left,
+        width: rect.width,
+      })
+      return
+    }
+
+    const rect = activeTrigger.getBoundingClientRect()
+    const listRect = list.getBoundingClientRect()
+    setPillStyle({
+      left: rect.left - listRect.left,
+      width: rect.width,
+    })
+  }, [_activeIndex])
+
+  // Update position when active tab changes
+  React.useLayoutEffect(() => {
+    updatePillPosition()
+  }, [updatePillPosition])
+
+  // Update after a delay for fonts/layout
+  React.useEffect(() => {
+    const id = setTimeout(updatePillPosition, 100)
+    return () => clearTimeout(id)
+  }, [updatePillPosition])
+
+  // Update on resize
+  React.useEffect(() => {
+    const handleResize = () => updatePillPosition()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [updatePillPosition])
+
+  // Use ResizeObserver on the list container
+  React.useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+
+    const ro = new ResizeObserver(() => {
+      updatePillPosition()
+    })
+    ro.observe(list)
+
+    return () => ro.disconnect()
+  }, [updatePillPosition])
 
   return (
     <TabsList
+      ref={listRef}
       className={cn('relative flex w-full gap-1.5 rounded-xl p-1.5', styles.list, listClassName)}
     >
-      {tabs.map((tab, i) => (
+      {tabs.map(tab => (
         <TabsTrigger
           key={tab.value}
-          ref={el => {
-            triggerRefs.current[i] = el
-          }}
           value={tab.value}
           disabled={tab.disabled}
           className={cn(
@@ -81,8 +136,7 @@ export function SlidingPillTabsList({
       ))}
       <motion.div
         className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
-        initial={{ left: initialLeft, width: initialWidth }}
-        animate={{ left, width }}
+        animate={{ left: pillStyle.left, width: pillStyle.width }}
         transition={{ type: 'spring', stiffness: 400, damping: 30 }}
       />
     </TabsList>


### PR DESCRIPTION
## Problem

When clicking from the right tab (Insights) to the left tab (Submissions) in the Desk panel's mode selector, the sliding pill animates in the wrong direction — it appears from the left side and slides off-screen to the right instead of smoothly moving from right to left.

## Root Cause

React ref callbacks () are called with  during cleanup and then with the new element. In React 18's concurrent mode, this timing is unpredictable. When switching tabs,  could run while refs still pointed to stale elements, causing  to return incorrect values and the pill to animate from the wrong starting position.

## Solution

Replace per-trigger refs with a single container ref and query the DOM directly for the active tab via . Use  relative to the container for accurate positioning regardless of parent layout. Watch the container with  instead of individual triggers.

### Changes

- **SlidingPillTabsList** (): Inline position calculation, no per-trigger refs
- **SessionCalendarPanel** (): Same fix, inline position calculation

### Why this works

1. **No per-trigger refs** → eliminates ref callback timing issues entirely
2. **Query  directly from DOM** → always gets the correct active element
3. ** relative to container** → accurate positioning regardless of parent layout changes
4. **ResizeObserver on container** → catches all layout changes in one place

### Testing

- [ ] Click from Submissions → Insights (left → right): pill should slide right
- [ ] Click from Insights → Submissions (right → left): pill should slide left
- [ ] Resize window: pill should stay correctly positioned
- [ ] Font loading: pill should recalculate after fonts load (100ms delay)

## Related

Fixes the reverse animation issue reported in previous PRs #730, #731.