### PR TITLE
feat(classroom): Test-tab consistency + doc-in-chat polish

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
@@ -9,18 +9,10 @@
  * server-side (see /api/student/assignments/[taskId]/task-chat).
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import {
-  Send,
-  Loader2,
-  CheckCircle2,
-  Sparkles,
-  FileText,
-  ChevronDown,
-  ChevronRight,
-} from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Send, Loader2, CheckCircle2, Sparkles } from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
-import { PDFViewer } from '@/components/pdf/PDFViewer'
+import { TaskDocumentCard, type TaskDocumentSource } from '@/components/task/TaskDocumentCard'
 import { toast } from 'sonner'
 
 interface ChatMsg {
@@ -28,13 +20,6 @@ interface ChatMsg {
   content: string
   /** For an AI response: the student answer it addresses. */
   re?: string
-}
-
-interface TaskSourceDocument {
-  fileName?: string | null
-  fileUrl?: string | null
-  fileKey?: string | null
-  mimeType?: string | null
 }
 
 export function TaskChatPanel({
@@ -47,7 +32,7 @@ export function TaskChatPanel({
   taskTitle?: string
   /** The task's document (PDF/image). Shown full until the first message, then
    *  collapsed into a pinned, re-expandable "document" card in the chat. */
-  sourceDocument?: TaskSourceDocument | null
+  sourceDocument?: TaskDocumentSource | null
   /** Fired after the task is completed, with the student's answers — the page
    *  uses it to broadcast the live "completed" tick to the tutor. */
   onCompleted?: (answers: string[]) => void
@@ -64,34 +49,11 @@ export function TaskChatPanel({
     if (el) el.scrollTop = el.scrollHeight
   }, [messages, busy])
 
-  // The task document shows full at the top until the student sends their first
-  // message, then it collapses into a pinned card so the whole panel reads as one
-  // chat. The student can re-expand it inline at any time.
+  // The task document shows full until the student sends their first message,
+  // then auto-collapses into a pinned card (see TaskDocumentCard). Keep it
+  // collapsed until the prior-chat check resolves so a returning (already
+  // completed) student doesn't see it flash open then slam shut.
   const hasSentMessage = messages.some(m => m.role === 'student')
-  const [pdfOpen, setPdfOpen] = useState(true)
-  const didAutoCollapse = useRef(false)
-  useEffect(() => {
-    if (hasSentMessage && !didAutoCollapse.current) {
-      didAutoCollapse.current = true
-      setPdfOpen(false)
-    }
-  }, [hasSentMessage])
-
-  const doc = useMemo(() => {
-    if (!sourceDocument) return null
-    const rawUrl = sourceDocument.fileUrl || ''
-    const url = sourceDocument.fileKey
-      ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
-      : rawUrl
-    const loadable = !!sourceDocument.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
-    if (!loadable) return null
-    const name = sourceDocument.fileName || 'Task document'
-    const isPdf =
-      sourceDocument.mimeType === 'application/pdf' ||
-      (!sourceDocument.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument.fileName || rawUrl))
-    const isImage = !!sourceDocument.mimeType?.startsWith('image/')
-    return { url, name, isPdf, isImage }
-  }, [sourceDocument])
 
   // Restore a prior chat: if the student already completed this task, rebuild the
   // transcript (their answers, each AI response, and any follow-ups) and drop
@@ -227,56 +189,10 @@ export function TaskChatPanel({
         )}
       </div>
 
-      {/* Task document, pinned at the top of the chat. Full until the student's
-          first message, then a collapsed "document" card they can re-expand. */}
-      {doc && (
-        <div className="shrink-0 border-b border-orange-100 bg-white">
-          <button
-            type="button"
-            onClick={() => setPdfOpen(o => !o)}
-            className="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-orange-50/50"
-          >
-            <FileText className="h-4 w-4 shrink-0 text-[#F17623]" />
-            <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">
-              {doc.name}
-            </span>
-            <span className="text-xs text-gray-500">{pdfOpen ? 'Hide' : 'Click to view'}</span>
-            {pdfOpen ? (
-              <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
-            ) : (
-              <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" />
-            )}
-          </button>
-          {pdfOpen && (
-            <div className="h-[46vh] w-full border-t border-orange-100">
-              {doc.isPdf ? (
-                <PDFViewer fileUrl={doc.url} className="h-full w-full" />
-              ) : doc.isImage ? (
-                <div className="flex h-full items-center justify-center bg-slate-50 p-2">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={doc.url}
-                    alt={doc.name}
-                    className="max-h-full max-w-full object-contain"
-                  />
-                </div>
-              ) : (
-                <div className="flex h-full flex-col items-center justify-center gap-2">
-                  <FileText className="h-8 w-8 text-blue-600" />
-                  <a
-                    href={doc.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-sm text-blue-600 underline"
-                  >
-                    Open document
-                  </a>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      {/* Task document — full until the student's first message, then a pinned,
+          re-expandable "document" card (kept collapsed until the prior-chat
+          check resolves so a returning student doesn't see it flash). */}
+      <TaskDocumentCard sourceDocument={sourceDocument} autoOpen={loaded && !hasSentMessage} />
 
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
         {!loaded && (

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -2083,7 +2083,7 @@ function StudentFeedbackContent() {
                             "Task complete" → the AI responds to each answer per the
                             PCI, then they can ask about what they got wrong. */}
                         {isChatTask && activeTaskId && (
-                          <div className="mt-2 h-[78vh] min-h-[520px]">
+                          <div className="mt-2 h-[78vh] max-h-[calc(100vh-160px)] min-h-[420px]">
                             <TaskChatPanel
                               taskId={activeTaskId}
                               taskTitle={activeTask.title}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9702,6 +9702,45 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             )
                                           }
 
+                                          // Test-tab task preview: render the exact student chat flow
+                                          // (the document collapses into the chat on the first sample
+                                          // answer) filling this panel — instead of a separate PDF +
+                                          // chat, so the tutor previews what students actually see.
+                                          if (mainTab === 'test-pci' && testPciSource === 'task') {
+                                            const previewExt = taskBuilder.activeExtensionId
+                                              ? taskBuilder.extensions.find(
+                                                  e => e.id === taskBuilder.activeExtensionId
+                                                )
+                                              : null
+                                            const previewKey = `${previewExt ? previewExt.id : 'base'}:${tab.id}`
+                                            return (
+                                              <div className="h-full min-h-0 w-full">
+                                                <TestTaskChat
+                                                  pci={
+                                                    (previewExt
+                                                      ? previewExt.pci
+                                                      : taskBuilder.taskPci) || ''
+                                                  }
+                                                  pciSpec={
+                                                    previewExt ? undefined : taskBuilder.pciSpec
+                                                  }
+                                                  questionText={`${taskBuilder.title}\n\n${previewExt ? previewExt.content : taskBuilder.taskContent}`}
+                                                  sourceDocument={
+                                                    previewExt
+                                                      ? previewExt.sourceDocument
+                                                      : currentTaskDocument
+                                                  }
+                                                  initialState={
+                                                    testTaskChatStore.current[previewKey]
+                                                  }
+                                                  onPersist={s => {
+                                                    testTaskChatStore.current[previewKey] = s
+                                                  }}
+                                                />
+                                              </div>
+                                            )
+                                          }
+
                                           // Document-only: render directly without ResizablePanelGroup
                                           // so the PDF fills the entire tab area.
                                           if (hasDoc && !hasDmi) {
@@ -10004,29 +10043,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                               // flow students get (chat → Task complete → per-answer
                               // responses → follow-up); assessments keep the composer.
                               (mainTab === 'test-pci' && testPciSource === 'task' ? (
-                                (() => {
-                                  const ext = taskBuilder.activeExtensionId
-                                    ? taskBuilder.extensions.find(
-                                        e => e.id === taskBuilder.activeExtensionId
-                                      )
-                                    : null
-                                  // Persist per task/extension AND per student tab, so each
-                                  // preview keeps its own conversation across remounts.
-                                  const persistKey = `${ext ? ext.id : 'base'}:${testPciActiveTab}`
-                                  return (
-                                    <div key={persistKey} className="mt-1 h-[55vh] min-h-[340px]">
-                                      <TestTaskChat
-                                        pci={(ext ? ext.pci : taskBuilder.taskPci) || ''}
-                                        pciSpec={ext ? undefined : taskBuilder.pciSpec}
-                                        questionText={`${taskBuilder.title}\n\n${ext ? ext.content : taskBuilder.taskContent}`}
-                                        initialState={testTaskChatStore.current[persistKey]}
-                                        onPersist={s => {
-                                          testTaskChatStore.current[persistKey] = s
-                                        }}
-                                      />
-                                    </div>
-                                  )
-                                })()
+                                // A task is previewed via the chat flow rendered in the panel
+                                // above (the document collapses into the chat), so nothing
+                                // extra is needed here.
+                                <></>
                               ) : mainTab === 'test-pci' && testPciSource === 'assessment' ? (
                                 // Assessments are answered in the DMI: test-grade per question
                                 // above (type an answer under a question and click Grade) rather

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Send, Loader2, CheckCircle2, Sparkles } from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { TaskDocumentCard, type TaskDocumentSource } from '@/components/task/TaskDocumentCard'
 import { toast } from 'sonner'
 
 export interface TestTaskChatMsg {
@@ -34,12 +35,16 @@ export function TestTaskChat({
   pci,
   pciSpec,
   questionText,
+  sourceDocument,
   initialState,
   onPersist,
 }: {
   pci?: string
   pciSpec?: unknown
   questionText?: string
+  /** The task's document — previewed inline exactly as students see it (full
+   *  until the first sample answer, then a collapsed, re-expandable card). */
+  sourceDocument?: TaskDocumentSource | null
   initialState?: TestTaskChatState
   onPersist?: (state: TestTaskChatState) => void
 }) {
@@ -164,6 +169,14 @@ export function TestTaskChat({
           )}
         </span>
       </div>
+
+      {/* Document preview — mirrors the student flow: full until the first sample
+          answer, then a pinned, re-expandable card. */}
+      <TaskDocumentCard
+        sourceDocument={sourceDocument}
+        autoOpen={!studentAnswers.length}
+        accent="violet"
+      />
 
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
         {messages.length === 0 && (

--- a/tutorme-app/src/components/task/TaskDocumentCard.tsx
+++ b/tutorme-app/src/components/task/TaskDocumentCard.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+/**
+ * TaskDocumentCard — the task document (PDF/image) shown inside the chat-based
+ * task flow. It renders full while the chat is empty, then collapses into a
+ * pinned, re-expandable "document" card once the student has started chatting,
+ * so the whole panel reads as one conversation.
+ *
+ * Shared by the student Classroom (TaskChatPanel) and the tutor Test-tab
+ * preview (TestTaskChat) so the tutor previews exactly what students see.
+ */
+
+import { useState } from 'react'
+import { FileText, ChevronDown, ChevronRight } from 'lucide-react'
+import { PDFViewer } from '@/components/pdf/PDFViewer'
+import { cn } from '@/lib/utils'
+
+export interface TaskDocumentSource {
+  fileName?: string | null
+  fileUrl?: string | null
+  fileKey?: string | null
+  mimeType?: string | null
+}
+
+const ACCENTS = {
+  orange: { border: 'border-orange-100', hover: 'hover:bg-orange-50/50', icon: 'text-[#F17623]' },
+  violet: { border: 'border-violet-100', hover: 'hover:bg-violet-50/50', icon: 'text-violet-600' },
+} as const
+
+export function TaskDocumentCard({
+  sourceDocument,
+  /** Default open state before the viewer is manually toggled (typically
+   *  `!hasSentMessage`): full while the chat is empty, collapsed after. */
+  autoOpen,
+  accent = 'orange',
+}: {
+  sourceDocument?: TaskDocumentSource | null
+  autoOpen: boolean
+  accent?: keyof typeof ACCENTS
+}) {
+  // Manual toggle overrides the auto (message-driven) state. Deriving the shown
+  // state instead of syncing it via an effect keeps it flicker-free.
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null)
+
+  const rawUrl = sourceDocument?.fileUrl || ''
+  const url = sourceDocument?.fileKey
+    ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
+    : rawUrl
+  const loadable = !!sourceDocument?.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
+  if (!sourceDocument || !loadable) return null
+
+  const name = sourceDocument.fileName || 'Task document'
+  const isPdf =
+    sourceDocument.mimeType === 'application/pdf' ||
+    (!sourceDocument.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument.fileName || rawUrl))
+  const isImage = !!sourceDocument.mimeType?.startsWith('image/')
+  const styles = ACCENTS[accent]
+  const open = manualOpen ?? autoOpen
+
+  return (
+    <div className={cn('shrink-0 border-b bg-white', styles.border)}>
+      <button
+        type="button"
+        onClick={() => setManualOpen(!open)}
+        aria-expanded={open}
+        className={cn(
+          'flex w-full items-center gap-2 px-4 py-2 text-left transition-colors',
+          styles.hover
+        )}
+      >
+        <FileText className={cn('h-4 w-4 shrink-0', styles.icon)} />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">{name}</span>
+        <span className="text-xs text-gray-500">{open ? 'Hide' : 'Click to view'}</span>
+        {open ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" />
+        )}
+      </button>
+      {open && (
+        <div className={cn('h-[42vh] max-h-[560px] min-h-[220px] w-full border-t', styles.border)}>
+          {isPdf ? (
+            <PDFViewer fileUrl={url} className="h-full w-full" />
+          ) : isImage ? (
+            <div className="flex h-full items-center justify-center bg-slate-50 p-2">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={url} alt={name} className="max-h-full max-w-full object-contain" />
+            </div>
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-2">
+              <FileText className="h-8 w-8 text-blue-600" />
+              <a
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-blue-600 underline"
+              >
+                Open document
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Follow-up to #841 — both items requested.

## 1. Tutor Test-tab consistency
The tutor's Test tab previewed a task as a **full PDF above a separate chat** — no longer matching the student (where the PDF collapses into the chat, #841). Now the Test tab renders the **same flow**: the document shows full, then collapses into a pinned card on the first sample answer.

- Extracted a shared **`TaskDocumentCard`** used by both the student `TaskChatPanel` and the tutor `TestTaskChat`, so the tutor previews exactly what students see.
- In `CourseBuilder`, the task preview now renders `TestTaskChat` (with the document) inside the existing preview panel; the redundant standalone chat block below was removed. (No layout gap — it fills the existing bounded panel rather than leaving an empty `flex-1` box.)

## 2. Minor polishes (baked into the shared card)
- **Flicker-free**: open state is now *derived* (`manualOpen ?? autoOpen`) instead of synced via an effect. The student panel keeps the doc collapsed until the prior-chat check resolves, so a **returning (completed) student never sees the PDF flash open then slam shut**.
- **Responsive heights**: the viewer is bounded (`42vh`, min `220` / max `560px`) and the chat containers cap at `calc(100vh-160px)` so they don't overflow short screens.
- **A11y**: the document toggle button exposes `aria-expanded`.

## Testing
- `npm run typecheck` clean (only pre-existing stale `.next` cache errors); prettier + eslint clean (0 errors).
- **Not exercised live** — `CourseBuilder.tsx` is complex and I can't run the Test tab here. Worth a manual pass: open a chat task in **Test** mode → confirm the document shows full, collapses into the chat on the first sample answer, and re-expands on click (matching the student view); and confirm assessments/DMI previews are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)