### PR TITLE
fix(communications): ensure notification cards span full panel width

### DIFF
--- a/tutorme-app/src/components/communications/notifications-panel.tsx
+++ b/tutorme-app/src/components/communications/notifications-panel.tsx
@@ -126,7 +126,7 @@ export default function NotificationsPanel({
         ) : notifications.length === 0 ? (
           EmptyState
         ) : (
-          <div className="space-y-2 pt-4">
+          <div className="w-full space-y-2 pt-4">
             {notifications.map(notification => {
               const content = (
                 <div


### PR DESCRIPTION
The notification list container was a flex item with no explicit width, defaulting to flex-basis: auto. This meant the container only stretched as wide as its content, causing the w-full cards inside to potentially not span the full Notifications panel width.

Add w-full to the space-y-2 list container to explicitly stretch it to the full width of the scrollable flex parent, ensuring cards inside have a guaranteed full-width containing block.