### PR TITLE
test+fix: unit tests for new logic + catch numbered study notes mislabelled as papers

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -132,6 +132,7 @@ import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
 import { PciSpecSoFar } from './PciSpecSoFar'
 import { TestTaskChat, type TestTaskChatState } from './TestTaskChat'
+import { splitDocIntoSections } from '@/lib/documents/split-sections'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
@@ -427,58 +428,6 @@ const pdfPageCache = new Map<string, string[]>()
 // Collapsible explainer at the top of a PCI tab. PCI ("how to mark this") is easy
 // to confuse with the question content, so this spells out what it is, the flow,
 // and concrete things worth telling the assistant — to point tutors the right way.
-/**
- * Split a document's extracted text into logical sections for creating one
- * task/extension per section. Tries, in order: real page breaks (form feed or
- * "--- Page N ---" markers from PDF extraction), numbered headings at line start
- * (e.g. "1. Title", "2) Title"), then blank-line paragraph groups. Falls back to
- * the whole text as one section. Used when a per-page PDF split isn't available —
- * notably for .docx, whose extracted text carries no page markers, so it would
- * otherwise collapse into a single task.
- */
-function splitDocIntoSections(text: string): string[] {
-  const trimmed = (text || '').trim()
-  if (!trimmed) return []
-
-  // 1) Real page breaks from PDF/text extraction.
-  if (trimmed.includes('\f')) {
-    const pages = trimmed
-      .split('\f')
-      .map(p => p.trim())
-      .filter(Boolean)
-    if (pages.length > 1) return pages
-  }
-  if (/--- Page \d+ ---/.test(trimmed)) {
-    const pages = trimmed
-      .split(/--- Page \d+ ---/)
-      .map(p => p.trim())
-      .filter(Boolean)
-    if (pages.length > 1) return pages
-  }
-
-  // 2) Numbered headings at the start of a line ("1. ", "2) ", "3 - "…). Split
-  //    BEFORE each heading so the number stays with its section. Guarded so a
-  //    short numbered list inside one section doesn't shatter into tiny tasks.
-  const numbered = trimmed
-    .split(/\n(?=\s{0,3}\d{1,3}[.)]\s+\S)/)
-    .map(p => p.trim())
-    .filter(Boolean)
-  if (numbered.length > 1 && numbered.length <= 60) {
-    const avgLen = numbered.reduce((sum, s) => sum + s.length, 0) / numbered.length
-    if (avgLen > 60) return numbered
-  }
-
-  // 3) Blank-line separated blocks of meaningful length.
-  const blocks = trimmed
-    .split(/\n\s*\n+/)
-    .map(p => p.trim())
-    .filter(p => p.length > 50)
-  if (blocks.length > 1) return blocks
-
-  // 4) Whole document as a single section.
-  return [trimmed]
-}
-
 function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
   const noun = kind === 'assessment' ? 'assessment' : 'task'
   return (

--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -19,7 +19,7 @@ import {
 } from '@/lib/assessment/question-types'
 import { extractQuestionRef } from '@/lib/assessment/marking-scheme'
 import { scoreDocumentConfidence } from '@/lib/assessment/confidence'
-import { analyzeDocumentSignals } from '@/lib/assessment/document-signals'
+import { analyzeDocumentSignals, documentKindLooksWrong } from '@/lib/assessment/document-signals'
 import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
@@ -541,18 +541,7 @@ export async function POST(request: NextRequest) {
     // "question paper". Text-only, so skipped for image-only PDFs.
     const signals = content && content.trim() ? analyzeDocumentSignals(content) : null
     const needsKindConfirmation =
-      !questionSpec &&
-      !documentKindOverride &&
-      // The model was unsure / didn't classify — ask rather than assume a paper.
-      (modelKind === null ||
-        // The model called it a paper, but the text shows no paper markers at all
-        // and reads like prose — a likely false "question paper".
-        (modelKind === 'question_paper' &&
-          signals != null &&
-          signals.paperSignal === 'none' &&
-          signals.proseChars > 400) ||
-        // The model called it study material, but the text has strong paper markers.
-        (modelKind === 'study_material' && signals != null && signals.paperSignal === 'strong'))
+      !questionSpec && !documentKindOverride && documentKindLooksWrong(modelKind, signals)
 
     // Warn-only assessment guardrails. Checks wording fidelity against the
     // source (ASMT-4) and other structural rules where data is available.

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -13,6 +13,7 @@ import { generateWithFallback } from '@/lib/agents'
 import { generateWithKimiVision } from '@/lib/ai/kimi'
 import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
 import { normalizePciSpec, type PciSpec } from '@/lib/assessment/pci-spec'
+import { signalsPciFinalize } from '@/lib/assessment/pci-finalize'
 import {
   guardrailSystemPrompt,
   runTaskGuardrails,
@@ -334,19 +335,10 @@ export async function POST(request: NextRequest) {
     // is the conversational chat text, `pci` is the finalized rubric (non-empty
     // only after the tutor approves finalizing). Extract both so the chat never
     // shows a raw spec and the builder can write a clean PCI to the field.
-    // TASK-5 (Confirmation): the tutor's message must explicitly signal approval
-    // to FINALIZE THE RUBRIC before the engine presents a finalized one — the
-    // model alone cannot finalize. The tutor's explicit "Apply to PCI" click is
-    // the real gate; this flag only informs pciUnconfirmed + the validator.
-    //
-    // Match ONLY unambiguous finalize intent. We deliberately exclude generic
-    // agreement words — "confirm", "correct", "looks good", "sounds good",
-    // "agreed", "go ahead" — because they also mean "yes, the SUMMARY is right"
-    // in the confirm-summary step, and must not be misread as finalizing.
-    const tutorSignaledFinalize =
-      /\b(finali[sz]e|approve the (rubric|pci|policy|marking policy)|lock it in|activate the (rubric|pci|policy)|apply (it|this|the (rubric|pci|policy|marking policy))|save (it|the (rubric|pci|policy))|use this (rubric|policy) as (the )?final)\b/i.test(
-        safeMessage
-      )
+    // TASK-5 (Confirmation): only an explicit finalize request flags this — the
+    // tutor's "Apply to PCI" click is the real gate. See signalsPciFinalize for
+    // why generic agreement words are excluded (they collide with confirm-summary).
+    const tutorSignaledFinalize = signalsPciFinalize(safeMessage)
 
     let pciDraft = ''
     let pciSpec: PciSpec | null = null

--- a/tutorme-app/src/lib/assessment/document-signals.test.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect } from 'vitest'
-import { analyzeDocumentSignals } from './document-signals'
+import { analyzeDocumentSignals, documentKindLooksWrong } from './document-signals'
+
+// Numbered study notes: numbered headings + prose, but NO marks / MCQ / blanks.
+const STUDY_NOTES = [
+  '1. AGENT MARKETPLACE INTERFACE',
+  'The agent marketplace interface lets buyers and sellers discover each other and transact. '.repeat(
+    3
+  ),
+  '2. TRUST AND SAFETY',
+  'Trust and safety mechanisms include reputation scores, escrow, and dispute resolution flows. '.repeat(
+    3
+  ),
+  '3. PRICING MODELS',
+  'Pricing can be fixed, auction-based, or negotiated depending on the category and demand. '.repeat(
+    3
+  ),
+].join('\n')
+
+const REAL_PAPER = `Section A
+1. Calculate the mean of the data set. [3]
+2. Determine the standard deviation. [4]
+(a) State one advantage.
+(b) State one disadvantage.`
 
 describe('analyzeDocumentSignals', () => {
   it('flags a real question paper as a strong paper signal', () => {
@@ -49,5 +71,43 @@ There are two main stages: the light-dependent reactions and the light-independe
     // Numbered headings alone (no marks, no options, no answer blanks, no task
     // verbs) must not read as a strong question paper.
     expect(s.paperSignal).not.toBe('strong')
+  })
+
+  it('sees prose (not hard markers) in numbered study notes', () => {
+    const s = analyzeDocumentSignals(STUDY_NOTES)
+    expect(s.markAllocations).toBe(0)
+    expect(s.answerBlanks).toBe(0)
+    expect(s.mcqOptionLines).toBeLessThan(2)
+    expect(s.proseChars).toBeGreaterThan(400)
+    expect(s.paperSignal).not.toBe('strong')
+  })
+})
+
+describe('documentKindLooksWrong', () => {
+  it('flags an unclassified document', () => {
+    expect(documentKindLooksWrong(null, analyzeDocumentSignals(REAL_PAPER))).toBe(true)
+    expect(documentKindLooksWrong(null, null)).toBe(true)
+  })
+
+  it('flags prose study notes mislabelled as a question paper (the reported bug)', () => {
+    expect(documentKindLooksWrong('question_paper', analyzeDocumentSignals(STUDY_NOTES))).toBe(true)
+  })
+
+  it('does NOT flag a genuine question paper called a question paper', () => {
+    expect(documentKindLooksWrong('question_paper', analyzeDocumentSignals(REAL_PAPER))).toBe(false)
+  })
+
+  it('flags a marker-rich paper mislabelled as study material', () => {
+    expect(documentKindLooksWrong('study_material', analyzeDocumentSignals(REAL_PAPER))).toBe(true)
+  })
+
+  it('does NOT flag study notes correctly called study material', () => {
+    expect(documentKindLooksWrong('study_material', analyzeDocumentSignals(STUDY_NOTES))).toBe(
+      false
+    )
+  })
+
+  it('does not flag a classified doc when signals are unavailable (image-only PDF)', () => {
+    expect(documentKindLooksWrong('question_paper', null)).toBe(false)
   })
 })

--- a/tutorme-app/src/lib/assessment/document-signals.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.ts
@@ -45,6 +45,33 @@ function countMatches(text: string, re: RegExp): number {
   return m ? m.length : 0
 }
 
+/**
+ * Given the AI's `documentKind` and the code-level signals, does the claim look
+ * wrong enough to double-check with the tutor before generating a DMI? Catches
+ * the two failure modes:
+ *  - a prose document with numbered HEADINGS (e.g. study notes "1. …, 2. …")
+ *    mislabelled "question paper" — it has numbered lines but NONE of the hard
+ *    paper markers (marks, MCQ options, answer blanks) and reads like prose;
+ *  - a marker-rich paper mislabelled "study material".
+ * When signals are unavailable (image-only PDF), only an unclassified doc is
+ * flagged. Returns true → the route asks the tutor to confirm the kind.
+ */
+export function documentKindLooksWrong(
+  modelKind: 'question_paper' | 'study_material' | null,
+  signals: DocumentSignals | null
+): boolean {
+  if (modelKind === null) return true
+  if (!signals) return false
+  if (modelKind === 'question_paper') {
+    const noHardPaperMarkers =
+      signals.markAllocations === 0 && signals.answerBlanks === 0 && signals.mcqOptionLines < 2
+    // No hard markers AND reads like prose → probably material, not a paper.
+    return noHardPaperMarkers && signals.proseChars > 400
+  }
+  // study_material but strong paper markers → probably a paper.
+  return signals.paperSignal === 'strong'
+}
+
 export function analyzeDocumentSignals(content: string): DocumentSignals {
   const text = content ?? ''
   const lines = text.split('\n')

--- a/tutorme-app/src/lib/assessment/pci-finalize.test.ts
+++ b/tutorme-app/src/lib/assessment/pci-finalize.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { signalsPciFinalize } from './pci-finalize'
+
+describe('signalsPciFinalize', () => {
+  it('matches explicit finalize intent', () => {
+    for (const msg of [
+      'finalize it',
+      'Please finalise the rubric',
+      'apply the rubric',
+      'apply it',
+      'lock it in',
+      'approve the marking policy',
+      'save the pci',
+      'use this rubric as the final',
+    ]) {
+      expect(signalsPciFinalize(msg)).toBe(true)
+    }
+  })
+
+  it('does NOT fire on generic agreement / confirm-summary words', () => {
+    for (const msg of [
+      'yes, it is correct',
+      "yes that's right",
+      'looks good',
+      'sounds good',
+      'confirmed',
+      'agreed',
+      'go ahead',
+      'that is correct, continue',
+      'ok',
+    ]) {
+      expect(signalsPciFinalize(msg)).toBe(false)
+    }
+  })
+
+  it('handles empty / non-string safely', () => {
+    expect(signalsPciFinalize('')).toBe(false)
+    expect(signalsPciFinalize(undefined as unknown as string)).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/assessment/pci-finalize.ts
+++ b/tutorme-app/src/lib/assessment/pci-finalize.ts
@@ -1,0 +1,17 @@
+/**
+ * TASK-5 (Confirmation): does the tutor's message unambiguously ask to FINALIZE
+ * the marking policy/rubric?
+ *
+ * The tutor's explicit "Apply to PCI" click is the real gate; this signal only
+ * informs `pciUnconfirmed` and the guardrail validator. It matches ONLY explicit
+ * finalize intent and deliberately EXCLUDES generic agreement words ("confirm",
+ * "correct", "looks good", "sounds good", "agreed", "go ahead") because those
+ * also mean "yes, the SUMMARY is right" in the confirm-summary step and must not
+ * be misread as finalizing the rubric.
+ */
+const FINALIZE_INTENT_RE =
+  /\b(finali[sz]e|approve the (rubric|pci|policy|marking policy)|lock it in|activate the (rubric|pci|policy)|apply (it|this|the (rubric|pci|policy|marking policy))|save (it|the (rubric|pci|policy))|use this (rubric|policy) as (the )?final)\b/i
+
+export function signalsPciFinalize(message: string): boolean {
+  return FINALIZE_INTENT_RE.test(message || '')
+}

--- a/tutorme-app/src/lib/documents/split-sections.test.ts
+++ b/tutorme-app/src/lib/documents/split-sections.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { splitDocIntoSections } from './split-sections'
+
+describe('splitDocIntoSections', () => {
+  it('returns [] for empty/whitespace input', () => {
+    expect(splitDocIntoSections('')).toEqual([])
+    expect(splitDocIntoSections('   \n  ')).toEqual([])
+  })
+
+  it('splits on form-feed page breaks', () => {
+    const out = splitDocIntoSections('first page text\fsecond page text')
+    expect(out).toHaveLength(2)
+    expect(out[0]).toBe('first page text')
+  })
+
+  it('splits on "--- Page N ---" markers', () => {
+    const out = splitDocIntoSections('--- Page 1 ---\nalpha\n--- Page 2 ---\nbeta')
+    expect(out).toEqual(['alpha', 'beta'])
+  })
+
+  it('splits a numbered study doc into one section per heading', () => {
+    const doc = [
+      '1. AGENT MARKETPLACE INTERFACE',
+      'This section describes the marketplace interface in enough detail to matter here.',
+      '2. SECOND SECTION TITLE',
+      'More descriptive content for the second section that is also reasonably long.',
+      '3. THIRD SECTION',
+      'Even more content to round out the third section fully and completely here.',
+    ].join('\n')
+    const out = splitDocIntoSections(doc)
+    expect(out).toHaveLength(3)
+    expect(out[0]).toContain('1. AGENT MARKETPLACE INTERFACE')
+  })
+
+  it('does NOT shatter a short inline numbered list into tiny sections (guard)', () => {
+    const doc = 'A short numbered list inside one section.\n1. tiny\n2. tiny'
+    expect(splitDocIntoSections(doc)).toHaveLength(1)
+  })
+
+  it('falls back to blank-line blocks when there are no numbered headings', () => {
+    const doc =
+      'Intro paragraph long enough to pass the fifty character block filter easily here.\n\n' +
+      'Second paragraph also long enough to be its own separate block for splitting.'
+    expect(splitDocIntoSections(doc)).toHaveLength(2)
+  })
+
+  it('returns the whole document as one section when nothing splits it', () => {
+    const doc = 'Just one short line of prose with no markers.'
+    expect(splitDocIntoSections(doc)).toEqual([doc])
+  })
+})

--- a/tutorme-app/src/lib/documents/split-sections.ts
+++ b/tutorme-app/src/lib/documents/split-sections.ts
@@ -1,0 +1,51 @@
+/**
+ * Split a document's extracted text into logical sections for creating one
+ * task/extension per section. Tries, in order: real page breaks (form feed or
+ * "--- Page N ---" markers from PDF extraction), numbered headings at line start
+ * (e.g. "1. Title", "2) Title"), then blank-line paragraph groups. Falls back to
+ * the whole text as one section. Used when a per-page PDF split isn't available —
+ * notably for .docx, whose extracted text carries no page markers, so it would
+ * otherwise collapse into a single task.
+ */
+export function splitDocIntoSections(text: string): string[] {
+  const trimmed = (text || '').trim()
+  if (!trimmed) return []
+
+  // 1) Real page breaks from PDF/text extraction.
+  if (trimmed.includes('\f')) {
+    const pages = trimmed
+      .split('\f')
+      .map(p => p.trim())
+      .filter(Boolean)
+    if (pages.length > 1) return pages
+  }
+  if (/--- Page \d+ ---/.test(trimmed)) {
+    const pages = trimmed
+      .split(/--- Page \d+ ---/)
+      .map(p => p.trim())
+      .filter(Boolean)
+    if (pages.length > 1) return pages
+  }
+
+  // 2) Numbered headings at the start of a line ("1. ", "2) ", "3 - "…). Split
+  //    BEFORE each heading so the number stays with its section. Guarded so a
+  //    short numbered list inside one section doesn't shatter into tiny tasks.
+  const numbered = trimmed
+    .split(/\n(?=\s{0,3}\d{1,3}[.)]\s+\S)/)
+    .map(p => p.trim())
+    .filter(Boolean)
+  if (numbered.length > 1 && numbered.length <= 60) {
+    const avgLen = numbered.reduce((sum, s) => sum + s.length, 0) / numbered.length
+    if (avgLen > 60) return numbered
+  }
+
+  // 3) Blank-line separated blocks of meaningful length.
+  const blocks = trimmed
+    .split(/\n\s*\n+/)
+    .map(p => p.trim())
+    .filter(p => p.length > 50)
+  if (blocks.length > 1) return blocks
+
+  // 4) Whole document as a single section.
+  return [trimmed]
+}


### PR DESCRIPTION
The "do the tests and the rest" pass — hardening the logic changed by hand across recent PRs, plus the #4 classification root-cause fix.

## Tests (21 new; 313 lib tests green)
Extracted two pure functions so they're unit-testable (no behaviour change), then covered them:
- **`splitDocIntoSections`** → `src/lib/documents/split-sections.ts` — page breaks, numbered headings, the short-inline-list guard, blank-line fallback, whole-doc fallback.
- **`signalsPciFinalize`** (the PCI finalize-intent match) → `src/lib/assessment/pci-finalize.ts` — asserts explicit finalize phrases match ("apply the rubric", "finalize", "lock it in") and generic agreement / confirm-summary words do **not** ("yes it's correct", "looks good", "confirmed", "go ahead").
- **`documentKindLooksWrong`** — the new classification guard (below).

## #4 — classification root cause
Previously, a numbered study doc slipped through as a "question paper" because it has numbered lines (so `paperSignal` was `'weak'`, not `'none'`), and the check only flagged `'none'`. 

New `documentKindLooksWrong(modelKind, signals)` (in `document-signals.ts`, used by `generate-dmi`) flags a document the model called a **question paper** when it has **no hard paper markers** (no mark allocations, no MCQ option lines, no answer blanks) **and reads like prose** (`proseChars > 400`) — i.e. numbered study notes. It still flags marker-rich docs called "study material" and unclassified docs. Net effect: the earlier "numbered notes → number-only DMI" case now prompts the kind-confirmation dialog instead of silently mis-generating.

## Verification
21 new tests + all **313** lib unit tests pass; `npm run typecheck`, `npx eslint`, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)