### PR TITLE
chore(parent): English-only sweep of the parent area (no Chinese)

### DIFF
--- a/tutorme-app/src/app/[locale]/parent/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/parent/settings/page.tsx
@@ -71,7 +71,7 @@ export default function ParentSettingsPage() {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="zh-CN">简体中文</SelectItem>
+                  <SelectItem value="zh-CN">Chinese (Simplified)</SelectItem>
                   <SelectItem value="en">English</SelectItem>
                 </SelectContent>
               </Select>

--- a/tutorme-app/src/app/[locale]/parent/students/[studentId]/ai-tutor/page.tsx
+++ b/tutorme-app/src/app/[locale]/parent/students/[studentId]/ai-tutor/page.tsx
@@ -141,7 +141,7 @@ export default function StudentAITutorPage() {
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
-        <p className="text-gray-500">无法加载AI辅导数据</p>
+        <p className="text-gray-500">Failed to load AI tutoring data</p>
       </div>
     )
   }
@@ -158,8 +158,10 @@ export default function StudentAITutorPage() {
             </Link>
           </Button>
           <div>
-            <h1 className="text-2xl font-bold">AI 辅导</h1>
-            <p className="text-sm text-gray-500">AI互动历史、苏格拉底式对话与学习表现</p>
+            <h1 className="text-2xl font-bold">AI Tutor</h1>
+            <p className="text-sm text-gray-500">
+              AI interaction history, Socratic dialogue, and learning performance
+            </p>
           </div>
         </div>
       </div>
@@ -170,7 +172,7 @@ export default function StudentAITutorPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">总对话次数</p>
+                <p className="text-sm text-gray-500">Total conversations</p>
                 <p className="text-2xl font-bold">{metrics.totalSessions}</p>
               </div>
               <MessageSquare className="h-8 w-8 text-blue-500" />
@@ -181,7 +183,7 @@ export default function StudentAITutorPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">总消息数</p>
+                <p className="text-sm text-gray-500">Total messages</p>
                 <p className="text-2xl font-bold">{metrics.totalMessages}</p>
               </div>
               <Bot className="h-8 w-8 text-purple-500" />
@@ -192,7 +194,7 @@ export default function StudentAITutorPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">使用时长 (分钟)</p>
+                <p className="text-sm text-gray-500">Time used (minutes)</p>
                 <p className="text-2xl font-bold">{metrics.totalMinutes}</p>
               </div>
               <Calendar className="h-8 w-8 text-green-500" />
@@ -203,7 +205,7 @@ export default function StudentAITutorPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">活跃科目</p>
+                <p className="text-sm text-gray-500">Active subjects</p>
                 <p className="text-2xl font-bold">{metrics.activeSubjects}</p>
               </div>
               <BookOpen className="h-8 w-8 text-amber-500" />
@@ -218,9 +220,9 @@ export default function StudentAITutorPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Lightbulb className="h-5 w-5" />
-              学习建议
+              Learning suggestions
             </CardTitle>
-            <CardDescription>基于AI辅导数据的个性化建议</CardDescription>
+            <CardDescription>Personalized suggestions based on AI tutoring data</CardDescription>
           </CardHeader>
           <CardContent>
             <ul className="space-y-2">
@@ -240,13 +242,15 @@ export default function StudentAITutorPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <MessageSquare className="h-5 w-5" />
-            课程对话记录
+            Lesson conversation history
           </CardTitle>
-          <CardDescription>课程中的AI辅导对话，采用苏格拉底式引导</CardDescription>
+          <CardDescription>
+            In-lesson AI tutoring conversations using Socratic guidance
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {sessionSummaries.length === 0 ? (
-            <p className="py-8 text-center text-gray-500">暂无课程对话记录</p>
+            <p className="py-8 text-center text-gray-500">No lesson conversations yet</p>
           ) : (
             <div className="space-y-4">
               {sessionSummaries.slice(0, 15).map(s => (
@@ -257,7 +261,7 @@ export default function StudentAITutorPage() {
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
-                        <h3 className="font-medium">{s.lessonTitle ?? '未命名课程'}</h3>
+                        <h3 className="font-medium">{s.lessonTitle ?? 'Untitled lesson'}</h3>
                         {s.courseName && (
                           <Badge variant="outline" className="text-xs">
                             {s.courseName}
@@ -267,16 +271,16 @@ export default function StudentAITutorPage() {
                           variant={s.status === 'completed' ? 'default' : 'secondary'}
                           className="text-xs"
                         >
-                          {s.status === 'completed' ? '已完成' : s.currentSection}
+                          {s.status === 'completed' ? 'Completed' : s.currentSection}
                         </Badge>
                       </div>
                       <p className="mt-1 text-sm text-gray-500">
-                        {s.messageCount} 条消息 · 最后活动: {formatDate(s.lastActivityAt)}
+                        {s.messageCount} messages · last active: {formatDate(s.lastActivityAt)}
                       </p>
                       {s.lastMessage && (
                         <div className="mt-2 rounded bg-gray-50 p-2 text-sm">
                           <p className="text-gray-600">
-                            <span className="font-medium text-gray-700">学生:</span>{' '}
+                            <span className="font-medium text-gray-700">Student:</span>{' '}
                             {s.lastMessage.length > 100
                               ? s.lastMessage.slice(0, 100) + '...'
                               : s.lastMessage}
@@ -306,9 +310,9 @@ export default function StudentAITutorPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <BookOpen className="h-5 w-5" />
-              已注册科目
+              Enrolled subjects
             </CardTitle>
-            <CardDescription>AI辅导已注册的科目及使用情况</CardDescription>
+            <CardDescription>Subjects enrolled in AI tutoring, and usage</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -316,11 +320,11 @@ export default function StudentAITutorPage() {
                 <div key={e.subjectCode} className="flex flex-col gap-2 rounded-lg border p-4">
                   <span className="font-medium">{e.subjectCode}</span>
                   <p className="text-sm text-gray-500">
-                    {e.totalSessions} 次对话 · {e.totalMinutes} 分钟
+                    {e.totalSessions} conversations · {e.totalMinutes} min
                   </p>
                   {e.lastSessionAt && (
                     <p className="text-xs text-gray-400">
-                      最近: {formatDateShort(e.lastSessionAt)}
+                      Latest: {formatDateShort(e.lastSessionAt)}
                     </p>
                   )}
                 </div>
@@ -336,9 +340,9 @@ export default function StudentAITutorPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <BarChart3 className="h-5 w-5" />
-              近期使用
+              Recent usage
             </CardTitle>
-            <CardDescription>最近7天的AI辅导使用情况</CardDescription>
+            <CardDescription>AI tutoring usage over the last 7 days</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="flex gap-2 overflow-x-auto pb-2">
@@ -346,8 +350,8 @@ export default function StudentAITutorPage() {
                 <div key={u.date} className="w-24 shrink-0 rounded-lg border p-3 text-center">
                   <p className="text-xs text-gray-500">{formatDateShort(u.date)}</p>
                   <p className="font-semibold">{u.messageCount}</p>
-                  <p className="text-xs text-gray-400">条消息</p>
-                  <p className="text-xs text-gray-400">{u.minutesUsed} 分钟</p>
+                  <p className="text-xs text-gray-400">messages</p>
+                  <p className="text-xs text-gray-400">{u.minutesUsed} min</p>
                 </div>
               ))}
             </div>

--- a/tutorme-app/src/app/[locale]/parent/students/[studentId]/assignments/page.tsx
+++ b/tutorme-app/src/app/[locale]/parent/students/[studentId]/assignments/page.tsx
@@ -115,21 +115,21 @@ export default function StudentAssignmentsPage() {
         return (
           <Badge variant="default" className="bg-green-600">
             <CheckCircle2 className="mr-1 h-3 w-3" />
-            已提交
+            Submitted
           </Badge>
         )
       case 'overdue':
         return (
           <Badge variant="destructive">
             <AlertCircle className="mr-1 h-3 w-3" />
-            已逾期
+            Overdue
           </Badge>
         )
       default:
         return (
           <Badge variant="secondary">
             <Clock className="mr-1 h-3 w-3" />
-            待完成
+            Pending
           </Badge>
         )
     }
@@ -137,11 +137,11 @@ export default function StudentAssignmentsPage() {
 
   const getTypeLabel = (type: string) => {
     const map: Record<string, string> = {
-      quiz: '测验',
-      assignment: '作业',
-      practice: '练习',
-      assessment: '评估',
-      project: '项目',
+      quiz: 'Quiz',
+      assignment: 'Assignment',
+      practice: 'Practice',
+      assessment: 'Assessment',
+      project: 'Project',
     }
     return map[type] ?? type
   }
@@ -156,8 +156,10 @@ export default function StudentAssignmentsPage() {
             </Link>
           </Button>
           <div>
-            <h1 className="text-2xl font-bold">作业与测验</h1>
-            <p className="text-sm text-gray-500">查看孩子的作业完成情况、AI评分和教师反馈</p>
+            <h1 className="text-2xl font-bold">Assignments</h1>
+            <p className="text-sm text-gray-500">
+              View your child's assignment completion, AI grading, and tutor feedback
+            </p>
           </div>
         </div>
       </div>
@@ -168,7 +170,7 @@ export default function StudentAssignmentsPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">总计</p>
+                <p className="text-sm text-gray-500">Total</p>
                 <p className="text-2xl font-bold">{stats.total}</p>
               </div>
               <ClipboardList className="h-8 w-8 text-gray-400" />
@@ -179,7 +181,7 @@ export default function StudentAssignmentsPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">待完成</p>
+                <p className="text-sm text-gray-500">Pending</p>
                 <p className="text-2xl font-bold">{stats.pending}</p>
               </div>
               <Clock className="h-8 w-8 text-amber-500" />
@@ -190,7 +192,7 @@ export default function StudentAssignmentsPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">已提交</p>
+                <p className="text-sm text-gray-500">Submitted</p>
                 <p className="text-2xl font-bold">{stats.submitted}</p>
               </div>
               <CheckCircle2 className="h-8 w-8 text-green-500" />
@@ -201,7 +203,7 @@ export default function StudentAssignmentsPage() {
           <CardContent className="pt-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-500">已逾期</p>
+                <p className="text-sm text-gray-500">Overdue</p>
                 <p className="text-2xl font-bold">{stats.overdue}</p>
               </div>
               <AlertCircle className="h-8 w-8 text-red-500" />
@@ -213,8 +215,10 @@ export default function StudentAssignmentsPage() {
       {/* Assignments list */}
       <Card>
         <CardHeader>
-          <CardTitle>全部作业</CardTitle>
-          <CardDescription>包含作业、测验、练习等，支持AI评分与教师反馈</CardDescription>
+          <CardTitle>All assignments</CardTitle>
+          <CardDescription>
+            Includes assignments, quizzes, and practice — with AI grading and tutor feedback
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {loading ? (
@@ -224,10 +228,10 @@ export default function StudentAssignmentsPage() {
           ) : (
             <Tabs value={activeTab} onValueChange={setActiveTab}>
               <TabsList className="mb-4">
-                <TabsTrigger value="all">全部 ({stats.total})</TabsTrigger>
-                <TabsTrigger value="pending">待完成 ({stats.pending})</TabsTrigger>
-                <TabsTrigger value="submitted">已提交 ({stats.submitted})</TabsTrigger>
-                <TabsTrigger value="overdue">已逾期 ({stats.overdue})</TabsTrigger>
+                <TabsTrigger value="all">All ({stats.total})</TabsTrigger>
+                <TabsTrigger value="pending">Pending ({stats.pending})</TabsTrigger>
+                <TabsTrigger value="submitted">Submitted ({stats.submitted})</TabsTrigger>
+                <TabsTrigger value="overdue">Overdue ({stats.overdue})</TabsTrigger>
               </TabsList>
 
               <TabsContent value={activeTab} className="mt-0">
@@ -259,11 +263,11 @@ export default function StudentAssignmentsPage() {
                               <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-500">
                                 {a.lessonTitle && <span>{a.lessonTitle}</span>}
                                 {a.courseName && <span>· {a.courseName}</span>}
-                                {a.tutorName && <span>· 教师: {a.tutorName}</span>}
+                                {a.tutorName && <span>· Tutor: {a.tutorName}</span>}
                                 {a.dueDate && (
                                   <span className="flex items-center gap-1">
                                     <Calendar className="h-3 w-3" />
-                                    截止: {formatDate(a.dueDate)}
+                                    Due: {formatDate(a.dueDate)}
                                   </span>
                                 )}
                               </div>
@@ -277,7 +281,7 @@ export default function StudentAssignmentsPage() {
                               )}
                               <div className="text-sm text-gray-500">
                                 <FileQuestion className="mr-1 inline h-4 w-4" />
-                                {a.questionCount} 题
+                                {a.questionCount} questions
                               </div>
                             </div>
                           </div>
@@ -290,7 +294,7 @@ export default function StudentAssignmentsPage() {
                                   <Bot className="mt-0.5 h-4 w-4 shrink-0 text-purple-500" />
                                   <div className="text-sm">
                                     <span className="font-medium text-gray-700">
-                                      AI 评分
+                                      AI grading
                                       {a.aiScore != null && `: ${Math.round(a.aiScore)}%`}
                                     </span>
                                     {a.aiComments && (
@@ -298,12 +302,12 @@ export default function StudentAssignmentsPage() {
                                     )}
                                     {a.aiStrengths.length > 0 && (
                                       <p className="mt-1 text-green-700">
-                                        优点: {a.aiStrengths.join('、')}
+                                        Strengths: {a.aiStrengths.join(', ')}
                                       </p>
                                     )}
                                     {a.aiImprovements.length > 0 && (
                                       <p className="mt-1 text-amber-700">
-                                        改进: {a.aiImprovements.join('、')}
+                                        Improvements: {a.aiImprovements.join(', ')}
                                       </p>
                                     )}
                                   </div>
@@ -314,10 +318,10 @@ export default function StudentAssignmentsPage() {
                                   <User className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
                                   <div className="text-sm">
                                     <span className="font-medium text-gray-700">
-                                      教师反馈
+                                      Tutor feedback
                                       {a.tutorApproved && (
                                         <Badge variant="secondary" className="ml-2 text-xs">
-                                          已批阅
+                                          Reviewed
                                         </Badge>
                                       )}
                                     </span>
@@ -330,10 +334,9 @@ export default function StudentAssignmentsPage() {
 
                           {a.status === 'submitted' && a.submittedAt && (
                             <div className="border-t px-4 py-2 text-xs text-gray-500">
-                              提交于 {formatDate(a.submittedAt)}
-                              {a.timeSpent != null &&
-                                ` · 用时 ${Math.round(a.timeSpent / 60)} 分钟`}
-                              {a.attempts > 0 && ` · 第 ${a.attempts}/${a.maxAttempts} 次尝试`}
+                              Submitted on {formatDate(a.submittedAt)}
+                              {a.timeSpent != null && ` · ${Math.round(a.timeSpent / 60)} min`}
+                              {a.attempts > 0 && ` · Attempt ${a.attempts}/${a.maxAttempts} `}
                             </div>
                           )}
                         </CardContent>
@@ -341,7 +344,7 @@ export default function StudentAssignmentsPage() {
                     ))}
                   {assignments.filter(a => (activeTab === 'all' ? true : a.status === activeTab))
                     .length === 0 && (
-                    <div className="py-12 text-center text-gray-500">暂无作业</div>
+                    <div className="py-12 text-center text-gray-500">No assignments yet</div>
                   )}
                 </div>
               </TabsContent>

--- a/tutorme-app/src/app/[locale]/parent/students/[studentId]/layout.tsx
+++ b/tutorme-app/src/app/[locale]/parent/students/[studentId]/layout.tsx
@@ -28,31 +28,31 @@ interface StudentData {
 const tabs = [
   {
     id: 'overview',
-    label: '概览',
+    label: 'Overview',
     href: (id: string) => `/parent/students/${id}`,
     icon: TrendingUp,
   },
   {
     id: 'assignments',
-    label: '作业与测验',
+    label: 'Assignments',
     href: (id: string) => `/parent/students/${id}/assignments`,
     icon: ClipboardList,
   },
   {
     id: 'ai-tutor',
-    label: 'AI 辅导',
+    label: 'AI Tutor',
     href: (id: string) => `/parent/students/${id}/ai-tutor`,
     icon: Bot,
   },
   {
     id: 'classes',
-    label: '课程安排',
+    label: 'Classes',
     href: (id: string) => `/parent/students/${id}`,
     icon: Calendar,
   },
   {
     id: 'financial',
-    label: '财务',
+    label: 'Finance',
     href: (id: string) => `/parent/students/${id}`,
     icon: CreditCard,
   },
@@ -96,7 +96,7 @@ export default function StudentLayout({ children }: { children: React.ReactNode 
               {loading ? (
                 <span className="inline-block h-7 w-32 animate-pulse rounded bg-gray-200" />
               ) : (
-                (student?.name ?? '学生')
+                (student?.name ?? 'Student')
               )}
             </h1>
             <p className="text-sm text-gray-500">
@@ -106,7 +106,7 @@ export default function StudentLayout({ children }: { children: React.ReactNode 
                 <>
                   {student?.email && `${student.email} · `}
                   {student?.relation}
-                  {student?.level != null && ` · 等级 ${student.level}`}
+                  {student?.level != null && ` · Level ${student.level}`}
                   {student?.xp != null && ` · ${student.xp} XP`}
                 </>
               )}

--- a/tutorme-app/src/app/api/parent/dashboard/route.ts
+++ b/tutorme-app/src/app/api/parent/dashboard/route.ts
@@ -15,7 +15,10 @@ export const GET = withAuth(
     const startTime = Date.now()
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户，请先完成家长注册' }, { status: 404 })
+      return NextResponse.json(
+        { error: 'No family account found. Please complete parent registration first.' },
+        { status: 404 }
+      )
     }
 
     const cacheKey = `parent:dashboard:${family.familyAccountId}:${session.user.id}`

--- a/tutorme-app/src/app/api/parent/financial/budget/route.ts
+++ b/tutorme-app/src/app/api/parent/financial/budget/route.ts
@@ -23,7 +23,7 @@ export const GET = withAuth(
     try {
       const family = await getFamilyAccountForParent(session)
       if (!family) {
-        return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+        return NextResponse.json({ error: 'No family account found' }, { status: 404 })
       }
 
       const cacheKey = `parent:financial:budget:${family.familyAccountId}`
@@ -85,7 +85,7 @@ export const GET = withAuth(
 
       return NextResponse.json({ success: true, data })
     } catch (err) {
-      return handleApiError(err, '获取预算信息失败', 'ParentFinancialBudget')
+      return handleApiError(err, 'Failed to fetch budget information', 'ParentFinancialBudget')
     }
   },
   { role: 'PARENT' }

--- a/tutorme-app/src/app/api/parent/financial/dashboard/route.ts
+++ b/tutorme-app/src/app/api/parent/financial/dashboard/route.ts
@@ -24,7 +24,7 @@ export const GET = withAuth(
     try {
       const family = await getFamilyAccountForParent(session)
       if (!family) {
-        return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+        return NextResponse.json({ error: 'No family account found' }, { status: 404 })
       }
 
       const { searchParams } = new URL(req.url)
@@ -80,7 +80,7 @@ export const GET = withAuth(
       res.headers.set('X-Response-Time', `${Date.now() - startTime}ms`)
       return res
     } catch (err) {
-      return handleApiError(err, '获取财务概览失败', 'ParentFinancialDashboard')
+      return handleApiError(err, 'Failed to fetch financial overview', 'ParentFinancialDashboard')
     }
   },
   { role: 'PARENT' }

--- a/tutorme-app/src/app/api/parent/financial/payments/route.ts
+++ b/tutorme-app/src/app/api/parent/financial/payments/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(
     try {
       const family = await getFamilyAccountForParent(session)
       if (!family) {
-        return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+        return NextResponse.json({ error: 'No family account found' }, { status: 404 })
       }
 
       const { searchParams } = new URL(req.url)
@@ -73,7 +73,7 @@ export const GET = withAuth(
 
       return NextResponse.json({ success: true, data })
     } catch (err) {
-      return handleApiError(err, '获取支付记录失败', 'ParentFinancialPayments')
+      return handleApiError(err, 'Failed to fetch payment records', 'ParentFinancialPayments')
     }
   },
   { role: 'PARENT' }

--- a/tutorme-app/src/app/api/parent/financial/spending/route.ts
+++ b/tutorme-app/src/app/api/parent/financial/spending/route.ts
@@ -20,7 +20,7 @@ export const GET = withAuth(
     try {
       const family = await getFamilyAccountForParent(session)
       if (!family) {
-        return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+        return NextResponse.json({ error: 'No family account found' }, { status: 404 })
       }
 
       const { searchParams } = new URL(req.url)
@@ -66,7 +66,7 @@ export const GET = withAuth(
 
       return NextResponse.json({ success: true, data })
     } catch (err) {
-      return handleApiError(err, '获取消费分析失败', 'ParentFinancialSpending')
+      return handleApiError(err, 'Failed to fetch spending analysis', 'ParentFinancialSpending')
     }
   },
   { role: 'PARENT' }

--- a/tutorme-app/src/app/api/parent/messages/route.ts
+++ b/tutorme-app/src/app/api/parent/messages/route.ts
@@ -16,7 +16,7 @@ export const GET = withAuth(
   async (req: NextRequest, session) => {
     const userId = session.user?.id
     if (!userId) {
-      return NextResponse.json({ error: '未授权' }, { status: 401 })
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
     const cacheKey = `parent:messages:${userId}`

--- a/tutorme-app/src/app/api/parent/notifications/route.ts
+++ b/tutorme-app/src/app/api/parent/notifications/route.ts
@@ -23,7 +23,7 @@ export const GET = withAuth(
   async (req: NextRequest, session) => {
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+      return NextResponse.json({ error: 'No family account found' }, { status: 404 })
     }
 
     const cacheKey = `parent:notifications:${family.familyAccountId}`
@@ -60,14 +60,14 @@ export const PATCH = withAuth(
   async (req: NextRequest, session) => {
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+      return NextResponse.json({ error: 'No family account found' }, { status: 404 })
     }
 
     let body: { ids?: string[]; all?: boolean }
     try {
       body = markReadSchema.parse(await req.json().catch(() => ({})))
     } catch {
-      return NextResponse.json({ error: '无效请求' }, { status: 400 })
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
 
     const conditions: any[] = [eq(familyNotification.parentId, family.familyAccountId)]
@@ -77,7 +77,7 @@ export const PATCH = withAuth(
     } else if (body.ids?.length) {
       conditions.push(inArray(familyNotification.notificationId, body.ids))
     } else {
-      return NextResponse.json({ error: '请提供 ids 或 all' }, { status: 400 })
+      return NextResponse.json({ error: 'Provide ids or all' }, { status: 400 })
     }
 
     await drizzleDb

--- a/tutorme-app/src/app/api/parent/progress/route.ts
+++ b/tutorme-app/src/app/api/parent/progress/route.ts
@@ -14,7 +14,7 @@ export const GET = withAuth(
   async (req: NextRequest, session) => {
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+      return NextResponse.json({ error: 'No family account found' }, { status: 404 })
     }
 
     const cacheKey = `parent:progress:${family.familyAccountId}`

--- a/tutorme-app/src/app/api/parent/students/[studentId]/route.ts
+++ b/tutorme-app/src/app/api/parent/students/[studentId]/route.ts
@@ -24,18 +24,18 @@ export const GET = withAuth(
 
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+      return NextResponse.json({ error: 'No family account found' }, { status: 404 })
     }
 
     if (!family.studentIds.includes(studentId)) {
-      return NextResponse.json({ error: '无权查看该学生' }, { status: 403 })
+      return NextResponse.json({ error: 'Not authorized to view this student' }, { status: 403 })
     }
 
     const member = family.members.find(
       m => m.userId === studentId || m.familyMemberId === studentId
     )
     if (!member?.userId) {
-      return NextResponse.json({ error: '学生未关联' }, { status: 404 })
+      return NextResponse.json({ error: 'Student not linked' }, { status: 404 })
     }
 
     const cacheKey = `parent:student:analytics:${family.familyAccountId}:${studentId}`
@@ -67,7 +67,7 @@ export const GET = withAuth(
     ])
 
     if (!userData) {
-      return NextResponse.json({ error: '学生不存在' }, { status: 404 })
+      return NextResponse.json({ error: 'Student not found' }, { status: 404 })
     }
 
     const data = {

--- a/tutorme-app/src/app/api/parent/students/route.ts
+++ b/tutorme-app/src/app/api/parent/students/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(
   async (req: NextRequest, session) => {
     const family = await getFamilyAccountForParent(session)
     if (!family) {
-      return NextResponse.json({ error: '未找到家庭账户' }, { status: 404 })
+      return NextResponse.json({ error: 'No family account found' }, { status: 404 })
     }
 
     const cacheKey = `parent:students:${family.familyAccountId}`


### PR DESCRIPTION
## Summary
Dedicated English sweep of the parent area — translates **all** remaining Chinese UI text and API error strings to natural English. Follows up on #749 (which converted the parent student-detail page).

## Scope (14 files)
**Frontend**
- `parent/students/[studentId]/layout.tsx` — sub-nav tabs: Overview / Assignments / AI Tutor / Classes / Finance; `Student` name fallback; `Level`.
- `parent/students/[studentId]/assignments/page.tsx` — headers, stat labels (Total/Pending/Submitted/Overdue), status badges, type labels (Quiz/Assignment/Practice/Assessment/Project), AI/tutor feedback labels (Strengths/Improvements/Tutor feedback/Reviewed), empty states, and interpolated bits (`{n} questions`, `· Attempt x/y`, `· {n} min`, `Submitted on …`, `Due: …`).
- `parent/students/[studentId]/ai-tutor/page.tsx` — headers, metric labels, session/subject/usage cards, empty states, interpolations (`{n} messages · last active: …`).
- `parent/settings/page.tsx` — language option shown as `Chinese (Simplified)`.

**API** — parent route error/response strings: `No family account found`, `Not authorized to view this student`, `Student not linked/found`, `Invalid request`, `Provide ids or all`, `Failed to fetch payment records / spending analysis / financial overview / budget information`, `Unauthorized`.

## Verification
- **No Chinese characters remain** anywhere under `src/app/[locale]/parent` or `src/app/api/parent` (grep for CJK range = 0).
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- Text-only; no logic changes.

## Note
The one place I kept a non-English *value* is the language `<SelectItem value="zh-CN">` — now labeled `Chinese (Simplified)` in English (it's the option to pick the Chinese locale, not Chinese UI chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)