### PR TITLE
fix(builder): robust document loading — Generate DMI, Load as Tasks, Task+Extensions

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -427,6 +427,58 @@ const pdfPageCache = new Map<string, string[]>()
 // Collapsible explainer at the top of a PCI tab. PCI ("how to mark this") is easy
 // to confuse with the question content, so this spells out what it is, the flow,
 // and concrete things worth telling the assistant — to point tutors the right way.
+/**
+ * Split a document's extracted text into logical sections for creating one
+ * task/extension per section. Tries, in order: real page breaks (form feed or
+ * "--- Page N ---" markers from PDF extraction), numbered headings at line start
+ * (e.g. "1. Title", "2) Title"), then blank-line paragraph groups. Falls back to
+ * the whole text as one section. Used when a per-page PDF split isn't available —
+ * notably for .docx, whose extracted text carries no page markers, so it would
+ * otherwise collapse into a single task.
+ */
+function splitDocIntoSections(text: string): string[] {
+  const trimmed = (text || '').trim()
+  if (!trimmed) return []
+
+  // 1) Real page breaks from PDF/text extraction.
+  if (trimmed.includes('\f')) {
+    const pages = trimmed
+      .split('\f')
+      .map(p => p.trim())
+      .filter(Boolean)
+    if (pages.length > 1) return pages
+  }
+  if (/--- Page \d+ ---/.test(trimmed)) {
+    const pages = trimmed
+      .split(/--- Page \d+ ---/)
+      .map(p => p.trim())
+      .filter(Boolean)
+    if (pages.length > 1) return pages
+  }
+
+  // 2) Numbered headings at the start of a line ("1. ", "2) ", "3 - "…). Split
+  //    BEFORE each heading so the number stays with its section. Guarded so a
+  //    short numbered list inside one section doesn't shatter into tiny tasks.
+  const numbered = trimmed
+    .split(/\n(?=\s{0,3}\d{1,3}[.)]\s+\S)/)
+    .map(p => p.trim())
+    .filter(Boolean)
+  if (numbered.length > 1 && numbered.length <= 60) {
+    const avgLen = numbered.reduce((sum, s) => sum + s.length, 0) / numbered.length
+    if (avgLen > 60) return numbered
+  }
+
+  // 3) Blank-line separated blocks of meaningful length.
+  const blocks = trimmed
+    .split(/\n\s*\n+/)
+    .map(p => p.trim())
+    .filter(p => p.length > 50)
+  if (blocks.length > 1) return blocks
+
+  // 4) Whole document as a single section.
+  return [trimmed]
+}
+
 function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
   const noun = kind === 'assessment' ? 'assessment' : 'task'
   return (
@@ -2837,14 +2889,31 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }
 
+    // Build a same-origin proxy URL for fetching a stored file. Prefer the by-key
+    // streaming path (?key=) when we have the storage key: it downloads via the
+    // service account's read access and is resilient to signed-URL problems — a
+    // missing signBlob permission makes "signed" URLs fall back to public URLs
+    // that 403 under uniform bucket-level access (the cause of "Failed to fetch
+    // PDF"). Fall back to ?url= for non-GCS or keyless sources.
+    const proxyFetchUrl = (fileUrl: string, fileKey?: string): string => {
+      if (fileKey && /^(documents|assets|resources)\//.test(fileKey) && !fileKey.includes('..')) {
+        return `/api/proxy-file?key=${encodeURIComponent(fileKey)}`
+      }
+      if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
+        return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
+      }
+      return fileUrl
+    }
+
     // Helper: render PDF pages to base64 PNG images
