### PR TITLE
fix(pci): Board is assessment-only + auto-detect it from the paper

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6828,9 +6828,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     }, [currentAssessmentDocument, assessmentBuilder.title])
     const pciBoard =
       pciBoardOverride ??
-      (detectedAssessmentBoard ||
-        deriveExamContext(pciCategory || null, courseName).examBody ||
-        '')
+      (detectedAssessmentBoard || deriveExamContext(pciCategory || null, courseName).examBody || '')
 
     // DMI-first gate: an assessment's marking-policy (PCI) chat unlocks only once
     // the DMI exists with questions, marks, and an answer key/rubric (the "basic"

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -742,9 +742,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [pciBoardOverride, setPciBoardOverride] = useState<string | null>(null)
     const pciCategory =
       courseCategoryOverride ?? (designatedFolder !== 'Uncategorized' ? designatedFolder : '')
-    const pciBoard =
-      pciBoardOverride ?? deriveExamContext(pciCategory || null, courseName).examBody ?? ''
     const pciCategoryOptions = useMemo(() => getAllCourseCategoryOptions(), [])
+    // `pciBoard` (the exam Board — AP, IB, SAT…) is derived further down, once the
+    // loaded assessment document is available, so it can be auto-detected from the
+    // paper itself rather than the course folder. Board applies to assessments only.
 
     const [assetFoldersList, setAssetFoldersList] = useState<string[]>(() => {
       if (typeof window !== 'undefined') {
@@ -6810,6 +6811,27 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const currentAssessmentDocument = assessmentSourceDocument || assessmentBuilder.sourceDocument
     const hasAssessmentDocument = !!currentAssessmentDocument
 
+    // Auto-detect the exam Board from the ASSESSMENT itself — its file name,
+    // title, and the start of its extracted text — so it reflects THIS paper
+    // (e.g. an SAT paper reads "SAT") instead of being fixed to the course
+    // folder. Falls back to the course category, and the tutor can always
+    // override it in the Guided form. Board applies to assessments only.
+    const detectedAssessmentBoard = useMemo(() => {
+      const probe = [
+        currentAssessmentDocument?.fileName,
+        assessmentBuilder.title,
+        (currentAssessmentDocument?.extractedText || '').slice(0, 1200),
+      ]
+        .filter(Boolean)
+        .join('\n')
+      return deriveExamContext(probe || null).examBody || ''
+    }, [currentAssessmentDocument, assessmentBuilder.title])
+    const pciBoard =
+      pciBoardOverride ??
+      (detectedAssessmentBoard ||
+        deriveExamContext(pciCategory || null, courseName).examBody ||
+        '')
+
     // DMI-first gate: an assessment's marking-policy (PCI) chat unlocks only once
     // the DMI exists with questions, marks, and an answer key/rubric (the "basic"
     // bar). Per-question gaps are surfaced but don't block. See assessmentDmiReadiness.
@@ -10836,8 +10858,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                           {renderCurrentPci('task', activeTaskPci)}
                                           <PciSpecSoFar
                                             spec={activeTaskThread.specSoFar}
-                                            board={pciBoard}
                                             subject={pciCategory}
+                                            showBoard={false}
                                             editable={canEdit}
                                             onEditField={(key, value) =>
                                               editSpecSoFar(activeTaskTarget, key, value)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -14,6 +14,7 @@ import { HelpCircle, Loader2, Sparkles, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import { PCI_SPEC_FIELDS, pciSpecToText, type PciSpec } from '@/lib/assessment/pci-spec'
 import { EXAM_BOARDS } from '@/lib/assessment/marking-scheme'
+import { cn } from '@/lib/utils'
 
 /**
  * Per-field help: a plain-language explanation plus a set of ready-to-use
@@ -422,29 +423,37 @@ export function PciQuestionnaire({
       </p>
 
       {onExamContextChange && (
-        <div className="mb-3 grid grid-cols-2 gap-2 rounded-md border border-slate-200 bg-white/70 p-2">
-          <div>
-            <label
-              htmlFor={`pci-board-${source}`}
-              className="block text-[11px] font-medium text-slate-700"
-            >
-              Board
-            </label>
-            <select
-              id={`pci-board-${source}`}
-              value={board ?? ''}
-              disabled={!canEdit}
-              onChange={e => onExamContextChange({ board: e.target.value })}
-              className="mt-0.5 w-full rounded-md border border-gray-300 p-1.5 text-[11px] text-gray-900"
-            >
-              <option value="">—</option>
-              {EXAM_BOARDS.map(b => (
-                <option key={b} value={b}>
-                  {b}
-                </option>
-              ))}
-            </select>
-          </div>
+        <div
+          className={cn(
+            'mb-3 grid gap-2 rounded-md border border-slate-200 bg-white/70 p-2',
+            // Board (AP, IB, SAT…) applies to assessments only; tasks show subject alone.
+            source === 'assessment' ? 'grid-cols-2' : 'grid-cols-1'
+          )}
+        >
+          {source === 'assessment' && (
+            <div>
+              <label
+                htmlFor={`pci-board-${source}`}
+                className="block text-[11px] font-medium text-slate-700"
+              >
+                Board
+              </label>
+              <select
+                id={`pci-board-${source}`}
+                value={board ?? ''}
+                disabled={!canEdit}
+                onChange={e => onExamContextChange({ board: e.target.value })}
+                className="mt-0.5 w-full rounded-md border border-gray-300 p-1.5 text-[11px] text-gray-900"
+              >
+                <option value="">—</option>
+                {EXAM_BOARDS.map(b => (
+                  <option key={b} value={b}>
+                    {b}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div>
             <label
               htmlFor={`pci-subject-${source}`}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciSpecSoFar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciSpecSoFar.tsx
@@ -24,13 +24,27 @@ interface PciSpecSoFarProps {
   spec?: PciSpec
   board?: string
   subject?: string
+  /** Whether to show the exam Board — Board applies to assessments only, not
+   *  tasks. Defaults to true; pass false for tasks. */
+  showBoard?: boolean
   /** Allow inline corrections of captured fields. */
   editable?: boolean
   onEditField?: (key: PciSpecKey, value: string) => void
 }
 
-export function PciSpecSoFar({ spec, board, subject, editable, onEditField }: PciSpecSoFarProps) {
-  const hasContext = !!board?.trim() || !!subject?.trim()
+export function PciSpecSoFar({
+  spec,
+  board,
+  subject,
+  showBoard = true,
+  editable,
+  onEditField,
+}: PciSpecSoFarProps) {
+  // Board (AP, IB, SAT…) is an assessment-only concept; tasks show subject only.
+  const contextValue = showBoard
+    ? [board?.trim(), subject?.trim()].filter(Boolean).join(' · ')
+    : subject?.trim() || ''
+  const hasContext = !!contextValue
   const total = PCI_SPEC_FIELDS.length
   const filledCount = PCI_SPEC_FIELDS.filter(f => spec?.[f.key]?.trim()).length
 
@@ -76,10 +90,10 @@ export function PciSpecSoFar({ spec, board, subject, editable, onEditField }: Pc
       <ul className="space-y-0.5">
         {hasContext && (
           <li className="px-1 py-0.5 text-xs">
-            <span className="font-medium text-slate-600">Board / Subject:</span>{' '}
-            <span className="text-slate-700">
-              {[board?.trim(), subject?.trim()].filter(Boolean).join(' · ')}
-            </span>
+            <span className="font-medium text-slate-600">
+              {showBoard ? 'Board / Subject:' : 'Subject:'}
+            </span>{' '}
+            <span className="text-slate-700">{contextValue}</span>
           </li>
         )}
         {PCI_SPEC_FIELDS.map(f => {


### PR DESCRIPTION
Two related fixes to the exam **Board** (AP, IB, SAT…) in the PCI panels.

## Problem
Board was derived from the **course folder** (`pciCategory`), so a "Pre-SAT" course made every panel show **"SAT / Pre-SAT"** — including **tasks**, which shouldn't have a Board at all.

## Fixes
1. **Board is assessment-only — removed from tasks.**
   - `PciSpecSoFar` gains a `showBoard` prop (default `true`). The task "Your policy so far" passes `showBoard={false}`; the context line then reads **"Subject:"** only.
   - The guided `PciQuestionnaire` hides its **Board** `<select>` for `source === 'task'` (Subject spans full width).
2. **Assessments auto-detect the Board from the paper.**
   - New `detectedAssessmentBoard` runs `deriveExamContext` over the assessment's **file name + title + start of its extracted text**, so the Board reflects THIS paper (an SAT paper → "SAT", an IB paper → "IB") rather than the course folder.
   - Falls back to the course category if nothing is detected; the tutor can still override it in the Guided form. `pciBoard` was moved below the loaded-document derivation so the detector can see the document.

Board stays **UI-only** (never sent to the PCI agent).

## Verification
- `tsc` clean · `eslint` 0 errors · `prettier` clean · `deriveExamContext` tests **20 pass**.
- Live behavior (tasks show no Board; an assessment's Board matches the loaded paper) best confirmed after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)