### PR TITLE
feat(assessment/test): author questions from study material + Test-tab fixes

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -131,7 +131,7 @@ import { parsePciTranscript, type PciMessage } from '@/lib/assessment/pci'
 import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
 import { PciSpecSoFar } from './PciSpecSoFar'
-import { TestTaskChat } from './TestTaskChat'
+import { TestTaskChat, type TestTaskChatState } from './TestTaskChat'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
@@ -1214,6 +1214,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [newSubmissionCount, setNewSubmissionCount] = useState(0)
 
     const [testPciSource, setTestPciSource] = useState<'task' | 'assessment'>('task')
+    // Persists each Test-tab task-chat preview (keyed by task/extension + student
+    // tab) across the remounts that happen when switching Test students, so the
+    // conversation isn't lost. A ref: writing it must not trigger a re-render.
+    const testTaskChatStore = useRef<Record<string, TestTaskChatState>>({})
+    // Test-tab-only DEBUG control: grade against all available bases (default) or
+    // isolate one (PCI / rubric / model answer) to see its effect alone. Never
+    // affects student/production grading — only the tutor's test-grade requests.
+    const [testPciBasis, setTestPciBasis] = useState<'all' | 'pci' | 'rubric' | 'model'>('all')
     const [alertDialog, setAlertDialog] = useState<{
       open: boolean
       title: string
@@ -2840,16 +2848,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         })
       }
 
