### PR TITLE
fix(pitch-deck): restore fixed iframe height for PDF scrolling

### DIFF
--- a/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
+++ b/tutorme-app/src/app/[locale]/pitch-deck/page.tsx
@@ -14,7 +14,7 @@ export default function PitchDeckPage() {
           <div className="scrollbar-hide h-[85vh] overflow-y-auto rounded-xl border-2 border-slate-300 shadow-2xl">
             <iframe
               src="/documents/solocorn-pitch-deck.pdf#toolbar=0&navpanes=0&scrollbar=0"
-              className="block h-full w-full border-0"
+              className="block h-[3000px] w-full border-0"
               title="Solocorn Pitch Deck"
             />
           </div>


### PR DESCRIPTION
The previous fix (PR #845) changed the iframe from `h-[3000px]` to `h-full`, but this broke PDF scrolling because `h-full` doesn't work reliably inside an `overflow-y-auto` container.

**Fix:**
- Restored `h-[3000px]` on the iframe so the PDF content extends beyond the viewport
- Kept the viewer chrome suppression (`#toolbar=0&navpanes=0&scrollbar=0`)
- The parent `div` with `h-[85vh] overflow-y-auto` and `scrollbar-hide` provides the scrollable viewport with hidden scrollbar

**How it works:**
- The iframe is 3000px tall, forcing the parent container to scroll
- The parent container is 85vh tall with hidden scrollbar
- User sees a seamless scrolling PDF viewer without native scrollbars