### PR TITLE
feat(student): add "Find Tutors" panel header (re-applies #744 cleanly)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/tutors/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/tutors/page.tsx
@@ -316,10 +316,15 @@ export default function StudentTutorDirectoryPage() {
       <div className="flex min-h-0 flex-1 flex-col pt-2">
         <Card
           hoverable={false}
-          className="shadow-hover-lift flex h-full flex-col rounded-2xl border border-[#E5E7EB] bg-white p-5 ring-1 ring-black/5"
+          className="shadow-hover-lift flex h-full flex-col overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white ring-1 ring-black/5"
         >
+          {/* Panel header — gives the panel a visible top edge for the floating effect */}
+          <div className="flex flex-shrink-0 items-center justify-between border-b border-[#E5E7EB] bg-slate-50 px-5 py-2.5">
+            <h3 className="text-sm font-semibold text-slate-700">Find Tutors</h3>
+            <span className="text-xs text-slate-400">{filteredTutors.length} available</span>
+          </div>
           {/* Filters */}
-          <div className="grid grid-cols-1 gap-3 pb-0 md:grid-cols-4">
+          <div className="grid grid-cols-1 gap-3 px-5 pb-0 pt-5 md:grid-cols-4">
             {/* Edit 3: Search input with category grid icon */}
             <div className="relative flex items-center gap-2">
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
@@ -420,7 +425,7 @@ export default function StudentTutorDirectoryPage() {
           </div>
 
           {/* Tutor grid */}
-          <div className="flex flex-1 flex-col pt-3 sm:pt-4">
+          <div className="flex flex-1 flex-col px-5 pb-5 pt-3 sm:pt-4">
             <div className="flex flex-1 flex-col justify-start">
               <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
                 {loading ? (


### PR DESCRIPTION
Re-applies the one genuinely-new intent from the stale UI PRs cleanly onto current main.

## Context
While clearing the PR backlog, I checked the 4 remaining UI PRs (#460, #515, #551, #744) against current main. Three were already superseded/obsolete (details below). **#744** was the only one with a change not on main — a "Find Tutors" panel header — but its branch predated the tutor panel's move to a `<Card>` (merged in #746), so merging it as-is would have **reverted #746**. This PR grafts only the header onto main's current Card, harmlessly.

## Change
- Move padding from the `Card` onto its inner sections + add `overflow-hidden`, so the header sits flush against the rounded top edge (the intended floating-panel "visible top edge").
- Header shows **"Find Tutors"** + a live **"{n} available"** count (`filteredTutors.length`).
- Scoped to one presentational file (`student/tutors/page.tsx`); no logic changes.

## Testing
- Prettier + eslint clean (0 errors); `npm run typecheck` clean.
- Presentational only — worth a quick visual check that the header reads well and the panel padding looks right after deploy (I can't render it here).

## The other 3 (being closed as superseded/obsolete)
- **#515** — the top-panel "+" button it removes is already gone from main.
- **#551** — the parent First/Middle/Last name fields it adds already exist on main.
- **#460** — targeted a "narrow right panel" bug; the panel is now a fixed 400px width, so it's already addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)