### PR TITLE
fix(ui): remove focus flash from DropdownMenuSubTrigger

### DIFF
--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+      'focus-visible:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
       inset && 'pl-8',
       className
     )}


### PR DESCRIPTION
The DropdownMenuSubTrigger still had focus:bg-accent which causes a focus flash when dropdown menus open. Changed to focus-visible:bg-accent to match the other dropdown items and only show highlight on keyboard navigation, not on programmatic focus when menu opens via mouse click.