### PR TITLE
fix(pitch-deck): implement requested layout edits

### DIFF
--- a/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
+++ b/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -7,16 +9,18 @@ export default function PitchDeckPage() {
       <div className="w-full max-w-5xl px-4">
         <h1 className="mb-6 text-center text-2xl font-bold text-slate-800">Solocorn Pitch Deck</h1>
 
+        {/* PDF Viewer - centred with border, hidden scrollbar */}
         <div className="relative mx-auto max-w-4xl">
           <div className="scrollbar-hide h-[85vh] overflow-y-auto rounded-xl border-2 border-slate-300 shadow-2xl">
             <iframe
-              src="/documents/solocorn-pitch-deck.pdf"
-              className="h-[3000px] w-full"
+              src="/documents/solocorn-pitch-deck.pdf#toolbar=0&navpanes=0&scrollbar=0"
+              className="block h-full w-full border-0"
               title="Solocorn Pitch Deck"
             />
           </div>
         </div>
 
+        {/* Download button below PDF */}
         <div className="mt-8 flex justify-center">
           <a href="/documents/solocorn-pitch-deck.pdf" download="solocorn-pitch-deck.pdf">
             <Button variant="default" size="lg">


### PR DESCRIPTION
Implements the requested edits for the pitch-deck page:

- PDF centred on page with download button below
- Hidden scrollbar while still allowing scroll
- Each PDF page visible with border around the viewer
- Removed hardcoded iframe height, using container-based scrolling
- Added PDF viewer chrome suppression (toolbar, navpanes, scrollbar)