### PR TITLE
fix(builder): stop large PDFs from blocking assessment upload/display

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5159,6 +5159,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
               fileMimeType = uploadData.isPdf
                 ? 'application/pdf'
                 : uploadData.type || 'application/pdf'
+            } else {
+              // Surface the server's reason (e.g. "File too large (max 20MB)")
+              // instead of a generic failure, so load problems are diagnosable.
+              const reason = await uploadRes
+                .json()
+                .then(d => d?.error)
+                .catch(() => null)
+              toast.error(
+                reason ? `Upload failed: ${reason}` : `Upload failed (${uploadRes.status})`
+              )
+              return
             }
           } catch {
             toast.error('Failed to upload document')

--- a/tutorme-app/src/lib/extract-file-text.ts
+++ b/tutorme-app/src/lib/extract-file-text.ts
@@ -105,27 +105,48 @@ function readAsArrayBuffer(file: File): Promise<ArrayBuffer> {
   })
 }
 
+// Client-side PDF text extraction is best-effort: its output is only a preview /
+// fallback (the server re-extracts for DMI generation). It runs *before* the
+// upload in the builder, so it must never hang or block the upload on a big,
+// many-page document (e.g. a 56-page SAT paper). We therefore cap the pages we
+// read and race the whole thing against a hard timeout, returning whatever text
+// we've gathered so far rather than stalling.
+const PDF_MAX_PAGES = 40
+const PDF_EXTRACT_TIMEOUT_MS = 15_000
+
 async function extractPdfText(file: File): Promise<string> {
-  const pdfjs = await import('pdfjs-dist')
-  if (typeof window !== 'undefined') {
-    const opts = (pdfjs as { GlobalWorkerOptions?: { workerSrc?: string } }).GlobalWorkerOptions
-    if (opts && !opts.workerSrc) {
-      opts.workerSrc = '/pdf.worker.min.mjs'
-    }
-  }
-  const data = await file.arrayBuffer()
-  const doc = await pdfjs.getDocument({ data }).promise
-  const numPages = doc.numPages
   const parts: string[] = []
-  for (let i = 1; i <= numPages; i++) {
-    const page = await doc.getPage(i)
-    const content = await page.getTextContent()
-    const pageText = content.items
-      .map((item: { str?: string }) => (item as { str?: string }).str ?? '')
-      .join(' ')
-    parts.push(pageText)
-  }
-  return parts.join('\n\n').trim() || ''
+
+  const run = (async () => {
+    const pdfjs = await import('pdfjs-dist')
+    if (typeof window !== 'undefined') {
+      const opts = (pdfjs as { GlobalWorkerOptions?: { workerSrc?: string } }).GlobalWorkerOptions
+      if (opts && !opts.workerSrc) {
+        opts.workerSrc = '/pdf.worker.min.mjs'
+      }
+    }
+    const data = await file.arrayBuffer()
+    const doc = await pdfjs.getDocument({ data }).promise
+    const numPages = Math.min(doc.numPages, PDF_MAX_PAGES)
+    for (let i = 1; i <= numPages; i++) {
+      const page = await doc.getPage(i)
+      const content = await page.getTextContent()
+      const pageText = content.items
+        .map((item: { str?: string }) => (item as { str?: string }).str ?? '')
+        .join(' ')
+      parts.push(pageText)
+    }
+    return parts.join('\n\n').trim()
+  })()
+
+  // If parsing stalls (huge PDF, worker failing to load and falling back to the
+  // main thread, etc.), give up after the budget and hand back partial text so
+  // the caller can proceed with the upload instead of appearing to freeze.
+  const timeout = new Promise<string>(resolve =>
+    setTimeout(() => resolve(parts.join('\n\n').trim()), PDF_EXTRACT_TIMEOUT_MS)
+  )
+
+  return (await Promise.race([run, timeout])) || ''
 }
 
 async function extractDocxText(file: File): Promise<string> {


### PR DESCRIPTION
## Problem
Loading a large SAT paper (56 pages / ~10.5 MB) as an assessment showed **"No document selected"** and never displayed, while smaller papers loaded fine.

## Root cause
In the course builder, `extractTextFromFile(f)` runs **before** the upload and read *every* page of the PDF with **no page cap and no timeout**. On a big, many-page PDF the pdf.js pass could stall (main-thread parsing / worker fallback), so the upload never fired → the assessment document (`currentAssessmentDocument.fileUrl`) never got set → the panel rendered the empty state. Smaller papers extract in a few ms, so they were unaffected.

## Fix
- **Bound the extraction** (`src/lib/extract-file-text.ts`): cap at 40 pages and race the whole PDF pass against a 15s hard timeout, returning whatever text was gathered so far. Extraction is best-effort here — the server re-extracts for DMI generation — so it must never block the upload. Centralized, so every builder call site benefits.
- **Surface the real upload error** (`CourseBuilder.tsx`): on a non-OK assessment upload, show the server's reason (e.g. `File too large (max 20MB)`) instead of a generic toast, so any remaining load failure is diagnosable.

## Verification
- `tsc --noEmit`: clean (no new errors)
- `eslint` on changed files: 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)