### PR TITLE
feat(pdf): fit-to-width with centered vertical padding for Task views

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9651,6 +9651,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                     fileUrl={doc.fileUrl}
                                                     fileKey={doc.fileKey}
                                                     className="absolute inset-0 h-full w-full"
+                                                    fitToWidth
                                                   />
                                                 ) : (
                                                   <p className="text-muted-foreground absolute inset-0 h-full w-full overflow-y-auto whitespace-pre-wrap p-2 text-sm">
@@ -9683,6 +9684,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                       fileUrl={doc.fileUrl}
                                                       fileKey={doc.fileKey}
                                                       className="absolute inset-0 h-full w-full"
+                                                      fitToWidth
                                                     />
                                                   ) : (
                                                     <p className="text-muted-foreground absolute inset-0 h-full w-full overflow-y-auto whitespace-pre-wrap p-2 text-sm">
@@ -10513,7 +10515,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                   fileUrl={currentTaskDocument.fileUrl}
                                                   fileKey={currentTaskDocument.fileKey}
                                                   className="absolute inset-0 h-full w-full"
-                                                  defaultScale={0.75}
+                                                  fitToWidth
                                                   onHidePreview={() => {
                                                     if (!taskTextVisible) setTaskTextVisible(true)
                                                     setTaskPdfVisible(false)

--- a/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
+++ b/tutorme-app/src/components/pdf/FloatingZoomPill.tsx
@@ -9,6 +9,9 @@ interface FloatingZoomPillProps {
   minScale?: number
   maxScale?: number
   defaultScale?: number
+  /** When provided, the slider operates relative to this fit-to-width scale.
+   *  100% on the slider = fitScale. The reset button returns to fitScale. */
+  fitScale?: number | null
   onHidePreview?: () => void
   className?: string
   containerRef?: React.RefObject<HTMLElement | null>
@@ -21,6 +24,7 @@ export function FloatingZoomPill({
   minScale = 0.5,
   maxScale = 1.5,
   defaultScale = 1.0,
+  fitScale,
   onHidePreview,
   className,
   containerRef,
@@ -31,16 +35,22 @@ export function FloatingZoomPill({
   const dragStartRef = useRef({ x: 0, y: 0 })
   const pillRef = useRef<HTMLDivElement>(null)
 
-  // Convert scale (0.5-1.5) to slider percentage (0-100)
+  const isFitMode = fitScale !== null && fitScale !== undefined
+
+  // Effective min/max for the slider: if in fit mode, allow 0.25x to 4x of fitScale
+  const effectiveMinScale = isFitMode ? fitScale * 0.25 : minScale
+  const effectiveMaxScale = isFitMode ? fitScale * 4.0 : maxScale
+
+  // Convert scale to slider percentage (0-100)
   const scaleToPercent = useCallback(
-    (s: number) => ((s - minScale) / (maxScale - minScale)) * 100,
-    [minScale, maxScale]
+    (s: number) => ((s - effectiveMinScale) / (effectiveMaxScale - effectiveMinScale)) * 100,
+    [effectiveMinScale, effectiveMaxScale]
   )
 
-  // Convert slider percentage (0-100) to scale (0.5-1.5)
+  // Convert slider percentage (0-100) to scale
   const percentToScale = useCallback(
-    (p: number) => minScale + (p / 100) * (maxScale - minScale),
-    [minScale, maxScale]
+    (p: number) => effectiveMinScale + (p / 100) * (effectiveMaxScale - effectiveMinScale),
+    [effectiveMinScale, effectiveMaxScale]
   )
 
   const handleMouseDown = useCallback(
@@ -101,6 +111,18 @@ export function FloatingZoomPill({
 
   const sliderPercent = scaleToPercent(scale)
 
+  // Display percentage: in fit mode, show relative to fit (100% = fit)
+  // In normal mode, show absolute (100% = scale 1.0)
+  const displayPercent = isFitMode ? Math.round((scale / fitScale) * 100) : Math.round(scale * 100)
+
+  const handleReset = () => {
+    if (isFitMode) {
+      onScaleChange(fitScale)
+    } else {
+      onScaleChange(defaultScale)
+    }
+  }
+
   return (
     <div
       ref={pillRef}
@@ -117,7 +139,7 @@ export function FloatingZoomPill({
     >
       {/* Zoom percentage with space above */}
       <div className="mt-1 flex flex-col items-center gap-1">
-        <span className="text-[10px] font-medium text-gray-700">{Math.round(scale * 100)}%</span>
+        <span className="text-[10px] font-medium text-gray-700">{displayPercent}%</span>
         <div className="relative h-24 w-4">
           <input
             type="range"
@@ -137,9 +159,9 @@ export function FloatingZoomPill({
 
       {/* Reset zoom button */}
       <button
-        onClick={() => onScaleChange(defaultScale)}
+        onClick={handleReset}
         className="flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 shadow-sm transition-colors hover:bg-gray-50 hover:text-gray-700"
-        title="Reset Zoom"
+        title={isFitMode ? 'Fit to Width' : 'Reset Zoom'}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -17,6 +17,9 @@ interface PDFViewerProps {
   className?: string
   defaultScale?: number
   onHidePreview?: () => void
+  /** When true, the PDF page is scaled to fit the container width on load,
+   *  with the zoom slider operating relative to this fit scale (100% = fit). */
+  fitToWidth?: boolean
 }
 
 function getProxiedPdfUrl(fileUrl: string, fileKey?: string): string {
@@ -39,6 +42,7 @@ export function PDFViewer({
   className = '',
   defaultScale = 1.25,
   onHidePreview,
+  fitToWidth = false,
 }: PDFViewerProps) {
   const [numPages, setNumPages] = useState<number>(0)
   const [pageNumber, setPageNumber] = useState<number>(1)
@@ -49,8 +53,43 @@ export function PDFViewer({
   const [pdfData, setPdfData] = useState<string | ArrayBuffer | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
+  // Fit-to-width state
+  const [fitScale, setFitScale] = useState<number | null>(null)
+  const [pageNaturalWidth, setPageNaturalWidth] = useState<number | null>(null)
+  const hasSetInitialScaleRef = useRef(false)
+
   // Detect blob URLs immediately — they are client-side only and break after refresh
   const isBlobUrl = typeof fileUrl === 'string' && fileUrl.startsWith('blob:')
+
+  // Calculate fit-to-width scale from container and page dimensions
+  const calculateFitScale = useCallback(() => {
+    if (!fitToWidth || !scrollContainerRef.current || !pageNaturalWidth) return
+    const containerWidth = scrollContainerRef.current.clientWidth
+    // Account for horizontal padding (px-4 = 16px each side)
+    const padding = 32
+    const availableWidth = Math.max(containerWidth - padding, 100)
+    const newFitScale = availableWidth / pageNaturalWidth
+    setFitScale(Math.max(0.25, Math.min(4.0, newFitScale)))
+  }, [fitToWidth, pageNaturalWidth])
+
+  // Recalculate fit scale when container resizes
+  useEffect(() => {
+    if (!fitToWidth || !scrollContainerRef.current) return
+    const el = scrollContainerRef.current
+    const ro = new ResizeObserver(() => {
+      calculateFitScale()
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [fitToWidth, calculateFitScale])
+
+  // Set initial scale to fit scale once calculated
+  useEffect(() => {
+    if (fitToWidth && fitScale !== null && !hasSetInitialScaleRef.current) {
+      setScale(fitScale)
+      hasSetInitialScaleRef.current = true
+    }
+  }, [fitToWidth, fitScale])
 
   // Fetch PDF through proxy so expired GCS URLs get refreshed server-side
   useEffect(() => {
@@ -60,6 +99,9 @@ export function PDFViewer({
     setLoading(true)
     setError(null)
     setPdfData(null)
+    hasSetInitialScaleRef.current = false
+    setFitScale(null)
+    setPageNaturalWidth(null)
 
     const fetchPdf = async () => {
       try {
@@ -115,13 +157,24 @@ export function PDFViewer({
     setLoading(false)
   }, [])
 
+  // Called when a Page loads — gives us the natural page dimensions
+  const onPageLoadSuccess = useCallback(
+    (page: pdfjs.PDFPageProxy) => {
+      if (!fitToWidth) return
+      const viewport = page.getViewport({ scale: 1 })
+      setPageNaturalWidth(viewport.width)
+      calculateFitScale()
+    },
+    [fitToWidth, calculateFitScale]
+  )
+
   const changeScale = useCallback((deltaOrValue: number, absolute = false) => {
     setScale(prev => {
       if (absolute) {
-        return Math.max(0.5, Math.min(3.0, Math.round(deltaOrValue * 100) / 100))
+        return Math.max(0.25, Math.min(4.0, Math.round(deltaOrValue * 100) / 100))
       }
       const next = Math.round((prev + deltaOrValue) * 100) / 100
-      return Math.max(0.5, Math.min(3.0, next))
+      return Math.max(0.25, Math.min(4.0, next))
     })
   }, [])
 
@@ -196,6 +249,7 @@ export function PDFViewer({
                   minScale={0.5}
                   maxScale={1.5}
                   defaultScale={defaultScale}
+                  fitScale={fitScale}
                   onHidePreview={onHidePreview}
                   containerRef={scrollContainerRef}
                   fixed
@@ -240,6 +294,7 @@ export function PDFViewer({
                   renderAnnotationLayer
                   scale={scale}
                   className="shadow-lg"
+                  onLoadSuccess={onPageLoadSuccess}
                   loading={
                     <div className="flex h-[600px] w-[600px] items-center justify-center bg-white">
                       <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-200 border-t-blue-600" />


### PR DESCRIPTION
Add fitToWidth prop to PDFViewer that calculates the optimal scale to make the PDF page fill the container width while preserving aspect ratio. The page is vertically centered with equal top/bottom padding via flexbox.

Changes:
- PDFViewer.tsx: Add fitToWidth prop. On page load, measure container width and PDF natural page width (via getViewport({scale: 1})), compute fitScale. Use ResizeObserver to recalculate on container resize. Pass fitScale to FloatingZoomPill. Reset button returns to fit scale.
- FloatingZoomPill.tsx: When fitScale is provided, slider operates relative to fit (100% = fit-to-width). Display shows percentage relative to fit. Range: 25%-400% of fit scale. Reset returns to fit.
- CourseBuilder.tsx: Add fitToWidth to Task Slide PDFViewer (removes defaultScale={0.75}) and Classroom PDFViewers (live/test modes). Assessment Slide PDFViewer keeps defaultScale={0.75} unchanged.

Applies only to Task views (single-page display). Assessment views unchanged.