-    const renderPdfToImages = async (pdfUrl: string, maxPages = 3): Promise<string[]> => {
+    const renderPdfToImages = async (
+      pdfUrl: string,
+      maxPages = 3,
+      fileKey?: string
+    ): Promise<string[]> => {
       try {
-        // Proxy external URLs through our API to avoid CORS issues (e.g. GCS)
-        const fetchUrl =
-          pdfUrl.startsWith('http://') || pdfUrl.startsWith('https://')
-            ? `/api/proxy-file?url=${encodeURIComponent(pdfUrl)}`
-            : pdfUrl
+        // Proxy through our API to avoid CORS issues (e.g. GCS); by key when possible.
+        const fetchUrl = proxyFetchUrl(pdfUrl, fileKey)
         const response = await fetch(fetchUrl)
         if (!response.ok) throw new Error('Failed to fetch PDF')
         const arrayBuffer = await response.arrayBuffer()
@@ -2881,12 +2950,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // page-images for digital papers so a long multi-page question paper is fully
     // captured (image analysis is capped at a few pages). Returns '' if the PDF
     // has no extractable text (e.g. a scan) so the caller can fall back to images.
-    const extractPdfText = async (pdfUrl: string, maxPages = 30): Promise<string> => {
+    const extractPdfText = async (
+      pdfUrl: string,
+      maxPages = 30,
+      fileKey?: string
+    ): Promise<string> => {
       try {
-        const fetchUrl =
-          pdfUrl.startsWith('http://') || pdfUrl.startsWith('https://')
-            ? `/api/proxy-file?url=${encodeURIComponent(pdfUrl)}`
-            : pdfUrl
+        const fetchUrl = proxyFetchUrl(pdfUrl, fileKey)
         const response = await fetch(fetchUrl)
         if (!response.ok) throw new Error('Failed to fetch PDF')
         const arrayBuffer = await response.arrayBuffer()
@@ -3053,11 +3123,26 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           // reach the questions, then drop the leading cover/instructions so the
           // budget is spent on the actual questions. Fall back to page images
           // for scanned PDFs.
-          const extracted = await extractPdfText(sourceDoc.fileUrl, 60)
+          const extracted = await extractPdfText(sourceDoc.fileUrl, 60, sourceDoc.fileKey)
           if (extracted.trim().length > 200) {
             pdfText = focusOnQuestions(extracted).slice(0, 70000)
           } else {
-            pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8)
+            try {
+              pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8, sourceDoc.fileKey)
+            } catch (fetchErr) {
+              // The stored PDF couldn't be fetched (e.g. a broken/expired storage
+              // link). Rather than failing outright with "Failed to fetch PDF",
+              // fall back to the text we already extracted from the document at
+              // upload time so DMI generation still proceeds.
+              console.error('PDF fetch for DMI failed; falling back to extracted text:', fetchErr)
+              const fallbackText = (sourceDoc.extractedText || content || '').trim()
+              if (fallbackText.length > 40) {
+                pdfText = focusOnQuestions(fallbackText).slice(0, 70000)
+                toast.info('Could not read the PDF file; using the document text instead.')
+              } else {
+                throw fetchErr
+              }
+            }
           }
         }
 
@@ -5607,15 +5692,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
                       const textToInsert = assetToLoad.content || `[Asset: ${assetToLoad.name}]`
 
-                      let pages: string[] = []
-                      if (textToInsert.includes('\f')) {
-                        pages = textToInsert.split('\f').filter(p => p.trim())
-                      } else if (textToInsert.includes('--- Page')) {
-                        pages = textToInsert.split(/--- Page \d+ ---/).filter(p => p.trim())
-                      } else {
-                        const chunks = textToInsert.split(/\n\n+/).filter(p => p.trim().length > 50)
-                        pages = chunks.length > 1 ? chunks : [textToInsert]
-                      }
+                      const pages: string[] = splitDocIntoSections(textToInsert)
+                      if (pages.length === 0) pages.push(textToInsert)
 
                       setIsSplittingTasks(true)
                       const newTasks: Task[] = []
@@ -5695,21 +5773,20 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         }
 
                         if (isPdf && assetToLoad.url && !pdfSplitSucceeded) {
-                          // The document is a PDF and we attempted to split it into one
-                          // task per page, but fetching/splitting failed (e.g. the file
-                          // is missing from storage or its link expired). Surface the
-                          // real reason instead of silently degrading to a single task
-                          // with a broken document link.
-                          toast.error(
-                            `Could not split '${assetToLoad.name}' into page tasks${
-                              pdfSplitError ? `: ${pdfSplitError}` : ''
-                            }. The task was left unchanged.`
+                          // Splitting the stored PDF into per-page files failed (e.g. the
+                          // link is broken/expired or the object is unreadable). Don't
+                          // abort — fall back to splitting the extracted text into
+                          // sections below so the tutor still gets multiple tasks.
+                          toast.warning(
+                            `Couldn't split '${assetToLoad.name}' by page${
+                              pdfSplitError ? ` (${pdfSplitError})` : ''
+                            } — split it into sections from the text instead.`
                           )
-                          return
                         }
 
                         if (!pdfSplitSucceeded) {
-                          // Text-based split for non-PDF (or url-less) assets: one task per page.
+                          // Text-based split for non-PDF (or url-less) assets, and the
+                          // fallback when a PDF page-split failed: one task per section.
                           pages.forEach((pageContent, idx) => {
                             if (existingTask && existingTaskIndex !== -1 && idx === 0) {
                               updatedExistingTask = {
@@ -5872,16 +5949,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         }
 
                         if (!pdfSplitSucceeded) {
-                          if (textToInsert.includes('\f')) {
-                            pages = textToInsert.split('\f').filter(p => p.trim())
-                          } else if (textToInsert.includes('--- Page')) {
-                            pages = textToInsert.split(/--- Page \d+ ---/).filter(p => p.trim())
-                          } else {
-                            const chunks = textToInsert
-                              .split(/\n\n+/)
-                              .filter(p => p.trim().length > 50)
-                            pages = chunks.length > 1 ? chunks : [textToInsert]
-                          }
+                          // No per-page PDFs (e.g. a .docx, or the page-split failed):
+                          // split the extracted text into sections so a structured
+                          // document still becomes multiple extensions, not one task.
+                          pages = splitDocIntoSections(textToInsert)
+                          if (pages.length === 0) pages = [textToInsert]
                         }
 
                         let nodeIndex = -1


### PR DESCRIPTION
Fixes three document-loading failures. Root causes below.

## 1. "Failed to fetch PDF" on Generate DMI (assessment)
The client fetched the stored PDF through `/api/proxy-file?url=<signed-url>`. When the deploy can't sign URLs (missing `signBlob` → "signed" URLs fall back to public URLs that **403** under uniform bucket-level access), that fetch fails immediately.

**Fix:** switch to the resilient **by-key** streaming path `/api/proxy-file?key=<fileKey>`, which downloads via the service account's read access — the *same path already used for student document display* precisely because it sidesteps signing problems. `extractPdfText`/`renderPdfToImages` now take an optional `fileKey` and prefer it; `handleGenerateDMI` passes `sourceDoc.fileKey`. Plus a fallback: if the PDF still can't be fetched, use the text already extracted at upload time instead of aborting.

## 2. "Document not found in storage. The task was left unchanged." (Load as Tasks)
The per-page PDF split **hard-aborted** when the stored file couldn't be retrieved.

**Fix:** it now falls back (a warning, not a blocking error) to splitting the extracted **text** into sections, so the tutor still gets multiple tasks.

## 3. Task+Extensions put the whole document in a single task
The text fallback only split on `\f` / `--- Page` / blank lines — markers that `.docx` text (extracted via mammoth) doesn't have, so it collapsed to one task.

**Fix:** a shared `splitDocIntoSections()` also splits on **numbered headings** ("1. …", "2) …"), guarded so a short inline numbered list doesn't shatter into tiny tasks. A structured `.docx` now becomes multiple extensions. Verified on sample inputs: numbered doc → 3 sections; short inline list → 1 (guarded); paragraph doc → 2; page-markers → 2.

## Note on infra
Where the object is **genuinely absent** from storage (a GCS/config misconfiguration I can't fix in code), the by-key path and the text fallbacks keep these flows **usable** rather than failing outright — but the ideal fix for a truly-missing object is on the storage/config side.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` all green; the splitter logic sanity-checked on representative inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)