### PR TITLE
feat(pci): sticky tutor corrections in "policy so far" panel (+ reducer tests)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.test.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.test.ts
@@ -138,4 +138,81 @@ describe('pciReducer', () => {
     expect(getThread(s, task).draft).toBe('')
     expect(getThread(s, task).draftSpec).toBeUndefined()
   })
+
+  // ── "policy so far" panel: cumulative capture + sticky tutor edits ──────────
+
+  it('sendSuccess accumulates specSoFar across turns (keeps fields a turn omits)', () => {
+    let s = pciReducer(initialPciState(), {
+      type: 'sendSuccess',
+      target: asmt,
+      assistant: { role: 'assistant', content: 'a1' },
+      specSoFar: { evaluationLogic: 'method marks' },
+      warnings: [],
+    })
+    s = pciReducer(s, {
+      type: 'sendSuccess',
+      target: asmt,
+      assistant: { role: 'assistant', content: 'a2' },
+      specSoFar: { retryPolicy: 'two tries' }, // this turn omits evaluationLogic
+      warnings: [],
+    })
+    expect(getThread(s, asmt).specSoFar).toEqual({
+      evaluationLogic: 'method marks',
+      retryPolicy: 'two tries',
+    })
+  })
+
+  it('editSpecSoFar sets a field and marks it edited; clearing removes + un-marks it', () => {
+    let s = pciReducer(initialPciState(), {
+      type: 'editSpecSoFar',
+      target: task,
+      key: 'instructionalTone',
+      value: '  warm and patient  ',
+    })
+    expect(getThread(s, task).specSoFar).toEqual({ instructionalTone: 'warm and patient' })
+    expect(getThread(s, task).editedSpecKeys).toEqual(['instructionalTone'])
+
+    s = pciReducer(s, { type: 'editSpecSoFar', target: task, key: 'instructionalTone', value: '' })
+    expect(getThread(s, task).specSoFar).toEqual({})
+    expect(getThread(s, task).editedSpecKeys).toEqual([])
+  })
+
+  it('a tutor edit is STICKY — a later model turn cannot overwrite it, but updates other fields', () => {
+    let s = pciReducer(initialPciState(), {
+      type: 'editSpecSoFar',
+      target: asmt,
+      key: 'retryPolicy',
+      value: 'one try only',
+    })
+    // The model returns a different retryPolicy AND a new field.
+    s = pciReducer(s, {
+      type: 'sendSuccess',
+      target: asmt,
+      assistant: { role: 'assistant', content: 'a' },
+      specSoFar: { retryPolicy: 'three tries', noResponseBehavior: 'give a hint' },
+      warnings: [],
+    })
+    const t = getThread(s, asmt)
+    expect(t.specSoFar?.retryPolicy).toBe('one try only') // protected
+    expect(t.specSoFar?.noResponseBehavior).toBe('give a hint') // non-edited field updated
+  })
+
+  it('clearing an edited field un-protects it so the assistant may re-capture it', () => {
+    let s = pciReducer(initialPciState(), {
+      type: 'editSpecSoFar',
+      target: task,
+      key: 'evaluationLogic',
+      value: 'exact match',
+    })
+    s = pciReducer(s, { type: 'editSpecSoFar', target: task, key: 'evaluationLogic', value: '' })
+    // After clearing, a model turn can capture it again.
+    s = pciReducer(s, {
+      type: 'sendSuccess',
+      target: task,
+      assistant: { role: 'assistant', content: 'a' },
+      specSoFar: { evaluationLogic: 'accept equivalents' },
+      warnings: [],
+    })
+    expect(getThread(s, task).specSoFar?.evaluationLogic).toBe('accept equivalents')
+  })
 })

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
@@ -31,6 +31,13 @@ export interface PciThread {
    * "policy so far" panel. Distinct from `draftSpec` (the finalized mirror).
    */
   specSoFar?: import('@/lib/assessment/pci-spec').PciSpec
+  /**
+   * "policy so far" fields the tutor corrected inline. These are STICKY: a later
+   * model turn (or the server-side fallback extraction) may not overwrite them,
+   * so a correction holds until the tutor edits it again. Clearing a field drops
+   * it from here so the assistant may re-capture it.
+   */
+  editedSpecKeys?: string[]
   guardrailWarnings: PciGuardrailWarning[]
 }
 
