### PR TITLE
feat(pci): warn-only guardrails on the assessment marking-policy chat

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -400,6 +400,26 @@ export async function POST(request: NextRequest) {
           guardrailWarnings.map(v => `${v.ruleId} ${v.severity}`).join(', ')
         )
       }
+    } else if (guardrailDomain === 'assessment') {
+      // Warn-only hygiene for the assessment marking-policy chat. The DMI's
+      // STRUCTURAL guardrails (question-wording fidelity, rubric/marks totals,
+      // evaluation-layer separation) run in generate-dmi, where the parsed
+      // question structure exists. In this CONVERSATIONAL chat the relevant
+      // checks are the domain-agnostic ones — fabricated evaluation policy
+      // (marks/retries/penalties not in the source), false certainty, and
+      // keeping the reply conversational. Reuse those and surface them under a
+      // neutral PCI-* label so they aren't misattributed to a TASK-* rule.
+      guardrailWarnings = runTaskGuardrails(response.response, {
+        sourceContent: context?.content,
+        finalizing: tutorSignaledFinalize,
+        finalizedPci: pciDraft,
+      }).violations.map(v => ({ ...v, ruleId: v.ruleId.replace(/^TASK-/, 'PCI-') }))
+      if (guardrailWarnings.length > 0) {
+        console.warn(
+          `[guardrails] pci-master assessment violations (${guardrailWarnings.length}):`,
+          guardrailWarnings.map(v => `${v.ruleId} ${v.severity}`).join(', ')
+        )
+      }
     }
 
     return NextResponse.json({


### PR DESCRIPTION
The PCI chat only ran guardrails for the **task** domain (`if (guardrailDomain === 'task')`), so assessment turns returned no `guardrailWarnings`. This adds parity.

Assessments now get the same **warn-only** hygiene checks on each chat turn:
- fabricated evaluation policy (marks / retries / penalties not present in the source),
- false certainty about an answer/rubric the tutor never gave,
- non-conversational replies (raw JSON dumped into the chat).

Surfaced under a neutral **`PCI-*`** label (not `TASK-*`), since the banner shows the rule ID.

The **structural** DMI guardrails (question-wording fidelity, rubric/marks totals, evaluation-layer separation) continue to run in `generate-dmi`, where the parsed question structure actually exists — the conversational chat produces a marking *policy*, not a question set, so the text-hygiene checks are the ones that apply here.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build`, and the guardrail unit tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)