### PR TITLE
fix(builder): abort loading a file-less asset (no junk empty assessment)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6282,19 +6282,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                       // fails to refresh an expired presigned URL, which silently
                       // left the assessment with no source document ("No document
                       // selected", no error).
-                      if (assetToLoad.url || assetToLoad.fileKey) {
-                        targetAssess.sourceDocument = {
-                          fileName: assetToLoad.name,
-                          fileUrl: assetToLoad.url || '',
-                          fileKey: assetToLoad.fileKey,
-                          mimeType: assetToLoad.mimeType || 'application/pdf',
-                          uploadedAt: new Date().toISOString(),
-                          extractedText,
-                        }
-                      } else {
+                      // A durable fileKey is enough (the viewer streams it via the
+                      // by-key proxy), so don't require a signed url. But with NO
+                      // stored file at all, there is nothing to preview or deploy —
+                      // abort instead of creating an empty assessment and then
+                      // (mis)reporting "Loaded …". This happens for stale/broken
+                      // assets whose upload never stored a file; the tutor must
+                      // re-upload the document to get a working asset.
+                      if (!assetToLoad.url && !assetToLoad.fileKey) {
                         toast.error(
                           'This document has no stored file — please re-upload it before loading.'
                         )
+                        setLoadAsModalOpen(false)
+                        setAssetToLoad(null)
+                        return
+                      }
+
+                      targetAssess.sourceDocument = {
+                        fileName: assetToLoad.name,
+                        fileUrl: assetToLoad.url || '',
+                        fileKey: assetToLoad.fileKey,
+                        mimeType: assetToLoad.mimeType || 'application/pdf',
+                        uploadedAt: new Date().toISOString(),
+                        extractedText,
                       }
 
                       const newCourseBuilderNodes = [...nodes]


### PR DESCRIPTION
## Symptom
Loading the SAT paper into an assessment produced **two contradictory toasts** — *"This document has no stored file — please re-upload it before loading."* immediately followed by *"Loaded 'sat-practice-test-4-digital.pdf' into Assessment"* — and **no document preview**. Other documents (e.g. AP statistics papers) preview fine.

## Root cause
The SAT **asset in the library is file-less** — it has neither a `url` nor a `fileKey` (a stale/broken asset whose upload never persisted a file). The assessment-load handler warned about the missing file but **did not stop**: it went on to create the assessment with an empty `sourceDocument`, kicked off DMI generation, and reported success. Result: a junk assessment with no preview.

(Investigation confirmed the file itself is valid — 10.05 MB, 56 pages, not encrypted, loads in pdf-lib — and that loading this asset never even sends an upload request. The asset simply has no file behind it.)

## Fix
If the asset has **no url and no fileKey**, show the single clear error, close the modal, and `return` — no empty assessment, no false "Loaded" toast, no DMI run. Assets that carry a durable `fileKey` load and preview exactly as before.

This doesn't magically restore the SAT (there's no file to restore) — the tutor must **re-upload** it to get a working asset — but it removes the confusing/broken behavior and makes the required action unambiguous.

## Testing
- Prettier + eslint clean (0 errors; pre-existing warnings only). `npm run typecheck` clean.
- Behavior change is scoped to the no-file branch of the assessment-load handler; the normal (has-fileKey) path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)