### PR TITLE
fix(api): populate tutorNationalities from profile data

### DIFF
--- a/tutorme-app/src/app/api/public/tutors/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/route.ts
@@ -87,7 +87,11 @@ export async function GET(request: NextRequest) {
             specialties: categories,
             hourlyRate: profileData.hourlyRate,
             oneOnOneEnabled: profileData.oneOnOneEnabled ?? true,
-            tutorNationalities: [],
+            tutorNationalities: profileData.nationality
+              ? [profileData.nationality]
+              : profileData.countryOfResidence
+                ? [profileData.countryOfResidence]
+                : [],
             categoryNationalityCombinations: [],
             courseCount: tutorCourses.length,
             totalEnrollments: 0,


### PR DESCRIPTION
Fixes missing country flags on tutor cards in the Book a Tutor page.

**Root cause:** The  field in the public tutors API was hardcoded to an empty array , so no country data was passed to the frontend regardless of what the tutor had set in their profile.

**Fix:** Now populates  from the tutor's profile:
- Uses  if available
- Falls back to  if nationality is not set
- Only returns empty array if neither field is set

**Before:** Tutors like @solocorn1 (registered with Canada) showed no country flag
**After:** Country flag displays correctly based on profile data

**File changed:**
- 
