### PR TITLE
fix(course-builder): PCI tab won't scroll with long chat/content

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10517,13 +10517,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                           </div>
 
                           {/* Content area */}
-                          <div className="relative flex-1 rounded-none border-0 bg-transparent p-0 shadow-none">
+                          <div className="relative min-h-0 flex-1 rounded-none border-0 bg-transparent p-0 shadow-none">
                             {/* Task Builder Tab */}
                             <TabsContent
                               value="task"
                               className="flex h-full flex-col space-y-px overflow-hidden data-[state=inactive]:hidden"
                             >
-                              <div className="flex flex-1 gap-px overflow-hidden">
+                              <div className="flex min-h-0 flex-1 gap-px overflow-hidden">
                                 {/* Main content with tabs */}
                                 <div className="flex flex-1 flex-col overflow-hidden">
                                   <Tabs
@@ -10987,7 +10987,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                               value="assessment"
                               className="flex h-full flex-col space-y-px overflow-hidden data-[state=inactive]:hidden"
                             >
-                              <div className="flex flex-1 gap-px overflow-hidden">
+                              <div className="flex min-h-0 flex-1 gap-px overflow-hidden">
                                 {/* Main content with tabs */}
                                 <div className="flex flex-1 flex-col overflow-hidden">
                                   <Tabs


### PR DESCRIPTION
## Bug
On the PCI tab (Task **and** Assessment builders), a long PCI chat/content can't be scrolled — it runs off with no scrollbar. A prior attempt (#481, merged) targeted this but was incomplete, so the bug persisted.

## Root cause (full height-chain trace)
The scroll container and its immediate parents are already correct:
`min-h-0 flex-1 overflow-y-auto` inside `h-full min-h-0 flex-col` inside the `h-full min-h-0 flex-1` PCI `TabsContent`.

But **three `flex-1` ancestors higher up lacked `min-h-0`**. In a flex column a `flex-1` child defaults to `min-height:auto` (content-sized), so a long chat grows those ancestors instead of keeping them bounded — the inner `overflow-y-auto` never gets a constrained height, so it never scrolls. The chain is bounded above (`CardContent h-full` → `Tabs h-full`) and below, so these three were the only gaps.

## Fix
Add `min-h-0` to the three `flex-1`-in-column ancestors:
1. the **shared Task/Assessment content area** — fixes both builders at once
2. the **task** builder inner content row
3. the **assessment** builder inner content row

**Additive only** — `min-h-0` just lets these flex items shrink so the existing `overflow-y-auto` can scroll; it changes nothing when content already fits, so it can't regress the normal layout.

## Testing
- Prettier + eslint clean (0 errors); `npm run typecheck` clean.
- Can't render here — please verify after deploy: open a Task (and an Assessment) → **PCI** tab, run a long chat, confirm the message area scrolls while the composer/apply bar stays pinned.

_(Note: the old `fix/pci-tab-scroll` branch — from the incomplete #481 — still exists; left untouched. This lands on a fresh branch.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)