### PR TITLE
refactor(dmi): extract + test resolveDocumentKind (question-paper backstop)

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -19,7 +19,11 @@ import {
 } from '@/lib/assessment/question-types'
 import { extractQuestionRef } from '@/lib/assessment/marking-scheme'
 import { scoreDocumentConfidence } from '@/lib/assessment/confidence'
-import { analyzeDocumentSignals, documentKindLooksWrong } from '@/lib/assessment/document-signals'
+import {
+  analyzeDocumentSignals,
+  documentKindLooksWrong,
+  resolveDocumentKind,
+} from '@/lib/assessment/document-signals'
 import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
@@ -470,8 +474,7 @@ export async function POST(request: NextRequest) {
     // exam paper whose reading passages read "prose-heavy"). The tutor's explicit
     // override still wins. Text-only, so it can't help an image-only PDF.
     const signals = content && content.trim() ? analyzeDocumentSignals(content) : null
-    const effectiveKindOverride: 'question_paper' | 'study_material' | undefined =
-      documentKindOverride ?? (signals?.paperSignal === 'strong' ? 'question_paper' : undefined)
+    const { settled: effectiveKindOverride } = resolveDocumentKind(documentKindOverride, signals)
 
     // Study-material path. If the tutor specified question types + counts, generate
     // exactly that mix. Otherwise (option A) still AUTHOR a sensible set of questions
@@ -544,7 +547,7 @@ export async function POST(request: NextRequest) {
 
     // A settled kind (tutor override, or a strong code-level paper signal) wins;
     // otherwise use the model's classification.
-    const documentKind = effectiveKindOverride ?? modelKind
+    const { documentKind } = resolveDocumentKind(documentKindOverride, signals, modelKind)
 
     // When the kind isn't already settled, flag a LIKELY misclassification so the
     // tutor confirms rather than silently defaulting an ambiguous document. A

--- a/tutorme-app/src/lib/assessment/document-signals.test.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest'
-import { analyzeDocumentSignals, documentKindLooksWrong } from './document-signals'
+import {
+  analyzeDocumentSignals,
+  documentKindLooksWrong,
+  resolveDocumentKind,
+  type DocumentSignals,
+} from './document-signals'
+
+const signalsWith = (paperSignal: DocumentSignals['paperSignal']): DocumentSignals => ({
+  markAllocations: 0,
+  questionLines: 0,
+  mcqOptionLines: 0,
+  answerBlanks: 0,
+  imperativeCues: 0,
+  proseChars: 0,
+  paperSignal,
+})
 
 // Numbered study notes: numbered headings + prose, but NO marks / MCQ / blanks.
 const STUDY_NOTES = [
@@ -109,5 +124,58 @@ describe('documentKindLooksWrong', () => {
 
   it('does not flag a classified doc when signals are unavailable (image-only PDF)', () => {
     expect(documentKindLooksWrong('question_paper', null)).toBe(false)
+  })
+})
+
+describe('resolveDocumentKind', () => {
+  it('a strong paper signal forces question_paper (the SAT/exam-paper backstop)', () => {
+    const r = resolveDocumentKind(undefined, signalsWith('strong'), 'study_material')
+    expect(r.settled).toBe('question_paper')
+    expect(r.documentKind).toBe('question_paper') // overrides the model's study_material
+  })
+
+  it('the tutor override always wins — even over a strong signal', () => {
+    const r = resolveDocumentKind('study_material', signalsWith('strong'), 'question_paper')
+    expect(r.settled).toBe('study_material')
+    expect(r.documentKind).toBe('study_material')
+  })
+
+  it('a weak/none signal is not settled — defers to the model classification', () => {
+    expect(resolveDocumentKind(undefined, signalsWith('weak'), 'study_material')).toEqual({
+      settled: undefined,
+      documentKind: 'study_material',
+    })
+    expect(resolveDocumentKind(undefined, signalsWith('none'), 'question_paper')).toEqual({
+      settled: undefined,
+      documentKind: 'question_paper',
+    })
+  })
+
+  it('no signals (image-only PDF) → defers to the model', () => {
+    expect(resolveDocumentKind(undefined, null, 'question_paper').documentKind).toBe(
+      'question_paper'
+    )
+    expect(resolveDocumentKind(undefined, null, null).documentKind).toBeNull()
+  })
+
+  it('computes the settled kind before generation (modelKind defaulting to null)', () => {
+    expect(resolveDocumentKind(undefined, signalsWith('strong')).settled).toBe('question_paper')
+    expect(resolveDocumentKind('question_paper', null).settled).toBe('question_paper')
+    expect(resolveDocumentKind(undefined, signalsWith('weak')).settled).toBeUndefined()
+  })
+
+  it('the real MCQ-paper signal resolves to question_paper even against a study_material model call', () => {
+    const mcq = `1. What is 2 + 2?
+A. 3
+B. 4
+C. 5
+D. 6
+2. Which is prime?
+A. 4
+B. 9
+C. 7
+D. 8`
+    const r = resolveDocumentKind(undefined, analyzeDocumentSignals(mcq), 'study_material')
+    expect(r.documentKind).toBe('question_paper')
   })
 })

--- a/tutorme-app/src/lib/assessment/document-signals.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.ts
@@ -45,6 +45,32 @@ function countMatches(text: string, re: RegExp): number {
   return m ? m.length : 0
 }
 
+export type DocumentKind = 'question_paper' | 'study_material'
+
+/**
+ * Resolve the document kind for DMI generation from the three inputs, in
+ * priority order:
+ *  1. the tutor's explicit choice (always wins);
+ *  2. a STRONG code-level paper signal → force `question_paper` (the backstop
+ *     that keeps SAT/exam papers from being mis-generated as study material when
+ *     their passages read "prose-heavy" and the model waffles);
+ *  3. otherwise the model's classification.
+ *
+ * `settled` is the kind known BEFORE generation (1 or 2) — used to instruct the
+ * model to extract vs author, and to skip the confirm dialog. `documentKind` is
+ * the final kind (falls back to the model's call). `modelKind` is null when the
+ * model hasn't classified yet (i.e. computing `settled` before generation).
+ */
+export function resolveDocumentKind(
+  tutorOverride: DocumentKind | undefined,
+  signals: DocumentSignals | null,
+  modelKind: DocumentKind | null = null
+): { settled?: DocumentKind; documentKind: DocumentKind | null } {
+  const settled =
+    tutorOverride ?? (signals?.paperSignal === 'strong' ? 'question_paper' : undefined)
+  return { settled, documentKind: settled ?? modelKind }
+}
+
 /**
  * Given the AI's `documentKind` and the code-level signals, does the claim look
  * wrong enough to double-check with the tutor before generating a DMI? Catches
@@ -57,7 +83,7 @@ function countMatches(text: string, re: RegExp): number {
  * flagged. Returns true → the route asks the tutor to confirm the kind.
  */
 export function documentKindLooksWrong(
-  modelKind: 'question_paper' | 'study_material' | null,
+  modelKind: DocumentKind | null,
   signals: DocumentSignals | null
 ): boolean {
   if (modelKind === null) return true


### PR DESCRIPTION
Locks in the SAT-detection backstop from #822 behind tests.

The document-kind decision (tutor override wins → else a **strong** code-level paper signal forces `question_paper` → else the model's call) was written inline in `generate-dmi` with no test. Extracted to a pure **`resolveDocumentKind(tutorOverride, signals, modelKind)`** in `document-signals.ts` — returns `{ settled, documentKind }` — and wired both call sites to it (the pre-generation `settled` that drives extract-vs-author, and the final `documentKind`). **No behaviour change.**

## Tests (6 new; also added a `DocumentKind` type)
- strong signal forces `question_paper` **over** a `study_material` model call (the SAT case)
- tutor override always wins — even over a strong signal
- weak / none signal defers to the model
- no signals (image-only PDF) defers to the model
- the before-generation `settled` kind (modelKind defaulting to null)
- a real MCQ paper resolves to `question_paper` against a `study_material` model call

## Verification
`npm run typecheck`, `npx eslint`, `npm run build` green; 17 `document-signals` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)