### PR TITLE
fix(uploads): raise proxy body cap to 25MB — fixes 10–20MB PDF upload failures

### DIFF
--- a/tutorme-app/next.config.mjs
+++ b/tutorme-app/next.config.mjs
@@ -43,6 +43,14 @@ const nextConfig = {
   },
   experimental: {
     optimizePackageImports: ['lucide-react', 'recharts', 'framer-motion'],
+    // Raise the proxy (middleware) request-body cap above the app's own 20MB
+    // upload limit. Next 16 defaults this to 10MB; a request body over the cap
+    // is TRUNCATED before route handlers run, which corrupts multipart FormData
+    // and makes `request.formData()` throw "Failed to parse body as FormData".
+    // That silently broke document uploads between 10–20MB (e.g. a 10.5MB SAT
+    // paper) while smaller papers succeeded. 25MB gives headroom over the 20MB
+    // limit enforced in /api/uploads/documents.
+    proxyClientMaxBodySize: '25mb',
   },
   serverExternalPackages: ['pg', 'pg-native', 'jspdf', 'jspdf-autotable', 'mathjax'],
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
## Root cause (confirmed from production logs)
The SAT paper (10.5 MB) failed to upload while smaller papers succeeded. The diagnostic logging from #849 caught it exactly:

```
Request body exceeded 10MB for /api/uploads/documents. Only the first 10MB will be available...
[uploads/documents upl_…] UNCAUGHT FAILURE {"stage":"start","message":"Failed to parse body as FormData.","name":"TypeError"}
```
vs. the AP paper that worked:
```
[uploads/documents upl_…] parsed formData {"name":"ap21-frq-statistics.pdf","sizeMB":4.3} → SUCCESS (gcs)
```

**Next 16 caps the proxy (middleware) request body at 10 MB by default** (`experimental.proxyClientMaxBodySize`, default `10_485_760`). Our proxy (`src/proxy.ts`) matches `/api/((?!auth|health).*)` — including `/api/uploads/documents` (needed for rate-limiting/RBAC) — so a body over 10 MB is **truncated before the route handler runs**. That severs the multipart FormData trailer, so `request.formData()` throws `Failed to parse body as FormData`. The handler's own 20 MB check never executes. Anything **10–20 MB** silently failed; under 10 MB worked.

## Fix
Set `experimental.proxyClientMaxBodySize: '25mb'` — above the 20 MB limit already enforced in `/api/uploads/documents`. The full body now reaches the handler, and the handler's own size check is the effective limit again.

(One line; `middlewareClientMaxBodySize` is the deprecated alias — `proxyClientMaxBodySize` is the current Next 16 key, verified against the installed `next` config schema.)

## Related
- #849 added the diagnostic logging that pinpointed this (I'll remove it in a follow-up cleanup now that the cause is found).
- #850 makes loading a *file-less* asset fail cleanly (the broken assets this bug produced).

## Testing
- Config loads cleanly with the new key; prettier clean. CI build validates the config schema.
- **Verify after deploy**: upload the 10.5 MB `sat-practice-test-4-digital.pdf` as an asset → should now succeed and preview in the Assessment tab. Confirm sub-10 MB uploads still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)