### PR TITLE
fix(dmi): detect MCQ papers via inline options (SAT fix) + resolveDocumentKind extract

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -19,7 +19,11 @@ import {
 } from '@/lib/assessment/question-types'
 import { extractQuestionRef } from '@/lib/assessment/marking-scheme'
 import { scoreDocumentConfidence } from '@/lib/assessment/confidence'
-import { analyzeDocumentSignals, documentKindLooksWrong } from '@/lib/assessment/document-signals'
+import {
+  analyzeDocumentSignals,
+  documentKindLooksWrong,
+  resolveDocumentKind,
+} from '@/lib/assessment/document-signals'
 import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
@@ -470,8 +474,7 @@ export async function POST(request: NextRequest) {
     // exam paper whose reading passages read "prose-heavy"). The tutor's explicit
     // override still wins. Text-only, so it can't help an image-only PDF.
     const signals = content && content.trim() ? analyzeDocumentSignals(content) : null
-    const effectiveKindOverride: 'question_paper' | 'study_material' | undefined =
-      documentKindOverride ?? (signals?.paperSignal === 'strong' ? 'question_paper' : undefined)
+    const { settled: effectiveKindOverride } = resolveDocumentKind(documentKindOverride, signals)
 
     // Study-material path. If the tutor specified question types + counts, generate
     // exactly that mix. Otherwise (option A) still AUTHOR a sensible set of questions
@@ -544,7 +547,7 @@ export async function POST(request: NextRequest) {
 
     // A settled kind (tutor override, or a strong code-level paper signal) wins;
     // otherwise use the model's classification.
-    const documentKind = effectiveKindOverride ?? modelKind
+    const { documentKind } = resolveDocumentKind(documentKindOverride, signals, modelKind)
 
     // When the kind isn't already settled, flag a LIKELY misclassification so the
     // tutor confirms rather than silently defaulting an ambiguous document. A

--- a/tutorme-app/src/lib/assessment/document-signals.test.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from 'vitest'
-import { analyzeDocumentSignals, documentKindLooksWrong } from './document-signals'
+import {
+  analyzeDocumentSignals,
+  documentKindLooksWrong,
+  resolveDocumentKind,
+  type DocumentSignals,
+} from './document-signals'
+
+const signalsWith = (paperSignal: DocumentSignals['paperSignal']): DocumentSignals => ({
+  markAllocations: 0,
+  questionLines: 0,
+  mcqOptionLines: 0,
+  mcqOptionMarkers: 0,
+  answerBlanks: 0,
+  imperativeCues: 0,
+  proseChars: 0,
+  paperSignal,
+})
+
+// SAT-style: pdfjs collapses each question's options onto one line, so the
+// options/numbers are INLINE (not line-anchored) amid heavy reading passages.
+const SAT_COLLAPSED = `--- Page 4 ---
+Module 1 Reading and Writing 33 QUESTIONS DIRECTIONS ... All questions in this section are multiple-choice with four answer choices. ${Array.from(
+  { length: 12 },
+  (_, i) =>
+    `${i + 1} A long reading passage sets up the context for the question in considerable detail here. Which choice completes the text with the most logical and precise word? A) alpha B) beta C) gamma D) delta`
+).join(' ')}`
 
 // Numbered study notes: numbered headings + prose, but NO marks / MCQ / blanks.
 const STUDY_NOTES = [
@@ -109,5 +134,61 @@ describe('documentKindLooksWrong', () => {
 
   it('does not flag a classified doc when signals are unavailable (image-only PDF)', () => {
     expect(documentKindLooksWrong('question_paper', null)).toBe(false)
+  })
+})
+
+describe('analyzeDocumentSignals — inline MCQ options (SAT / collapsed extraction)', () => {
+  it('detects an MCQ paper as STRONG even when options are inline, not line-anchored', () => {
+    const s = analyzeDocumentSignals(SAT_COLLAPSED)
+    // The line-anchored counts are defeated by the collapsed layout...
+    expect(s.mcqOptionLines).toBeLessThan(4)
+    // ...but the inline option markers catch it.
+    expect(s.mcqOptionMarkers).toBeGreaterThanOrEqual(8)
+    expect(s.paperSignal).toBe('strong')
+  })
+
+  it('a bit of prose with one or two lettered items is NOT strong', () => {
+    const s = analyzeDocumentSignals(
+      'The framework has two parts. A) the parser and B) the evaluator, described below at length in prose that continues.'
+    )
+    expect(s.mcqOptionMarkers).toBeLessThan(8)
+    expect(s.paperSignal).not.toBe('strong')
+  })
+})
+
+describe('resolveDocumentKind', () => {
+  it('a strong paper signal forces question_paper (the SAT/exam-paper backstop)', () => {
+    const r = resolveDocumentKind(undefined, signalsWith('strong'), 'study_material')
+    expect(r.settled).toBe('question_paper')
+    expect(r.documentKind).toBe('question_paper')
+  })
+
+  it('the tutor override always wins — even over a strong signal', () => {
+    const r = resolveDocumentKind('study_material', signalsWith('strong'), 'question_paper')
+    expect(r.settled).toBe('study_material')
+    expect(r.documentKind).toBe('study_material')
+  })
+
+  it('a weak/none signal defers to the model classification', () => {
+    expect(resolveDocumentKind(undefined, signalsWith('weak'), 'study_material').documentKind).toBe(
+      'study_material'
+    )
+    expect(resolveDocumentKind(undefined, signalsWith('weak')).settled).toBeUndefined()
+  })
+
+  it('no signals (image-only PDF) → defers to the model', () => {
+    expect(resolveDocumentKind(undefined, null, 'question_paper').documentKind).toBe(
+      'question_paper'
+    )
+    expect(resolveDocumentKind(undefined, null, null).documentKind).toBeNull()
+  })
+
+  it('resolves a collapsed SAT paper to question_paper against a study_material model call', () => {
+    const r = resolveDocumentKind(
+      undefined,
+      analyzeDocumentSignals(SAT_COLLAPSED),
+      'study_material'
+    )
+    expect(r.documentKind).toBe('question_paper')
   })
 })

--- a/tutorme-app/src/lib/assessment/document-signals.ts
+++ b/tutorme-app/src/lib/assessment/document-signals.ts
@@ -16,6 +16,14 @@ export interface DocumentSignals {
   questionLines: number
   /** Lines that begin like a lettered multiple-choice option (A., b)). */
   mcqOptionLines: number
+  /**
+   * Lettered MCQ option markers (A)/B)/C)/D)) counted INLINE too, not only at
+   * line-starts — because PDF text extraction routinely runs a whole question's
+   * options together on one line ("A) … B) … C) … D)"), which defeats the
+   * line-anchored `mcqOptionLines`. Many of these strongly indicate an MCQ paper
+   * (e.g. SAT) regardless of layout.
+   */
+  mcqOptionMarkers: number
   /** Blank answer spaces / "Answer:" prompts. */
   answerBlanks: number
   /** Imperative task verbs at a line/sentence start (calculate, explain, …). */
@@ -36,6 +44,9 @@ const MARK_ALLOCATION_RE = /\[\s*\d{1,3}\s*\]|\(\s*\d{1,3}\s*marks?\s*\)/gi
 const QUESTION_LINE_RE = /^\s*(?:Q(?:uestion)?\s*)?\d{1,3}\s*[.)]\s+\S/
 const SUBPART_LINE_RE = /^\s*\(?(?:[a-z]|i{1,3}|iv|v|vi{0,3}|ix|x)\)\s+\S/i
 const MCQ_OPTION_LINE_RE = /^\s*[A-Ea-e]\s*[.)]\s+\S/
