### PR TITLE
fix(ui): improve BackButton hover to match student classroom style

### DIFF
--- a/tutorme-app/src/components/navigation/BackButton.tsx
+++ b/tutorme-app/src/components/navigation/BackButton.tsx
@@ -44,7 +44,7 @@ export function BackButton({
       variant={variant}
       size={size}
       onClick={!href ? handleClick : undefined}
-      className={cn('h-9 w-9 rounded-full p-0 transition-colors hover:bg-gray-100', className)}
+      className={cn('h-9 w-9 rounded-lg p-0 transition-colors hover:bg-slate-200', className)}
       aria-label="Go back"
     >
       <Icon className="h-5 w-5" />
@@ -57,7 +57,7 @@ export function BackButton({
         variant={variant}
         size={size}
         asChild
-        className={cn('h-9 w-9 rounded-full p-0 transition-colors hover:bg-gray-100', className)}
+        className={cn('h-9 w-9 rounded-lg p-0 transition-colors hover:bg-slate-200', className)}
         aria-label="Go back"
       >
         <Link href={href} className="inline-flex">


### PR DESCRIPTION
Updates the BackButton component hover effect to match the student classroom hero panel style.

**Before:**
- Circular button (rounded-full)
- Very subtle hover: hover:bg-gray-100 (barely visible)

**After:**
- Rounded square button (rounded-lg) — matches the student classroom back button shape
- More visible hover: hover:bg-slate-200 — clearly visible gray background on hover

This affects all BackButton instances throughout the app (tutor course builder, quizzes, my-page, registration pages, etc.).