### PR TITLE
fix: replace Framer Motion with CSS transitions in SessionCalendarPanel

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { useRef, useState, useCallback } from 'react'
-import { motion } from 'framer-motion'
 import { Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Card } from '@/components/ui/card'
@@ -161,10 +160,13 @@ export function SessionCalendarPanel({
                   {tab.label}
                 </TabsTrigger>
               ))}
-              <motion.div
-                className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm"
-                animate={{ left: pillStyle.left, width: pillStyle.width }}
-                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+              <div
+                className="absolute bottom-1.5 top-1.5 rounded-lg bg-white shadow-sm transition-all duration-300 ease-out"
+                style={{
+                  left: pillStyle.left,
+                  width: pillStyle.width,
+                  transitionProperty: 'left, width',
+                }}
               />
             </TabsList>
 


### PR DESCRIPTION
## Problem

The SessionCalendarPanel component (used on the tutor Account Settings page with the charcoal mode selector) still used Framer Motion's motion.div with animate={{ left, width }} for the sliding pill animation. This had the same problem as SlidingPillTabsList — Framer Motion animates from the element's current DOM position, but useLayoutEffect updates the position state before Framer Motion can see the change, causing the pill to snap instead of sliding smoothly.

When clicking a different tab, the pill would remain on the old tab (e.g., Profile) and turn white instead of sliding to the new tab.

## Solution

Replace Framer Motion motion.div with a plain div using CSS transitions (transition-all duration-300 ease-out), which animates actual DOM property changes regardless of when React re-renders.

## Changes

- motion.div → div with CSS transition
- Removed framer-motion import
- Same fix as PR #735 for SlidingPillTabsList