### PR TITLE
refactor(assessment): extract the DMI-first gate into a tested helper

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -133,6 +133,7 @@ import { PciQuestionnaire } from './PciQuestionnaire'
 import { PciSpecSoFar } from './PciSpecSoFar'
 import { TestTaskChat, type TestTaskChatState } from './TestTaskChat'
 import { splitDocIntoSections } from '@/lib/documents/split-sections'
+import { assessmentDmiReadiness } from '@/lib/assessment/dmi-readiness'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
@@ -6700,16 +6701,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
     // DMI-first gate: an assessment's marking-policy (PCI) chat unlocks only once
     // the DMI exists with questions, marks, and an answer key/rubric (the "basic"
-    // bar). Per-question gaps are surfaced but don't block.
-    const assessmentDmiTotalMarks = assessmentDmiItems.reduce(
-      (sum, q) => sum + (typeof q.marks === 'number' && q.marks > 0 ? q.marks : 0),
-      0
-    )
-    const assessmentDmiHasAnswerKey = assessmentDmiItems.some(
-      q => (q.answer?.trim()?.length ?? 0) > 0 || (q.rubric?.trim()?.length ?? 0) > 0
-    )
-    const assessmentDmiReady =
-      assessmentDmiItems.length > 0 && assessmentDmiTotalMarks > 0 && assessmentDmiHasAnswerKey
+    // bar). Per-question gaps are surfaced but don't block. See assessmentDmiReadiness.
+    const { totalMarks: assessmentDmiTotalMarks, ready: assessmentDmiReady } =
+      assessmentDmiReadiness(assessmentDmiItems)
 
     // PCI assistant state + actions, consolidated into a reducer-backed hook.
     // Called late (all deps below are defined by here); the two early consumers

--- a/tutorme-app/src/lib/assessment/dmi-readiness.test.ts
+++ b/tutorme-app/src/lib/assessment/dmi-readiness.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { assessmentDmiReadiness } from './dmi-readiness'
+
+describe('assessmentDmiReadiness', () => {
+  it('is not ready with no questions', () => {
+    const r = assessmentDmiReadiness([])
+    expect(r).toEqual({ hasQuestions: false, totalMarks: 0, hasAnswerKey: false, ready: false })
+  })
+
+  it('is not ready when there are no marks (even with an answer key)', () => {
+    const r = assessmentDmiReadiness([{ answer: '42' }, { rubric: 'method marks' }])
+    expect(r.hasQuestions).toBe(true)
+    expect(r.totalMarks).toBe(0)
+    expect(r.hasAnswerKey).toBe(true)
+    expect(r.ready).toBe(false)
+  })
+
+  it('is not ready when marks exist but there is no answer key/rubric (e.g. a bare question paper)', () => {
+    const r = assessmentDmiReadiness([
+      { marks: 3, answer: '', rubric: '' },
+      { marks: 2, answer: '   ' },
+    ])
+    expect(r.totalMarks).toBe(5)
+    expect(r.hasAnswerKey).toBe(false)
+    expect(r.ready).toBe(false)
+  })
+
+  it('is ready with questions + positive marks + an answer OR rubric', () => {
+    const r = assessmentDmiReadiness([
+      { marks: 3, answer: 'x = 4' },
+      { marks: 2, rubric: 'award method marks' },
+    ])
+    expect(r.totalMarks).toBe(5)
+    expect(r.hasAnswerKey).toBe(true)
+    expect(r.ready).toBe(true)
+  })
+
+  it('ignores non-positive / non-numeric marks when totalling', () => {
+    const r = assessmentDmiReadiness([
+      { marks: 0, answer: 'a' },
+      { marks: -1, answer: 'b' },
+      { marks: null, rubric: 'c' },
+      { marks: 4, answer: 'd' },
+    ])
+    expect(r.totalMarks).toBe(4)
+    expect(r.ready).toBe(true)
+  })
+
+  it('a rubric alone (no model answer) still counts as an answer key', () => {
+    const r = assessmentDmiReadiness([{ marks: 5, rubric: 'one mark per valid point' }])
+    expect(r.hasAnswerKey).toBe(true)
+    expect(r.ready).toBe(true)
+  })
+})

--- a/tutorme-app/src/lib/assessment/dmi-readiness.ts
+++ b/tutorme-app/src/lib/assessment/dmi-readiness.ts
@@ -1,0 +1,39 @@
+/**
+ * "DMI-first" readiness gate for the assessment marking-policy (PCI) chat.
+ *
+ * The chat unlocks only once the DMI is set up to the "basic" bar: it has
+ * questions, a positive total marks, and at least one answer or rubric (the
+ * answer key / marking scheme). Per-question gaps are allowed here (surfaced
+ * elsewhere), not blocking. Pure + framework-free so it's unit-tested directly.
+ */
+
+export interface DmiReadinessItem {
+  marks?: number | null
+  answer?: string | null
+  rubric?: string | null
+}
+
+export interface DmiReadiness {
+  hasQuestions: boolean
+  totalMarks: number
+  hasAnswerKey: boolean
+  /** True when the marking-policy chat may unlock. */
+  ready: boolean
+}
+
+const hasText = (v: string | null | undefined): boolean => (v?.trim()?.length ?? 0) > 0
+
+export function assessmentDmiReadiness(items: readonly DmiReadinessItem[]): DmiReadiness {
+  const hasQuestions = items.length > 0
+  const totalMarks = items.reduce(
+    (sum, q) => sum + (typeof q.marks === 'number' && q.marks > 0 ? q.marks : 0),
+    0
+  )
+  const hasAnswerKey = items.some(q => hasText(q.answer) || hasText(q.rubric))
+  return {
+    hasQuestions,
+    totalMarks,
+    hasAnswerKey,
+    ready: hasQuestions && totalMarks > 0 && hasAnswerKey,
+  }
+}


### PR DESCRIPTION
Locks in the gate logic that now controls the whole DMI-first flow.

The "DMI ready" check (questions + positive total marks + an answer key/rubric) was written inline in `CourseBuilder` with no test. Extracted to a pure **`assessmentDmiReadiness(items)`** in `src/lib/assessment/dmi-readiness.ts` — returns `{ hasQuestions, totalMarks, hasAnswerKey, ready }` — and wired `CourseBuilder` to it. **No behaviour change.**

## Tests (6)
- no questions → not ready
- marks missing (answer key present) → not ready
- answer key/rubric missing (bare question paper, marks present) → not ready
- questions + marks + answer/rubric → ready
- non-positive / non-numeric marks ignored in the total
- a rubric alone (no model answer) counts as an answer key

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; 6 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)