@@ -124,21 +131,32 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
         loading: true,
       })
 
-    case 'sendSuccess':
+    case 'sendSuccess': {
       // Append the assistant reply, hold any finalized draft + structured spec,
       // clear the error, record guardrail warnings, and stop loading.
+      const cur = getThread(state, action.target)
+      // Merge captured-so-far fields; keep prior values if a turn omits them.
+      // Tutor-corrected fields are STICKY — the model may not overwrite them, so
+      // an inline correction holds until the tutor edits it again.
+      let specSoFarPatch: Partial<PciThread> = {}
+      if (action.specSoFar) {
+        const edited = new Set(cur.editedSpecKeys ?? [])
+        const merged: Record<string, string> = { ...(cur.specSoFar ?? {}) }
+        for (const [k, v] of Object.entries(action.specSoFar)) {
+          if (!edited.has(k)) merged[k] = v
+        }
+        specSoFarPatch = { specSoFar: merged }
+      }
       return patch(state, action.target, {
-        messages: [...getThread(state, action.target).messages, action.assistant],
+        messages: [...cur.messages, action.assistant],
         ...(action.draft ? { draft: action.draft } : {}),
         ...(action.spec ? { draftSpec: action.spec } : {}),
-        // Merge captured-so-far fields; keep prior values if a turn omits them.
-        ...(action.specSoFar
-          ? { specSoFar: { ...getThread(state, action.target).specSoFar, ...action.specSoFar } }
-          : {}),
+        ...specSoFarPatch,
         errorHint: '',
         guardrailWarnings: action.warnings,
         loading: false,
       })
+    }
 
     case 'sendError':
       return patch(state, action.target, {
@@ -154,12 +172,20 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
       return patch(state, action.target, { draft: '', draftSpec: undefined })
 
     case 'editSpecSoFar': {
-      const current = getThread(state, action.target).specSoFar ?? {}
-      const next = { ...current }
+      const t = getThread(state, action.target)
+      const next = { ...(t.specSoFar ?? {}) }
+      const edited = new Set(t.editedSpecKeys ?? [])
       const v = action.value.trim()
-      if (v) next[action.key] = v
-      else delete next[action.key]
-      return patch(state, action.target, { specSoFar: next })
+      if (v) {
+        // Set + protect: this correction is now sticky.
+        next[action.key] = v
+        edited.add(action.key)
+      } else {
+        // Cleared: drop the value and un-protect so the assistant may re-capture.
+        delete next[action.key]
+        edited.delete(action.key)
+      }
+      return patch(state, action.target, { specSoFar: next, editedSpecKeys: [...edited] })
     }
 
     case 'reset':


### PR DESCRIPTION
Follow-up to #816 — closes the correctness gap I flagged.

## Problem
An inline correction in the **"policy so far"** panel could be **silently overwritten** on the next turn: the reducer merged the model's `specSoFar` as *model-wins*, and the #4 server-side fallback extraction flows through the same path. So the model (or the extractor) ignoring `capturedSoFar` would clobber the tutor's fix.

## Fix — sticky edits
- The thread now tracks **`editedSpecKeys`** (fields the tutor corrected inline). On `sendSuccess`, the model's `specSoFar` may update any field **except** those — a correction **holds until the tutor edits it again**. Clearing a field **un-protects** it so the assistant may re-capture it.
- The guard lives in the reducer (the single choke point), so it protects against **both** the model output and the fallback extraction — no server change needed.

## Tests
4 new `pci-reducer` unit tests (14 total): cumulative `specSoFar` accumulation, `editSpecSoFar` set/clear + edited-key tracking, sticky-edit-not-overwritten (while non-edited fields still update), and re-capture-after-clear.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; 14 reducer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)