### PR TITLE
diag(uploads): stage logging to trace large-PDF (SAT) upload failures

### DIFF
--- a/tutorme-app/src/app/api/uploads/documents/route.ts
+++ b/tutorme-app/src/app/api/uploads/documents/route.ts
@@ -124,8 +124,23 @@ async function convertToPdf(inputPath: string, outputDir: string): Promise<strin
 
 export const POST = withCsrf(
   withAuth(async (request: NextRequest, session: Session) => {
+    // ── DIAGNOSTIC (temporary) ──────────────────────────────────────────────
+    // Stage-by-stage tracing to pinpoint why large PDFs (e.g. a 10.5MB SAT
+    // paper) fail to upload while smaller papers succeed. Logs size + each
+    // step's elapsed ms and the exact error/stack on failure. Remove once the
+    // root cause is fixed. Correlate by the `rid` prefix in Cloud Run logs.
+    const rid = `upl_${Date.now().toString(36)}`
+    const t0 = Date.now()
+    const diag = (stage: string, extra?: Record<string, unknown>) =>
+      console.log(
+        `[uploads/documents ${rid}] ${stage} (+${Date.now() - t0}ms)`,
+        extra ? JSON.stringify(extra) : ''
+      )
+    let stage = 'start'
     try {
+      diag('received request')
       const formData = await request.formData()
+      stage = 'parsed-formdata'
       const file = formData.get('file')
 
       // Duck typing to avoid `instanceof File` issues in different Node.js environments
@@ -134,6 +149,12 @@ export const POST = withCsrf(
       }
 
       const fileObj = file as File
+      diag('parsed formData', {
+        name: fileObj.name,
+        size: fileObj.size,
+        sizeMB: +(fileObj.size / 1048576).toFixed(2),
+        type: fileObj.type,
+      })
 
       if (fileObj.size > MAX_FILE_SIZE_BYTES) {
         return NextResponse.json({ error: 'File too large (max 20MB)' }, { status: 400 })
@@ -160,8 +181,12 @@ export const POST = withCsrf(
 
       const storedName = `${timestamp}-${safeName}`
       const absolutePath = path.join(absoluteDir, storedName)
+      stage = 'buffering'
       const bytes = Buffer.from(await fileObj.arrayBuffer())
+      diag('buffered arrayBuffer', { bytes: bytes.length })
+      stage = 'writing-temp'
       await writeFile(absolutePath, bytes)
+      diag('wrote temp file', { absolutePath })
 
       let finalPath = absolutePath
       let finalName = storedName
@@ -198,13 +223,19 @@ export const POST = withCsrf(
       if (isGcsConfigured()) {
         try {
           const gcsKey = `documents/${userId}/${finalName}`
+          stage = 'gcs-upload'
+          diag('gcs upload start', { gcsKey, finalMime, convertedToPdf })
           const uploadResult = await uploadLocalFile(finalPath, gcsKey, finalMime, true)
+          diag('gcs upload done')
 
           // Generate a fresh presigned URL instead of relying on the public URL
           // which may 403 when uniform bucket-level access is enabled
+          stage = 'refresh-signed-url'
           const signedUrl = await refreshGcsUrl(uploadResult.url, 7 * 24 * 3600)
+          diag('signed url refreshed', { hasUrl: !!signedUrl })
 
           await cleanupTempFiles()
+          diag('SUCCESS (gcs)', { hasUrl: !!signedUrl, key: gcsKey })
 
           return NextResponse.json({
             url: signedUrl,
@@ -217,16 +248,26 @@ export const POST = withCsrf(
             isPdf: finalMime === 'application/pdf',
           })
         } catch (uploadError: any) {
+          diag('GCS FAILED', {
+            stage,
+            message: uploadError?.message,
+            code: uploadError?.code,
+            name: uploadError?.name,
+            stack: uploadError?.stack?.split('\n').slice(0, 4).join(' | '),
+          })
           await cleanupTempFiles()
           throw new Error(`GCS Upload Failed: ${uploadError.message}`)
         }
       }
 
       // Fallback to persistent local storage if GCS is not configured
+      stage = 'local-store'
+      diag('gcs not configured — using local storage')
       const buffer = await readFile(finalPath)
       const storageKey = `documents/${userId}/${finalName}`
       const result = await storeFile(buffer, storageKey, finalMime)
       await cleanupTempFiles()
+      diag('SUCCESS (local)', { hasUrl: !!result.url, key: result.key })
 
       return NextResponse.json({
         url: result.url,
@@ -239,6 +280,13 @@ export const POST = withCsrf(
         isPdf: finalMime === 'application/pdf',
       })
     } catch (err: any) {
+      diag('UNCAUGHT FAILURE', {
+        stage,
+        message: err?.message,
+        code: err?.code,
+        name: err?.name,
+        stack: err?.stack?.split('\n').slice(0, 5).join(' | '),
+      })
       return handleApiError(err, 'Upload failed', 'api/uploads/documents/route.ts')
     }
   })


### PR DESCRIPTION
**Diagnostic only — logging, no behavior change.** Follow-up to #840/#843/#846.

## Why
The 10.5 MB SAT paper fails to upload while smaller papers succeed (#846), which leaves a **file-less asset** that later shows *"No document selected"* / *"This document has no stored file"*. We've confirmed the symptom but not **which layer** fails (GCS resumable upload? timeout? signed-URL refresh? memory?). Repeated manual attempts keep surfacing the stale asset rather than a clean upload error, so this instruments the server path to catch the real failure in Cloud Run logs.

## What
Adds per-request tracing to `POST /api/uploads/documents`:
- A correlation id (`upl_<base36>`), the received file size (bytes + MB) and mime.
- Elapsed-ms markers at each stage: `parsed formData → buffered → wrote temp → gcs upload start/done → signed url refreshed → SUCCESS`.
- On failure, the **exact** `message` / `code` / `name` / first stack frames **and the stage** it died at (`GCS FAILED` vs `UNCAUGHT FAILURE`).

No functional change — every code path returns exactly as before.

## How to use
After deploy, re-upload `sat-practice-test-4-digital.pdf` in production, then grep Cloud Run logs for the `upl_` line — it'll show the last stage reached and the error. That pinpoints the fix (buffered/resumable fallback, raised limit, or timeout bump), which lands in a follow-up that also **removes this logging**.

## Testing
- Prettier + eslint clean (0 errors; only pre-existing `any`/unused warnings). `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)