### PR TITLE
feat(pci): auto-kickoff the marking-policy chat after the DMI + give it the marking scheme

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6727,6 +6727,23 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       autoCreateAssessment,
       renderPdfToImages,
       pdfPageCache,
+      // DMI digest (marks + rubric, no answers) so the policy chat sees the
+      // actual questions/marks/rubrics.
+      assessmentMarkingScheme: assessmentDmiItems
+        .map(q => {
+          const label = q.questionLabel || `Q${q.questionNumber ?? ''}`
+          const text =
+            q.questionText && q.questionText.trim() && q.questionText.trim() !== label
+              ? ` ${q.questionText.trim()}`
+              : ''
+          const marks =
+            typeof q.marks === 'number' && q.marks > 0
+              ? ` [${q.marks} mark${q.marks === 1 ? '' : 's'}]`
+              : ''
+          const rubric = q.rubric?.trim() ? `\n  rubric: ${q.rubric.trim()}` : ''
+          return `${label}:${text}${marks}${rubric}`
+        })
+        .join('\n'),
     })
     const { pci, handlePciSend, applyTaskPciDraft, applyAssessmentPciDraft, setPciInput } = pciApi
     const editSpecSoFar = pciApi.editSpecSoFar
@@ -6967,6 +6984,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         })
       }
     }, [loadedTaskId, hasTaskDocument])
+
+    // DMI-first kickoff: once the assessment's DMI is ready (chat unlocked) and
+    // the marking-policy chat has no messages yet, auto-start the guided flow —
+    // skipping the document summary (the DMI review already covered the
+    // questions) and going straight to probing the marking policy. Fires once
+    // per assessment.
+    const pciKickoffRef = useRef<Set<string>>(new Set())
+    useEffect(() => {
+      const id = loadedAssessmentId
+      if (!id || !assessmentDmiReady || !canEdit) return
+      const thread = getThread(pci, { kind: 'assessment', id })
+      if (thread.messages.length > 0 || thread.loading) return
+      if (pciKickoffRef.current.has(id)) return
+      pciKickoffRef.current.add(id)
+      const t = setTimeout(() => {
+        handlePciSend(
+          'assessment',
+          'The questions and marking scheme (the DMI) are already set up, so skip any document summary. Go straight to helping me build the marking policy: ask me ONE simple question at a time about how answers should be marked — in clear, simple language with a small example each time. Start with the most important point.'
+        )
+      }, 300)
+      return () => clearTimeout(t)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [loadedAssessmentId, assessmentDmiReady, canEdit])
 
     // Auto-switch assessment panels based on document presence
     useEffect(() => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -39,6 +39,12 @@ interface UsePciDeps {
     sourceDocument?: PciSourceDoc
   }
   assessmentBuilder: { taskContent: string; taskPci: string; title: string }
+  /**
+   * Compact digest of the assessment's DMI (per-question marks + rubric, no
+   * answers) so the marking-policy chat builds the policy WITH the actual
+   * questions/marks/rubrics in view. Empty when there's no DMI.
+   */
+  assessmentMarkingScheme?: string
   /** Writes the finalized rubric to the active task/assessment PCI field. */
   setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
@@ -222,6 +228,12 @@ export function usePci(deps: UsePciDeps) {
               // authoritative and carries them forward (doesn't re-capture a
               // stale value).
               capturedSoFar: thread.specSoFar,
+              // The DMI marking scheme (assessment only), so the policy is built
+              // with the actual questions/marks/rubrics in view.
+              markingScheme:
+                !isTask && deps.assessmentMarkingScheme
+                  ? deps.assessmentMarkingScheme.slice(0, 12000)
+                  : undefined,
             },
             pdfPages,
           }),

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -71,6 +71,9 @@ const PciMasterRequestSchema = z.object({
       // The captured "policy so far" (incl. tutor inline corrections), sent back
       // so the model treats it as authoritative and carries it forward.
       capturedSoFar: z.record(z.string(), z.string()).optional(),
+      // Assessment DMI digest (per-question marks + rubric, no answers) so the
+      // marking policy is built with the real questions/marks/rubrics in view.
+      markingScheme: z.string().max(16000).optional(),
     })
     .optional(),
   // Rendered page images (data URLs) of an attached PDF, so the model can SEE the
@@ -186,6 +189,11 @@ export async function POST(request: NextRequest) {
       context?.extensionName && `Extension Name: ${context.extensionName}`,
       context?.sourceDocument &&
         `Attached Document: ${context.sourceDocument.fileName} (${context.sourceDocument.mimeType})\nURL: ${context.sourceDocument.fileUrl}`,
+      context?.markingScheme &&
+        `Marking scheme (the DMI — per-question marks + rubric; use it to ask targeted marking-policy questions and to ground the policy in the real questions/marks; do NOT copy per-question rubric text into the policy):\n${truncate(
+          context.markingScheme,
+          12000
+        )}`,
       context?.capturedSoFar &&
         Object.keys(context.capturedSoFar).length > 0 &&
         `Policy captured so far (the tutor may have corrected these — treat them as AUTHORITATIVE and carry these exact values forward in "specSoFar"; do not overwrite or re-capture a stale value):\n${JSON.stringify(


### PR DESCRIPTION
Follow-up to the DMI-first flow (#818) — the two improvements I flagged.

## 1. Auto-kickoff (the requested follow-up)
Once an assessment's DMI is **ready** (chat unlocked) and the PCI chat has **no messages yet**, the guided flow now **starts itself** — a one-time kickoff (ref-guarded, once per assessment) that tells the assistant to **skip the document summary** (the DMI review already covered the questions) and go **straight to probing the marking policy**, one simple question at a time. So the summarize→confirm step is no longer needed here — the DMI *is* the confirmed understanding.

## 2. The policy chat now sees the marking scheme
The assessment PCI chat sends a compact **DMI digest** — per-question label/text + marks + rubric, **no answers** — as `context.markingScheme`. `pci-master` surfaces it in the prompt so the policy is built **with the real questions, marks, and rubrics in view** (targeted questions like "Q3 is worth 5 marks with a rubric — how strict on partial credit?"), while explicitly not copying per-question rubric text into the policy. This is what makes the kickoff meaningful — the assistant can reason about the actual scheme instead of asking generic questions.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; 21 hooks unit tests pass. The kickoff effect is placed with the other component-body effects (no rules-of-hooks risk; verified no early returns precede it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)