### PR TITLE
feat(pdf): fit-to-width for Task views

### DIFF
--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -277,6 +277,7 @@ export function PDFViewer({
                     renderAnnotationLayer
                     scale={scale}
                     className="shadow-lg"
+                    onLoadSuccess={index === 0 ? onPageLoadSuccess : undefined}
                     loading={
                       <div className="flex h-[600px] w-[600px] items-center justify-center bg-white">
                         <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-200 border-t-blue-600" />


### PR DESCRIPTION
## Summary
Adds a \fit-to-width\ mode to the PDF viewer for Task and Classroom views. The PDF automatically scales to match the container width on load, and the zoom slider operates relative to this fit scale (100% = fit-to-width).

## Changes
- **PDFViewer.tsx**: Added \fitToWidth\ prop with ResizeObserver-based recalculation
- **FloatingZoomPill.tsx**: Added \fitScale\ prop for relative zoom slider behavior
- **CourseBuilder.tsx**: Applied \fitToWidth\ to Task Slide and Classroom views (Assessment views unchanged)
- **Fix**: Attached \onPageLoadSuccess\ to first Page in scroll mode so fit scale calculates correctly in multi-page view

## Testing
- [ ] Task Builder slide view: PDF should fit container width on load
- [ ] Zoom slider: 100% should equal fit-to-width, not default 1.25
- [ ] Resize window: PDF should refit to new container width
- [ ] Classroom views: same fit-to-width behavior
- [ ] Assessment views: should remain at defaultScale=0.75 (unchanged)