### PR TITLE
fix(pci): bound generation time + clean timeout so later chat turns don't "Load failed"

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -187,32 +187,43 @@ export function usePci(deps: UsePciDeps) {
         }
       }
 
-      const response = await fetch('/api/ai/pci-master', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: userMessage,
-          sessionId,
-          // Prior turns so the model can hold a real conversation (the local /
-          // vision provider paths have no server-side memory; ADK keys on
-          // sessionId). Capped and lightly truncated to bound the payload.
-          history: thread.messages.slice(-10).map(m => ({
-            role: m.role,
-            content: m.content.slice(0, 4000),
-          })),
-          context: {
-            type,
-            title: isTask ? taskBuilder.title : assessmentBuilder.title,
-            // Bounded to stay under the server's content limit and keep the
-            // request small on every turn.
-            content: (slideContent || '').slice(0, 48000),
-            pci: pciText,
-            extensionName,
-            sourceDocument,
-          },
-          pdfPages,
-        }),
-      })
+      // Abort a hung request after a bound comfortably above the server's worst
+      // case (2×45s) so a stuck turn fails cleanly with a retry prompt instead
+      // of hanging or surfacing a raw "Load failed".
+      const controller = new AbortController()
+      const abortTimer = setTimeout(() => controller.abort(), 120_000)
+      let response: Response
+      try {
+        response = await fetch('/api/ai/pci-master', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          signal: controller.signal,
+          body: JSON.stringify({
+            message: userMessage,
+            sessionId,
+            // Prior turns so the model can hold a real conversation (the local /
+            // vision provider paths have no server-side memory; ADK keys on
+            // sessionId). Capped and lightly truncated to bound the payload.
+            history: thread.messages.slice(-10).map(m => ({
+              role: m.role,
+              content: m.content.slice(0, 4000),
+            })),
+            context: {
+              type,
+              title: isTask ? taskBuilder.title : assessmentBuilder.title,
+              // Bounded to stay under the server's content limit and keep the
+              // request small on every turn.
+              content: (slideContent || '').slice(0, 48000),
+              pci: pciText,
+              extensionName,
+              sourceDocument,
+            },
+            pdfPages,
+          }),
+        })
+      } finally {
+        clearTimeout(abortTimer)
+      }
       if (!response.ok) {
         let errorMessage = `Failed to get AI response (${response.status})`
         try {
@@ -248,12 +259,15 @@ export function usePci(deps: UsePciDeps) {
       // as a TypeError with a terse, non-actionable message like "Load failed"
       // (Safari) or "Failed to fetch" (Chrome). Translate those into a clear hint.
       const raw = error instanceof Error ? error.message : ''
+      const isAbort = error instanceof DOMException && error.name === 'AbortError'
       const isNetworkError =
         error instanceof TypeError ||
         /load failed|failed to fetch|networkerror|network error/i.test(raw)
-      const hint = isNetworkError
-        ? "Couldn't reach the PCI assistant — check your connection and try again."
-        : raw || 'Unable to reach the PCI assistant. Please try again.'
+      const hint = isAbort
+        ? 'The assistant took too long to respond — please try again.'
+        : isNetworkError
+          ? "Couldn't reach the PCI assistant — check your connection and try again."
+          : raw || 'Unable to reach the PCI assistant. Please try again.'
       toast.error(`PCI Assistant error: ${hint}`)
       dispatch({
         type: 'sendError',

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -244,8 +244,11 @@ export async function POST(request: NextRequest) {
     // Timeout + retry budget for the upstream model call. Moonshot/Kimi is the
     // sole provider, so a slow or 5xx/429 response has no second provider to fall
     // back to — bound each attempt and retry a couple of times before giving up.
-    const GEN_TIMEOUT_MS = 60_000
-    const GEN_RETRIES = 3
+    // Kept well under Cloud Run's 300s request timeout (worst case 2×45s = 90s)
+    // so a slow turn returns a clean error instead of the connection dropping
+    // and surfacing as "Load failed" in the chat.
+    const GEN_TIMEOUT_MS = 45_000
+    const GEN_RETRIES = 2
     const fallbackOptions = {
       temperature: activeTemperature,
       maxTokens: 4096,


### PR DESCRIPTION
## Why you saw the error
"Load failed" is a browser-level fetch rejection (the connection dropped), not an HTTP error. Two contributing factors, addressed in two PRs:

1. **#789 (already deployed — was NOT live during your test):** the chat re-sent the attached PDF's page images (several MB) on *every* turn, forcing the slow vision path and a big payload each time. Now the images go on the **first turn only**. In your transcript the failure hit a later turn (turn 5) precisely because of this.

2. **This PR:** even without the images, a slow Kimi turn could hang — the server retried up to **3× at 60s (worst case 180s)**, and a stuck request eventually dropped the connection → "Load failed".

## This change
- **Server (`pci-master`):** generation budget cut to **2 retries × 45s = 90s worst case**, comfortably under Cloud Run's 300s request timeout, so a slow turn returns a clean error rather than dropping the connection.
- **Client (`use-pci`):** abort the request after **120s** and show *"The assistant took too long to respond — please try again."* — no more raw "Load failed", and a hung turn can't spin forever.

Together with #789 (now live), the confirm step and the following turns should hold. The chat also correctly identified the doc as a worksheet with no diagrams — so the earlier framing fixes are working.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build`, and the hooks unit tests (`use-pci` + `pci-reducer`, 17 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)