### PR TITLE
fix(api): include profile nationality in tutor directory flags

### DIFF
--- a/tutorme-app/src/app/api/public/tutors/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/route.ts
@@ -322,7 +322,15 @@ export async function GET(request: NextRequest) {
       const tutorCombinations = [
         ...new Set(tutorVariants.map(v => `${v.category} - ${v.nationality}`)),
       ]
-      const tutorNationalities = [...new Set(tutorVariants.map(v => v.nationality))]
+      const tutorNationalities = [
+        ...new Set(
+          [
+            ...tutorVariants.map(v => v.nationality),
+            profileData?.nationality,
+            profileData?.countryOfResidence,
+          ].filter(Boolean)
+        ),
+      ]
       const allCategories = [...new Set(tutorCourses.flatMap(c => c.categories || []))]
 
       const latestCourse = tutorCourses.sort(


### PR DESCRIPTION
Fixes missing country flags on tutor cards in the public directory for tutors who have profile nationality/country set but no published course variants.

**Root cause:**
The main paginated query in `/api/public/tutors` derived `tutorNationalities` only from course variant nationalities:
```ts
const tutorNationalities = [...new Set(tutorVariants.map(v => v.nationality))]
```
If a tutor had no published course variants, `tutorNationalities` was empty `[]`, even when `profile.nationality` or `profile.countryOfResidence` was set.

The fast path (favorites/bookmarks by IDs) already correctly fell back to profile data — so favorites showed flags while the directory did not.

**Fix:**
Now includes `profileData.nationality` and `profileData.countryOfResidence` as fallback sources, consistent with the fast path:
```ts
const tutorNationalities = [...new Set([
  ...tutorVariants.map(v => v.nationality),
  profileData?.nationality,
  profileData?.countryOfResidence,
].filter(Boolean))]
```