### PR TITLE
feat(communications): full-width notification cards + course/tutor me…

### DIFF
--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -37,16 +37,22 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
       }
       const data = await res.json()
       const list: AppNotification[] = (data.notifications || []).map(
-        (n: Record<string, unknown>) => ({
-          id: (n.notificationId as string) || (n.id as string),
-          type: (n.type as string) || 'message',
-          title: n.title as string,
-          message: n.message as string,
-          read: !!n.read,
-          createdAt: (n.createdAt as string) || new Date().toISOString(),
-          actionUrl: (n.actionUrl as string | null) || null,
-          data: (n.data as Record<string, unknown> | null) || null,
-        })
+        (n: Record<string, unknown>) => {
+          const dataObj = (n.data as Record<string, unknown> | null) || null
+          return {
+            id: (n.notificationId as string) || (n.id as string),
+            type: (n.type as string) || 'message',
+            title: n.title as string,
+            message: n.message as string,
+            read: !!n.read,
+            createdAt: (n.createdAt as string) || new Date().toISOString(),
+            actionUrl: (n.actionUrl as string | null) || null,
+            data: dataObj,
+            courseName: (dataObj?.courseName as string) || null,
+            tutorName: (dataObj?.tutorName as string) || null,
+            tutorUsername: (dataObj?.tutorUsername as string) || null,
+          }
+        }
       )
       setNotifications(list)
     } catch {

--- a/tutorme-app/src/components/communications/notifications-panel.tsx
+++ b/tutorme-app/src/components/communications/notifications-panel.tsx
@@ -131,7 +131,7 @@ export default function NotificationsPanel({
               const content = (
                 <div
                   className={cn(
-                    'border-border/20 flex items-start gap-3 rounded-xl border p-3 shadow-sm transition-colors',
+                    'border-border/20 flex w-full items-start gap-3 rounded-xl border p-3 shadow-sm transition-colors',
                     notification.read ? 'bg-white' : 'bg-blue-50/40'
                   )}
                 >
@@ -150,6 +150,16 @@ export default function NotificationsPanel({
                         <p className="mt-0.5 text-[11px] leading-tight text-slate-600">
                           {notification.message}
                         </p>
+                        {(notification.courseName || notification.tutorName) && (
+                          <p className="mt-0.5 text-[11px] text-slate-500">
+                            {notification.courseName}
+                            {notification.courseName && notification.tutorName && ' • '}
+                            {notification.tutorName}
+                            {notification.tutorName && notification.tutorUsername && (
+                              <span className="text-slate-400"> @{notification.tutorUsername}</span>
+                            )}
+                          </p>
+                        )}
                         <p className="mt-0.5 text-[10px] text-slate-400">
                           {formatTime(notification.createdAt)}
                         </p>

--- a/tutorme-app/src/components/communications/types.ts
+++ b/tutorme-app/src/components/communications/types.ts
@@ -42,4 +42,8 @@ export interface AppNotification {
   createdAt: string
   actionUrl?: string | null
   data?: Record<string, unknown> | null
+  // Derived from data for UI display
+  courseName?: string | null
+  tutorName?: string | null
+  tutorUsername?: string | null
 }

--- a/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
+++ b/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
@@ -18,7 +18,7 @@
 
 import { and, eq, gte, lte, inArray, isNull } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession, courseEnrollment } from '@/lib/db/schema'
+import { liveSession, courseEnrollment, course, profile } from '@/lib/db/schema'
 import { notify, notifyMany } from './notify'
 
 /** How far ahead of a session's start to send the reminder. */
@@ -73,10 +73,29 @@ export async function runSessionReminderScan(): Promise<void> {
 
     const minutes = Math.max(1, Math.round((s.scheduledAt.getTime() - Date.now()) / 60000))
     const message = `"${s.title}" starts in about ${minutes} minute${minutes === 1 ? '' : 's'}.`
+
+    // Fetch course name and tutor profile for enriched notification data
+    const [courseRow] = s.courseId
+      ? await drizzleDb
+          .select({ name: course.name })
+          .from(course)
+          .where(eq(course.courseId, s.courseId))
+          .limit(1)
+      : [null]
+
+    const [tutorProfile] = await drizzleDb
+      .select({ name: profile.name, username: profile.username })
+      .from(profile)
+      .where(eq(profile.userId, s.tutorId))
+      .limit(1)
+
     const data = {
       sessionId: s.sessionId,
       scheduledAt: s.scheduledAt.toISOString(),
       kind: 'session-reminder',
+      courseName: courseRow?.name || null,
+      tutorName: tutorProfile?.name || null,
+      tutorUsername: tutorProfile?.username || null,
     }
 
     // Tutor reminder.


### PR DESCRIPTION
…tadata

- Make notification cards span full width of the Notifications panel (w-full)
- Add courseName, tutorName, and tutorUsername to AppNotification type
- Extract course/tutor fields from notification data JSONB in API response mapping
- Render course • tutorName @username line on each notification card
- Enrich session-reminder notifications with course name and tutor profile data