### PR TITLE
feat(pci): richer "policy so far" panel — checklist, highlight, inline edit, guaranteed fill

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6713,6 +6713,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       pdfPageCache,
     })
     const { pci, handlePciSend, applyTaskPciDraft, applyAssessmentPciDraft, setPciInput } = pciApi
+    const editSpecSoFar = pciApi.editSpecSoFar
     loadPciMessagesRef.current = pciApi.loadPciMessages
     resetPciRef.current = pciApi.resetPci
 
@@ -10587,6 +10588,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             spec={activeTaskThread.specSoFar}
                                             board={pciBoard}
                                             subject={pciCategory}
+                                            editable={canEdit}
+                                            onEditField={(key, value) =>
+                                              editSpecSoFar(activeTaskTarget, key, value)
+                                            }
                                           />
                                           {activeTaskPciMessages.length === 0 && (
                                             <p className="text-muted-foreground text-xs">
@@ -11026,6 +11031,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             }
                                             board={pciBoard}
                                             subject={pciCategory}
+                                            editable={canEdit}
+                                            onEditField={(key, value) =>
+                                              editSpecSoFar(
+                                                {
+                                                  kind: 'assessment',
+                                                  id: loadedAssessmentId || '',
+                                                },
+                                                key,
+                                                value
+                                              )
+                                            }
                                           />
                                           {(
                                             assessmentPciMessagesMap[loadedAssessmentId || ''] || []

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciSpecSoFar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciSpecSoFar.tsx
@@ -1,48 +1,163 @@
 'use client'
 
 /**
- * PciSpecSoFar — a compact, read-only "policy so far" panel for the PCI
- * assistant chat. As the tutor answers the assistant's probing questions, the
- * model reports what it has captured (a partial PciSpec) each turn; this shows
- * those fields filling in so the tutor can see the marking policy taking shape
- * and catch anything wrong early. It does NOT finalize anything — the saved PCI
- * is still only written when the tutor applies it.
+ * PciSpecSoFar — the live "policy so far" panel for the PCI assistant chat.
+ *
+ * As the tutor answers the assistant's probing questions, the model reports what
+ * it has captured (a partial PciSpec); this shows a CHECKLIST of every policy
+ * point — captured (✓, with the value) vs still to define (○) — plus an "X of N"
+ * count, so the tutor sees the marking policy taking shape AND what's left. A
+ * just-captured field flashes briefly. Each captured field can be corrected
+ * inline (the correction is fed back to the assistant as authoritative). It does
+ * NOT finalize anything — the saved PCI is still only written when the tutor
+ * applies it.
  */
 
-import { ListChecks } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { ListChecks, Check, Pencil, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { PCI_SPEC_FIELDS, type PciSpec } from '@/lib/assessment/pci-spec'
+
+type PciSpecKey = keyof PciSpec
 
 interface PciSpecSoFarProps {
   spec?: PciSpec
   board?: string
   subject?: string
+  /** Allow inline corrections of captured fields. */
+  editable?: boolean
+  onEditField?: (key: PciSpecKey, value: string) => void
 }
 
-export function PciSpecSoFar({ spec, board, subject }: PciSpecSoFarProps) {
-  const filled = PCI_SPEC_FIELDS.filter(f => spec?.[f.key]?.trim())
+export function PciSpecSoFar({ spec, board, subject, editable, onEditField }: PciSpecSoFarProps) {
   const hasContext = !!board?.trim() || !!subject?.trim()
-  if (filled.length === 0 && !hasContext) return null
+  const total = PCI_SPEC_FIELDS.length
+  const filledCount = PCI_SPEC_FIELDS.filter(f => spec?.[f.key]?.trim()).length
+
+  // Flash a field the moment its captured value appears or changes.
+  const prevRef = useRef<Record<string, string>>({})
+  const [flash, setFlash] = useState<Set<string>>(new Set())
+  useEffect(() => {
+    const changed = new Set<string>()
+    for (const f of PCI_SPEC_FIELDS) {
+      const v = (spec?.[f.key] ?? '').trim()
+      if (v && v !== (prevRef.current[f.key] ?? '')) changed.add(f.key)
+      prevRef.current[f.key] = v
+    }
+    if (changed.size === 0) return
+    setFlash(changed)
+    const t = setTimeout(() => setFlash(new Set()), 1400)
+    return () => clearTimeout(t)
+  }, [spec])
+
+  // Inline edit state.
+  const [editingKey, setEditingKey] = useState<PciSpecKey | null>(null)
+  const [draft, setDraft] = useState('')
+  const startEdit = (key: PciSpecKey, current: string) => {
+    setEditingKey(key)
+    setDraft(current)
+  }
+  const saveEdit = (key: PciSpecKey) => {
+    onEditField?.(key, draft.trim())
+    setEditingKey(null)
+  }
+
+  // Nothing captured and no board/subject yet → stay hidden (pre-interview).
+  if (filledCount === 0 && !hasContext) return null
 
   return (
     <div className="rounded-lg border border-indigo-200 bg-indigo-50/50 px-3 py-2">
-      <p className="mb-1.5 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-indigo-700">
+      <p className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-indigo-700">
         <ListChecks className="h-3.5 w-3.5" /> Your policy so far
+        <span className="ml-auto rounded-full bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium normal-case text-indigo-700">
+          {filledCount} of {total}
+        </span>
       </p>
-      <ul className="space-y-1.5">
+      <ul className="space-y-0.5">
         {hasContext && (
-          <li className="text-xs">
+          <li className="px-1 py-0.5 text-xs">
             <span className="font-medium text-slate-600">Board / Subject:</span>{' '}
             <span className="text-slate-700">
               {[board?.trim(), subject?.trim()].filter(Boolean).join(' · ')}
             </span>
           </li>
         )}
-        {filled.map(f => (
-          <li key={f.key} className="text-xs">
-            <span className="font-medium text-slate-600">{f.label}:</span>{' '}
-            <span className="text-slate-700">{spec?.[f.key]}</span>
-          </li>
-        ))}
+        {PCI_SPEC_FIELDS.map(f => {
+          const value = spec?.[f.key]?.trim() ?? ''
+          const done = !!value
+          const isEditing = editingKey === f.key
+          return (
+            <li
+              key={f.key}
+              className={cn(
+                'group rounded px-1 py-0.5 text-xs transition-colors duration-500',
+                flash.has(f.key) && 'bg-emerald-100'
+              )}
+            >
+              <div className="flex items-start gap-1.5">
+                {done ? (
+                  <Check className="mt-0.5 h-3 w-3 shrink-0 text-emerald-600" />
+                ) : (
+                  <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full border border-slate-300" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <span className={cn('font-medium', done ? 'text-slate-600' : 'text-slate-400')}>
+                    {f.label}
+                  </span>
+                  {isEditing ? (
+                    <div className="mt-1 flex items-center gap-1">
+                      <input
+                        value={draft}
+                        autoFocus
+                        onChange={e => setDraft(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') saveEdit(f.key)
+                          if (e.key === 'Escape') setEditingKey(null)
+                        }}
+                        aria-label={`Correct ${f.label}`}
+                        className="min-w-0 flex-1 rounded border border-indigo-300 px-1 py-0.5 text-xs text-gray-900 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => saveEdit(f.key)}
+                        title="Save correction"
+                        className="text-emerald-600 hover:text-emerald-700"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditingKey(null)}
+                        title="Cancel"
+                        className="text-slate-400 hover:text-slate-600"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ) : done ? (
+                    <>
+                      {': '}
+                      <span className="text-slate-700">{value}</span>
+                      {editable && onEditField && (
+                        <button
+                          type="button"
+                          onClick={() => startEdit(f.key, value)}
+                          title="Correct this"
+                          aria-label={`Correct ${f.label}`}
+                          className="ml-1 inline-flex align-middle text-indigo-500 opacity-0 transition-opacity hover:text-indigo-700 group-hover:opacity-100"
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </button>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-slate-400"> — not yet defined</span>
+                  )}
+                </div>
+              </div>
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
@@ -78,6 +78,13 @@ export type PciAction =
   | { type: 'sendError'; target: PciTarget; hint: string; assistant: PciMessage }
   | { type: 'sendDone'; target: PciTarget }
   | { type: 'clearDraft'; target: PciTarget }
+  // Tutor correction of a captured "policy so far" field (empty value clears it).
+  | {
+      type: 'editSpecSoFar'
+      target: PciTarget
+      key: keyof import('@/lib/assessment/pci-spec').PciSpec
+      value: string
+    }
   | { type: 'reset' }
 
 /** Read a thread (returns a fresh empty thread for an unseen extension/assessment). */
@@ -145,6 +152,15 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
 
     case 'clearDraft':
       return patch(state, action.target, { draft: '', draftSpec: undefined })
+
+    case 'editSpecSoFar': {
+      const current = getThread(state, action.target).specSoFar ?? {}
+      const next = { ...current }
+      const v = action.value.trim()
+      if (v) next[action.key] = v
+      else delete next[action.key]
+      return patch(state, action.target, { specSoFar: next })
+    }
 
     case 'reset':
       return initialPciState()

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -217,6 +217,11 @@ export function usePci(deps: UsePciDeps) {
               pci: pciText,
               extensionName,
               sourceDocument,
+              // The captured "policy so far" — including any fields the tutor
+              // corrected inline. Sent back so the model treats these as
+              // authoritative and carries them forward (doesn't re-capture a
+              // stale value).
+              capturedSoFar: thread.specSoFar,
             },
             pdfPages,
           }),
@@ -281,6 +286,13 @@ export function usePci(deps: UsePciDeps) {
     }
   }
 
+  // Tutor correction of a captured "policy so far" field (empty value clears it).
+  const editSpecSoFar = (
+    target: PciTarget,
+    key: keyof import('@/lib/assessment/pci-spec').PciSpec,
+    value: string
+  ) => dispatch({ type: 'editSpecSoFar', target, key, value })
+
   return {
     pci,
     handlePciSend,
@@ -289,6 +301,7 @@ export function usePci(deps: UsePciDeps) {
     setPciInput,
     loadPciMessages,
     resetPci,
+    editSpecSoFar,
   }
 }
 

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -12,7 +12,7 @@ import { adkPciMasterChat } from '@/lib/adk-client'
 import { generateWithFallback } from '@/lib/agents'
 import { generateWithKimiVision } from '@/lib/ai/kimi'
 import { parseLlmJson, stripCodeFences } from '@/lib/ai/llm-response'
-import { normalizePciSpec, type PciSpec } from '@/lib/assessment/pci-spec'
+import { normalizePciSpec, PCI_SPEC_FIELDS, type PciSpec } from '@/lib/assessment/pci-spec'
 import { signalsPciFinalize } from '@/lib/assessment/pci-finalize'
 import {
   guardrailSystemPrompt,
@@ -68,6 +68,9 @@ const PciMasterRequestSchema = z.object({
           mimeType: z.string().max(200).optional(),
         })
         .optional(),
+      // The captured "policy so far" (incl. tutor inline corrections), sent back
+      // so the model treats it as authoritative and carries it forward.
+      capturedSoFar: z.record(z.string(), z.string()).optional(),
     })
     .optional(),
   // Rendered page images (data URLs) of an attached PDF, so the model can SEE the
@@ -183,6 +186,11 @@ export async function POST(request: NextRequest) {
       context?.extensionName && `Extension Name: ${context.extensionName}`,
       context?.sourceDocument &&
         `Attached Document: ${context.sourceDocument.fileName} (${context.sourceDocument.mimeType})\nURL: ${context.sourceDocument.fileUrl}`,
+      context?.capturedSoFar &&
+        Object.keys(context.capturedSoFar).length > 0 &&
+        `Policy captured so far (the tutor may have corrected these — treat them as AUTHORITATIVE and carry these exact values forward in "specSoFar"; do not overwrite or re-capture a stale value):\n${JSON.stringify(
+          context.capturedSoFar
+        )}`,
     ]
       .filter(Boolean)
       .join('\n\n')
@@ -378,6 +386,41 @@ export async function POST(request: NextRequest) {
       // applied without it, so this never silently finalizes.
       if ((pciDraft || pciSpec) && !tutorSignaledFinalize) {
         pciUnconfirmed = true
+      }
+    }
+
+    // Guaranteed population (bulletproofing): if the model returned NOTHING
+    // structured this turn but the tutor has been answering marking questions,
+    // extract the captured policy from the conversation ourselves so the "policy
+    // so far" panel still fills. Bounded — only on an empty result, only once
+    // there's real back-and-forth, and only for a substantive tutor message.
+    if (
+      guardrailDomain &&
+      !pciSpecSoFar &&
+      (history?.length ?? 0) >= 2 &&
+      safeMessage.length > 12
+    ) {
+      try {
+        const convo = [
+          ...(history ?? []).map(
+            h => `${h.role === 'assistant' ? 'Assistant' : 'Tutor'}: ${h.content}`
+          ),
+          `Tutor: ${safeMessage}`,
+        ]
+          .join('\n')
+          .slice(-8000)
+        const keys = PCI_SPEC_FIELDS.map(f => f.key).join(', ')
+        const extractPrompt = `From this conversation between an assistant and a tutor setting up a marking policy, extract ONLY what the TUTOR has actually stated about how answers should be marked. Return ONE JSON object using any of these optional keys (omit anything the tutor has not stated): ${keys}. Each value a short plain phrase in the tutor's own meaning. No prose, no code fences.\n\nConversation:\n${convo}`
+        const extracted = await generateWithFallback(extractPrompt, {
+          temperature: 0.1,
+          maxTokens: 500,
+          skipCache: true,
+          timeoutMs: 20_000,
+          retries: 1,
+        })
+        pciSpecSoFar = normalizePciSpec(parseLlmJson(extracted.content))
+      } catch (err) {
+        console.warn('[pci-master] specSoFar fallback extraction failed:', err)
       }
     }
 


### PR DESCRIPTION
All four improvements to the live **"Your policy so far"** panel.

## 1. Checklist (see progress + what's left)
The panel now shows **every** policy point — captured (**✓** with the value) vs **still to define** (○) — with an **"X of N"** count in the header. Previously it listed only captured fields, so the tutor couldn't see what the assistant would ask next.

## 2. Highlight on capture
A field **flashes** (emerald) the moment its value is captured or changes — reinforcing the on-the-fly feel.

## 3. Inline edit / correct
Each captured field has a hover **pencil** → edit the value right in the panel. The correction is stored (`editSpecSoFar` reducer action) **and** sent back to the assistant as `capturedSoFar` context, flagged **authoritative**, so the model carries the corrected value forward instead of re-capturing a stale one.

## 4. Guaranteed fill (bulletproofing)
If a turn returns **nothing structured** but the tutor has been answering marking questions, `pci-master` now **extracts the captured policy from the conversation itself** — bounded (only on an empty result, only once there's real back-and-forth, only for a substantive message). So the panel fills even when the model ignores the `specSoFar` JSON contract.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; reducer + hooks + guardrail unit tests (33) pass. Best confirmed live: run a PCI chat, answer a couple of marking questions, watch the checklist tick over and flash, then correct a field inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)