### PR TITLE
fix(ui): remove focus:bg flash from dropdown and kebab menu items

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -2243,7 +2243,7 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
                 <SelectItem
                   key={region.id}
                   value={region.id}
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   {region.name}
                 </SelectItem>
@@ -2264,7 +2264,7 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
                 <SelectItem
                   key={country.code}
                   value={country.code}
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   {country.name}
                 </SelectItem>

--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -253,7 +253,7 @@ export default function StudentTutorDirectoryPage() {
                   <SelectItem
                     key={region.id}
                     value={region.id}
-                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                   >
                     {region.name}
                   </SelectItem>
@@ -273,7 +273,7 @@ export default function StudentTutorDirectoryPage() {
                   <SelectItem
                     key={country.code}
                     value={country.code}
-                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                    className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                   >
                     {country.name}
                   </SelectItem>
@@ -287,25 +287,25 @@ export default function StudentTutorDirectoryPage() {
               <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
                 <SelectItem
                   value="popular"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   Most Popular
                 </SelectItem>
                 <SelectItem
                   value="newest"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   Recently Updated
                 </SelectItem>
                 <SelectItem
                   value="courses"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   Most Courses
                 </SelectItem>
                 <SelectItem
                   value="rate"
-                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
+                  className="mx-1.5 rounded-md text-slate-700 hover:bg-slate-100/50 focus:text-slate-900 focus:outline-none"
                 >
                   Highest Rated
                 </SelectItem>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7253,7 +7253,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                 Duplicate
                                               </DropdownMenuItem>
                                               <DropdownMenuItem
-                                                className="text-red-600 focus:bg-red-50 focus:text-red-600"
+                                                className="text-red-600 focus:text-red-600"
                                                 onSelect={() => deleteCourseBuilderNode(node.id)}
                                               >
                                                 Delete

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -1061,7 +1061,7 @@ export function InteractiveCalendar({
                     <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-200 !bg-white !bg-none p-1.5 !text-slate-700 shadow-lg">
                       <SelectItem
                         value="all"
-                        className="!hover:bg-slate-100 !focus:bg-slate-100 rounded-md text-xs !text-slate-700"
+                        className="!hover:bg-slate-100 rounded-md text-xs !text-slate-700"
                       >
                         All Categories
                       </SelectItem>
@@ -1078,7 +1078,7 @@ export function InteractiveCalendar({
                         <SelectItem
                           key={name}
                           value={name}
-                          className="!hover:bg-slate-100 !focus:bg-slate-100 rounded-md text-xs !text-slate-700"
+                          className="!hover:bg-slate-100 rounded-md text-xs !text-slate-700"
                         >
                           {name}
                         </SelectItem>

--- a/tutorme-app/src/components/session-calendar-panel.tsx
+++ b/tutorme-app/src/components/session-calendar-panel.tsx
@@ -205,7 +205,7 @@ export function SessionCalendarPanel({
                         <SelectItem
                           key={tz}
                           value={tz}
-                          className="!hover:bg-slate-100 !focus:bg-slate-100 rounded-md text-xs !text-slate-700"
+                          className="!hover:bg-slate-100 rounded-md text-xs !text-slate-700"
                         >
                           {city}
                         </SelectItem>


### PR DESCRIPTION
Remove focus:bg-... classes that caused a flashing focus ring effect when hovering over or keyboard-navigating through dropdown items and kebab menu items. The hover highlight (hover:bg-... and data-[highlighted]:bg-...) is preserved.

Files changed:
- student/tutors/page.tsx: 6 SelectItem instances
- page.tsx (landing): 2 SelectItem instances
- InteractiveCalendar.tsx: 2 SelectItem instances
- CourseBuilder.tsx: 1 DropdownMenuItem (Delete)
- session-calendar-panel.tsx: 1 SelectItem instance