### PR TITLE
fix(tutor-insights): open Course Builder in Editing mode by default

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -137,12 +137,10 @@ function TutorInsightsPageInner() {
     // Otherwise detect from which list the course belongs to
     const isLive = courses.some(c => c.id === courseId)
     const isDraft = draftCourses.some(c => c.id === courseId)
-    // If mode=edit was explicitly passed, prefer draft — BUT never for a real DB
-    // course (present in the live list). Detached/draft mode reads from empty
-    // localStorage (blank builder) and, on save, can hard-delete the course's real
-    // lessons. mode=edit only makes sense for the local scratchpad, so honor it
-    // solely when the course isn't a known live DB course.
-    if (searchParams.get('mode') === 'edit' && !isLive) {
+    // If mode=edit was explicitly passed (from Course Builder nav), prefer draft
+    // mode for editing. For live DB courses, this keeps dataMode as 'default' (not
+    // 'detached') so content loads from the DB safely rather than empty localStorage.
+    if (searchParams.get('mode') === 'edit') {
       setSaveMode('draft')
       return
     }
@@ -1232,7 +1230,8 @@ function TutorInsightsPageInner() {
     )
   }
 
-  const dataMode = saveMode === 'draft' && !sessionId ? 'detached' : 'default'
+  const dataMode =
+    saveMode === 'draft' && !sessionId && courseId === 'insights-draft' ? 'detached' : 'default'
 
   return (
     <div className="flex h-screen w-full flex-col items-stretch bg-gray-50">


### PR DESCRIPTION
When a tutor clicks 'Course Builder' from the sidebar, the page now opens in 'Editing' mode instead of 'Live' mode.

**Root cause:** The  that auto-detects saveMode was overriding the  query param for live/published courses, forcing them to open in 'Live' mode. Tutors had to manually switch the mode dropdown to 'Editing'.

**Changes:**
-  now honors  for ALL courses (both live and draft)
-  is only 'detached' (localStorage) for the insights-draft scratchpad
- For existing live courses,  stays 'default' so content safely loads from DB

**Before:** Clicking Course Builder with a live course selected → opens in 'Live' mode
**After:** Clicking Course Builder with a live course selected → opens in 'Editing' mode, content loads from DB

**File changed:**
- 
