### PR TITLE
fix(ui): eliminate focus flash on dropdowns and kebab menus

### DIFF
--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -721,13 +721,6 @@
     z-index: 1000;
   }
 
-  /* Allow Radix UI hover highlight on Select and Dropdown items */
-  [data-radix-select-viewport] [data-highlighted],
-  [data-radix-dropdown-menu-content] [data-highlighted],
-  [role='option'][data-highlighted],
-  [role='menuitem'][data-highlighted] {
-    /* Let component classes handle hover/focus styling */
-  }
 
   /* Typography Hierarchy - Fira Code for headings */
   h1,

--- a/tutorme-app/src/components/categories/CategorySelector.tsx
+++ b/tutorme-app/src/components/categories/CategorySelector.tsx
@@ -172,7 +172,7 @@ export function CategorySelector({
                     <SelectItem
                       key={region.id}
                       value={region.id}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white focus-visible:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:bg-white focus-visible:text-[#1F2933] focus-visible:outline-none focus-visible:ring-0 data-[disabled]:opacity-50"
                     >
                       {region.name}
                     </SelectItem>
@@ -202,7 +202,7 @@ export function CategorySelector({
                     <SelectItem
                       key={country.code}
                       value={country.code}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white focus-visible:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:bg-white focus-visible:text-[#1F2933] focus-visible:outline-none focus-visible:ring-0 data-[disabled]:opacity-50"
                     >
                       {country.name}
                     </SelectItem>

--- a/tutorme-app/src/components/categories/CategorySelector.tsx
+++ b/tutorme-app/src/components/categories/CategorySelector.tsx
@@ -172,7 +172,7 @@ export function CategorySelector({
                     <SelectItem
                       key={region.id}
                       value={region.id}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:bg-transparent focus:text-white/[0.94] focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white focus-visible:text-[#1F2933] data-[disabled]:opacity-50"
                     >
                       {region.name}
                     </SelectItem>
@@ -202,7 +202,7 @@ export function CategorySelector({
                     <SelectItem
                       key={country.code}
                       value={country.code}
-                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:bg-transparent focus:text-white/[0.94] focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[highlighted]:bg-white data-[highlighted]:text-[#1F2933] data-[disabled]:opacity-50"
+                      className="rounded-full px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white hover:text-[#1F2933] focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white focus-visible:text-[#1F2933] data-[disabled]:opacity-50"
                     >
                       {country.name}
                     </SelectItem>

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-white/[0.12] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-white/[0.12] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[highlighted]:bg-white/[0.12] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white/10 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:bg-white/10 focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[highlighted]:bg-white/10 data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:bg-white/10 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/solocorn-popup.tsx
+++ b/tutorme-app/src/components/ui/solocorn-popup.tsx
@@ -52,7 +52,7 @@ const SolocornPopupItem = React.forwardRef<HTMLDivElement, SolocornPopupItemProp
       ref={ref}
       className={cn(
         'flex cursor-pointer select-none items-center gap-3.5 rounded-lg px-4 py-2 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 active:scale-[0.98]',
-        destructive && 'text-red-400 hover:bg-red-500/10 focus:bg-red-500/10',
+        destructive && 'text-red-400 hover:bg-red-500/10 focus-visible:bg-red-500/10',
         className
       )}
       {...props}


### PR DESCRIPTION
The flashing focus ring when dropdowns/selects/kebab menus open was caused by Radix UI's data-[highlighted] attribute being styled with a background color. When a menu opens, Radix sets data-highlighted on the first item (for keyboard accessibility), causing an immediate background flash that disappears as focus shifts.

Previous fixes oscillated between:
- data-[highlighted]:bg-transparent (removes flash but breaks keyboard nav)
- data-[highlighted]:bg-white/[0.12] (restores keyboard nav but flash returns)

This fix takes a different approach: replace data-[highlighted]:bg-* with focus-visible:bg-* across all base components. The :focus-visible pseudo-class only matches when focus is meaningfully visible to the user (typically keyboard navigation), NOT on programmatic focus when a menu opens via mouse click.

Changes:
- dropdown-menu.tsx: Remove data-[highlighted]:bg-white/[0.12] from DropdownMenuItem, DropdownMenuCheckboxItem, DropdownMenuRadioItem. Add focus-visible:bg-white/[0.12] instead.
- select.tsx: Remove data-[highlighted]:bg-white/10 from SelectItem. Add focus-visible:bg-white/10 instead.
- solocorn-popup.tsx: Change focus:bg-red-500/10 to focus-visible:bg-red-500/10 on destructive items.
- CategorySelector.tsx: Replace data-[highlighted]:bg-white and focus:bg-transparent with focus-visible:bg-white on inline SelectItems.
- globals.css: Remove empty CSS rule block for data-[highlighted].

This preserves:
- Mouse hover highlight (hover:bg-* still applies)
- Keyboard navigation visibility (focus-visible:bg-* applies on arrow keys)
- No flash on mouse-open (focus-visible does not match programmatic focus)