### PR TITLE
feat(landing): add /pitch-deck page with centered PDF viewer

### DIFF
--- a/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
+++ b/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
@@ -1,0 +1,31 @@
+import { Download } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export default function PitchDeckPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-gradient-to-b from-slate-50 to-slate-100 py-8">
+      <div className="w-full max-w-5xl px-4">
+        <h1 className="mb-6 text-center text-2xl font-bold text-slate-800">Solocorn Pitch Deck</h1>
+
+        <div className="relative mx-auto max-w-4xl">
+          <div className="scrollbar-hide h-[85vh] overflow-y-auto rounded-xl border-2 border-slate-300 shadow-2xl">
+            <iframe
+              src="/documents/solocorn-pitch-deck.pdf"
+              className="h-[3000px] w-full"
+              title="Solocorn Pitch Deck"
+            />
+          </div>
+        </div>
+
+        <div className="mt-8 flex justify-center">
+          <a href="/documents/solocorn-pitch-deck.pdf" download="solocorn-pitch-deck.pdf">
+            <Button variant="default" size="lg">
+              <Download className="mr-2 h-5 w-5" />
+              Download Pitch Deck
+            </Button>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a dedicated /pitch-deck page for viewing the Solocorn Pitch Deck PDF in a centered, styled viewer.

**Features:**
- PDF centered in a bordered, rounded container with shadow
- Scrollable container with hidden scrollbar (uses existing .scrollbar-hide utility)
- Tall iframe (3000px) ensures all PDF pages render for smooth scrolling
- Download button below the viewer
- Landing page How It Works dialog card unchanged — still downloads PDF directly

**Page URL:** /pitch-deck (or /{locale}/pitch-deck)