### PR TITLE
fix(ui): restore reverse sliding pill animation direction

### DIFF
--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -55,7 +55,7 @@ export function SlidingPillTabsList({
 }: SlidingPillTabsListProps) {
   const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
   const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
   const styles = VARIANT_STYLES[variant]
 
   return (
@@ -81,7 +81,7 @@ export function SlidingPillTabsList({
       ))}
       <motion.div
         className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
-        initial={false}
+        initial={{ left: initialLeft, width: initialWidth }}
         animate={{ left, width }}
         transition={{ type: 'spring', stiffness: 400, damping: 30 }}
       />


### PR DESCRIPTION
Commit 2fbc27108 reverted SlidingPillTabsList to an older implementation that used initial={false}, but the useSlidingPillMetrics hook still tracks initialLeft/initialWidth for reverse animation. This mismatch broke the pill animation when switching from right tabs to left tabs - the pill appeared to slide from the wrong direction.

Restore the integration by:
1. Destructuring initialLeft and initialWidth from the hook
2. Passing them to motion.div initial prop instead of initial={false}

This ensures Framer Motion starts the animation from the previous tab's position, creating smooth bidirectional sliding.