### PR TITLE
polish: a11y labels, Test-tab e2e smoke, post-deploy storage health check

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -208,3 +208,25 @@ jobs:
 
       - name: Show production URL
         run: echo "Production URL -> ${{ steps.deploy-prod.outputs.url }}"
+
+      # Non-blocking post-deploy smoke of document storage. Hits the existing
+      # unauthenticated diagnostic and surfaces a GH annotation if GCS is
+      # mis-set (e.g. signBlob missing → signed URLs fall back to 403 public
+      # URLs), so a "Failed to fetch PDF" class of incident is caught here
+      # instead of by a tutor. Never fails the deploy.
+      - name: Storage health smoke (non-blocking)
+        continue-on-error: true
+        run: |
+          URL="${{ steps.deploy-prod.outputs.url }}"
+          echo "Checking storage health at $URL/api/health/storage"
+          body=$(curl -s -m 30 -w $'\n%{http_code}' "$URL/api/health/storage" || printf '\n000')
+          code=$(printf '%s' "$body" | tail -1)
+          json=$(printf '%s' "$body" | sed '$d')
+          echo "HTTP $code"
+          echo "$json"
+          overall=$(printf '%s' "$json" | grep -o '"overall":"[a-z_]*"' | head -1)
+          case "$overall" in
+            *healthy*) echo "Storage OK ($overall)";;
+            "") echo "::warning title=Storage health::Could not read storage health (HTTP $code).";;
+            *) echo "::warning title=Storage health::$overall — see JSON above (check signBlob / bucket / credentials).";;
+          esac

--- a/tutorme-app/e2e/tutor-test-tab.spec.ts
+++ b/tutorme-app/e2e/tutor-test-tab.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E smoke: the tutor "Test" tab renders and is interactive.
+ *
+ * Skeleton/starter (extend with a seeded course + generated DMI to exercise the
+ * inline per-question grading end-to-end). It guards that switching into Test
+ * mode renders the Test-tab shell — its student sub-tabs and the marking-policy
+ * area — without crashing. Requires E2E_TUTOR_EMAIL / E2E_TUTOR_PASSWORD; the
+ * navigation mirrors insights-tab-loop.spec.ts (the known-good builder path).
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Tutor Test tab', () => {
+  test('switching to Test mode renders the Test-tab shell without crashing', async ({ page }) => {
+    const fatal: string[] = []
+    page.on('pageerror', e => {
+      if (/#185|Maximum update depth|Minified React error/i.test(e.message)) {
+        fatal.push(`pageerror: ${e.message}`)
+      }
+    })
+
+    // Log in as a tutor (same convention as the other tutor specs).
+    await page.goto('/login')
+    await page.locator('#email').fill(process.env.E2E_TUTOR_EMAIL ?? 'tutor@example.com')
+    await page.locator('#password').fill(process.env.E2E_TUTOR_PASSWORD ?? 'Password1')
+    await page.getByRole('button', { name: 'Login' }).click()
+    await expect(page).toHaveURL(/\/tutor\/dashboard/, { timeout: 10000 })
+
+    // Open the builder shell and switch to Test mode.
+    await page.goto('/tutor/insights')
+    const modeTabs = page.getByTestId('builder-mode-tabs')
+    await expect(modeTabs.getByRole('tab', { name: 'Test', exact: true })).toBeVisible({
+      timeout: 15000,
+    })
+    await modeTabs.getByRole('tab', { name: 'Test', exact: true }).click()
+
+    // The Test-tab shell should appear (its student sub-tabs / marking-policy
+    // area) and nothing should have crashed the builder.
+    const crashText = page.getByText(
+      /Couldn.t display the insights builder|Maximum update depth|Minified React error/i
+    )
+    await expect(crashText).toHaveCount(0)
+
+    await expect(
+      page.getByText(/Classroom|Test Student|marking policy|Start a PCI chat/i).first()
+    ).toBeVisible({ timeout: 10000 })
+
+    expect(fatal, `unexpected fatal errors:\n${fatal.join('\n')}`).toEqual([])
+  })
+})

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9715,6 +9715,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                           </span>
                                                           <select
                                                             value={testPciBasis}
+                                                            aria-label="Marking basis to test against (debug — does not affect student grading)"
                                                             onChange={e =>
                                                               setTestPciBasis(
                                                                 e.target.value as
@@ -9847,6 +9848,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                                   }
                                                                   rows={2}
                                                                   placeholder="Type a test answer to grade against this question…"
+                                                                  aria-label={`Test answer for question ${item.questionLabel ?? item.questionNumber}`}
                                                                   className="w-full resize-none rounded-md border border-gray-300 px-2 py-1.5 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-violet-400"
                                                                 />
                                                                 <div className="mt-1 flex items-center gap-2">
@@ -9861,6 +9863,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                                     onClick={() =>
                                                                       gradeTestDmiItem(item)
                                                                     }
+                                                                    aria-label={`Grade test answer for question ${item.questionLabel ?? item.questionNumber}`}
                                                                     className="rounded-md bg-violet-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-violet-700 disabled:opacity-50"
                                                                   >
                                                                     {result?.loading
@@ -10085,6 +10088,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               <span className="text-slate-500">Test with:</span>
                                               <select
                                                 value={testPciBasis}
+                                                aria-label="Marking basis to test against (debug — does not affect student grading)"
                                                 onChange={e =>
                                                   setTestPciBasis(
                                                     e.target.value as


### PR DESCRIPTION
The three polish items from the list.

## Accessibility
The controls added this session relied on placeholder/title only. Added accessible names (`aria-label`):
- the per-question **test-answer textarea** and its **Grade** button (labelled with the question ref),
- both **"Test with"** basis `<select>`s.

## E2E smoke (`e2e/tutor-test-tab.spec.ts`)
Logs in as a tutor, switches the builder into **Test** mode, and asserts the Test-tab shell renders without crashing — using the same known-good navigation as `insights-tab-loop.spec.ts`. It's a **skeleton**: extend with a seeded course + generated DMI to exercise the inline per-question grading end to end. (E2E is an advisory check, so this won't block merges.)

## Post-deploy storage health smoke
A **non-blocking** deploy step curls the existing `/api/health/storage` diagnostic and raises a GitHub `::warning::` if GCS is mis-set (e.g. missing `signBlob` → signed URLs fall back to 403 public URLs). So a "Failed to fetch PDF" class of incident is caught **at deploy time** rather than by a tutor. `continue-on-error: true` — it can never fail a deploy.

> Note: I found a teammate already ships a comprehensive **unauthenticated** `/api/health/storage`, so I dropped my planned token-guarded variant and pointed the smoke step at theirs.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; deploy YAML validated with a parser. The deploy-workflow change is a single additive, non-blocking step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)