### PR TITLE
fix(one-on-one): make Book 1-on-1 fully operational

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -23,10 +23,12 @@ export interface CalendarEvent {
   start: string
   end: string
   duration: number
-  type: 'class'
+  type: 'class' | 'one-on-one'
   tutorName: string | null
   tutorAvatarUrl?: string | null
   courseDescription?: string | null
+  meetingUrl?: string | null
+  status?: string
 }
 
 interface DashboardCalendarProps {
@@ -136,6 +138,8 @@ export function DashboardCalendar({
   // Exclude completed/ended sessions and sort chronologically so the next session is on top.
   const classes = useMemo<ClassItem[]>(() => {
     const mapped = events
+      // 1-on-1 sessions have their own Bookings tab, so keep them out of Sessions.
+      .filter(ev => ev.type !== 'one-on-one')
       .map(ev => {
         const evStatus = (ev as any).status as string | undefined
         const status: ClassItem['status'] =
@@ -204,6 +208,15 @@ export function DashboardCalendar({
     })
   }, [events])
 
+  // Paid 1-on-1 sessions the student has booked (surfaced by the events API).
+  const oneOnOneSessions = useMemo(
+    () =>
+      events
+        .filter(ev => ev.type === 'one-on-one')
+        .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()),
+    [events]
+  )
+
   return (
     <SessionCalendarPanel
       value={activeTab}
@@ -243,13 +256,57 @@ export function DashboardCalendar({
             <h3 className="mb-1 text-base font-semibold text-[#1F2933]">1-on-1 Sessions</h3>
             <p className="mb-4 text-xs text-gray-500">Upcoming private tutoring sessions.</p>
             <div className="flex-1 overflow-y-auto pr-1">
-              <div className="rounded-[12px] border border-dashed border-gray-200 bg-gray-50/60 py-10 text-center">
-                <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
-                <p className="text-muted-foreground text-sm">No 1-on-1 sessions booked yet.</p>
-                <p className="text-muted-foreground/70 mt-1 text-xs">
-                  Your upcoming private sessions will appear here.
-                </p>
-              </div>
+              {oneOnOneSessions.length === 0 ? (
+                <div className="rounded-[12px] border border-dashed border-gray-200 bg-gray-50/60 py-10 text-center">
+                  <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
+                  <p className="text-muted-foreground text-sm">No 1-on-1 sessions booked yet.</p>
+                  <p className="text-muted-foreground/70 mt-1 text-xs">
+                    Your upcoming private sessions will appear here.
+                  </p>
+                </div>
+              ) : (
+                <ul className="space-y-2">
+                  {oneOnOneSessions.map(s => {
+                    const isLive = s.status === 'live' || s.status === 'active'
+                    return (
+                      <li
+                        key={s.id}
+                        className="flex items-center justify-between gap-3 rounded-[12px] border border-gray-200 bg-white p-3"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-[#1F2933]">
+                            {s.title}
+                            {s.tutorName ? (
+                              <span className="font-normal text-gray-400"> · {s.tutorName}</span>
+                            ) : null}
+                          </p>
+                          <p className="mt-0.5 text-xs text-gray-500">
+                            {formatDate(s.start)} · {formatEventTime(s.start)}
+                          </p>
+                        </div>
+                        {s.meetingUrl ? (
+                          <a
+                            href={s.meetingUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={cn(
+                              'inline-flex shrink-0 items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
+                              isLive
+                                ? 'bg-emerald-600 hover:bg-emerald-700'
+                                : 'bg-blue-600 hover:bg-blue-700'
+                            )}
+                          >
+                            <Video className="h-3.5 w-3.5" />
+                            {isLive ? 'Join now' : 'Join'}
+                          </a>
+                        ) : (
+                          <span className="shrink-0 text-xs text-gray-400">Scheduled</span>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
             </div>
           </div>
 

--- a/tutorme-app/src/app/api/one-on-one/cancel/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/cancel/route.ts
@@ -39,8 +39,10 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'Not authorized to cancel this request' }, { status: 403 })
     }
 
-    // Only allow canceling if status is PENDING or ACCEPTED (not yet paid)
-    if (!['PENDING', 'ACCEPTED'].includes(existingRequest.status)) {
+    // Cancellable while still upcoming: pending, accepted, or paid. A paid
+    // cancellation frees the session and flags a refund (processed via the
+    // standard tutor/admin refund flow — see the refund-owed notification below).
+    if (!['PENDING', 'ACCEPTED', 'PAID'].includes(existingRequest.status)) {
       return NextResponse.json(
         {
           error: `Cannot cancel a request that is already ${existingRequest.status.toLowerCase()}`,
@@ -48,6 +50,7 @@ export async function PATCH(request: NextRequest) {
         { status: 400 }
       )
     }
+    const wasPaid = existingRequest.status === 'PAID'
 
     // If there's a calendar event, mark it as cancelled and end the linked live session
     if (existingRequest.calendarEventId) {
@@ -100,8 +103,27 @@ export async function PATCH(request: NextRequest) {
       actionUrl: isStudent ? '/tutor/dashboard' : '/student/dashboard',
     }).catch(console.error)
 
+    // A paid booking that's cancelled owes the student a refund. Flag the tutor
+    // to process it via the standard refund flow (automated gateway refunds for
+    // 1-on-1 are not yet wired, so this stays a deliberate human step).
+    if (wasPaid) {
+      notify({
+        userId: existingRequest.tutorId,
+        type: 'class',
+        title: 'Refund required — 1-on-1 cancelled',
+        message: `A paid 1-on-1 session was cancelled. Please issue a refund of ${existingRequest.costPerSession} to the student.`,
+        data: {
+          requestId: updatedRequest[0].requestId,
+          type: 'one-on-one-refund-required',
+          amount: existingRequest.costPerSession,
+        },
+        actionUrl: '/tutor/dashboard',
+      }).catch(console.error)
+    }
+
     return NextResponse.json({
       success: true,
+      refundRequired: wasPaid,
       request: updatedRequest[0],
     })
   } catch (error) {

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -152,6 +152,8 @@ export async function PATCH(request: NextRequest) {
             status: 'ACCEPTED',
             tutorNotes: validated.tutorNotes || existingRequest.tutorNotes,
             tutorResponseAt: new Date(),
+            // Payment window: the student has 48h to pay before the hold lapses.
+            paymentDueAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
             calendarEventId: newEvent.eventId,
             updatedAt: new Date(),
           })

--- a/tutorme-app/src/app/api/one-on-one/status/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/status/route.ts
@@ -33,7 +33,8 @@ export async function GET(request: NextRequest) {
         eq(oneOnOneBookingRequest.studentId, targetStudentId),
         or(
           eq(oneOnOneBookingRequest.status, 'PENDING'),
-          eq(oneOnOneBookingRequest.status, 'ACCEPTED')
+          eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
+          eq(oneOnOneBookingRequest.status, 'PAID')
         )
       ),
       with: {

--- a/tutorme-app/src/app/api/payments/webhooks/airwallex/route.ts
+++ b/tutorme-app/src/app/api/payments/webhooks/airwallex/route.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/db/schema'
 import { AirwallexGateway } from '@/lib/payments'
 import { sendPaymentConfirmation } from '@/lib/notifications/payment-email'
+import { notify } from '@/lib/notifications/notify'
 import { eq, and, sql } from 'drizzle-orm'
 
 export async function POST(req: NextRequest) {
@@ -190,6 +191,15 @@ export async function POST(req: NextRequest) {
             .limit(1)
 
           if (requestRow) {
+            // Notify the tutor that the booking is now paid & confirmed.
+            notify({
+              userId: requestRow.tutorId,
+              type: 'class',
+              title: '1-on-1 payment received',
+              message: 'The student has paid — the 1-on-1 session is confirmed.',
+              data: { requestId: meta.requestId as string, type: 'one-on-one-paid' },
+              actionUrl: '/tutor/dashboard',
+            }).catch(() => {})
             const [userRow] = await drizzleDb
               .select({ email: user.email, name: profile.name })
               .from(user)

--- a/tutorme-app/src/app/api/payments/webhooks/hitpay/route.ts
+++ b/tutorme-app/src/app/api/payments/webhooks/hitpay/route.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/db/schema'
 import { HitpayGateway } from '@/lib/payments'
 import { sendPaymentConfirmation } from '@/lib/notifications/payment-email'
+import { notify } from '@/lib/notifications/notify'
 import { eq, and, or, sql } from 'drizzle-orm'
 
 export async function POST(req: NextRequest) {
@@ -207,6 +208,15 @@ export async function POST(req: NextRequest) {
                 description: '1-on-1 tutoring session',
               }).catch(() => {})
             }
+            // Notify the tutor that the booking is now paid & confirmed.
+            notify({
+              userId: requestRow.tutorId,
+              type: 'class',
+              title: '1-on-1 payment received',
+              message: 'The student has paid — the 1-on-1 session is confirmed.',
+              data: { requestId: meta.requestId as string, type: 'one-on-one-paid' },
+              actionUrl: '/tutor/dashboard',
+            }).catch(() => {})
           }
         } else if (paymentRow.bookingId) {
           // Clinics removed: no booking notifications.

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -15,6 +15,7 @@ import {
   liveSession,
   course,
   sessionParticipant,
+  oneOnOneBookingRequest,
 } from '@/lib/db/schema'
 import { eq, and, gte, lte, inArray, isNull, sql } from 'drizzle-orm'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
@@ -41,11 +42,10 @@ export const GET = withAuth(
 
     const courseIds = enrollments.map(e => e.courseId).filter(Boolean)
 
-    if (courseIds.length === 0) {
-      return NextResponse.json({ events: [] })
-    }
-
-    // --- Primary source: CalendarEvent ---
+    // --- Primary source: CalendarEvent (course sessions) ---
+    // Only queried when the student is enrolled in courses; 1-on-1 sessions
+    // (which have no courseId) are fetched separately by studentId below, so a
+    // student with no course enrollments still sees their booked 1-on-1s.
     const calFilters = [
       inArray(calendarEvent.courseId, courseIds),
       eq(calendarEvent.isCancelled, false),
@@ -59,26 +59,28 @@ export const GET = withAuth(
       calFilters.push(lte(calendarEvent.startTime, endDate))
     }
 
-    const calEvents = await drizzleDb
-      .select({
-        eventId: calendarEvent.eventId,
-        title: calendarEvent.title,
-        description: calendarEvent.description,
-        startTime: calendarEvent.startTime,
-        endTime: calendarEvent.endTime,
-        status: calendarEvent.status,
-        meetingUrl: calendarEvent.meetingUrl,
-        courseId: calendarEvent.courseId,
-        location: calendarEvent.location,
-        isVirtual: calendarEvent.isVirtual,
-        tutorId: calendarEvent.tutorId,
-        externalId: calendarEvent.externalId,
-        sessionStatus: liveSession.status,
-      })
-      .from(calendarEvent)
-      .leftJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
-      .where(and(...calFilters))
-      .orderBy(calendarEvent.startTime)
+    const calEvents = courseIds.length
+      ? await drizzleDb
+          .select({
+            eventId: calendarEvent.eventId,
+            title: calendarEvent.title,
+            description: calendarEvent.description,
+            startTime: calendarEvent.startTime,
+            endTime: calendarEvent.endTime,
+            status: calendarEvent.status,
+            meetingUrl: calendarEvent.meetingUrl,
+            courseId: calendarEvent.courseId,
+            location: calendarEvent.location,
+            isVirtual: calendarEvent.isVirtual,
+            tutorId: calendarEvent.tutorId,
+            externalId: calendarEvent.externalId,
+            sessionStatus: liveSession.status,
+          })
+          .from(calendarEvent)
+          .leftJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
+          .where(and(...calFilters))
+          .orderBy(calendarEvent.startTime)
+      : []
 
     // --- Fallback source: LiveSession (for courses published before CalendarEvent bridge) ---
     const lsFilters = [
@@ -93,21 +95,59 @@ export const GET = withAuth(
       lsFilters.push(lte(liveSession.scheduledAt, endDate))
     }
 
-    const liveSessions = await drizzleDb
+    const liveSessions = courseIds.length
+      ? await drizzleDb
+          .select({
+            sessionId: liveSession.sessionId,
+            title: liveSession.title,
+            description: liveSession.description,
+            scheduledAt: liveSession.scheduledAt,
+            status: liveSession.status,
+            roomUrl: liveSession.roomUrl,
+            courseId: liveSession.courseId,
+            durationMinutes: liveSession.durationMinutes,
+            tutorId: liveSession.tutorId,
+          })
+          .from(liveSession)
+          .where(and(...lsFilters))
+          .orderBy(liveSession.scheduledAt)
+      : []
+
+    // --- 1-on-1 sessions the student has PAID for (no courseId; keyed by
+    // studentId). Only PAID bookings are surfaced so a session becomes visible/
+    // joinable exactly when payment clears. ---
+    const oneOnOneFilters = [
+      eq(calendarEvent.studentId, studentId),
+      eq(oneOnOneBookingRequest.status, 'PAID'),
+      eq(calendarEvent.isCancelled, false),
+      isNull(calendarEvent.deletedAt),
+    ]
+    if (startParam) oneOnOneFilters.push(gte(calendarEvent.startTime, startDate))
+    if (endParam) oneOnOneFilters.push(lte(calendarEvent.startTime, endDate))
+
+    const oneOnOneEvents = await drizzleDb
       .select({
-        sessionId: liveSession.sessionId,
-        title: liveSession.title,
-        description: liveSession.description,
-        scheduledAt: liveSession.scheduledAt,
-        status: liveSession.status,
-        roomUrl: liveSession.roomUrl,
-        courseId: liveSession.courseId,
-        durationMinutes: liveSession.durationMinutes,
-        tutorId: liveSession.tutorId,
+        eventId: calendarEvent.eventId,
+        title: calendarEvent.title,
+        description: calendarEvent.description,
+        startTime: calendarEvent.startTime,
+        endTime: calendarEvent.endTime,
+        status: calendarEvent.status,
+        meetingUrl: calendarEvent.meetingUrl,
+        location: calendarEvent.location,
+        isVirtual: calendarEvent.isVirtual,
+        tutorId: calendarEvent.tutorId,
+        externalId: calendarEvent.externalId,
+        sessionStatus: liveSession.status,
       })
-      .from(liveSession)
-      .where(and(...lsFilters))
-      .orderBy(liveSession.scheduledAt)
+      .from(calendarEvent)
+      .innerJoin(
+        oneOnOneBookingRequest,
+        eq(oneOnOneBookingRequest.calendarEventId, calendarEvent.eventId)
+      )
+      .leftJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
+      .where(and(...oneOnOneFilters))
+      .orderBy(calendarEvent.startTime)
 
     // Build a set of externalIds already covered by CalendarEvent to avoid duplicates
     const coveredExternalIds = new Set(calEvents.map(e => e.externalId).filter(Boolean) as string[])
@@ -155,6 +195,26 @@ export const GET = withAuth(
           status: ls.status,
           courseId: ls.courseId,
         })),
+      ...oneOnOneEvents.map(e => ({
+        id: e.eventId,
+        sessionId: e.externalId,
+        bookingId: e.eventId,
+        title: e.title || '1-on-1 Session',
+        subject: e.description || '1-on-1 tutoring session',
+        start: e.startTime?.toISOString() ?? new Date().toISOString(),
+        end: e.endTime?.toISOString() ?? new Date().toISOString(),
+        duration:
+          e.endTime && e.startTime
+            ? Math.round((new Date(e.endTime).getTime() - new Date(e.startTime).getTime()) / 60000)
+            : 60,
+        type: 'one-on-one' as const,
+        tutorId: e.tutorId,
+        meetingUrl: e.meetingUrl,
+        location: e.location,
+        isVirtual: e.isVirtual,
+        status: e.sessionStatus || e.status || 'scheduled',
+        courseId: null as string | null,
+      })),
     ]
 
     // Sort by start time


### PR DESCRIPTION
## Context
An audit found the Book 1-on-1 flow was wired **through payment**, but then the session became **invisible to the student** — money was collected, the room existed, but there was no way to see or join it. This PR closes the gaps so the flow is fully operational.

## Fixes
### Critical — student can see & join their paid session
- **`/api/student/calendar/events`**: now surfaces **PAID** 1-on-1 sessions by `studentId` (1-on-1 events have `courseId = null`), by joining `OneOnOneBookingRequest` and filtering `status = PAID`. Also removed the early `return []` when the student has no course enrollments, so a booking-only student still sees their sessions. Only **PAID** sessions appear → a session becomes visible/joinable exactly when payment clears.
- **Student dashboard "Bookings" tab**: was a hardcoded "No 1-on-1 sessions booked yet." placeholder — now lists the real 1-on-1 sessions with tutor, time, and a **Join** button (uses `meetingUrl`). 1-on-1s also appear on the Calendar; they're excluded from the course **Sessions** list to avoid duplication.

### Supporting gaps
- **`/api/one-on-one/status`**: returns `PAID` bookings too (was PENDING/ACCEPTED only) so the booking dialog reflects the confirmed/paid state.
- **`/api/one-on-one/cancel`**: now allows cancelling a **PAID** booking (was blocked → deadlock). It frees the session and notifies the tutor with a **refund-required** notification.
- **Payment webhooks (Hitpay + Airwallex)**: notify the **tutor** when a 1-on-1 is paid (previously only the student got an email).
- **Accept** sets `paymentDueAt` (48h), recording the payment window.

## Deliberate scope note (honest)
- **Refunds**: the existing `/api/payments/refund` route is course-payment-specific and rejects booking payments, and it's tutor/admin-initiated. Rather than ship an **untested automated gateway refund** for 1-on-1 (risky — I can't exercise real payments here), I **unblocked cancellation** and route the money via the existing human refund flow, surfaced by a clear "refund required" notification with amount + requestId. Automated 1-on-1 gateway refunds are a sensible follow-up.
- **Session-created-before-payment**: I gate student visibility on `PAID`, so the session is effectively unusable until paid. Moving session creation entirely into the payment webhook is the "ideal" but higher-risk change; left as a follow-up.

## Testing
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- **Not exercised against a live DB / real payments** here. Recommended manual pass: parent sets availability → student books a 1-on-1 → tutor accepts → student pays (sandbox) → confirm the session shows in the student's **Bookings** tab + Calendar with a working Join, the tutor is notified of payment, and cancelling a paid booking frees the session + fires the refund-required notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)