+      // DEBUG basis isolation (test-tab only): drop the bases the tutor didn't
+      // pick so grading rests on just the selected one. 'all' keeps everything.
+      const usesPci = testPciBasis === 'all' || testPciBasis === 'pci'
+      const usesRubric = testPciBasis === 'all' || testPciBasis === 'rubric'
+      const usesModel = testPciBasis === 'all' || testPciBasis === 'model'
+
       try {
         // Grade through the shared engine — identical to what students get.
         const response = await fetchWithCsrf('/api/tutor/test-grade', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            pci: pciContent,
-            pciSpec,
-            rubric,
-            modelAnswer,
+            pci: usesPci ? pciContent : '',
+            pciSpec: usesPci ? pciSpec : undefined,
+            rubric: usesRubric ? rubric : '',
+            modelAnswer: usesModel ? modelAnswer : '',
             questionText,
             responseType,
             sourceDependencies,
@@ -9663,6 +9677,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               >
                                                 <div className="ml-1 h-full w-full overflow-y-auto bg-white p-4">
                                                   <div className="space-y-4">
+                                                    {(version?.items ?? []).length === 0 && (
+                                                      <p className="text-muted-foreground text-sm">
+                                                        No questions in this DMI yet. Open{' '}
+                                                        <span className="font-medium">
+                                                          Edit marks &amp; answers
+                                                        </span>{' '}
+                                                        and generate the DMI — for study material
+                                                        the AI will author questions from the
+                                                        content.
+                                                      </p>
+                                                    )}
                                                     {(version?.items ?? []).map(item => (
                                                       <div
                                                         key={item.id}
@@ -9758,22 +9783,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                               // flow students get (chat → Task complete → per-answer
                               // responses → follow-up); assessments keep the composer.
                               (mainTab === 'test-pci' && testPciSource === 'task' ? (
-                                <div key={testPciActiveTab} className="mt-1 h-[55vh] min-h-[340px]">
-                                  {(() => {
-                                    const ext = taskBuilder.activeExtensionId
-                                      ? taskBuilder.extensions.find(
-                                          e => e.id === taskBuilder.activeExtensionId
-                                        )
-                                      : null
-                                    return (
+                                (() => {
+                                  const ext = taskBuilder.activeExtensionId
+                                    ? taskBuilder.extensions.find(
+                                        e => e.id === taskBuilder.activeExtensionId
+                                      )
+                                    : null
+                                  // Persist per task/extension AND per student tab, so each
+                                  // preview keeps its own conversation across remounts.
+                                  const persistKey = `${ext ? ext.id : 'base'}:${testPciActiveTab}`
+                                  return (
+                                    <div key={persistKey} className="mt-1 h-[55vh] min-h-[340px]">
                                       <TestTaskChat
                                         pci={(ext ? ext.pci : taskBuilder.taskPci) || ''}
                                         pciSpec={ext ? undefined : taskBuilder.pciSpec}
                                         questionText={`${taskBuilder.title}\n\n${ext ? ext.content : taskBuilder.taskContent}`}
+                                        initialState={testTaskChatStore.current[persistKey]}
+                                        onPersist={s => {
+                                          testTaskChatStore.current[persistKey] = s
+                                        }}
                                       />
-                                    )
-                                  })()}
-                                </div>
+                                    </div>
+                                  )
+                                })()
                               ) : (
                                 <div
                                   className={cn(
@@ -9882,6 +9914,36 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             <Chip ok={hasRubric}>Rubric</Chip>
                                             <Chip ok={hasModel}>Model answer</Chip>
                                           </div>
+                                          {anyBasis && (
+                                            <div className="flex items-center gap-1">
+                                              <span className="text-slate-500">Test with:</span>
+                                              <select
+                                                value={testPciBasis}
+                                                onChange={e =>
+                                                  setTestPciBasis(
+                                                    e.target.value as
+                                                      | 'all'
+                                                      | 'pci'
+                                                      | 'rubric'
+                                                      | 'model'
+                                                  )
+                                                }
+                                                title="Debug: isolate one marking basis to see its effect (test only — never affects student grading)"
+                                                className="rounded border border-slate-300 bg-white px-1.5 py-0.5 text-xs text-slate-700"
+                                              >
+                                                <option value="all">All bases</option>
+                                                <option value="pci" disabled={!hasPci}>
+                                                  PCI only
+                                                </option>
+                                                <option value="rubric" disabled={!hasRubric}>
+                                                  Rubric only
+                                                </option>
+                                                <option value="model" disabled={!hasModel}>
+                                                  Model answer only
+                                                </option>
+                                              </select>
+                                            </div>
+                                          )}
                                           {!anyBasis && (
                                             <span className="text-amber-600">
                                               Add a PCI, rubric, or model answer to grade.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -4,7 +4,11 @@
  * TestTaskChat — previews the student's chat-based TASK flow inside the "Test"
  * tab, using the IN-BUILDER PCI (via /api/tutor/test-grade). It mirrors what a
  * student gets: chat answers → "Task complete" → the AI responds to each answer
- * per the PCI → ask follow-ups. Stateless preview (persists nothing).
+ * per the PCI → ask follow-ups.
+ *
+ * State can be persisted by the parent: pass `initialState` to seed the chat and
+ * `onPersist` to mirror every change into a store, so switching Test-tab
+ * students (which remounts this component) doesn't lose the conversation.
  */
 
 import { useEffect, useRef, useState } from 'react'
@@ -12,24 +16,36 @@ import { Send, Loader2, CheckCircle2, Sparkles } from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { toast } from 'sonner'
 
-interface ChatMsg {
+export interface TestTaskChatMsg {
   role: 'student' | 'ai'
   content: string
   re?: string
 }
 
+export interface TestTaskChatState {
+  messages: TestTaskChatMsg[]
+  draft: string
+  completed: boolean
+}
+
+type ChatMsg = TestTaskChatMsg
+
 export function TestTaskChat({
   pci,
   pciSpec,
   questionText,
+  initialState,
+  onPersist,
 }: {
   pci?: string
   pciSpec?: unknown
   questionText?: string
+  initialState?: TestTaskChatState
+  onPersist?: (state: TestTaskChatState) => void
 }) {
-  const [messages, setMessages] = useState<ChatMsg[]>([])
-  const [draft, setDraft] = useState('')
-  const [completed, setCompleted] = useState(false)
+  const [messages, setMessages] = useState<ChatMsg[]>(initialState?.messages ?? [])
+  const [draft, setDraft] = useState(initialState?.draft ?? '')
+  const [completed, setCompleted] = useState(initialState?.completed ?? false)
   const [busy, setBusy] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -37,6 +53,12 @@ export function TestTaskChat({
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [messages, busy])
+
+  // Mirror state to the parent's store so a remount (switching Test students)
+  // can rehydrate it. Cheap; runs only when the persisted fields change.
+  useEffect(() => {
+    onPersist?.({ messages, draft, completed })
+  }, [messages, draft, completed, onPersist])
 
   const studentAnswers = messages.filter(m => m.role === 'student').map(m => m.content)
 

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -94,7 +94,7 @@ Rules:
   question wording, instructions, marks, or answers. Enumerate EVERY part across ALL pages, in
   order, exactly once: do not skip, merge, summarise, repeat, or stop early. A 6-question paper with
   sub-parts typically yields 15-30 fields.
-- For study_material: generate 5-10 questions; here "label" is the full question text.
+- For study_material: AUTHOR 5-10 questions that TEST the material — never bare numbers, section titles, or headings. Here "label" is the FULL question wording (a complete, answerable question), and each item carries a model "answer" and a "rubric". Choose a sensible mix of types for the content.
 - "type" is exactly one of: short, long, mcq, true_false, multiple_response, fill_blank, matching,
   ordering, hotspot, drag_drop. Choose by how EACH part is answered: a multiple-choice item (lettered
   options on the paper) -> "mcq"; a numeric / one-line response -> "short"; an extended written
@@ -463,14 +463,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No content or PDF pages provided' }, { status: 400 })
     }
 
-    // When the tutor has specified question types + counts (study material path),
-    // tell the model to generate exactly that mix.
+    // Study-material path. If the tutor specified question types + counts, generate
+    // exactly that mix. Otherwise (option A) still AUTHOR a sensible set of questions
+    // from the material — do NOT emit bare question numbers. Only a genuine printed
+    // question paper is extracted number-by-number (the model classifies, and the
+    // question_paper override forces extraction).
     const specInstruction =
       questionSpec && questionSpec.length > 0
         ? `\n\nThis source is study material. Generate exactly: ${questionSpec
             .map(s => `${s.count} ${DMI_QUESTION_TYPE_LABELS[s.type]} (${s.type})`)
             .join(', ')}. Use those exact types and counts.`
-        : ''
+        : documentKindOverride === 'question_paper'
+          ? ''
+          : `\n\nIf this source is NOT a printed question paper (i.e. documentKind is study_material or uncertain), do NOT emit bare question numbers. Instead AUTHOR 5-10 NEW questions that assess the key points of this material — each with the FULL question wording as "label", a suitable "type", "marks", a model "answer", and a "rubric" — choosing a sensible mix of types for the content. ONLY when the document genuinely IS a printed question paper should you extract its existing question references instead of authoring.`
 
     // When the tutor has explicitly confirmed the document kind, tell the model
     // so it classifies + extracts accordingly (and we skip re-confirmation).


### PR DESCRIPTION
Covers the implementable items from the latest batch.

## 1a. Generate real questions from non-question-paper material (option A)
`generate-dmi` now branches on the detected document kind:
- **Question paper** → extract question references number-by-number (unchanged).
- **Study material / uncertain** → the AI **authors 5–10 questions** from the material (full question wording as the label, plus model answer + rubric, a sensible AI-chosen mix of types) instead of emitting bare question numbers. The tutor's explicit question-spec still overrides the count/mix.

This is the fix for "it always creates question numbers regardless of document type," and it also resolves the empty Test-tab DMI list for study-material assessments (there are real questions to show now).

## 1b. Marking-basis debug toggle (Test tab only)
New **"Test with"** selector next to the basis badges: grade against **All bases** (default) or isolate **PCI only / Rubric only / Model answer only** to see each one's effect. It only filters the tutor's *test-grade* request — **student/production grading is untouched** (still uses all bases with PCI as the tiebreaker).

## 2. Empty-state for the DMI panel
A DMI with no questions now shows a short "generate the DMI" message instead of a silently blank panel.

## 3. Persistent task Test-chat
The task chat preview (`TestTaskChat`) now persists its conversation per task/extension + student tab. Previously switching Test students remounted it (`key` change) and wiped the chat; state is now mirrored to a store in `CourseBuilder` and rehydrated on remount.

## Not included — #4 (remove the assessment "chat box")
Reporting back rather than removing: on the assessment Test tab, answers are **not** entered in the DMI — that panel is **read-only** (it shows the question/answer/rubric scheme). The composer **is** the test-answer input (type an answer → grade). So it's currently necessary for testing assessment grading. Options if the confusion remains: relabel it clearly as "test a sample answer", or rebuild it to let you type answers into the DMI question fields (mirroring the student DMI) and drop the free-text composer. Happy to do either — flagged for your call.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)