### PR TITLE
fix(ui): restore original SlidingPillTabsList with Framer Motion

### DIFF
--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import * as React from 'react'
-import { useRef, useState, useCallback } from 'react'
+import { useRef } from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
+import { useSlidingPillMetrics } from '@/hooks/use-sliding-pill'
 import { TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export interface SlidingPillTab {
@@ -46,88 +48,26 @@ export function SlidingPillTabsList({
   value,
   tabs,
   variant = 'charcoal',
-  className: _className,
+  className,
   listClassName,
   triggerClassName,
   pillClassName,
 }: SlidingPillTabsListProps) {
-  const listRef = useRef<HTMLDivElement>(null)
-  const [pillStyle, setPillStyle] = useState({ left: 0, width: 0 })
-  const _activeIndex = tabs.findIndex(tab => tab.value === value)
+  const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const activeIndex = tabs.findIndex(tab => tab.value === value)
+  const { left, width } = useSlidingPillMetrics(triggerRefs, activeIndex)
   const styles = VARIANT_STYLES[variant]
-
-  const updatePillPosition = useCallback(() => {
-    const list = listRef.current
-    if (!list) return
-
-    const activeTrigger = list.children[_activeIndex] as HTMLElement | undefined
-    if (!activeTrigger || activeTrigger.getAttribute('role') !== 'tab') {
-      // Fallback: find by data-state="active"
-      const triggers = Array.from(list.querySelectorAll('[role="tab"]'))
-      const active = triggers.find(t => t.getAttribute('data-state') === 'active')
-      if (!active) return
-      const rect = active.getBoundingClientRect()
-      const listRect = list.getBoundingClientRect()
-      setPillStyle({
-        left: rect.left - listRect.left,
-        width: rect.width,
-      })
-      return
-    }
-
-    const rect = activeTrigger.getBoundingClientRect()
-    const listRect = list.getBoundingClientRect()
-    setPillStyle({
-      left: rect.left - listRect.left,
-      width: rect.width,
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // Update position when active tab changes
-  React.useLayoutEffect(() => {
-    // Defer to next frame so Radix UI has time to update data-state attributes
-    const id = requestAnimationFrame(() => {
-      updatePillPosition()
-    })
-    return () => cancelAnimationFrame(id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value])
-
-  // Update after a delay for fonts/layout
-  React.useEffect(() => {
-    const id = setTimeout(updatePillPosition, 100)
-    return () => clearTimeout(id)
-  }, [updatePillPosition])
-
-  // Update on resize
-  React.useEffect(() => {
-    const handleResize = () => updatePillPosition()
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [updatePillPosition])
-
-  // Use ResizeObserver on the list container
-  React.useEffect(() => {
-    const list = listRef.current
-    if (!list) return
-
-    const ro = new ResizeObserver(() => {
-      updatePillPosition()
-    })
-    ro.observe(list)
-
-    return () => ro.disconnect()
-  }, [updatePillPosition])
 
   return (
     <TabsList
-      ref={listRef}
       className={cn('relative flex w-full gap-1.5 rounded-xl p-1.5', styles.list, listClassName)}
     >
-      {tabs.map(tab => (
+      {tabs.map((tab, i) => (
         <TabsTrigger
           key={tab.value}
+          ref={el => {
+            triggerRefs.current[i] = el
+          }}
           value={tab.value}
           disabled={tab.disabled}
           className={cn(
@@ -139,17 +79,11 @@ export function SlidingPillTabsList({
           {tab.label}
         </TabsTrigger>
       ))}
-      <div
-        className={cn(
-          'absolute bottom-1.5 top-1.5 rounded-lg transition-all duration-300 ease-out',
-          styles.pill,
-          pillClassName
-        )}
-        style={{
-          left: pillStyle.left,
-          width: pillStyle.width,
-          transitionProperty: 'left, width',
-        }}
+      <motion.div
+        className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
+        initial={false}
+        animate={{ left, width }}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
       />
     </TabsList>
   )


### PR DESCRIPTION
Reverted SlidingPillTabsList to its original implementation using:
- Framer Motion (motion.div) for the sliding pill animation
- useSlidingPillMetrics hook with individual trigger refs
- Original position calculation via offsetLeft/offsetWidth

The CSS transition replacement was breaking the pill positioning and causing the mode selector to display incorrectly in the Insights panel.