### PR TITLE
feat(tutor): "class weak spots" — class-wide topic mastery

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/submissions/page.tsx
@@ -22,6 +22,7 @@ import {
 import { toast } from 'sonner'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { FollowUpInsightsCard } from '@/components/tutor/follow-up-insights-card'
+import { ClassMasteryCard } from '@/components/tutor/class-mastery-card'
 import { MathText, hasMath } from '@/components/answer/MathText'
 import { cn } from '@/lib/utils'
 
@@ -136,6 +137,7 @@ export default function TutorSubmissionsPage() {
       </section>
 
       <div className="px-1">
+        <ClassMasteryCard />
         <FollowUpInsightsCard />
       </div>
 

--- a/tutorme-app/src/app/api/tutor/class-mastery/route.ts
+++ b/tutorme-app/src/app/api/tutor/class-mastery/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/tutor/class-mastery
+ *
+ * Class weak spots. Aggregates the tutor's students' graded submissions by the
+ * lesson each task belongs to (the "topic") and reports, weakest-first, the
+ * class average, how many students struggled, and the misconceptions that recur
+ * across the class (from the persisted AI study hints). The tutor-side mirror of
+ * the student's own topic-mastery view. Read-only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { handleApiError } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, courseLesson, taskSubmission } from '@/lib/db/schema'
+
+/** A class average below this counts a student as "struggling" on a topic. */
+const STRUGGLING_BELOW = 60
+
+interface TopicWeakSpot {
+  topic: string
+  averageScore: number
+  attempts: number
+  students: number
+  strugglingStudents: number
+  misconceptions: { label: string; count: number }[]
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const isAdmin = session.user.role === 'ADMIN'
+
+    const rows = await drizzleDb
+      .select({
+        score: taskSubmission.score,
+        studentId: taskSubmission.studentId,
+        aiFeedback: taskSubmission.aiFeedback,
+        taskTitle: builderTask.title,
+        lessonTitle: courseLesson.title,
+      })
+      .from(taskSubmission)
+      .innerJoin(builderTask, eq(taskSubmission.taskId, builderTask.taskId))
+      .leftJoin(courseLesson, eq(builderTask.lessonId, courseLesson.lessonId))
+      .where(
+        isAdmin
+          ? isNotNull(taskSubmission.score)
+          : and(eq(builderTask.tutorId, session.user.id), isNotNull(taskSubmission.score))
+      )
+      .limit(2000)
+
+    // topic → per-student scores + recurring misconceptions.
+    const groups = new Map<
+      string,
+      { byStudent: Map<string, number[]>; misconceptions: Map<string, number> }
+    >()
+
+    for (const r of rows) {
+      const topic = (r.lessonTitle ?? r.taskTitle ?? 'General').trim() || 'General'
+      const score = typeof r.score === 'number' ? Math.round(r.score) : null
+      if (score === null) continue
+
+      let g = groups.get(topic)
+      if (!g) {
+        g = { byStudent: new Map(), misconceptions: new Map() }
+        groups.set(topic, g)
+      }
+      const list = g.byStudent.get(r.studentId) ?? []
+      list.push(score)
+      g.byStudent.set(r.studentId, list)
+
+      const items = (r.aiFeedback as { items?: Array<{ misconception?: string }> } | null)?.items
+      if (Array.isArray(items)) {
+        for (const it of items) {
+          const label = it?.misconception?.trim()
+          if (label) g.misconceptions.set(label, (g.misconceptions.get(label) ?? 0) + 1)
+        }
+      }
+    }
+
+    const mean = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length
+
+    const topics: TopicWeakSpot[] = Array.from(groups.entries()).map(([topic, g]) => {
+      const allScores: number[] = []
+      let strugglingStudents = 0
+      for (const scores of g.byStudent.values()) {
+        allScores.push(...scores)
+        if (mean(scores) < STRUGGLING_BELOW) strugglingStudents++
+      }
+      return {
+        topic,
+        averageScore: Math.round(mean(allScores)),
+        attempts: allScores.length,
+        students: g.byStudent.size,
+        strugglingStudents,
+        misconceptions: Array.from(g.misconceptions.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([label, count]) => ({ label, count })),
+      }
+    })
+
+    // Weakest topics first — where the class needs the most attention.
+    topics.sort((a, b) => a.averageScore - b.averageScore)
+
+    return NextResponse.json({ topics: topics.slice(0, 20) })
+  } catch (error) {
+    return handleApiError(error, 'Failed to load class mastery', 'api/tutor/class-mastery/route.ts')
+  }
+}

--- a/tutorme-app/src/components/tutor/class-mastery-card.tsx
+++ b/tutorme-app/src/components/tutor/class-mastery-card.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+/**
+ * ClassMasteryCard — "class weak spots". Reads /api/tutor/class-mastery and lists
+ * the tutor's topics weakest-first, with the class average, how many students
+ * struggled, and the misconceptions that recur across the class. Renders nothing
+ * until there's at least one graded submission.
+ */
+
+import { useEffect, useState } from 'react'
+import { TrendingDown, ChevronDown, ChevronUp } from 'lucide-react'
+
+interface TopicWeakSpot {
+  topic: string
+  averageScore: number
+  attempts: number
+  students: number
+  strugglingStudents: number
+  misconceptions: { label: string; count: number }[]
+}
+
+function barColor(score: number): string {
+  if (score >= 80) return 'bg-emerald-500'
+  if (score >= 60) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+export function ClassMasteryCard() {
+  const [topics, setTopics] = useState<TopicWeakSpot[] | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/tutor/class-mastery', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { topics: [] }))
+      .then(d => active && setTopics(Array.isArray(d?.topics) ? d.topics : []))
+      .catch(() => active && setTopics([]))
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!topics || topics.length === 0) return null
+
+  return (
+    <div className="mb-6 rounded-xl border border-rose-200 bg-rose-50/40 p-4">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        <span className="inline-flex items-center gap-2 text-sm font-semibold text-rose-900">
+          <TrendingDown className="h-4 w-4" />
+          Class weak spots
+        </span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 text-rose-500" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-rose-500" />
+        )}
+      </button>
+
+      {open && (
+        <div className="mt-3 space-y-3">
+          {topics.map(t => (
+            <div key={t.topic}>
+              <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                <span className="min-w-0 truncate font-medium text-gray-800">{t.topic}</span>
+                <span className="flex shrink-0 items-center gap-2 text-xs text-gray-500">
+                  {t.strugglingStudents > 0 && (
+                    <span className="rounded-full bg-rose-100 px-2 py-0.5 font-medium text-rose-700">
+                      {t.strugglingStudents}/{t.students} struggling
+                    </span>
+                  )}
+                  <span className="font-semibold tabular-nums text-gray-700">
+                    {t.averageScore}%
+                  </span>
+                </span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+                <div
+                  className={`h-full rounded-full ${barColor(t.averageScore)}`}
+                  style={{ width: `${Math.max(2, t.averageScore)}%` }}
+                />
+              </div>
+              {t.misconceptions.length > 0 && (
+                <p className="mt-1 text-xs text-gray-500">
+                  Recurring slips: {t.misconceptions.map(m => m.label).join(', ')}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
The tutor mirror of the student topic-mastery view (rounds out the feedback loop with the follow-up hotspots already shipped).

- **`GET /api/tutor/class-mastery`** — aggregates the tutor's students' graded submissions by the lesson each task belongs to (the "topic", via `builderTask.lessonId → courseLesson.title`) and returns, **weakest-first**: class **average**, **struggling students** (those whose topic-average is < 60%), and the top **recurring misconceptions** across the class (from the misconception tags in `aiFeedback`). Read-only; scoped to the tutor's tasks (admins see all).
- A collapsible **"Class weak spots"** card atop the grading page, beside the follow-up hotspots — a bar per topic (colour-coded), the struggling count, and recurring slips. Renders nothing until there's a graded submission.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.