### PR TITLE
fix(builder): surface asset-upload failures (SAT 'no stored file')

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -5574,7 +5574,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                       typeof window !== 'undefined'
                         ? localStorage.getItem('tutor-parse-documents') === 'true'
                         : false
-                    const newAssets = await Promise.all(
+                    const results = await Promise.all(
                       files.map(async (f: File) => {
                         let textContent = ''
                         if (parsePref) {
@@ -5588,10 +5588,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                           textContent = `[Imported ${f.name}]`
                         }
 
-                        // Upload to server — any file gets converted to PDF
-                        let fileUrl = ''
-                        let fileKey = ''
-                        let fileMimeType = 'application/pdf'
+                        // Upload to server. A failed upload must NOT silently
+                        // create a file-less asset (that later fails to load with
+                        // "no stored file") — surface the real reason instead.
                         try {
                           const uploadForm = new FormData()
                           uploadForm.append('file', f)
@@ -5600,32 +5599,60 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                             method: 'POST',
                             body: uploadForm,
                           })
-                          if (uploadRes.ok) {
-                            const uploadData = await uploadRes.json()
-                            fileUrl = uploadData.url || ''
-                            fileKey = uploadData.key || ''
-                            fileMimeType = uploadData.isPdf
-                              ? 'application/pdf'
-                              : uploadData.type || 'application/pdf'
+                          if (!uploadRes.ok) {
+                            const reason = await uploadRes
+                              .json()
+                              .then(d => d?.error)
+                              .catch(() => null)
+                            return {
+                              ok: false as const,
+                              name: f.name,
+                              error: reason || `upload failed (${uploadRes.status})`,
+                            }
                           }
-                        } catch {
-                          // Fallback: no server URL
-                        }
-
-                        return {
-                          id: `asset-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`,
-                          name: f.name,
-                          content: textContent,
-                          url: fileUrl || undefined,
-                          fileKey: fileKey || undefined,
-                          mimeType: fileMimeType || undefined,
-                          folder:
-                            designatedFolder !== 'Uncategorized' ? designatedFolder : undefined,
+                          const uploadData = await uploadRes.json()
+                          const fileUrl = uploadData.url || ''
+                          const fileKey = uploadData.key || ''
+                          if (!fileUrl && !fileKey) {
+                            return {
+                              ok: false as const,
+                              name: f.name,
+                              error: 'upload returned no file reference',
+                            }
+                          }
+                          return {
+                            ok: true as const,
+                            asset: {
+                              id: `asset-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`,
+                              name: f.name,
+                              content: textContent,
+                              url: fileUrl || undefined,
+                              fileKey: fileKey || undefined,
+                              mimeType: uploadData.isPdf
+                                ? 'application/pdf'
+                                : uploadData.type || 'application/pdf',
+                              folder:
+                                designatedFolder !== 'Uncategorized' ? designatedFolder : undefined,
+                            },
+                          }
+                        } catch (err: any) {
+                          return {
+                            ok: false as const,
+                            name: f.name,
+                            error: err?.message || 'network error',
+                          }
                         }
                       })
                     )
-                    setCourseAssets(prev => [...prev, ...newAssets])
-                    if (files.length > 0) toast.success(`${files.length} asset(s) imported`)
+                    const okAssets = results.flatMap(r => (r.ok ? [r.asset] : []))
+                    const failures = results.filter(r => !r.ok)
+                    if (okAssets.length > 0) {
+                      setCourseAssets(prev => [...prev, ...okAssets])
+                      toast.success(`${okAssets.length} asset(s) imported`)
+                    }
+                    for (const fail of failures) {
+                      toast.error(`Could not import '${fail.name}': ${fail.error}`)
+                    }
                     e.target.value = ''
                   }}
                 />


### PR DESCRIPTION
## What the tutor sees
Loading the SAT paper as an assessment shows **"This document has no stored file — please re-upload it before loading"** — and re-uploading doesn't help.

## Why
That error (added in #843) fires when an asset has **neither `url` nor `fileKey`**. The **Assets-library upload handler** was creating exactly such assets: on a failed upload it left `url`/`fileKey` empty, **still added the asset**, and **always showed "asset(s) imported"** — hiding the failure. So the SAT's upload is actually failing (it's 10.5 MB; smaller papers succeed), but the failure was invisible.

```js
if (uploadRes.ok) { fileUrl = ...; fileKey = ... }   // no else
} catch { /* Fallback: no server URL */ }             // swallowed
return { url: fileUrl || undefined, fileKey: fileKey || undefined }
// then always: toast.success('asset(s) imported')
```

## Fix
- Only add an asset when the upload returns a real `url` **or** `fileKey`.
- Show the **actual** per-file failure reason (server error text / HTTP status / network error) instead of a false success.

This doesn't yet fix *why* the large upload fails — but it makes the real reason visible (server error, 413, timeout, etc.) so the next step can target it precisely.

## Verification
`tsc` clean · `eslint` 0 new errors · `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)