### PR TITLE
fix(student): add padding to Book a Tutor panel to reveal card shadow

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -222,7 +222,7 @@ export default function StudentTutorDirectoryPage() {
       </section>
 
       {/* Bottom panel: filters + results */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2">
         <Card
           hoverable={false}
           className="shadow-hover-lift flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5"


### PR DESCRIPTION
The Card's shadow-hover-lift shadow was being clipped by the parent overflow-hidden container because the Card filled 100% of its parent's height with zero padding/margin around it, leaving no room for the shadow to render.

Add p-2 to the bottom panel wrapper to create 8px of space around the Card, allowing the shadow to be fully visible.