### PR TITLE
fix(ui): add h-full to CollapsibleCard inner wrapper for proper flex …

### DIFF
--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -42,7 +42,7 @@ export function CollapsibleCard({
         )}
       >
         {/* Inner wrapper with overflow hidden for animation */}
-        <div className="flex flex-col overflow-hidden p-0">
+        <div className="flex h-full flex-col overflow-hidden p-0">
           <button
             type="button"
             onClick={() => setOpen(o => !o)}


### PR DESCRIPTION
…height

The CollapsibleCard's inner wrapper was missing h-full, breaking the flex height chain from the parent down to the content. This caused the MessagingPanel (and any other content inside CollapsibleCard) to not fill the full available height of the panel.

Add h-full to the inner wrapper div so the collapsible content area can properly use flex-1 to fill the remaining height.