### PR TITLE
fix(course-details): make BackButton visible on dark header

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -692,7 +692,10 @@ export default function TutorCoursePage() {
         <div className="space-y-6">
           <div className="relative">
             <div className="absolute left-0 top-1/2 z-10 -translate-y-1/2">
-              <BackButton href={`/tutor/insights?tab=builder&courseId=${id}&mode=edit`} />
+              <BackButton
+                href={`/tutor/insights?tab=builder&courseId=${id}&mode=edit`}
+                className="text-white hover:bg-white/20 hover:text-white"
+              />
             </div>
             <button
               type="button"


### PR DESCRIPTION
The BackButton on the Course Details page was invisible because it used the default 'ghost' variant with dark text color on a dark metallic gradient header.

**Changes:**
- Added  to the BackButton to make it visible on the dark metallic header background.

**Before:** BackButton was invisible (dark icon on dark background)
**After:** BackButton shows as white arrow with subtle white hover background