### PR TITLE
fix(builder): SAT assessment PDF won't display ("No document selected")

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1087,6 +1087,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [assessmentSourceDocument, setAssessmentSourceDocument] = useState<
       ImportedLearningResource | undefined
     >(undefined)
+    // When a DMI is generated from *study material* the tutor's upload stays
+    // visible in the builder, but must NOT be deployed to students (they get the
+    // generated questions as Classroom content instead). This flag records that
+    // "reference-only" state without wiping the document — wiping it previously
+    // produced a "No document selected" preview for study material, and for any
+    // question paper misclassified as study material (e.g. a large SAT paper
+    // whose server-side text extraction fell back to images).
+    const [assessmentSourceReferenceOnly, setAssessmentSourceReferenceOnly] = useState(false)
 
     // Test PCI state
     const [testPciInputs, setTestPciInputs] = useState<Record<string, string>>({
@@ -1336,6 +1344,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setSelectedItem(null)
       setTaskSourceDocument(undefined)
       setAssessmentSourceDocument(undefined)
+      setAssessmentSourceReferenceOnly(false)
       setTaskDmiItems([])
       setAssessmentDmiItems([])
       setTaskDmiVersions([])
@@ -1909,6 +1918,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           : []
       )
       setAssessmentSourceDocument(assessment.sourceDocument)
+      setAssessmentSourceReferenceOnly(false)
       setAssessmentBuilderActiveTab('content')
     }, [])
 
@@ -3162,8 +3172,16 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           // budget is spent on the actual questions. Fall back to page images
           // for scanned PDFs.
           const extracted = await extractPdfText(sourceDoc.fileUrl, 60, sourceDoc.fileKey)
+          const priorText = (sourceDoc.extractedText || '').trim()
           if (extracted.trim().length > 200) {
             pdfText = focusOnQuestions(extracted).slice(0, 70000)
+          } else if (priorText.length > 200) {
+            // Server-side re-extraction came back thin (large/complex PDF, slow
+            // proxy), but we already captured solid text at upload time. Prefer
+            // that over a handful of page images — real text carries the
+            // question/MCQ markers the classifier needs, so a genuine question
+            // paper (e.g. a large SAT) isn't misread as study material.
+            pdfText = focusOnQuestions(priorText).slice(0, 70000)
           } else {
             try {
               pdfPages = await renderPdfToImages(sourceDoc.fileUrl, 8, sourceDoc.fileKey)
@@ -3313,16 +3331,21 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             }))
             setTaskSourceDocument(undefined)
           } else {
+            // Keep the uploaded document visible in the builder; mark it
+            // reference-only so it isn't deployed to students.
             setAssessmentBuilder(prev => ({
               ...prev,
               taskContent: generatedClassroomContent,
-              sourceDocument: undefined,
             }))
-            setAssessmentSourceDocument(undefined)
+            setAssessmentSourceReferenceOnly(true)
           }
           toast.info(
             'Generated questions set as the Classroom content; the original material will not be deployed.'
           )
+        } else if (!isTask) {
+          // Question paper (or a re-run that reclassified): the document IS the
+          // deliverable, so clear any stale reference-only marker.
+          setAssessmentSourceReferenceOnly(false)
         }
 
         const existingVersions = isTask ? taskDmiVersions : assessmentDmiVersions
@@ -3492,21 +3515,32 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           deployedAt: Date.now(),
           polls: [],
           questions: [],
-          sourceDocument: currentAssessmentDocument
-            ? {
-                fileName: currentAssessmentDocument.fileName,
-                fileUrl: currentAssessmentDocument.fileUrl,
-                fileKey: currentAssessmentDocument.fileKey,
-                mimeType: currentAssessmentDocument.mimeType,
-              }
-            : undefined,
+          // Reference-only (study-material-derived) documents stay in the
+          // builder for the tutor but are NOT sent to students — they receive
+          // the generated questions as Classroom content instead.
+          sourceDocument:
+            currentAssessmentDocument && !assessmentSourceReferenceOnly
+              ? {
+                  fileName: currentAssessmentDocument.fileName,
+                  fileUrl: currentAssessmentDocument.fileUrl,
+                  fileKey: currentAssessmentDocument.fileKey,
+                  mimeType: currentAssessmentDocument.mimeType,
+                }
+              : undefined,
         }
 
         // Success is confirmed by the server's task:deployed broadcast (handled in
         // insights/page.tsx), not optimistically here.
         insightsProps.onDeployTask?.(task)
       },
