### PR TITLE
feat: DMI kind-override banner, finalize-detection hardening, storage health check

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1222,6 +1222,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // isolate one (PCI / rubric / model answer) to see its effect alone. Never
     // affects student/production grading — only the tutor's test-grade requests.
     const [testPciBasis, setTestPciBasis] = useState<'all' | 'pci' | 'rubric' | 'model'>('all')
+    // How the last-generated DMI was classified (per source). Lets the tutor
+    // override a confidently-wrong call — e.g. numbered study notes read as a
+    // question paper — via the "Detected as …" banner, which regenerates.
+    const [dmiDocumentKind, setDmiDocumentKind] = useState<{
+      task?: 'question_paper' | 'study_material'
+      assessment?: 'question_paper' | 'study_material'
+    }>({})
     const [alertDialog, setAlertDialog] = useState<{
       open: boolean
       title: string
@@ -3320,6 +3327,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           sections: deriveSections(dmiItems),
           totalMarks: deriveTotalMarks(dmiItems),
         }
+
+        // Remember how this DMI was classified so the tutor can override a wrong
+        // call (see the "Detected as …" banner) without needing the model to be
+        // unsure. study_material is inferred when the tutor supplied a question spec.
+        const detectedKind: 'question_paper' | 'study_material' =
+          data.documentKind === 'study_material' || (questionSpec?.length ?? 0) > 0
+            ? 'study_material'
+            : 'question_paper'
+        setDmiDocumentKind(prev => ({ ...prev, [type]: detectedKind }))
 
         if (isTask) {
           setTaskDmiItems(dmiItems)
@@ -9677,6 +9693,44 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               >
                                                 <div className="ml-1 h-full w-full overflow-y-auto bg-white p-4">
                                                   <div className="space-y-4">
+                                                    {dmiDocumentKind[testPciSource] && canEdit && (
+                                                      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                                                        <span>
+                                                          Detected as{' '}
+                                                          <span className="font-semibold">
+                                                            {dmiDocumentKind[testPciSource] ===
+                                                            'question_paper'
+                                                              ? 'a question paper'
+                                                              : 'study material'}
+                                                          </span>
+                                                          {dmiDocumentKind[testPciSource] ===
+                                                          'question_paper'
+                                                            ? ' — extracted the question numbers.'
+                                                            : ' — authored questions from the content.'}
+                                                        </span>
+                                                        <button
+                                                          type="button"
+                                                          disabled={dmiGenerating}
+                                                          onClick={() =>
+                                                            handleGenerateDMI(
+                                                              testPciSource,
+                                                              undefined,
+                                                              dmiDocumentKind[testPciSource] ===
+                                                                'question_paper'
+                                                                ? 'study_material'
+                                                                : 'question_paper'
+                                                            )
+                                                          }
+                                                          className="ml-auto rounded-md border border-amber-300 bg-white px-2 py-1 font-medium text-amber-800 hover:bg-amber-100 disabled:opacity-50"
+                                                        >
+                                                          Not right? Regenerate as{' '}
+                                                          {dmiDocumentKind[testPciSource] ===
+                                                          'question_paper'
+                                                            ? 'study material'
+                                                            : 'a question paper'}
+                                                        </button>
+                                                      </div>
+                                                    )}
                                                     {(version?.items ?? []).length === 0 && (
                                                       <p className="text-muted-foreground text-sm">
                                                         No questions in this DMI yet. Open{' '}

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -335,10 +335,16 @@ export async function POST(request: NextRequest) {
     // only after the tutor approves finalizing). Extract both so the chat never
     // shows a raw spec and the builder can write a clean PCI to the field.
     // TASK-5 (Confirmation): the tutor's message must explicitly signal approval
-    // before the engine presents a finalized rubric — the model alone cannot
-    // finalize. Used both to gate the draft and to inform the validator.
+    // to FINALIZE THE RUBRIC before the engine presents a finalized one — the
+    // model alone cannot finalize. The tutor's explicit "Apply to PCI" click is
+    // the real gate; this flag only informs pciUnconfirmed + the validator.
+    //
+    // Match ONLY unambiguous finalize intent. We deliberately exclude generic
+    // agreement words — "confirm", "correct", "looks good", "sounds good",
+    // "agreed", "go ahead" — because they also mean "yes, the SUMMARY is right"
+    // in the confirm-summary step, and must not be misread as finalizing.
     const tutorSignaledFinalize =
-      /\b(confirm(ed)?|finali[sz]e|approve[d]?|looks good|go ahead|activate|apply it|lock it in|use (that|this)|that'?s (right|correct|good|it)|sounds good|save it|agreed)\b/i.test(
+      /\b(finali[sz]e|approve the (rubric|pci|policy|marking policy)|lock it in|activate the (rubric|pci|policy)|apply (it|this|the (rubric|pci|policy|marking policy))|save (it|the (rubric|pci|policy))|use this (rubric|policy) as (the )?final)\b/i.test(
         safeMessage
       )
 

--- a/tutorme-app/src/app/api/tutor/storage-health/route.ts
+++ b/tutorme-app/src/app/api/tutor/storage-health/route.ts
@@ -1,0 +1,92 @@
+/**
+ * GET /api/tutor/storage-health
+ *
+ * One-shot diagnostic for document storage. It exercises the exact operations
+ * the builder relies on and reports which succeed, so a "Failed to fetch PDF" /
+ * "Document not found in storage" incident can be pinned to config in seconds:
+ *
+ *   1. write      — upload a tiny object to the tutor's documents/ prefix
+ *   2. readByKey  — download it back by key (service-account read; the resilient path)
+ *   3. signedUrl  — mint a presigned URL and fetch it (exercises iam signBlob)
+ *   4. cleanup    — delete the test object
+ *
+ * If `signedUrl` fails while `readByKey` succeeds, the deploy is missing
+ * `iam.serviceAccounts.signBlob` — signed URLs then fall back to public URLs that
+ * 403 under uniform bucket-level access (the by-key path is the workaround). If
+ * `readByKey` fails too, the object isn't persisting (bucket / creds problem).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { withAuth } from '@/lib/api/middleware'
+import type { Session } from 'next-auth'
+import {
+  isGcsConfigured,
+  uploadBuffer,
+  downloadBuffer,
+  createPresignedDownloadUrl,
+  deleteObject,
+} from '@/lib/storage/gcs'
+
+export const runtime = 'nodejs'
+
+interface StepResult {
+  ok: boolean
+  detail?: string
+}
+
+export const GET = withAuth(async (_request: NextRequest, session: Session) => {
+  if (!isGcsConfigured()) {
+    return NextResponse.json({
+      gcsConfigured: false,
+      note: 'GCS is not configured — uploads use the local-disk fallback, which is per-instance and ephemeral on Cloud Run (cross-instance reads fail). Set the GCS bucket + service-account credentials.',
+    })
+  }
+
+  const key = `documents/${session.user.id}/_healthcheck-${Date.now()}.txt`
+  const payload = Buffer.from(`storage-health ${new Date().toISOString()}`, 'utf8')
+  const steps: Record<string, StepResult> = {}
+
+  // 1. write
+  try {
+    await uploadBuffer(payload, key, 'text/plain', false)
+    steps.write = { ok: true }
+  } catch (err) {
+    steps.write = { ok: false, detail: err instanceof Error ? err.message : String(err) }
+    return NextResponse.json({ gcsConfigured: true, healthy: false, steps }, { status: 200 })
+  }
+
+  // 2. readByKey (service-account read — the path the builder falls back to)
+  try {
+    const buf = await downloadBuffer(key)
+    steps.readByKey = buf?.equals(payload)
+      ? { ok: true }
+      : { ok: false, detail: buf ? 'content mismatch' : 'object not found after write' }
+  } catch (err) {
+    steps.readByKey = { ok: false, detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  // 3. signedUrl round-trip (exercises signBlob)
+  try {
+    const url = await createPresignedDownloadUrl(key, 300)
+    const res = await fetch(url)
+    steps.signedUrl = res.ok
+      ? { ok: true }
+      : {
+          ok: false,
+          detail: `fetch returned ${res.status} (signed URL may have fallen back to a public URL — check signBlob)`,
+        }
+  } catch (err) {
+    steps.signedUrl = { ok: false, detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  // 4. cleanup (best-effort)
+  try {
+    await deleteObject(key)
+    steps.cleanup = { ok: true }
+  } catch (err) {
+    steps.cleanup = { ok: false, detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  const healthy = steps.write.ok && steps.readByKey.ok && steps.signedUrl.ok
+  return NextResponse.json({ gcsConfigured: true, healthy, steps })
+})


### PR DESCRIPTION
Three of the improvements from the list (the tractable ones). The (b) rebuild of the assessment test composer follows in a separate PR.

## #1 — Document-kind override banner
The study-material question-generation fix hinges on the model classifying "question paper vs material" correctly, and a numbered `.docx` is exactly what fools it. Today the tutor can only override when the model is *unsure*. Now, after any DMI generation, the Test-tab DMI panel shows a banner:

> Detected as **a question paper** — extracted the question numbers.  **[Not right? Regenerate as study material]**

One click re-runs generation with the explicit `documentKindOverride`, so a confidently-wrong call is trivially fixable.

## #3 — Finalize-detection hardening
The pci-master "tutor signalled finalize" regex matched generic agreement words (`confirm`, `correct`, `looks good`, `sounds good`, `agreed`, `go ahead`) — which now collide with the confirm-**summary** step. It now matches only unambiguous finalize intent (`finalize`, `approve the rubric`, `apply the rubric`, `lock it in`, …). The explicit **Apply to PCI** click remains the real finalize gate, so this only removes false positives.

## Storage health check
New `GET /api/tutor/storage-health` runs **write → read-by-key → signed-URL round-trip → cleanup** and reports which steps pass. Diagnoses the earlier "Failed to fetch PDF" / "Document not found" class of incidents in seconds:
- `readByKey` ok but `signedUrl` fails → missing `iam.serviceAccounts.signBlob` (signed URLs fall back to 403-ing public URLs).
- `readByKey` fails too → object isn't persisting (bucket/creds).
- `gcsConfigured: false` → using the ephemeral local fallback.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)