### PR TITLE
chore(tutor,student): English-only sweep of hardcoded Chinese UI text

### DIFF
--- a/tutorme-app/src/app/[locale]/student/account/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/account/page.tsx
@@ -43,11 +43,11 @@ import { CollapsibleCard } from '@/components/collapsible-card'
 
 const LANGUAGES = [
   { code: 'en', name: 'English' },
-  { code: 'zh', name: '中文 (Chinese)' },
+  { code: 'zh', name: 'Chinese' },
   { code: 'es', name: 'Español (Spanish)' },
   { code: 'fr', name: 'Français (French)' },
   { code: 'de', name: 'Deutsch (German)' },
-  { code: 'ja', name: '日本語 (Japanese)' },
+  { code: 'ja', name: 'Japanese' },
 ]
 
 interface PaymentMethod {

--- a/tutorme-app/src/app/[locale]/student/learn/[contentId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/learn/[contentId]/page.tsx
@@ -287,7 +287,7 @@ export default function LearnPage() {
             ) : (
               <Card>
                 <CardContent className="py-8 text-center text-gray-500">
-                  暂无视频链接。请先上传或设置视频地址。
+                  No video link yet. Please upload or set a video URL first.
                 </CardContent>
               </Card>
             )}

--- a/tutorme-app/src/app/[locale]/tutor/reports/[studentId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/reports/[studentId]/page.tsx
@@ -163,11 +163,11 @@ export default function StudentReportPage() {
   const getClusterLabel = (cluster: string) => {
     switch (cluster) {
       case 'advanced':
-        return '优秀'
+        return 'Excellent'
       case 'intermediate':
-        return '中等'
+        return 'Average'
       case 'struggling':
-        return '需帮助'
+        return 'Needs help'
       default:
         return cluster
     }

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -63,11 +63,11 @@ import SessionLog from '@/components/session-log'
 
 const LANGUAGES = [
   { code: 'en', name: 'English' },
-  { code: 'zh', name: '中文 (Chinese)' },
+  { code: 'zh', name: 'Chinese' },
   { code: 'es', name: 'Español (Spanish)' },
   { code: 'fr', name: 'Français (French)' },
   { code: 'de', name: 'Deutsch (German)' },
-  { code: 'ja', name: '日本語 (Japanese)' },
+  { code: 'ja', name: 'Japanese' },
 ]
 
 const SECTION_CARD_CLASS =


### PR DESCRIPTION
## Summary
English sweep of the tutor and student areas (following the parent-area sweep in #758). Translates the remaining **hardcoded, user-facing** Chinese to English.

## Changes (4 files)
- **tutor/reports/[studentId]** — student cluster labels: `Excellent` / `Average` / `Needs help`.
- **student/learn/[contentId]** — empty video-link message → "No video link yet. Please upload or set a video URL first."
- **tutor/settings** & **student/account** — language-picker option labels shown in English (`Chinese`, `Japanese`).

## Intentionally NOT changed
- `student/dashboard/dashboard-strings.ts` keeps its `zh` block. It's a **bilingual `en`/`zh` i18n file** (zh-CN is a documented primary locale), and **both consumers already call `getDashboardStrings('en')`** — so the dashboard UI is already English. Deleting the `zh` translations would strip localization, not anglicize the UI.

## Verification
- No hardcoded user-facing Chinese remains under tutor/student (the only CJK left is the intentional `dashboard-strings.ts` i18n data).
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- Text-only; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)