### PR TITLE
feat(classroom): collapse the task PDF into the chat after the first message

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
@@ -9,9 +9,18 @@
  * server-side (see /api/student/assignments/[taskId]/task-chat).
  */
 
-import { useEffect, useRef, useState } from 'react'
-import { Send, Loader2, CheckCircle2, Sparkles } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Send,
+  Loader2,
+  CheckCircle2,
+  Sparkles,
+  FileText,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { toast } from 'sonner'
 
 interface ChatMsg {
@@ -21,13 +30,24 @@ interface ChatMsg {
   re?: string
 }
 
+interface TaskSourceDocument {
+  fileName?: string | null
+  fileUrl?: string | null
+  fileKey?: string | null
+  mimeType?: string | null
+}
+
 export function TaskChatPanel({
   taskId,
   taskTitle,
+  sourceDocument,
   onCompleted,
 }: {
   taskId: string
   taskTitle?: string
+  /** The task's document (PDF/image). Shown full until the first message, then
+   *  collapsed into a pinned, re-expandable "document" card in the chat. */
+  sourceDocument?: TaskSourceDocument | null
   /** Fired after the task is completed, with the student's answers — the page
    *  uses it to broadcast the live "completed" tick to the tutor. */
   onCompleted?: (answers: string[]) => void
@@ -43,6 +63,35 @@ export function TaskChatPanel({
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [messages, busy])
+
+  // The task document shows full at the top until the student sends their first
+  // message, then it collapses into a pinned card so the whole panel reads as one
+  // chat. The student can re-expand it inline at any time.
+  const hasSentMessage = messages.some(m => m.role === 'student')
+  const [pdfOpen, setPdfOpen] = useState(true)
+  const didAutoCollapse = useRef(false)
+  useEffect(() => {
+    if (hasSentMessage && !didAutoCollapse.current) {
+      didAutoCollapse.current = true
+      setPdfOpen(false)
+    }
+  }, [hasSentMessage])
+
+  const doc = useMemo(() => {
+    if (!sourceDocument) return null
+    const rawUrl = sourceDocument.fileUrl || ''
+    const url = sourceDocument.fileKey
+      ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
+      : rawUrl
+    const loadable = !!sourceDocument.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
+    if (!loadable) return null
+    const name = sourceDocument.fileName || 'Task document'
+    const isPdf =
+      sourceDocument.mimeType === 'application/pdf' ||
+      (!sourceDocument.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument.fileName || rawUrl))
+    const isImage = !!sourceDocument.mimeType?.startsWith('image/')
+    return { url, name, isPdf, isImage }
+  }, [sourceDocument])
 
   // Restore a prior chat: if the student already completed this task, rebuild the
   // transcript (their answers, each AI response, and any follow-ups) and drop
@@ -177,6 +226,57 @@ export function TaskChatPanel({
           </span>
         )}
       </div>
+
+      {/* Task document, pinned at the top of the chat. Full until the student's
+          first message, then a collapsed "document" card they can re-expand. */}
+      {doc && (
+        <div className="shrink-0 border-b border-orange-100 bg-white">
+          <button
+            type="button"
+            onClick={() => setPdfOpen(o => !o)}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-orange-50/50"
+          >
+            <FileText className="h-4 w-4 shrink-0 text-[#F17623]" />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">
+              {doc.name}
+            </span>
+            <span className="text-xs text-gray-500">{pdfOpen ? 'Hide' : 'Click to view'}</span>
+            {pdfOpen ? (
+              <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+            ) : (
+              <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" />
+            )}
+          </button>
+          {pdfOpen && (
+            <div className="h-[46vh] w-full border-t border-orange-100">
+              {doc.isPdf ? (
+                <PDFViewer fileUrl={doc.url} className="h-full w-full" />
+              ) : doc.isImage ? (
+                <div className="flex h-full items-center justify-center bg-slate-50 p-2">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={doc.url}
+                    alt={doc.name}
+                    className="max-h-full max-w-full object-contain"
+                  />
+                </div>
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-2">
+                  <FileText className="h-8 w-8 text-blue-600" />
+                  <a
+                    href={doc.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-sm text-blue-600 underline"
+                  >
+                    Open document
+                  </a>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
         {!loaded && (

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -1995,7 +1995,11 @@ function StudentFeedbackContent() {
                           </div>
                         )}
 
-                        {activeTask.sourceDocument &&
+                        {/* For a chat task the document lives inside the chat panel
+                            (it collapses into a pinned card after the first message),
+                            so only render the standalone viewer for non-chat tasks. */}
+                        {!isChatTask &&
+                          activeTask.sourceDocument &&
                           (() => {
                             const doc = activeTask.sourceDocument
                             const rawUrl = doc.fileUrl || ''
@@ -2079,10 +2083,11 @@ function StudentFeedbackContent() {
                             "Task complete" → the AI responds to each answer per the
                             PCI, then they can ask about what they got wrong. */}
                         {isChatTask && activeTaskId && (
-                          <div className="mt-2 h-[60vh] min-h-[360px]">
+                          <div className="mt-2 h-[78vh] min-h-[520px]">
                             <TaskChatPanel
                               taskId={activeTaskId}
                               taskTitle={activeTask.title}
+                              sourceDocument={activeTask.sourceDocument}
                               onCompleted={answers => {
                                 // Broadcast the live "completed" tick to the tutor.
                                 // aiHandled=true → the server only marks completion


### PR DESCRIPTION
## Summary
When a tutor deploys a **chat-based task**, the student's Classroom view showed the task **PDF as a full display** above the chat. This makes the whole view read as **one chat interface**:

- The task document is now rendered **inside `TaskChatPanel`, pinned at the top**.
- It shows **full until the student sends their first message**, then **auto-collapses once** into a "document" card (📄 filename · "Click to view").
- **Clicking the card expands the PDF/image inline** (accordion) and collapses it again — the student can view the document any time without leaving the chat.

## Decisions (confirmed with the maintainer)
- **Chat-based tasks only** — the standalone PDF viewer still renders for non-chat tasks (the "first message" trigger only exists in the chat).
- **Inline expand** on click (not a modal).
- **Pinned at the top** of the chat.

## Notes
- Returning students who already completed the task have their transcript restored, so the document starts collapsed for them (there are already messages).
- The chat container was enlarged (`h-[78vh]`) so the full document + chat fit; the inline viewer uses `h-[46vh]` when open.
- Handles PDF, image, and non-previewable docs (open-in-new-tab fallback), mirroring the previous viewer.

## Testing
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- **Not exercised in a running classroom** here — worth a quick manual pass: deploy a chat task with a PDF → as the student, confirm the PDF shows full, collapses on the first message into a card, and re-expands inline on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)