### PR TITLE
style: strengthen Book a Tutor panel shadow to match Grading page

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -223,7 +223,7 @@ export default function StudentTutorDirectoryPage() {
 
       {/* Bottom panel: filters + results */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-4">
-        <div className="shadow-hover-lift flex h-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white ring-1 ring-black/5">
+        <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white shadow-[0_18px_60px_rgba(0,0,0,0.16)] ring-1 ring-black/5">
           {/* Filters */}
           <div className="grid grid-cols-1 gap-3 p-4 pb-0 sm:p-6 sm:pb-0 md:grid-cols-4">
             <div className="relative">


### PR DESCRIPTION
## Problem

The Book a Tutor page panel has a very subtle shadow that is barely visible against the white background, making it look flat compared to the Grading page which has a clear floating card appearance.

## Root Cause

The Book a Tutor page is a 'floating page' in the student layout (line 76-82 of layout.tsx), which means the layout does NOT apply the card shadow/border styling automatically. The page was using  which is defined as  — too subtle to be visible on a white background.

Non-floating pages (like Grading) get  applied by the layout automatically, giving them a much stronger floating effect.

## Fix

Replace  with  to match the shadow strength used by the layout for non-floating pages, making the panel visually match the Grading page's floating card appearance.