### PR TITLE
feat(register): add access code gate for Parent and Administrator

### DIFF
--- a/tutorme-app/src/app/[locale]/register/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/page.tsx
@@ -3,10 +3,27 @@
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { GraduationCap, Users, Presentation, Shield } from 'lucide-react'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
+import { useState, useRef, useEffect } from 'react'
 
-const roles = [
+const ACCESS_CODE = 'Solocorn123#'
+
+interface RoleConfig {
+  id: string
+  title: string
+  icon: React.ElementType
+  href: string
+  color: string
+  textColor: string
+  tintBg: string
+  borderColor: string
+  hoverText: string
+  requiresCode: boolean
+}
+
+const roles: RoleConfig[] = [
   {
     id: 'student',
     title: 'Student',
@@ -17,6 +34,7 @@ const roles = [
     tintBg: 'bg-orange-100/50',
     borderColor: 'border-orange-200',
     hoverText: 'hover:text-orange-500',
+    requiresCode: false,
   },
   {
     id: 'parent',
@@ -28,6 +46,7 @@ const roles = [
     tintBg: 'bg-emerald-100/50',
     borderColor: 'border-emerald-200',
     hoverText: 'hover:text-emerald-500',
+    requiresCode: true,
   },
   {
     id: 'tutor',
@@ -39,6 +58,7 @@ const roles = [
     tintBg: 'bg-blue-100/50',
     borderColor: 'border-blue-200',
     hoverText: 'hover:text-blue-600',
+    requiresCode: false,
   },
   {
     id: 'admin',
@@ -50,8 +70,110 @@ const roles = [
     tintBg: 'bg-red-100/50',
     borderColor: 'border-red-200',
     hoverText: 'hover:text-red-500',
+    requiresCode: true,
   },
 ]
+
+function RoleCard({ role, localePrefix }: { role: RoleConfig; localePrefix: string }) {
+  const router = useRouter()
+  const [showInput, setShowInput] = useState(false)
+  const [code, setCode] = useState('')
+  const [shake, setShake] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  // Focus input when shown
+  useEffect(() => {
+    if (showInput && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [showInput])
+
+  // Click outside to cancel
+  useEffect(() => {
+    if (!showInput) return
+    function handleClickOutside(e: MouseEvent) {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        setShowInput(false)
+        setCode('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [showInput])
+
+  const handleRegisterClick = (e: React.MouseEvent) => {
+    if (role.requiresCode) {
+      e.preventDefault()
+      setShowInput(true)
+    }
+    // Otherwise, Link handles navigation normally
+  }
+
+  const handleCodeSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (code === ACCESS_CODE) {
+      router.push(`${localePrefix}${role.href}`)
+    } else {
+      setShake(true)
+      setCode('')
+      setTimeout(() => setShake(false), 500)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setShowInput(false)
+      setCode('')
+    }
+  }
+
+  const cardContent = (
+    <Card
+      ref={cardRef}
+      className={`h-full cursor-pointer border ${role.borderColor} ${role.tintBg} shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl ${shake ? 'animate-shake' : ''}`}
+      onClick={handleRegisterClick}
+    >
+      <CardContent className="p-5">
+        <div className="flex items-center gap-3">
+          <div className={`${role.color} rounded-xl p-3 text-white shadow-lg`}>
+            <role.icon className="h-7 w-7" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-xl font-bold text-gray-800">{role.title}</h2>
+          </div>
+        </div>
+        {showInput ? (
+          <form onSubmit={handleCodeSubmit} className="mt-5">
+            <Input
+              ref={inputRef}
+              type="text"
+              value={code}
+              onChange={e => setCode(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Access Code"
+              className="h-10 w-full border-0 bg-white text-center text-sm font-semibold text-gray-800 shadow-md placeholder:text-gray-400"
+            />
+          </form>
+        ) : (
+          <Button
+            className={`mt-5 h-10 w-full border-0 text-sm font-semibold text-white ${role.color} shadow-md transition-colors duration-200 hover:bg-white ${role.hoverText}`}
+          >
+            Register
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+
+  // For roles requiring code, render without Link wrapper (we handle navigation manually)
+  // For others, wrap in Link for normal navigation
+  if (role.requiresCode) {
+    return cardContent
+  }
+
+  return <Link href={`${localePrefix}${role.href}`}>{cardContent}</Link>
+}
 
 export default function RoleSelectionPage() {
   const params = useParams<{ locale?: string }>()
@@ -73,27 +195,7 @@ export default function RoleSelectionPage() {
         {/* Role Cards */}
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {roles.map(role => (
-            <Link key={role.id} href={`${localePrefix}${role.href}`}>
-              <Card
-                className={`h-full cursor-pointer border ${role.borderColor} ${role.tintBg} shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl`}
-              >
-                <CardContent className="p-5">
-                  <div className="flex items-center gap-3">
-                    <div className={`${role.color} rounded-xl p-3 text-white shadow-lg`}>
-                      <role.icon className="h-7 w-7" />
-                    </div>
-                    <div className="flex-1">
-                      <h2 className="text-xl font-bold text-gray-800">{role.title}</h2>
-                    </div>
-                  </div>
-                  <Button
-                    className={`mt-5 h-10 w-full border-0 text-sm font-semibold text-white ${role.color} shadow-md transition-colors duration-200 hover:bg-white ${role.hoverText}`}
-                  >
-                    Register
-                  </Button>
-                </CardContent>
-              </Card>
-            </Link>
+            <RoleCard key={role.id} role={role} localePrefix={localePrefix} />
           ))}
         </div>
 

--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -721,7 +721,6 @@
     z-index: 1000;
   }
 
-
   /* Typography Hierarchy - Fira Code for headings */
   h1,
   h2,
@@ -1071,6 +1070,30 @@
   }
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Shake animation for access code error */
+  @keyframes shake {
+    0%,
+    100% {
+      transform: translateX(0);
+    }
+    10%,
+    30%,
+    50%,
+    70%,
+    90% {
+      transform: translateX(-4px);
+    }
+    20%,
+    40%,
+    60%,
+    80% {
+      transform: translateX(4px);
+    }
+  }
+  .animate-shake {
+    animation: shake 0.5s ease-in-out;
   }
 
   /* Tutor dashboard — invisible scrollbar (track + thumb match bg-gray-50) */


### PR DESCRIPTION
Adds temporary access code protection for Parent and Administrator registration.

**Changes:**
- Clicking Register on Parent/Admin cards reveals an access code input field
- Access code: `Solocorn123#`
- Correct code → immediate navigation to registration form
- Incorrect code → card shake animation + input reset
- Click outside or Escape → cancel and revert to Register button
- Student and Tutor registration remain unchanged (no code required)

**Files changed:**
- `tutorme-app/src/app/[locale]/register/page.tsx` — access code logic
- `tutorme-app/src/app/globals.css` — shake animation keyframes