-      [assessmentBuilder, assessmentDmiItems, insightsProps, loadedAssessmentId, deployAnswerReveal]
+      [
+        assessmentBuilder,
+        assessmentDmiItems,
+        assessmentSourceReferenceOnly,
+        insightsProps,
+        loadedAssessmentId,
+        deployAnswerReveal,
+      ]
     )
 
     useEffect(() => {
@@ -5213,6 +5247,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           }
 
           setAssessmentSourceDocument(newDoc)
+          setAssessmentSourceReferenceOnly(false)
           setAssessmentUploadedFiles([{ id: 'source', name: newAsset.name }])
           setAssessmentBuilder(prev => ({
             ...prev,

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6241,15 +6241,25 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
                       const extractedText = assetToLoad.content || `[Asset: ${assetToLoad.name}]`
                       targetAssess.description = extractedText
-                      if (assetToLoad.url) {
+                      // A durable fileKey is enough to display/deploy the doc (the
+                      // viewer streams it via the by-key proxy), so don't require a
+                      // signed url — it can come back empty when the assets API
+                      // fails to refresh an expired presigned URL, which silently
+                      // left the assessment with no source document ("No document
+                      // selected", no error).
+                      if (assetToLoad.url || assetToLoad.fileKey) {
                         targetAssess.sourceDocument = {
                           fileName: assetToLoad.name,
-                          fileUrl: assetToLoad.url,
+                          fileUrl: assetToLoad.url || '',
                           fileKey: assetToLoad.fileKey,
                           mimeType: assetToLoad.mimeType || 'application/pdf',
                           uploadedAt: new Date().toISOString(),
                           extractedText,
                         }
+                      } else {
+                        toast.error(
+                          'This document has no stored file — please re-upload it before loading.'
+                        )
                       }
 
                       const newCourseBuilderNodes = [...nodes]

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -91,9 +91,12 @@ export function PDFViewer({
     }
   }, [fitToWidth, fitScale])
 
-  // Fetch PDF through proxy so expired GCS URLs get refreshed server-side
+  // Fetch PDF through proxy so expired GCS URLs get refreshed server-side.
+  // A durable fileKey is enough on its own — the by-key proxy streams the
+  // object directly — so don't require a (possibly empty/expired) fileUrl.
+  const hasKey = typeof fileKey === 'string' && /^(documents|assets|resources)\//.test(fileKey)
   useEffect(() => {
-    if (!fileUrl || isBlobUrl) return
+    if ((!fileUrl && !hasKey) || isBlobUrl) return
 
     let cancelled = false
     setLoading(true)
@@ -139,7 +142,7 @@ export function PDFViewer({
     return () => {
       cancelled = true
     }
-  }, [fileUrl, fileKey, isBlobUrl])
+  }, [fileUrl, fileKey, hasKey, isBlobUrl])
 
   // Always render every page in a continuous scroll view, regardless of length.
   const isScrollMode = numPages > 0


### PR DESCRIPTION
## Problem
Loading the SAT paper as an **assessment** shows **"No document selected"** and never displays. Confirmed with the tutor: the preview **never appears** (not a flash-then-vanish) and there is **no error toast**. All other papers work.

## Root cause (the real one)
"Never set + no error" means the assessment's source document is silently never assigned. Two gaps, both around the durable GCS **`fileKey`**:

1. **`PDFViewer` bailed on empty `fileUrl`** (`if (!fileUrl || isBlobUrl) return`) — it never tried `fileKey`, even though `getProxiedPdfUrl` *prefers* the by-key proxy (`/api/proxy-file?key=`).
2. **"Load as Assessment" only set `sourceDocument` when `assetToLoad.url` was truthy** (no else, no error). The tutor-assets API refreshes presigned URLs on load and can **fail that refresh silently** (empty url) — leaving the assessment with no document.

Large files like the 56-page / 10.5 MB SAT are the most likely to come back with a failed/empty URL refresh, which is why smaller papers were unaffected.

## Fixes
- **`PDFViewer`**: load when a valid `fileKey` exists, regardless of `fileUrl` (the by-key proxy streams the object with the service account's read access).
- **"Load as Assessment"**: set the document whenever a `url` **or** `fileKey` is present; if neither exists, show an explicit error instead of failing silently.

## Also included (defensive hardening from earlier commits)
- Don't wipe the assessment source document when a DMI is generated from *study material* — keep it visible via a `sourceReferenceOnly` flag; deploy still omits raw study material from students.
- In DMI generation, prefer already-extracted text over page-images when server-side re-extraction is thin, so a genuine question paper isn't misclassified.

## Verification
- `tsc --noEmit` clean · `prettier --check` clean · `eslint` 0 new errors · `document-signals` tests 18/18.
- Root cause corroborated by the tutor's observation (never-appears + no-error) mapping to the exact silent `url`-only guard, plus PDFViewer's early-return on empty `fileUrl`.

⚠️ Not yet verified by driving the live builder with the SAT (no local env: DB/auth/storage/AI absent). This is the highest-confidence fix so far because it's derived from observed runtime behavior, not inferred classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)