### PR TITLE
feat(live): restore task chat on reopen + live completion tick

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
@@ -21,17 +21,73 @@ interface ChatMsg {
   re?: string
 }
 
-export function TaskChatPanel({ taskId, taskTitle }: { taskId: string; taskTitle?: string }) {
+export function TaskChatPanel({
+  taskId,
+  taskTitle,
+  onCompleted,
+}: {
+  taskId: string
+  taskTitle?: string
+  /** Fired after the task is completed, with the student's answers — the page
+   *  uses it to broadcast the live "completed" tick to the tutor. */
+  onCompleted?: (answers: string[]) => void
+}) {
   const [messages, setMessages] = useState<ChatMsg[]>([])
   const [draft, setDraft] = useState('')
   const [completed, setCompleted] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [loaded, setLoaded] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [messages, busy])
+
+  // Restore a prior chat: if the student already completed this task, rebuild the
+  // transcript (their answers, each AI response, and any follow-ups) and drop
+  // straight into follow-up mode instead of showing a blank panel.
+  useEffect(() => {
+    let active = true
+    fetch(`/api/student/assignments/${taskId}`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!active) return
+        if (data?.alreadySubmitted) {
+          const answersObj =
+            data.existingAnswers && typeof data.existingAnswers === 'object'
+              ? (data.existingAnswers as Record<string, string>)
+              : {}
+          const answers = Object.keys(answersObj)
+            .sort((a, b) => Number(a) - Number(b))
+            .map(k => String(answersObj[k]))
+          const aiItems: Array<{ explanation?: string }> = data.existingAiFeedback?.items ?? []
+          const followUps: Array<{ question?: string; answer?: string }> = Array.isArray(
+            data.existingFollowUps
+          )
+            ? data.existingFollowUps
+            : []
+          const restored: ChatMsg[] = []
+          answers.forEach(a => restored.push({ role: 'student', content: a }))
+          aiItems.forEach((it, i) =>
+            restored.push({ role: 'ai', content: it.explanation ?? '', re: answers[i] })
+          )
+          followUps.forEach(f => {
+            if (f.question) restored.push({ role: 'student', content: f.question })
+            if (f.answer) restored.push({ role: 'ai', content: f.answer })
+          })
+          if (restored.length > 0) {
+            setMessages(restored)
+            setCompleted(true)
+          }
+        }
+        setLoaded(true)
+      })
+      .catch(() => active && setLoaded(true))
+    return () => {
+      active = false
+    }
+  }, [taskId])
 
   const studentAnswers = messages.filter(m => m.role === 'student').map(m => m.content)
 
@@ -74,6 +130,7 @@ export function TaskChatPanel({ taskId, taskTitle }: { taskId: string; taskTitle
         ...responses.map(r => ({ role: 'ai' as const, content: r.response, re: r.answer })),
       ])
       setCompleted(true)
