### PR TITLE
fix(poll): implement 5×2 grid for 1-10 poll and add Likert/A-E previews

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -9492,9 +9492,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                     rows={3}
                                                   />
                                                   {/* Poll options preview */}
-                                                  <div className="mt-4 flex flex-wrap gap-2">
+                                                  <div className="mt-4">
                                                     {pollOptionMode === '1-10' && (
-                                                      <>
+                                                      <div className="grid grid-cols-5 gap-2">
                                                         {Array.from(
                                                           { length: 10 },
                                                           (_, i) => i + 1
@@ -9502,12 +9502,44 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                           <button
                                                             key={num}
                                                             type="button"
-                                                            className="flex h-8 w-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                            className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
                                                           >
                                                             {num}
                                                           </button>
                                                         ))}
-                                                      </>
+                                                      </div>
+                                                    )}
+                                                    {pollOptionMode === 'likert' && (
+                                                      <div className="flex flex-col gap-2">
+                                                        {[
+                                                          'Strongly Disagree',
+                                                          'Disagree',
+                                                          'Neutral',
+                                                          'Agree',
+                                                          'Strongly Agree',
+                                                        ].map((label, i) => (
+                                                          <button
+                                                            key={i}
+                                                            type="button"
+                                                            className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                          >
+                                                            {label}
+                                                          </button>
+                                                        ))}
+                                                      </div>
+                                                    )}
+                                                    {pollOptionMode === 'ae' && (
+                                                      <div className="flex flex-wrap gap-2">
+                                                        {['A', 'B', 'C', 'D', 'E'].map(letter => (
+                                                          <button
+                                                            key={letter}
+                                                            type="button"
+                                                            className="flex h-8 w-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                          >
+                                                            {letter}
+                                                          </button>
+                                                        ))}
+                                                      </div>
                                                     )}
                                                     {pollOptionMode === 'custom' && (
                                                       <p className="text-xs text-gray-600">
@@ -11855,21 +11887,53 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               rows={3}
                                             />
                                             {/* Poll options preview */}
-                                            <div className="mt-4 flex flex-wrap gap-2">
+                                            <div className="mt-4">
                                               {pollOptionMode === '1-10' && (
-                                                <>
+                                                <div className="grid grid-cols-5 gap-2">
                                                   {Array.from({ length: 10 }, (_, i) => i + 1).map(
                                                     num => (
                                                       <button
                                                         key={num}
                                                         type="button"
-                                                        className="flex h-8 w-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                        className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
                                                       >
                                                         {num}
                                                       </button>
                                                     )
                                                   )}
-                                                </>
+                                                </div>
+                                              )}
+                                              {pollOptionMode === 'likert' && (
+                                                <div className="flex flex-col gap-2">
+                                                  {[
+                                                    'Strongly Disagree',
+                                                    'Disagree',
+                                                    'Neutral',
+                                                    'Agree',
+                                                    'Strongly Agree',
+                                                  ].map((label, i) => (
+                                                    <button
+                                                      key={i}
+                                                      type="button"
+                                                      className="flex h-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                    >
+                                                      {label}
+                                                    </button>
+                                                  ))}
+                                                </div>
+                                              )}
+                                              {pollOptionMode === 'ae' && (
+                                                <div className="flex flex-wrap gap-2">
+                                                  {['A', 'B', 'C', 'D', 'E'].map(letter => (
+                                                    <button
+                                                      key={letter}
+                                                      type="button"
+                                                      className="flex h-8 w-8 items-center justify-center rounded-md border border-blue-200 bg-blue-50 text-xs font-medium text-blue-700"
+                                                    >
+                                                      {letter}
+                                                    </button>
+                                                  ))}
+                                                </div>
                                               )}
                                               {pollOptionMode === 'custom' && (
                                                 <p className="text-xs text-gray-600">


### PR DESCRIPTION
Implements the poll layout changes that were described in PR #842 but not actually applied:

**Changes:**
- 1-10 poll type: Changed from `flex flex-wrap` to `grid grid-cols-5 gap-2` for a proper 5×2 layout
- Likert poll type: Added vertical stacked preview layout (5 options: Strongly Disagree → Strongly Agree)
- A-E poll type: Added horizontal flex-wrap preview layout (5 letter buttons)
- Applied changes to both poll composer instances in CourseBuilder.tsx

**Before:** 1-10 numbers wrapped in a single row (7 on first row, 3 on second)
**After:** 1-10 numbers in a clean 5×2 grid layout