### PR TITLE
fix(desk): use CSS transitions instead of Framer Motion for sliding pill

### DIFF
--- a/tutorme-app/src/components/sliding-pill-tabs.tsx
+++ b/tutorme-app/src/components/sliding-pill-tabs.tsx
@@ -1,10 +1,8 @@
 'use client'
 
 import * as React from 'react'
-import { useRef } from 'react'
-import { motion } from 'framer-motion'
+import { useRef, useState, useCallback } from 'react'
 import { cn } from '@/lib/utils'
-import { useSlidingPillMetrics } from '@/hooks/use-sliding-pill'
 import { TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export interface SlidingPillTab {
@@ -53,21 +51,65 @@ export function SlidingPillTabsList({
   triggerClassName,
   pillClassName,
 }: SlidingPillTabsListProps) {
-  const triggerRefs = useRef<(HTMLButtonElement | null)[]>([])
-  const activeIndex = tabs.findIndex(tab => tab.value === value)
-  const { left, width, initialLeft, initialWidth } = useSlidingPillMetrics(triggerRefs, activeIndex)
+  const listRef = useRef<HTMLDivElement>(null)
+  const [pillStyle, setPillStyle] = useState({ left: 0, width: 0 })
+  const [isFirstRender, setIsFirstRender] = useState(true)
   const styles = VARIANT_STYLES[variant]
+
+  const updatePillPosition = useCallback(() => {
+    const list = listRef.current
+    if (!list) return
+    const triggers = Array.from(list.querySelectorAll('[role="tab"]'))
+    const active = triggers.find(t => t.getAttribute('data-state') === 'active')
+    if (!active) return
+    const rect = active.getBoundingClientRect()
+    const listRect = list.getBoundingClientRect()
+    setPillStyle({
+      left: rect.left - listRect.left,
+      width: rect.width,
+    })
+  }, [])
+
+  React.useLayoutEffect(() => {
+    // Defer to next frame so Radix UI has time to update data-state attributes
+    const id = requestAnimationFrame(() => {
+      updatePillPosition()
+      // After first measurement, enable transitions for subsequent tab changes
+      if (isFirstRender) {
+        setIsFirstRender(false)
+      }
+    })
+    return () => cancelAnimationFrame(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(updatePillPosition, 100)
+    return () => clearTimeout(timeoutId)
+  }, [updatePillPosition])
+
+  React.useEffect(() => {
+    const handleResize = () => updatePillPosition()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [updatePillPosition])
+
+  React.useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const ro = new ResizeObserver(() => updatePillPosition())
+    ro.observe(list)
+    return () => ro.disconnect()
+  }, [updatePillPosition])
 
   return (
     <TabsList
+      ref={listRef}
       className={cn('relative flex w-full gap-1.5 rounded-xl p-1.5', styles.list, listClassName)}
     >
-      {tabs.map((tab, i) => (
+      {tabs.map(tab => (
         <TabsTrigger
           key={tab.value}
-          ref={el => {
-            triggerRefs.current[i] = el
-          }}
           value={tab.value}
           disabled={tab.disabled}
           className={cn(
@@ -79,11 +121,15 @@ export function SlidingPillTabsList({
           {tab.label}
         </TabsTrigger>
       ))}
-      <motion.div
+      <div
         className={cn('absolute bottom-1.5 top-1.5 rounded-lg', styles.pill, pillClassName)}
-        initial={{ left: initialLeft, width: initialWidth }}
-        animate={{ left, width }}
-        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+        style={{
+          left: pillStyle.left,
+          width: pillStyle.width,
+          transitionProperty: isFirstRender ? 'none' : 'left, width',
+          transitionDuration: isFirstRender ? '0s' : '300ms',
+          transitionTimingFunction: 'ease-out',
+        }}
       />
     </TabsList>
   )


### PR DESCRIPTION
Replace Framer Motion motion.div with a plain div using CSS transition-all for the sliding pill animation. This matches the Dashboard mode selector approach and fixes the bug where the pill would appear to slide from the left instead of from the previously active tab when switching from Insights to Submissions.

- Query active tab via data-state="active" instead of refs by index
- Use requestAnimationFrame to wait for Radix UI state updates
- Add ResizeObserver, window resize, and timeout guards for robustness
- Add isFirstRender flag to skip transition on mount (prevents slide-from-left on remount)