### PR TITLE
feat(booking): 1-on-1 booking backend reads & enforces student availability

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -13,6 +13,7 @@ import {
   NotFoundError,
 } from '@/lib/api/middleware'
 import { parseJson } from '@/lib/api/parse'
+import { isSlotWithinStudentAvailability } from '@/lib/student-availability'
 
 const requestSchema = z.object({
   tutorId: z.string().min(1),
@@ -80,6 +81,22 @@ export const POST = withCsrf(
         },
         { status: 409 }
       )
+    }
+
+    // Every proposed time must fall within the student's availability (managed
+    // by their parent). Not enforced when no availability is configured yet.
+    for (const slot of validated.proposedSlots) {
+      const withinAvailability = await isSlotWithinStudentAvailability(
+        session.user.id,
+        slot.date,
+        slot.startTime,
+        slot.endTime
+      )
+      if (!withinAvailability) {
+        throw new ValidationError(
+          'One or more of your proposed times are outside your available hours. Ask your parent to update your availability, or choose a different time.'
+        )
+      }
     }
 
     // For the existing table, use the first proposed slot as the primary request

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -9,6 +9,7 @@ import { notify } from '@/lib/notifications/notify'
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
+import { isSlotWithinStudentAvailability } from '@/lib/student-availability'
 
 const respondSchema = z.object({
   requestId: z.string().min(1),
@@ -65,6 +66,24 @@ export async function PATCH(request: NextRequest) {
         validated.selectedSlot?.date || existingRequest.requestedDate.toISOString().split('T')[0]
       const slotStartTime = validated.selectedSlot?.startTime || existingRequest.startTime
       const slotEndTime = validated.selectedSlot?.endTime || existingRequest.endTime
+
+      // The accepted time must fall within the student's availability (managed
+      // by their parent). Not enforced when no availability is configured yet.
+      const withinAvailability = await isSlotWithinStudentAvailability(
+        existingRequest.studentId,
+        slotDate,
+        slotStartTime,
+        slotEndTime
+      )
+      if (!withinAvailability) {
+        return NextResponse.json(
+          {
+            error:
+              "That time is outside the student's available hours. Ask the student's parent to update their availability, or accept a different slot.",
+          },
+          { status: 400 }
+        )
+      }
 
       // Create event timestamps
       const eventStart = new Date(`${slotDate}T${slotStartTime}:00`)

--- a/tutorme-app/src/lib/student-availability.ts
+++ b/tutorme-app/src/lib/student-availability.ts
@@ -1,0 +1,67 @@
+/**
+ * Read helpers for a student's weekly availability (StudentAvailability),
+ * which is managed by the student's parent. Used by the booking backend so a
+ * 1-on-1 can only be scheduled within the hours the parent marked free.
+ */
+
+import { eq } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { studentAvailability } from '@/lib/db/schema'
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+/**
+ * The set of free hour keys ("<dayOfWeek>-HH:00", e.g. "1-14:00") a student is
+ * marked available for. Returns `null` when the student has NO availability
+ * configured at all, so callers can choose not to enforce (rather than block a
+ * student whose parent hasn't set any availability yet).
+ */
+export async function getStudentFreeHourSet(studentId: string): Promise<Set<string> | null> {
+  const rows = await drizzleDb
+    .select({
+      dayOfWeek: studentAvailability.dayOfWeek,
+      startTime: studentAvailability.startTime,
+      isAvailable: studentAvailability.isAvailable,
+    })
+    .from(studentAvailability)
+    .where(eq(studentAvailability.studentId, studentId))
+
+  if (rows.length === 0) return null
+
+  const free = new Set<string>()
+  for (const r of rows) {
+    if (r.isAvailable) free.add(`${r.dayOfWeek}-${r.startTime}`)
+  }
+  return free
+}
+
+/**
+ * Whether a proposed session time falls within the student's available hours.
+ *  - date: "YYYY-MM-DD"
+ *  - startTime / endTime: "HH:mm"
+ *
+ * Returns true when the student has no availability configured (not enforced),
+ * or when every clock hour the session overlaps is marked free; false otherwise.
+ */
+export async function isSlotWithinStudentAvailability(
+  studentId: string,
+  date: string,
+  startTime: string,
+  endTime: string
+): Promise<boolean> {
+  const free = await getStudentFreeHourSet(studentId)
+  if (free === null) return true // no availability configured → don't block
+
+  const day = new Date(`${date}T00:00:00`).getDay()
+  const [sh, sm] = startTime.split(':').map(Number)
+  const [eh, em] = endTime.split(':').map(Number)
+  const startMin = sh * 60 + (sm || 0)
+  const endMin = eh * 60 + (em || 0)
+  if (!Number.isFinite(startMin) || !Number.isFinite(endMin) || endMin <= startMin) return false
+
+  // Every clock hour the session overlaps must be marked free.
+  for (let h = Math.floor(startMin / 60); h * 60 < endMin; h++) {
+    if (!free.has(`${day}-${pad(h)}:00`)) return false
+  }
+  return true
+}


### PR DESCRIPTION
## Summary
Completes the availability wiring: the **1-on-1 booking backend now reads the parent-managed student availability** and only allows sessions within the hours marked free. (Follow-up to #749, which moved availability control to parents.)

## Changes
- **New helper** `src/lib/student-availability.ts`:
  - `getStudentFreeHourSet(studentId)` → set of free `"<dayOfWeek>-HH:00"` hours, or `null` when the student has **no availability configured** (so callers can choose not to enforce).
  - `isSlotWithinStudentAvailability(studentId, date, startTime, endTime)` → `true` if unconfigured (don't block) or every clock hour the session overlaps is marked free; `false` otherwise.
- **`POST /api/one-on-one/request`** (student proposes slots): rejects any proposed time outside the student's availability, with a clear message ("Ask your parent to update your availability…").
- **`PATCH /api/one-on-one/respond`** (tutor accepts a slot): rejects accepting a time outside the student's availability.

## Behavior
- A student can only propose, and a tutor can only accept, 1-on-1 times that fall within the hours the parent marked free.
- **Graceful default:** if a student's parent hasn't configured any availability yet (no rows), booking is **not** blocked — avoids locking out students before setup.
- Reads the same `StudentAvailability` table keyed by `studentId`, so it's consistent with the parent editor from #749.

## Testing
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- Not exercised against a live DB here. Suggested manual pass: set a child's availability as parent → as that student, request a 1-on-1 outside those hours (rejected) and inside (allowed) → as the tutor, try to accept an out-of-hours slot (rejected).

## Note
Independent of #749's files (touches only the one-on-one routes + new helper), so no conflict; branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)