### PR TITLE
fix: replace Framer Motion with CSS transitions for sliding pill

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { useRef, useState, useCallback } from 'react'
-import { motion } from 'framer-motion'
 import { Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Card } from '@/components/ui/card'
@@ -161,10 +160,13 @@ export function SessionCalendarPanel({
                   {tab.label}
                 </TabsTrigger>
               ))}
-              <motion.div
-                className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm"
-                animate={{ left: pillStyle.left, width: pillStyle.width }}
-                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+              <div
+                className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm transition-all duration-300 ease-out"
+                style={{
+                  left: pillStyle.left,
+                  width: pillStyle.width,
+                  transitionProperty: 'left, width',
+                }}
               />
             </TabsList>
 

--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { useRef, useState, useCallback } from 'react'
-import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { TabsList, TabsTrigger } from '@/components/ui/tabs'
 
@@ -134,10 +133,17 @@ export function SlidingPillTabsList({
           {tab.label}
         </TabsTrigger>
       ))}
-      <motion.div
-        className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
-        animate={{ left: pillStyle.left, width: pillStyle.width }}
-        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      <div
+        className={cn(
+          'absolute bottom-1.5 top-1.5 rounded-lg transition-all duration-300 ease-out',
+          styles.pill,
+          pillClassName
+        )}
+        style={{
+          left: pillStyle.left,
+          width: pillStyle.width,
+          transitionProperty: 'left, width',
+        }}
       />
     </TabsList>
   )


### PR DESCRIPTION
## Problem

The previous fix (PR #732) using Framer Motion's animate prop had no effect. This is because Framer Motion animates from the element's current DOM position, but React's useLayoutEffect was updating the position state before Framer Motion could see the change. The element was already at the new position when Framer Motion tried to animate it.

## Root Cause

With Framer Motion motion.div + animate={{ left, width }}:
1. User clicks tab → React re-renders
2. useLayoutEffect runs → setPillStyle(newPosition) → state updates
3. React re-renders again with new left/width values
4. Framer Motion sees animate={{ left: newLeft }} but the element is ALREADY at newLeft
5. No animation occurs because there's no distance to travel

## Solution

Replace Framer Motion with plain CSS transitions (transition-all duration-300 ease-out). CSS transitions animate actual DOM property changes, so when the left/width style properties change, the browser smoothly animates the transition regardless of React's render cycle.

With CSS transitions:
1. User clicks tab → React re-renders
2. useLayoutEffect runs → setPillStyle(newPosition) → state updates
3. React re-renders with new left/width values in the style attribute
4. The browser sees the style.left property change from oldValue to newValue
5. CSS transition: left 300ms ease-out smoothly animates the change

## Changes

- SlidingPillTabsList: motion.div → div with CSS transition
- SessionCalendarPanel: motion.div → div with CSS transition  
- Removed framer-motion import from SessionCalendarPanel
- Removed useSlidingPillMetrics hook usage (inline calculation instead)