+      onCompleted?.(answers)
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to complete the task')
     } finally {
@@ -122,7 +179,12 @@ export function TaskChatPanel({ taskId, taskTitle }: { taskId: string; taskTitle
       </div>
 
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
-        {messages.length === 0 && (
+        {!loaded && (
+          <div className="flex items-center gap-1.5 text-xs text-gray-400">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading…
+          </div>
+        )}
+        {loaded && messages.length === 0 && (
           <p className="text-sm leading-relaxed text-gray-500">
             {taskTitle ? <span className="font-medium text-gray-700">{taskTitle}. </span> : null}
             Chat your answer(s) below — send each one, then click{' '}

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -2080,7 +2080,27 @@ function StudentFeedbackContent() {
                             PCI, then they can ask about what they got wrong. */}
                         {isChatTask && activeTaskId && (
                           <div className="mt-2 h-[60vh] min-h-[360px]">
-                            <TaskChatPanel taskId={activeTaskId} taskTitle={activeTask.title} />
+                            <TaskChatPanel
+                              taskId={activeTaskId}
+                              taskTitle={activeTask.title}
+                              onCompleted={answers => {
+                                // Broadcast the live "completed" tick to the tutor.
+                                // aiHandled=true → the server only marks completion
+                                // and does NOT re-write the DB (the task-chat route
+                                // already persisted the answers + AI responses).
+                                if (!socket || !selectedSessionId || !activeTaskId) return
+                                const record: Record<string, string> = {}
+                                answers.forEach((a, i) => {
+                                  record[String(i + 1)] = a
+                                })
+                                socket.emit('task:complete', {
+                                  roomId: selectedSessionId,
+                                  taskId: activeTaskId,
+                                  answers: record,
+                                  aiHandled: true,
+                                })
+                              }}
+                            />
                           </div>
                         )}
 

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/route.ts
@@ -113,6 +113,7 @@ export async function GET(
         submittedAt: taskSubmission.submittedAt,
         gradedAt: taskSubmission.gradedAt,
         aiFeedback: taskSubmission.aiFeedback,
+        followUps: taskSubmission.followUps,
       })
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
@@ -170,6 +171,8 @@ export async function GET(
       // Grounded per-question AI study hints, if already generated (see the
       // ai-feedback endpoint — generated on demand and cached here).
       existingAiFeedback: existing?.aiFeedback ?? null,
+      // Persisted task-chat follow-ups, so a reopened task restores its full chat.
+      existingFollowUps: existing?.followUps ?? null,
       task: {
         id: task.taskId,
         title: task.title,

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1549,10 +1549,18 @@ export async function initEnhancedSocketServer(server: NetServer) {
     socket.on(
       'task:complete',
       (
-        data: { roomId: string; taskId: string; answers?: Record<string, string> },
+        data: {
+          roomId: string
+          taskId: string
+          answers?: Record<string, string>
+          // Set by the chat-task flow: the answers + AI responses were already
+          // persisted over HTTP (task-chat route), so this event should only
+          // broadcast the live completion tick and NOT write the DB again.
+          aiHandled?: boolean
+        },
         ack?: (resp: { ok: boolean; error?: string }) => void
       ) => {
-        const { roomId, taskId, answers } = data
+        const { roomId, taskId, answers, aiHandled } = data
         if (!roomId || !taskId) {
           ack?.({ ok: false, error: 'Invalid submission' })
           return
@@ -1607,6 +1615,11 @@ export async function initEnhancedSocketServer(server: NetServer) {
         // the payload had been dropped — e.g. too large — no ack would arrive
         // and the client would surface a real error instead of a false success.
         ack?.({ ok: true })
+
+        // Chat tasks already persisted everything (taskSubmission + AI responses)
+        // over HTTP — this event was only for the live completion tick, so stop
+        // before the DB write to avoid clobbering that richer row.
+        if (aiHandled) return
 
         // Persist the completion durably so it reaches the tutor's grading
         // views. There are THREE tutor readers with DIFFERENT requirements:


### PR DESCRIPTION
Closes the two gaps I flagged on the chat-based task flow.

## #1 — Restore the chat on reopen
`TaskChatPanel` now **loads any prior submission on mount** and rebuilds the transcript — the student's answers, each AI response, and the follow-up Q&A — then drops straight into **follow-up mode**. Previously a reopened/reloaded completed task showed a blank "answer by chat" panel (and let the student re-complete). The student task GET now also returns `existingFollowUps` so the whole conversation is restored.

## #2 — Live "completed" tick for the tutor
On complete, the panel fires `onCompleted` → the page emits socket `task:complete` with **`aiHandled: true`**. The server broadcasts the live completion tick (marks `completedBy` + `task:completed`) but **skips the DB write**, because the `task-chat` HTTP route already persisted the richer row (answers + per-answer AI responses). One-line early-return guard in the socket handler — no dual-write, no clobbering.

npm run typecheck ✅ · npm run build ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)