### PR TITLE
fix(student): strengthen shadow and fix bottom alignment on Book a Tu…

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -222,10 +222,10 @@ export default function StudentTutorDirectoryPage() {
       </section>
 
       {/* Bottom panel: filters + results */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <Card
           hoverable={false}
-          className="shadow-hover-lift flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5"
+          className="flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 shadow-[0_18px_60px_rgba(0,0,0,0.16)] ring-1 ring-black/5"
         >
           {/* Filters */}
           <div className="grid grid-cols-1 gap-3 pb-0 md:grid-cols-4">


### PR DESCRIPTION
…tor panel

- Changed shadow from shadow-hover-lift to shadow-[0_18px_60px_rgba(0,0,0,0.16)] to match the sidebar shadow strength, making the panel edge visible
- Removed pb-4 from panel wrapper so the panel bottom aligns with the sidebar bottom (both now use the same height calculation without extra bottom padding)