+// Uppercase lettered option markers anywhere (line-start OR inline), for papers
+// whose extracted text collapses the options onto one line.
+const MCQ_OPTION_MARKER_RE = /(?:^|[\s(])[A-E][).]\s+\S/g
 const ANSWER_BLANK_RE = /_{3,}|\bAnswers?\s*[:.]/gi
 const IMPERATIVE_RE =
   /(?:^|[.\n])\s*(?:calculate|determine|find|compute|show|prove|explain|justify|describe|state|estimate|sketch|construct|interpret|evaluate|solve|define|outline|discuss|identify|label|complete|derive|list)\b/gi
@@ -43,6 +54,32 @@ const IMPERATIVE_RE =
 function countMatches(text: string, re: RegExp): number {
   const m = text.match(re)
   return m ? m.length : 0
+}
+
+export type DocumentKind = 'question_paper' | 'study_material'
+
+/**
+ * Resolve the document kind for DMI generation from the three inputs, in
+ * priority order:
+ *  1. the tutor's explicit choice (always wins);
+ *  2. a STRONG code-level paper signal → force `question_paper` (the backstop
+ *     that keeps SAT/exam papers from being mis-generated as study material when
+ *     their passages read "prose-heavy" and the model waffles);
+ *  3. otherwise the model's classification.
+ *
+ * `settled` is the kind known BEFORE generation (1 or 2) — used to instruct the
+ * model to extract vs author, and to skip the confirm dialog. `documentKind` is
+ * the final kind (falls back to the model's call). `modelKind` is null when the
+ * model hasn't classified yet (i.e. computing `settled` before generation).
+ */
+export function resolveDocumentKind(
+  tutorOverride: DocumentKind | undefined,
+  signals: DocumentSignals | null,
+  modelKind: DocumentKind | null = null
+): { settled?: DocumentKind; documentKind: DocumentKind | null } {
+  const settled =
+    tutorOverride ?? (signals?.paperSignal === 'strong' ? 'question_paper' : undefined)
+  return { settled, documentKind: settled ?? modelKind }
 }
 
 /**
@@ -57,7 +94,7 @@ function countMatches(text: string, re: RegExp): number {
  * flagged. Returns true → the route asks the tutor to confirm the kind.
  */
 export function documentKindLooksWrong(
-  modelKind: 'question_paper' | 'study_material' | null,
+  modelKind: DocumentKind | null,
   signals: DocumentSignals | null
 ): boolean {
   if (modelKind === null) return true
@@ -91,17 +128,25 @@ export function analyzeDocumentSignals(content: string): DocumentSignals {
   const markAllocations = countMatches(text, MARK_ALLOCATION_RE)
   const answerBlanks = countMatches(text, ANSWER_BLANK_RE)
   const imperativeCues = countMatches(text, IMPERATIVE_RE)
+  const mcqOptionMarkers = countMatches(text, MCQ_OPTION_MARKER_RE)
 
-  // Hard markers of a real question paper.
+  // Hard markers of a real question paper. `mcqOptionMarkers >= 8` (≈ two full
+  // A–D questions) catches MCQ papers even when the extracted text collapses each
+  // question's options onto one line (e.g. SAT), which zeroes `mcqOptionLines`.
   const strong =
     markAllocations >= 2 ||
     mcqOptionLines >= 4 ||
+    mcqOptionMarkers >= 8 ||
     answerBlanks >= 2 ||
     (questionLines >= 4 && imperativeCues >= 2)
 
   // Essentially nothing that says "answer these questions".
   const none =
-    markAllocations === 0 && answerBlanks === 0 && mcqOptionLines < 2 && questionLines < 2
+    markAllocations === 0 &&
+    answerBlanks === 0 &&
+    mcqOptionLines < 2 &&
+    mcqOptionMarkers < 4 &&
+    questionLines < 2
 
   const paperSignal: DocumentSignals['paperSignal'] = strong ? 'strong' : none ? 'none' : 'weak'
 
@@ -109,6 +154,7 @@ export function analyzeDocumentSignals(content: string): DocumentSignals {
     markAllocations,
     questionLines,
     mcqOptionLines,
+    mcqOptionMarkers,
     answerBlanks,
     imperativeCues,
     proseChars,


### PR DESCRIPTION
## The actual SAT diagnosis
I analyzed the SAT PDF you dropped in the root. It **does** extract to text (91k chars → text path, not vision). But pdfjs **collapses each question's options onto one line**:

> `1 …long reading passage… Which choice…? A) alpha B) beta C) gamma D) delta 2 …`

My paper-detection regexes were anchored to **line starts** (`^[A-E][.)]`), so on the real SAT: `mcqOptionLines = 0`, `questionLines = 0`, `markAllocations = 0`. The **only** thing that pushed it to `strong` was **54 fill-in `___` blanks** in the Reading & Writing module — pure luck. An SAT **Math** section (MCQ, no blanks, no marks) would have scored **nothing** → fallen back to the model → "study material" (it sees 90k chars of passages). That's why yours was authored instead of extracted (that, and it likely predated #822 anyway).

## Fix
New **`mcqOptionMarkers`** signal counts uppercase `A)/B)/C)/D)` option markers **inline**, not just at line starts. **`>= 8`** (≈ two full A–D questions) marks the document a **strong** paper regardless of extraction layout.

**Verified on your actual file: 432 inline option markers → `strong` → `question_paper`.**

Also folds in the **#823** refactor (which — heads up — never actually merged; a GitHub API hiccup masked a failed merge, and the deploy I'd confirmed was a teammate's): `resolveDocumentKind` extracted to a pure, tested helper and wired into `generate-dmi`. #823 is closed as superseded by this PR.

## Tests (7 new; 18 total in the file)
inline MCQ → strong; a couple of stray inline letters is **not** strong; `resolveDocumentKind` priority / override-wins / defer-to-model; and a collapsed SAT-style paper resolving to `question_paper`.

## Verification
`npm run typecheck`, `npx eslint`, `npm run build`, and the document-signals tests all green; the fix confirmed against the real SAT practice test PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)