### PR TITLE
fix(ui): restore messaging panel height and add top padding

### DIFF
--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -30,11 +30,11 @@ export function CollapsibleCard({
   const cardRef = useAutoScrollOnExpand(open, { delay: 400, margin: 16, block: 'start' })
 
   return (
-    <div ref={cardRef} className="flex flex-col">
+    <div ref={cardRef} className="flex h-full flex-col">
       {/* Outer wrapper with shadow - overflow visible so shadow shows */}
       <div
         className={cn(
-          'flex flex-col',
+          'flex h-full flex-col',
           flush
             ? 'rounded-b-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]'
             : 'rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]',

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -210,6 +210,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
               defaultOpen
               className="flex-1"
+              contentClassName="pt-3"
             >
               <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
             </CollapsibleCard>


### PR DESCRIPTION
Revert the h-full removal from CollapsibleCard outer wrappers that unintentionally shortened the messaging panel. The h-full is needed for the flex height chain to properly fill the parent container.

Instead, add contentClassName="pt-3" to the Messaging CollapsibleCard to create the requested padding between the panel header and the top of the messaging interface. This achieves the spacing goal without breaking the panel height.