### PR TITLE
refactor(classroom): unify non-chat task doc rendering + consistent unavailable message

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -64,7 +64,6 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
-import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
 import type {
@@ -77,6 +76,7 @@ import type {
 import { normalizeDmiQuestionType, DMI_QUESTION_TYPE_LABELS } from '@/lib/assessment/question-types'
 import { TaskAiHelper } from './TaskAiHelper'
 import { TaskChatPanel } from './TaskChatPanel'
+import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 
 type WhiteboardPages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
 type WhiteboardPage = WhiteboardPages[number]
@@ -1998,67 +1998,17 @@ function StudentFeedbackContent() {
                         {/* For a chat task the document lives inside the chat panel
                             (it collapses into a pinned card after the first message),
                             so only render the standalone viewer for non-chat tasks. */}
-                        {!isChatTask &&
-                          activeTask.sourceDocument &&
-                          (() => {
-                            const doc = activeTask.sourceDocument
-                            const rawUrl = doc.fileUrl || ''
-                            // Prefer streaming by object key through our same-origin
-                            // proxy: it reads from storage server-side (no signed/
-                            // public URL needed), so it works even when GCS URL
-                            // signing is misconfigured or a stored URL has expired.
-                            // Fall back to the direct URL only when there's no key.
-                            const url = doc.fileKey
-                              ? `/api/proxy-file?key=${encodeURIComponent(doc.fileKey)}`
-                              : rawUrl
-                            // Without a key, a blob: URL only resolves in the tutor's
-                            // browser and an empty URL never reached storage — show a
-                            // clear message instead of a silently blank frame.
-                            const loadable =
-                              !!doc.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
-                            const isPdf =
-                              doc.mimeType === 'application/pdf' ||
-                              (!doc.mimeType && /\.pdf($|\?|#)/i.test(doc.fileName || rawUrl))
-                            const isImage = doc.mimeType?.startsWith('image/')
-                            return (
-                              <div className="mb-4 h-[55vh] w-full">
-                                {!loadable ? (
-                                  <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border bg-slate-50 text-center">
-                                    <FileText className="h-8 w-8 text-slate-400" />
-                                    <p className="text-sm text-slate-500">
-                                      This document is unavailable. Ask your tutor to re-deploy it.
-                                    </p>
-                                  </div>
-                                ) : isPdf ? (
-                                  // Paginated/continuous-scroll viewer so students can
-                                  // see EVERY page of a multi-page paper (the bare iframe
-                                  // with toolbar/navpanes hidden gave no page navigation).
-                                  <PDFViewer fileUrl={url} className="h-full w-full" />
-                                ) : isImage ? (
-                                  <div className="flex h-full items-center justify-center">
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img
-                                      src={url}
-                                      alt="Document"
-                                      className="max-h-full max-w-full object-contain"
-                                    />
-                                  </div>
-                                ) : (
-                                  <div className="flex h-full flex-col items-center justify-center gap-2">
-                                    <FileText className="h-8 w-8 text-blue-600" />
-                                    <a
-                                      href={url}
-                                      target="_blank"
-                                      rel="noreferrer"
-                                      className="text-sm text-blue-600 underline"
-                                    >
-                                      Open document
-                                    </a>
-                                  </div>
-                                )}
-                              </div>
-                            )
-                          })()}
+                        {!isChatTask && activeTask.sourceDocument && (
+                          // Same renderer the chat flow uses (via TaskDocumentCard),
+                          // in its non-collapsible mode — one code path for the PDF/
+                          // image viewer and the "document unavailable" fallback.
+                          <div className="mb-4 h-[55vh] w-full">
+                            <TaskDocumentCard
+                              sourceDocument={activeTask.sourceDocument}
+                              alwaysOpen
+                            />
+                          </div>
+                        )}
 
                         {/* The questions + answer inputs live in the right-hand
                             Assessment tab (single source of truth). Here we just

--- a/tutorme-app/src/components/task/TaskDocumentCard.tsx
+++ b/tutorme-app/src/components/task/TaskDocumentCard.tsx
@@ -1,16 +1,20 @@
 'use client'
 
 /**
- * TaskDocumentCard — the task document (PDF/image) shown inside the chat-based
- * task flow. It renders full while the chat is empty, then collapses into a
- * pinned, re-expandable "document" card once the student has started chatting,
- * so the whole panel reads as one conversation.
+ * TaskDocumentCard — the task document (PDF/image) shown for a deployed TASK.
  *
- * Shared by the student Classroom (TaskChatPanel) and the tutor Test-tab
- * preview (TestTaskChat) so the tutor previews exactly what students see.
+ * Two modes:
+ *  - Collapsible (default): renders full while the chat is empty, then collapses
+ *    into a pinned, re-expandable "document" card once the student has started
+ *    chatting, so the whole panel reads as one conversation. Used by the student
+ *    Classroom (TaskChatPanel) and the tutor Test-tab preview (TestTaskChat) so
+ *    the tutor previews exactly what students see.
+ *  - `alwaysOpen`: renders just the viewer (no toggle), filling its container.
+ *    Used by the non-chat task view, so both flows share one renderer and one
+ *    "document unavailable" message.
  */
 
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { FileText, ChevronDown, ChevronRight } from 'lucide-react'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { cn } from '@/lib/utils'
@@ -30,31 +34,77 @@ const ACCENTS = {
 export function TaskDocumentCard({
   sourceDocument,
   /** Default open state before the viewer is manually toggled (typically
-   *  `!hasSentMessage`): full while the chat is empty, collapsed after. */
-  autoOpen,
+   *  `!hasSentMessage`): full while the chat is empty, collapsed after.
+   *  Ignored when `alwaysOpen`. */
+  autoOpen = false,
   accent = 'orange',
+  /** Render just the viewer (no collapsible header), filling the container. */
+  alwaysOpen = false,
 }: {
   sourceDocument?: TaskDocumentSource | null
-  autoOpen: boolean
+  autoOpen?: boolean
   accent?: keyof typeof ACCENTS
+  alwaysOpen?: boolean
 }) {
   // Manual toggle overrides the auto (message-driven) state. Deriving the shown
   // state instead of syncing it via an effect keeps it flicker-free.
   const [manualOpen, setManualOpen] = useState<boolean | null>(null)
+  const regionId = useId()
 
-  const rawUrl = sourceDocument?.fileUrl || ''
-  const url = sourceDocument?.fileKey
+  if (!sourceDocument) return null
+
+  const rawUrl = sourceDocument.fileUrl || ''
+  // Prefer streaming by object key through our same-origin proxy: it reads from
+  // storage server-side (no signed/public URL needed), so it works even when GCS
+  // URL signing is misconfigured or a stored URL has expired. Fall back to the
+  // direct URL only when there's no key.
+  const url = sourceDocument.fileKey
     ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
     : rawUrl
-  const loadable = !!sourceDocument?.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
-  if (!sourceDocument || !loadable) return null
-
+  // Without a key, a blob: URL only resolves in the tutor's browser and an empty
+  // URL never reached storage — those are unavailable to the viewer.
+  const loadable = !!sourceDocument.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
   const name = sourceDocument.fileName || 'Task document'
   const isPdf =
     sourceDocument.mimeType === 'application/pdf' ||
     (!sourceDocument.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument.fileName || rawUrl))
   const isImage = !!sourceDocument.mimeType?.startsWith('image/')
   const styles = ACCENTS[accent]
+
+  // The actual document view (or a clear "unavailable" notice instead of a
+  // silently blank frame). Shared by both modes so the fallback is consistent.
+  const viewer = !loadable ? (
+    <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border bg-slate-50 p-4 text-center">
+      <FileText className="h-8 w-8 text-slate-400" />
+      <p className="text-sm text-slate-500">
+        This document is unavailable. Ask your tutor to re-deploy it.
+      </p>
+    </div>
+  ) : isPdf ? (
+    <PDFViewer fileUrl={url} className="h-full w-full" />
+  ) : isImage ? (
+    <div className="flex h-full items-center justify-center bg-slate-50 p-2">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={url} alt={name} className="max-h-full max-w-full object-contain" />
+    </div>
+  ) : (
+    <div className="flex h-full flex-col items-center justify-center gap-2">
+      <FileText className="h-8 w-8 text-blue-600" />
+      <a href={url} target="_blank" rel="noreferrer" className="text-sm text-blue-600 underline">
+        Open document
+      </a>
+    </div>
+  )
+
+  // Non-collapsible: just the viewer, filling whatever height the caller sets.
+  if (alwaysOpen) {
+    return (
+      <div className="h-full w-full" id={regionId}>
+        {viewer}
+      </div>
+    )
+  }
+
   const open = manualOpen ?? autoOpen
 
   return (
@@ -63,6 +113,7 @@ export function TaskDocumentCard({
         type="button"
         onClick={() => setManualOpen(!open)}
         aria-expanded={open}
+        aria-controls={regionId}
         className={cn(
           'flex w-full items-center gap-2 px-4 py-2 text-left transition-colors',
           styles.hover
@@ -78,27 +129,11 @@ export function TaskDocumentCard({
         )}
       </button>
       {open && (
-        <div className={cn('h-[42vh] max-h-[560px] min-h-[220px] w-full border-t', styles.border)}>
-          {isPdf ? (
-            <PDFViewer fileUrl={url} className="h-full w-full" />
-          ) : isImage ? (
-            <div className="flex h-full items-center justify-center bg-slate-50 p-2">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={url} alt={name} className="max-h-full max-w-full object-contain" />
-            </div>
-          ) : (
-            <div className="flex h-full flex-col items-center justify-center gap-2">
-              <FileText className="h-8 w-8 text-blue-600" />
-              <a
-                href={url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-sm text-blue-600 underline"
-              >
-                Open document
-              </a>
-            </div>
-          )}
+        <div
+          id={regionId}
+          className={cn('h-[42vh] max-h-[560px] min-h-[220px] w-full border-t', styles.border)}
+        >
+          {viewer}
         </div>
       )}
     </div>


### PR DESCRIPTION
Follow-up to #844 — removes the last duplicated task-document renderer and fixes an inconsistency it caused.

## Why
The **non-chat** task view (`feedback/page.tsx`) hand-rolled the same `url` / `loadable` / `isPdf` / `isImage` logic that already lives in the shared `TaskDocumentCard` (#844). Two copies drift — and they already behaved differently on a **broken document** (blob-only / no `fileKey`):
- Non-chat view → *"This document is unavailable. Ask your tutor to re-deploy it."*
- Chat card → silently rendered `null` (blank, no explanation).

## Changes
- **`TaskDocumentCard`** gains an `alwaysOpen` (non-collapsible) mode that renders just the viewer filling its container, and the **"document unavailable"** fallback now lives *inside* the shared component — so **both** flows show it. A chat-task student with a blob-only/keyless doc now gets the notice instead of a blank frame.
- The non-chat task view uses `TaskDocumentCard alwaysOpen`; the duplicated inline renderer and the now-unused `PDFViewer` import were removed from the student page.
- **A11y**: the collapsible toggle now also exposes `aria-controls` for its viewer region (complements the `aria-expanded` from #844).

Net: one renderer for the task document across chat + non-chat, one "unavailable" message.

## Testing
- Prettier + eslint clean (0 errors); `npm run typecheck` clean.
- Not exercised live. Manual pass worth doing: a **non-chat** task with a PDF, an image, and a broken/blob-only doc → viewer renders for the first two, "unavailable" notice for the third; confirm the **chat** task still collapses/expands as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)