### PR TITLE
fix: sliding pill position calculation for non-first tabs

### DIFF
--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -98,8 +98,13 @@ export function SessionCalendarPanel({
     })
   }, [])
   React.useLayoutEffect(() => {
-    updatePillPosition()
-  }, [updatePillPosition])
+    // Defer to next frame so Radix UI has time to update data-state attributes
+    const id = requestAnimationFrame(() => {
+      updatePillPosition()
+    })
+    return () => cancelAnimationFrame(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
 
   React.useEffect(() => {
     const id = setTimeout(updatePillPosition, 100)

--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -82,12 +82,18 @@ export function SlidingPillTabsList({
       left: rect.left - listRect.left,
       width: rect.width,
     })
-  }, [_activeIndex])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Update position when active tab changes
   React.useLayoutEffect(() => {
-    updatePillPosition()
-  }, [updatePillPosition])
+    // Defer to next frame so Radix UI has time to update data-state attributes
+    const id = requestAnimationFrame(() => {
+      updatePillPosition()
+    })
+    return () => cancelAnimationFrame(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
 
   // Update after a delay for fonts/layout
   React.useEffect(() => {


### PR DESCRIPTION
Fix sliding pill animation for all mode selectors. The pill was staying on the first tab when clicking other tabs. Root causes: (1) useCallback had empty deps so effect never re-fired, (2) useLayoutEffect ran before Radix UI updated data-state. Fix: use value as effect dep + wrap in requestAnimationFrame.