### PR TITLE
feat(assessment): author PCI by conversation instead of a form

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -130,6 +130,7 @@ import { getThread, type PciTarget } from './hooks/pci-reducer'
 import { parsePciTranscript, type PciMessage } from '@/lib/assessment/pci'
 import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
+import { PciInterview } from './PciInterview'
 import { TestTaskChat } from './TestTaskChat'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -1030,6 +1031,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [editingCurrentPci, setEditingCurrentPci] = useState(false)
     // Which source's guided PCI questionnaire is open ('task' | 'assessment' | null).
     const [pciFormSource, setPciFormSource] = useState<'task' | 'assessment' | null>(null)
+    // Assessment PCI is authored by a conversational agent by default; the
+    // box-filling Guided form stays as a fallback ('form').
+    const [pciFormMode, setPciFormMode] = useState<'chat' | 'form'>('chat')
     // Directly set the saved PCI (the marking policy used by grading) for the
     // active context — the active task extension, the base task, or the
     // assessment. Mirrors where applyTaskPciDraft / applyAssessmentPciDraft write.
@@ -6671,47 +6675,95 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             )}
           </div>
         </div>
-        {pciFormSource === source && (
-          <PciQuestionnaire
-            source={source}
-            title={source === 'task' ? taskBuilder.title : assessmentBuilder.title}
-            content={source === 'task' ? taskBuilder.taskContent : assessmentBuilder.taskContent}
-            currentPci={value}
-            // The official marking scheme (DMI) loaded in "Edit marks & answers",
-            // distilled to its policy-bearing bits (no answers) so the AI can
-            // infer award conventions from it.
-            markingScheme={(source === 'task' ? taskDmiItems : assessmentDmiItems)
-              .map(q => ({
-                label: q.questionLabel,
-                marks: typeof q.marks === 'number' ? q.marks : undefined,
-                rubric: q.rubric?.trim() || undefined,
-                responseType: q.responseType?.trim() || undefined,
-                hasVariants: (q.acceptableVariants?.length ?? 0) > 0,
-              }))
-              .filter(q => q.rubric || typeof q.marks === 'number' || q.hasVariants)}
-            // Upload a marking scheme straight from the Guided form: fills the
-            // DMI (marks & answers) via the same flow as "Edit marks & answers",
-            // then the form auto-prefills the PCI from it.
-            onUploadMarkingScheme={file => handleMarkingSchemeFile(file, source)}
-            markingSchemeLoading={markingSchemeLoading}
-            board={pciBoard}
-            subject={pciCategory}
-            categoryOptions={pciCategoryOptions}
-            onExamContextChange={patch => handlePciExamContextChange(source, patch)}
-            canEdit={canEdit}
-            onSave={(specText, spec) => {
-              setCurrentPci(source, specText, {
-                approvedPci: specText,
-                spec,
-                transcript: [],
-                approvedAt: Date.now(),
-              })
-              setPciFormSource(null)
-              toast.success('Marking policy saved to PCI')
-            }}
-            onClose={() => setPciFormSource(null)}
-          />
-        )}
+        {pciFormSource === source &&
+          // Assessment PCI: conversational agent by default, Guided form as fallback.
+          (source === 'assessment' && pciFormMode === 'chat' ? (
+            <PciInterview
+              source={source}
+              title={assessmentBuilder.title}
+              content={assessmentBuilder.taskContent}
+              markingScheme={assessmentDmiItems
+                .map(q => ({
+                  label: q.questionLabel,
+                  marks: typeof q.marks === 'number' ? q.marks : undefined,
+                  rubric: q.rubric?.trim() || undefined,
+                  responseType: q.responseType?.trim() || undefined,
+                  hasVariants: (q.acceptableVariants?.length ?? 0) > 0,
+                }))
+                .filter(q => q.rubric || typeof q.marks === 'number' || q.hasVariants)}
+              board={pciBoard}
+              subject={pciCategory}
+              onExamContextChange={patch => handlePciExamContextChange(source, patch)}
+              canEdit={canEdit}
+              onSave={(specText, spec) => {
+                setCurrentPci(source, specText, {
+                  approvedPci: specText,
+                  spec,
+                  transcript: [],
+                  approvedAt: Date.now(),
+                })
+                setPciFormSource(null)
+                toast.success('Marking policy saved to PCI')
+              }}
+              onClose={() => setPciFormSource(null)}
+              onSwitchToForm={() => setPciFormMode('form')}
+            />
+          ) : (
+            <>
+              {source === 'assessment' && (
+                <div className="mb-1 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => setPciFormMode('chat')}
+                    className="text-[11px] font-medium text-indigo-600 hover:text-indigo-700"
+                  >
+                    Use chat instead
+                  </button>
+                </div>
+              )}
+              <PciQuestionnaire
+                source={source}
+                title={source === 'task' ? taskBuilder.title : assessmentBuilder.title}
+                content={
+                  source === 'task' ? taskBuilder.taskContent : assessmentBuilder.taskContent
+                }
+                currentPci={value}
+                // The official marking scheme (DMI) loaded in "Edit marks & answers",
+                // distilled to its policy-bearing bits (no answers) so the AI can
+                // infer award conventions from it.
+                markingScheme={(source === 'task' ? taskDmiItems : assessmentDmiItems)
+                  .map(q => ({
+                    label: q.questionLabel,
+                    marks: typeof q.marks === 'number' ? q.marks : undefined,
+                    rubric: q.rubric?.trim() || undefined,
+                    responseType: q.responseType?.trim() || undefined,
+                    hasVariants: (q.acceptableVariants?.length ?? 0) > 0,
+                  }))
+                  .filter(q => q.rubric || typeof q.marks === 'number' || q.hasVariants)}
+                // Upload a marking scheme straight from the Guided form: fills the
+                // DMI (marks & answers) via the same flow as "Edit marks & answers",
+                // then the form auto-prefills the PCI from it.
+                onUploadMarkingScheme={file => handleMarkingSchemeFile(file, source)}
+                markingSchemeLoading={markingSchemeLoading}
+                board={pciBoard}
+                subject={pciCategory}
+                categoryOptions={pciCategoryOptions}
+                onExamContextChange={patch => handlePciExamContextChange(source, patch)}
+                canEdit={canEdit}
+                onSave={(specText, spec) => {
+                  setCurrentPci(source, specText, {
+                    approvedPci: specText,
+                    spec,
+                    transcript: [],
+                    approvedAt: Date.now(),
+                  })
+                  setPciFormSource(null)
+                  toast.success('Marking policy saved to PCI')
+                }}
+                onClose={() => setPciFormSource(null)}
+              />
+            </>
+          ))}
         {editingCurrentPci ? (
           <>
             <textarea

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciInterview.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciInterview.tsx
@@ -1,0 +1,302 @@
+'use client'
+
+/**
+ * PciInterview — a conversational way to author the marking policy (PCI).
+ *
+ * Instead of a form, an assistant probes the tutor one plain-language question at
+ * a time (Board, Subject, and the 10 PciSpec marking fields), interprets each
+ * answer into the structured spec (shown live in "Your policy so far"), and on
+ * finish saves the SAME { free-text pci + PciSpec } the Guided form produced —
+ * so grading is unchanged. Simple language for non-native speakers.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { Send, Loader2, Sparkles, CheckCircle2, ListChecks } from 'lucide-react'
+import { toast } from 'sonner'
+import { PCI_SPEC_FIELDS, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
+import type { MarkingSchemeDigestRow } from './PciQuestionnaire'
+
+interface Msg {
+  role: 'assistant' | 'user'
+  content: string
+}
+
+interface PciInterviewProps {
+  source: 'task' | 'assessment'
+  title?: string
+  content?: string
+  markingScheme?: MarkingSchemeDigestRow[]
+  board?: string
+  subject?: string
+  onExamContextChange?: (patch: { category?: string; board?: string }) => void
+  canEdit: boolean
+  onSave: (specText: string, spec: PciSpec) => void
+  onClose: () => void
+  /** Switch to the box-filling Guided form instead. */
+  onSwitchToForm?: () => void
+}
+
+function schemeToText(rows?: MarkingSchemeDigestRow[]): string | undefined {
+  if (!rows || rows.length === 0) return undefined
+  return rows
+    .map(r =>
+      [
+        r.label ? `${r.label}` : null,
+        typeof r.marks === 'number' ? `[${r.marks}]` : null,
+        r.rubric ? `— ${r.rubric}` : null,
+      ]
+        .filter(Boolean)
+        .join(' ')
+    )
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function PciInterview({
+  source,
+  title,
+  content,
+  markingScheme,
+  board,
+  subject,
+  onExamContextChange,
+  canEdit,
+  onSave,
+  onClose,
+  onSwitchToForm,
+}: PciInterviewProps) {
+  const [messages, setMessages] = useState<Msg[]>([])
+  const [spec, setSpec] = useState<PciSpec>({})
+  const [draft, setDraft] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState(false)
+  const [started, setStarted] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages, busy])
+
+  const turn = async (history: Msg[]) => {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/ai/pci-interview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          type: source,
+          title,
+          content,
+          markingScheme: schemeToText(markingScheme),
+          history: history.map(m => ({ role: m.role, content: m.content })),
+          spec,
+          boardKnown: !!board?.trim(),
+          subjectKnown: !!subject?.trim(),
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.error || 'The assistant is unavailable')
+
+      // Merge the extracted marking fields into the live spec.
+      if (data.updates && typeof data.updates === 'object') {
+        setSpec(prev => {
+          const next = { ...prev }
+          for (const { key } of PCI_SPEC_FIELDS) {
+            const v = (data.updates as Record<string, string>)[key]
+            if (typeof v === 'string' && v.trim()) next[key] = v.trim()
+          }
+          return next
+        })
+      }
+      // Board / Subject flow back to Course details (Model A).
+      const ex = data.examContext as { board?: string; category?: string } | undefined
+      if (ex && (ex.board || ex.category)) {
+        onExamContextChange?.({
+          ...(ex.board ? { board: ex.board } : {}),
+          ...(ex.category ? { category: ex.category } : {}),
+        })
+      }
+      if (typeof data.message === 'string' && data.message.trim()) {
+        setMessages(prev => [...prev, { role: 'assistant', content: data.message.trim() }])
+      }
+      if (data.done === true) setDone(true)
+    } catch (e) {
+      setMessages(prev => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: e instanceof Error ? e.message : 'Sorry — please try again.',
+        },
+      ])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Kick off the interview once.
+  useEffect(() => {
+    if (started) return
+    setStarted(true)
+    void turn([])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [started])
+
+  const send = () => {
+    const q = draft.trim()
+    if (!q || busy || !canEdit) return
+    const next = [...messages, { role: 'user' as const, content: q }]
+    setMessages(next)
+    setDraft('')
+    void turn(next)
+  }
+
+  const filledFields = PCI_SPEC_FIELDS.filter(f => spec[f.key]?.trim())
+  const hasAnything = filledFields.length > 0 || !!board?.trim() || !!subject?.trim()
+
+  const handleSave = () => {
+    const text = pciSpecToText(spec)
+    if (!text.trim()) {
+      toast.error('Answer a few questions first, so there is a policy to save.')
+      return
+    }
+    onSave(text, spec)
+  }
+
+  return (
+    <div className="mt-2 flex max-h-[70vh] flex-col overflow-hidden rounded-lg border border-indigo-200 bg-white">
+      <div className="flex items-center gap-2 border-b border-indigo-100 bg-indigo-50/60 px-3 py-2">
+        <Sparkles className="h-4 w-4 text-indigo-600" />
+        <span className="text-sm font-semibold text-indigo-900">
+          Set up your marking policy by chat
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          {onSwitchToForm && (
+            <button
+              type="button"
+              onClick={onSwitchToForm}
+              className="text-[11px] font-medium text-indigo-600 hover:text-indigo-700"
+            >
+              Use the form instead
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[11px] font-medium text-slate-500 hover:text-slate-700"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 sm:grid-cols-[1fr_240px]">
+        {/* Chat */}
+        <div className="flex min-h-0 flex-col">
+          <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+            {messages.map((m, i) =>
+              m.role === 'assistant' ? (
+                <div key={i} className="flex flex-col items-start">
+                  <span className="max-w-[90%] whitespace-pre-wrap rounded-2xl rounded-bl-sm border border-gray-200 bg-gray-50 px-3 py-2 text-sm leading-relaxed text-gray-800">
+                    {m.content}
+                  </span>
+                </div>
+              ) : (
+                <div key={i} className="flex justify-end">
+                  <span className="max-w-[90%] whitespace-pre-wrap rounded-2xl rounded-br-sm bg-indigo-600 px-3 py-2 text-sm text-white">
+                    {m.content}
+                  </span>
+                </div>
+              )
+            )}
+            {busy && (
+              <div className="flex items-center gap-1.5 text-xs text-gray-400">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Thinking…
+              </div>
+            )}
+          </div>
+          <div className="border-t border-gray-100 p-2">
+            <div className="flex items-end gap-2">
+              <textarea
+                value={draft}
+                onChange={e => setDraft(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    send()
+                  }
+                }}
+                disabled={busy || !canEdit}
+                rows={1}
+                placeholder="Type your answer…"
+                className="max-h-28 min-h-[38px] flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+              />
+              <button
+                type="button"
+                onClick={send}
+                disabled={busy || !draft.trim() || !canEdit}
+                title="Send"
+                className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-slate-400 text-white transition-colors hover:bg-slate-500 disabled:opacity-40"
+              >
+                <Send className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Live "policy so far" */}
+        <div className="min-h-0 overflow-y-auto border-t border-gray-100 bg-slate-50/60 p-3 sm:border-l sm:border-t-0">
+          <p className="mb-2 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+            <ListChecks className="h-3.5 w-3.5" /> Your policy so far
+          </p>
+          {!hasAnything ? (
+            <p className="text-xs text-slate-400">
+              As you answer, your marking policy fills in here.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {(board?.trim() || subject?.trim()) && (
+                <li className="text-xs">
+                  <span className="font-medium text-slate-600">Board / Subject:</span>{' '}
+                  <span className="text-slate-700">
+                    {[board?.trim(), subject?.trim()].filter(Boolean).join(' · ')}
+                  </span>
+                </li>
+              )}
+              {filledFields.map(f => (
+                <li key={f.key} className="text-xs">
+                  <span className="font-medium text-slate-600">{f.label}:</span>{' '}
+                  <span className="text-slate-700">{spec[f.key]}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {canEdit && (
+        <div className="flex items-center justify-between gap-2 border-t border-gray-100 px-3 py-2">
+          <span className="inline-flex items-center gap-1 text-[11px] text-slate-500">
+            {done ? (
+              <>
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> All done — review and
+                save.
+              </>
+            ) : (
+              `${filledFields.length} of ${PCI_SPEC_FIELDS.length} points set`
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!hasAnything}
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+          >
+            Save to PCI
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/api/ai/pci-interview/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-interview/route.ts
@@ -1,0 +1,187 @@
+/**
+ * POST /api/ai/pci-interview
+ *
+ * Drives ONE turn of a conversational PCI (marking policy) interview. Instead of
+ * a form, an assistant probes the tutor one plain-language question at a time —
+ * covering Board, Subject, and the 10 PciSpec marking fields — interprets each
+ * answer into the structured spec, and returns the next question. The client
+ * assembles the same { free-text pci + PciSpec } the Guided form produced, so
+ * grading is unchanged. Simple language (many tutors aren't native speakers).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, getSessionForRealm, authOptions } from '@/lib/auth'
+import { withRateLimitPreset } from '@/lib/api/middleware'
+import { AISecurityManager } from '@/lib/security/ai-sanitization'
+import { generateWithFallback } from '@/lib/agents'
+import { parseLlmJson } from '@/lib/ai/llm-response'
+import { PCI_SPEC_FIELDS, type PciSpec } from '@/lib/assessment/pci-spec'
+import { z } from 'zod'
+
+const SPEC_KEYS = PCI_SPEC_FIELDS.map(f => f.key)
+
+const RequestSchema = z.object({
+  type: z.enum(['task', 'assessment']).default('assessment'),
+  title: z.string().max(300).optional(),
+  content: z.string().max(20000).optional(),
+  markingScheme: z.string().max(16000).optional(),
+  history: z
+    .array(z.object({ role: z.enum(['assistant', 'user']), content: z.string().max(4000) }))
+    .max(40)
+    .default([]),
+  spec: z.record(z.string(), z.string()).default({}),
+  boardKnown: z.boolean().default(false),
+  subjectKnown: z.boolean().default(false),
+})
+
+const truncate = (s: string, n: number) => (s.length > n ? s.slice(0, n) + '…' : s)
+
+/**
+ * The interview script — plain-language question + example per point. The model
+ * conducts it, but this gives it the order and the tone to mirror.
+ */
+const FIELD_GUIDE = `Collect these points, in this order. Skip any already in FILLED. Skip "board"/"subject" if already known.
+- board — the exam board or curriculum. Ask: "Which exam board or curriculum is this for? For example: IB, Cambridge IGCSE, AP, or a national exam."
+- subject (key: "category") — the subject. Ask: "What subject is this assessment for? For example: Maths, Biology, or English."
+- instructionalContentReference — which lesson/topic it covers. Ask: "Which topic or material is this assessment about? For example: 'Chapter 3 — quadratic equations'."
+- triggerEvent — when marking should happen. Ask: "When should the AI mark an answer? For example: 'when the student sends an answer'."
+- evaluationLogic — how answers are marked (THE MOST IMPORTANT one — probe for detail). Ask: "How should answers be marked? For example: 'give marks for the correct method even if the final number is wrong; accept equal fractions'."
+- correctResponseBehavior — when a student is right. Ask: "When a student's answer is correct, what should the AI do? For example: 'say well done and move on'."
+- incorrectResponseBehavior — when a student is wrong. Ask: "When a student is wrong, what should happen? For example: 'give one small hint; do not show the answer'."
+- partialUnderstandingBehavior — when partly right. Ask: "If an answer is only partly right, how should you mark it? For example: 'give marks for each correct step'."
+- noResponseBehavior — when blank. Ask: "If a student leaves it blank, what should the AI do? For example: 'give a small hint to help them start'."
+- explanationRules — explaining answers. Ask: "Should the AI explain the answer, and when? For example: 'explain step by step, but only after the student tries'."
+- retryPolicy — number of tries. Ask: "How many tries does a student get before seeing the answer? For example: 'two tries, then show the correct answer'."
+- instructionalTone — the tone. Ask: "What tone should the AI use with students? For example: 'warm and patient'."`
+
+export async function POST(request: NextRequest) {
+  try {
+    const session =
+      (await getSessionForRealm(request, 'tutor')) ?? (await getServerSession(authOptions, request))
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
+    const body = await request.json().catch(() => null)
+    const parsed = RequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+    }
+    const { type, title, content, markingScheme, history, spec, boardKnown, subjectKnown } =
+      parsed.data
+
+    const filled: string[] = SPEC_KEYS.filter(k => (spec as Record<string, string>)[k]?.trim())
+    if (boardKnown) filled.push('board')
+    if (subjectKnown) filled.push('subject')
+
+    const contextBlock = [
+      title && `Assessment title: ${title}`,
+      content && `Assessment content:\n${truncate(content, 8000)}`,
+      markingScheme &&
+        `Official marking scheme (per-question — use it to suggest sensible defaults, but the tutor decides):\n${truncate(markingScheme, 10000)}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+
+    const conversation = history.length
+      ? history
+          .map(h => `${h.role === 'assistant' ? 'Assistant' : 'Tutor'}: ${h.content}`)
+          .join('\n')
+      : '(no messages yet — greet the tutor warmly in one short line, then ask the first needed question.)'
+
+    const instruction = `You are a warm, patient assistant helping a tutor set up their marking policy (the "PCI") for an ${type}, by TALKING with them — not with a form. Many tutors are not native English speakers, so:
+- Use short, simple sentences. Avoid difficult words and jargon.
+- Ask only ONE question at a time, and include a small example.
+- If the tutor's answer is unclear or very short, ask ONE gentle follow-up for detail; otherwise briefly confirm what you understood and move on.
+- Be encouraging.
+
+${FIELD_GUIDE}
+
+Return ONLY a JSON object (no prose, no code fences), shaped exactly:
+{
+  "updates": { <only the point(s) the tutor's LATEST message answers — use these exact keys: ${SPEC_KEYS.join(', ')}, and/or "board", "category". Each value a short, plain marking instruction rephrasing what the tutor said.> },
+  "message": "<your next message to the tutor: one short line confirming what you understood, then the next question with an example — simple language. If everything needed is collected, instead give a short, plain-language summary of the whole policy and say you are ready to save.>",
+  "done": <true ONLY when every needed point is collected>
+}
+Rules:
+- Put into "updates" ONLY what the tutor's latest message clearly states. If they say "skip" / "not needed", leave that field out — never invent policy they did not say.
+- Ask about the FIRST point in the list that is not already in FILLED.
+- Keep "message" short and friendly.
+
+FILLED (already collected — do NOT ask about these): ${filled.length ? filled.join(', ') : '(none yet)'}
+${contextBlock ? `\n${contextBlock}\n` : ''}
+Conversation so far:
+${conversation}`
+
+    let raw: string
+    try {
+      const result = await generateWithFallback(instruction, {
+        temperature: 0.4,
+        maxTokens: 800,
+        skipCache: true,
+        timeoutMs: 45_000,
+        retries: 1,
+      })
+      raw = result.content
+    } catch (err) {
+      console.error('[pci-interview] provider error:', err)
+      return NextResponse.json(
+        { error: 'The assistant is briefly unavailable. Please try again.', retryable: true },
+        { status: 503, headers: { 'Retry-After': '5' } }
+      )
+    }
+
+    const json = parseLlmJson<{
+      updates?: Record<string, unknown>
+      message?: unknown
+      done?: unknown
+    }>(raw)
+
+    // Keep only recognised, non-empty string updates (never fabricate structure).
+    const rawUpdates = (json?.updates ?? {}) as Record<string, unknown>
+    const specUpdates: Partial<PciSpec> = {}
+    for (const k of SPEC_KEYS) {
+      const v = rawUpdates[k]
+      if (typeof v === 'string' && v.trim()) specUpdates[k] = v.trim().slice(0, 1000)
+    }
+    const examContext: { board?: string; category?: string } = {}
+    if (typeof rawUpdates.board === 'string' && rawUpdates.board.trim()) {
+      examContext.board = rawUpdates.board.trim().slice(0, 120)
+    }
+    if (typeof rawUpdates.category === 'string' && rawUpdates.category.trim()) {
+      examContext.category = rawUpdates.category.trim().slice(0, 120)
+    }
+
+    const message =
+      typeof json?.message === 'string' && json.message.trim()
+        ? json.message.trim().slice(0, 1200)
+        : 'Could you tell me a bit more about how you want answers marked?'
+
+    // Warn-only safety scan of the assistant's message (it's tutor-facing).
+    const scan = await AISecurityManager.validateAiResponse(message)
+    if (!scan.isValid && scan.severity === 'CRITICAL') {
+      return NextResponse.json({
+        message: 'Let’s continue — how would you like answers to be marked?',
+        updates: {},
+        examContext: {},
+        done: false,
+      })
+    }
+
+    return NextResponse.json({
+      message,
+      updates: specUpdates,
+      examContext,
+      done: json?.done === true,
+    })
+  } catch (error) {
+    console.error('PCI interview error:', error)
+    return NextResponse.json({ error: 'Failed to run the PCI interview' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## What

For assessments, tutors now set up their **marking policy (PCI)** by **chatting with an assistant** instead of filling out a form. The agent probes them one plain-language question at a time — Board, Subject, and the 10 marking fields (instructional content reference, trigger event, evaluation logic, correct/incorrect/partial/no-response behaviour, explanation rules, retry policy, tone) — with simple language and examples, since many tutors aren't native English speakers.

Each answer is extracted into the structured spec and shown live in a **"Your policy so far"** panel, so the tutor sees progress and can correct as they go. On finish, it saves the **exact same** `{ free-text pci + PciSpec }` the Guided form produced — **grading and every downstream consumer are unchanged**.

## How

- **New `POST /api/ai/pci-interview`** — drives one interview turn, returning `{ message, updates: Partial<PciSpec>, examContext: {board?, category?}, done }`. Mirrors the auth/provider/rate-limit pattern of `pci-spec-suggest` (tutor/admin only, `aiGenerate` limit, warn-only `AISecurityManager` scan on the tutor-facing message). Only writes recognised, non-empty string fields — never fabricates policy the tutor didn't state.
- **New `PciInterview.tsx`** — chat UI + live spec panel + "Save to PCI".
- **`CourseBuilder`** — renders the interview for **assessments by default**, with a **"Use the form instead"** toggle falling back to the existing `PciQuestionnaire`. Board/Subject are **asked only when Course details doesn't already have them**, and flow back to the course category via `onExamContextChange` (Model A). Tasks are unchanged (still the form).

## Design decisions (confirmed with the user)
- **Agent default + form fallback** — interview is the default; the form stays as a fallback.
- **Incremental extraction** — extract after each answer, show a live "PCI so far" panel.
- **Ask Board/Subject, but skip if already set** — writes back to the course category.

## Verification
`npm run typecheck`, `npx eslint`, and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)