### PR TITLE
fix: apply redesigned poll composer to Desk panel Insights tab

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -185,9 +185,9 @@ export default function StudentTutorDirectoryPage() {
   }, [tutors])
 
   return (
-    <div className="text-foreground flex h-full flex-col bg-slate-50 px-6 pb-0 pt-2 lg:pt-0">
+    <div className="flex h-full min-h-full flex-col bg-white px-3 pb-0 lg:px-4">
       {/* Hero */}
-      <section className="relative mb-4 overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#F97316] to-[#EA580C] p-5 shadow-[0_12px_32px_rgba(0,0,0,0.12)]">
+      <section className="relative mb-4 flex-shrink-0 overflow-hidden rounded-[20px] border border-white/10 bg-gradient-to-br from-[#F97316] to-[#EA580C] p-5 shadow-[0_12px_40px_-4px_rgba(0,0,0,0.22)] ring-1 ring-white/20">
         <div className="relative flex flex-wrap items-center justify-center gap-3">
           <div className="text-center">
             <h2 className="text-xl font-bold text-white">Solocorn Tutors</h2>
@@ -223,7 +223,7 @@ export default function StudentTutorDirectoryPage() {
 
       {/* Bottom panel: filters + results */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-4">
-        <div className="flex h-full flex-col overflow-hidden rounded-[18px] border border-slate-200/80 bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+        <div className="shadow-hover-lift flex h-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white ring-1 ring-black/5">
           {/* Filters */}
           <div className="grid grid-cols-1 gap-3 p-4 pb-0 sm:p-6 sm:pb-0 md:grid-cols-4">
             <div className="relative">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10877,49 +10877,132 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                       value="poll"
                                       className="flex flex-1 flex-col overflow-hidden data-[state=active]:flex data-[state=inactive]:hidden"
                                     >
-                                      <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
-                                        <InsightsReportView
-                                          type="poll"
-                                          pollResults={pollResults}
-                                          onClose={handleCloseInsight}
-                                          onMentionStudent={name =>
-                                            setPollPrompt(
-                                              pollPrompt
-                                                ? `${pollPrompt} @[${name}](student:${name}) `
-                                                : `@[${name}](student:${name}) `
-                                            )
-                                          }
-                                        />
-                                      </div>
-                                      {pollOptionPicker}
-                                      <div className="mt-2 shrink-0 rounded-2xl border border-blue-100 bg-white p-2 shadow-sm">
-                                        <div className="relative">
-                                          <MentionTextarea
-                                            mentionItems={mentionItems}
-                                            className="min-h-[100px] w-full resize-none border-0 bg-transparent py-2 pl-3 pr-24 text-sm shadow-none focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-                                            disableAutoResize
-                                            value={pollPrompt}
-                                            onChange={event => setPollPrompt(event.target.value)}
-                                          />
-                                          <div className="absolute bottom-2 right-2 flex items-center gap-1">
-                                            <Button
-                                              size="icon"
-                                              variant="ghost"
-                                              className={cn(
-                                                'h-8 w-8 rounded-xl hover:bg-blue-100 hover:text-blue-700 disabled:opacity-30',
-                                                showAIPoll
-                                                  ? 'bg-blue-100 text-blue-700'
-                                                  : 'text-blue-600'
+                                      {pollComposeMode ? (
+                                        <div className="mb-2 flex flex-1 flex-col overflow-hidden rounded-2xl border border-blue-100 bg-white shadow-sm">
+                                          {/* Header with toggle */}
+                                          <div className="flex items-center justify-between border-b border-blue-100 px-4 py-2">
+                                            <span className="text-xs font-semibold text-blue-700">
+                                              New Poll
+                                            </span>
+                                            {pollResults.length > 0 && (
+                                              <button
+                                                type="button"
+                                                onClick={() => setPollComposeMode(false)}
+                                                className="text-xs text-blue-600 hover:text-blue-800"
+                                              >
+                                                View Results
+                                              </button>
+                                            )}
+                                          </div>
+                                          {/* Editable question area */}
+                                          <div className="flex-1 overflow-y-auto p-4">
+                                            <textarea
+                                              value={pollPrompt}
+                                              onChange={e => setPollPrompt(e.target.value)}
+                                              placeholder="Type your poll question here..."
+                                              className="w-full resize-none border-0 bg-transparent text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+                                              rows={3}
+                                            />
+                                            {/* Poll options preview */}
+                                            <div className="mt-4 flex flex-wrap gap-2">
+                                              {pollOptionMode === 'letters' && (
+                                                <>
+                                                  {['A', 'B', 'C', 'D', 'E'].map(letter => (
+                                                    <button
+                                                      key={letter}
+                                                      type="button"
+                                                      className="flex h-8 w-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                    >
+                                                      {letter}
+                                                    </button>
+                                                  ))}
+                                                </>
                                               )}
-                                              title="Generate with Socratic AI"
-                                              onClick={() => setShowAIPoll(!showAIPoll)}
-                                              disabled={!activeInsightsTaskId}
-                                            >
-                                              <Sparkles className="h-4 w-4" />
-                                            </Button>
+                                              {pollOptionMode === 'tf' && (
+                                                <>
+                                                  <button
+                                                    type="button"
+                                                    className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 px-3 text-xs font-medium text-blue-700"
+                                                  >
+                                                    True
+                                                  </button>
+                                                  <button
+                                                    type="button"
+                                                    className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 px-3 text-xs font-medium text-blue-700"
+                                                  >
+                                                    False
+                                                  </button>
+                                                </>
+                                              )}
+                                              {pollOptionMode === 'yn' && (
+                                                <>
+                                                  <button
+                                                    type="button"
+                                                    className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 px-3 text-xs font-medium text-blue-700"
+                                                  >
+                                                    Yes
+                                                  </button>
+                                                  <button
+                                                    type="button"
+                                                    className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 px-3 text-xs font-medium text-blue-700"
+                                                  >
+                                                    No
+                                                  </button>
+                                                </>
+                                              )}
+                                              {pollOptionMode === 'custom' && (
+                                                <>
+                                                  {resolvePollOptions()?.map((opt, i) => (
+                                                    <button
+                                                      key={i}
+                                                      type="button"
+                                                      className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 px-3 text-xs font-medium text-blue-700"
+                                                    >
+                                                      {opt}
+                                                    </button>
+                                                  )) || (
+                                                    <p className="text-xs text-gray-400">
+                                                      Enter custom options below
+                                                    </p>
+                                                  )}
+                                                </>
+                                              )}
+                                            </div>
+                                            {pollOptionMode === 'custom' && (
+                                              <textarea
+                                                value={pollCustomOptions}
+                                                onChange={e => setPollCustomOptions(e.target.value)}
+                                                rows={2}
+                                                placeholder="Options separated by commas, slashes, or new lines — e.g. Agree, Disagree, Unsure"
+                                                className={cn(
+                                                  'mt-2 w-full resize-none rounded-md border bg-white p-2 text-xs text-gray-900 placeholder:text-gray-400 focus:outline-none',
+                                                  customPollValid || !pollCustomOptions.trim()
+                                                    ? 'border-blue-100 focus-visible:border-blue-400'
+                                                    : 'border-amber-300 focus-visible:border-amber-400'
+                                                )}
+                                              />
+                                            )}
+                                          </div>
+                                          {/* Bottom button row */}
+                                          <div className="flex items-center gap-1.5 border-t border-blue-100 px-4 py-3">
+                                            {POLL_OPTION_PRESETS.map(preset => (
+                                              <button
+                                                key={preset.id}
+                                                type="button"
+                                                onClick={() => setPollOptionMode(preset.id)}
+                                                className={cn(
+                                                  'flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium transition-colors',
+                                                  pollOptionMode === preset.id
+                                                    ? 'border-blue-600 bg-blue-600 text-white'
+                                                    : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-50'
+                                                )}
+                                              >
+                                                {preset.label}
+                                              </button>
+                                            ))}
                                             <Button
-                                              size="icon"
-                                              className="h-8 w-8 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:opacity-30"
+                                              size="sm"
+                                              className="ml-auto h-8 rounded-md bg-blue-600 px-3 text-xs hover:bg-blue-700 disabled:opacity-30"
                                               disabled={
                                                 !activeInsightsTaskId ||
                                                 !insightsProps.sessionId ||
@@ -10931,25 +11014,57 @@ FEEDBACK: [one or two short sentences explaining the score]`
                                                   !insightsProps.sessionId
                                                 )
                                                   return
-                                                {
-                                                  const opts = resolvePollOptions()
-                                                  if (pollOptionMode === 'custom' && opts) {
-                                                    rememberPollOptionSet(opts)
-                                                  }
-                                                  insightsProps.onSendPoll({
-                                                    taskId: currentInsightsId,
-                                                    question: pollPrompt,
-                                                    options: opts,
-                                                  })
+                                                const opts = resolvePollOptions()
+                                                if (pollOptionMode === 'custom' && opts) {
+                                                  rememberPollOptionSet(opts)
                                                 }
-                                                setPollPrompt('')
+                                                insightsProps.onSendPoll({
+                                                  taskId: currentInsightsId,
+                                                  question: pollPrompt,
+                                                  options: opts,
+                                                })
+                                                setPollComposeMode(false)
                                               }}
                                             >
-                                              <Send className="h-4 w-4" />
+                                              <Send className="mr-1 h-3 w-3" />
+                                              Send
                                             </Button>
                                           </div>
                                         </div>
-                                      </div>
+                                      ) : (
+                                        <>
+                                          <div className="flex-1 overflow-auto rounded-2xl border border-blue-100 bg-white p-3 shadow-sm">
+                                            <InsightsReportView
+                                              type="poll"
+                                              pollResults={pollResults}
+                                              onClose={handleCloseInsight}
+                                              onMentionStudent={name =>
+                                                setPollPrompt(
+                                                  pollPrompt
+                                                    ? `${pollPrompt} @[${name}](student:${name}) `
+                                                    : `@[${name}](student:${name}) `
+                                                )
+                                              }
+                                            />
+                                          </div>
+                                          <div className="flex items-center justify-center py-2">
+                                            <button
+                                              type="button"
+                                              onClick={() => {
+                                                const lastPoll = pollResults[0]
+                                                if (lastPoll) {
+                                                  setPollPrompt(lastPoll.question)
+                                                }
+                                                setPollComposeMode(true)
+                                              }}
+                                              className="flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+                                            >
+                                              <Send className="h-3 w-3" />
+                                              New Poll
+                                            </button>
+                                          </div>
+                                        </>
+                                      )}
                                     </TabsContent>
                                     <TabsContent
                                       value="question"


### PR DESCRIPTION
## Problem

The poll composer redesign from PR #708 was only applied to the center panel's test/PCI tabs. The Desk panel's Insights tab still used the old layout with:
- InsightsReportView at top
- pollOptionPicker below
- MentionTextarea at bottom with AI button + Send icon button

## Solution

Apply the same redesigned composer to the Desk panel's Insights tab:
- Editable display area with textarea for poll question
- Poll options preview inside the display area (A–E, T/F, Y/N, custom)
- Custom options textarea inside display area
- Bottom button row with preset chips + Send button
- Toggle between compose mode and results view (New Poll ↔ View Results)

The shared state variables (pollComposeMode, pollPrompt, etc.) already exist and work across both contexts.