### PR TITLE
feat(pci): per-type marking-policy steering for the assessment PCI chat

### DIFF
--- a/docs/guardrails/assessments.md
+++ b/docs/guardrails/assessments.md
@@ -20,11 +20,11 @@ enforced (warn-only) by `validateAssessmentOutput` and `stripEvaluationLayer` in
 
 ## Enforcement model
 
-| Layer | Mechanism | Status |
-| --- | --- | --- |
-| Prompt | `ASSESSMENT_SYSTEM_PROMPT` (full) / a condensed guardrail block injected into `api/ai/generate-dmi` for the tutor-facing Draft DMI; temperature lowered to 0.2. | **Active** |
-| Validator | `validateAssessmentOutput` checks wording fidelity, provenance, rubric presence/sum, layer separation — returns `guardrailWarnings`. | **Active (warn-only)** |
-| Code (deterministic) | `stripEvaluationLayer` removes answers/rubrics from any student-facing payload; `canTransition` enforces the state machine. | **Active** |
+| Layer                | Mechanism                                                                                                                                                       | Status                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| Prompt               | `ASSESSMENT_SYSTEM_PROMPT` (full) / a condensed guardrail block injected into `api/ai/generate-dmi` for the tutor-facing Draft DMI; temperature lowered to 0.2. | **Active**             |
+| Validator            | `validateAssessmentOutput` checks wording fidelity, provenance, rubric presence/sum, layer separation — returns `guardrailWarnings`.                            | **Active (warn-only)** |
+| Code (deterministic) | `stripEvaluationLayer` removes answers/rubrics from any student-facing payload; `canTransition` enforces the state machine.                                     | **Active**             |
 
 The single guarantee that is **not** warn-only is `stripEvaluationLayer` — student payloads must
 always be run through it so the evaluation layer can never leak (ASMT-10/13/15).
@@ -61,3 +61,31 @@ illegal — it must pass through `Re-Verified`. Wire any code that advances asse
 - **ASMT-8** — Open-ended question with no rubric pathway.
 - **ASMT-9** — Rubric criteria that don't sum to the question's marks.
 - **ASMT-10 (error)** — Evaluation data (rubric/answer/provenance) present on a student-facing payload.
+
+## Prompt variants (per-type steering)
+
+The **PCI chat** tailors its marking-policy interview to what's being marked, by
+appending a short addendum to `ASSESSMENT_SYSTEM_PROMPT`. This is **prompt-layer
+steering only** — the addendum is added AFTER the full base prompt (which embeds
+all 15 rules), so no guardrail is ever dropped or relaxed; the validators and
+state machine are unchanged. Implementation: `src/lib/ai/guardrails/variants.ts`
+(`resolvePciComposition`, `assessmentVariantAddendum`), selected in
+`guardrailSystemPrompt('assessment', variant)`.
+
+The variant is derived client-side from the DMI and passed as `context.variant`:
+
+- **Composition** (from the DMI question mix; open = `short`/`long`):
+  - `objective` — ≥ 80% closed → short interview: partial credit for
+    multiple-response, negative marking, numeric/fill-in tolerance, blanks. No
+    rubric walk-throughs for auto-graded questions.
+  - `free_response` — ≥ 60% open → rubric-centric: method vs answer, partial-
+    credit bands, equivalent reasoning, key points, feedback tone; enforce the
+    ASMT-8 rubric pathway and ASMT-9 mark-sum.
+  - `mixed` — otherwise → ask whether one policy covers all, or closed vs written
+    parts differ, then branch.
+- **Source** (`documentKind`): a `study_material` note tells the model the
+  questions were generated (provenance `llm_inferred`) and to confirm coverage /
+  difficulty before building the policy.
+
+Tasks have no sub-variants yet — `guardrailSystemPrompt('task', …)` ignores the
+variant.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -206,7 +206,7 @@ import { getAllCourseCategoryOptions } from '@/lib/data/all-categories'
 import { reverifyAssessment } from '@/lib/assessment/assessment-gates'
 import { deriveSections, deriveTotalMarks } from '@/lib/assessment/sections'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
-import { findEvaluationLeaks } from '@/lib/ai/guardrails'
+import { findEvaluationLeaks, resolvePciComposition } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -7230,6 +7230,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           return `${label}:${text}${marks}${rubric}`
         })
         .join('\n'),
+      // Per-type steering for the assessment PCI chat: composition from the DMI
+      // question mix, source from the resolved documentKind. Forwarded as
+      // context.variant; undefined fields simply fall back to the base prompt.
+      assessmentPciVariant: {
+        composition: resolvePciComposition(assessmentDmiItems.map(q => q.questionType)),
+        documentKind: dmiDocumentKind.assessment,
+      },
     })
     const { pci, handlePciSend, applyTaskPciDraft, applyAssessmentPciDraft, setPciInput } = pciApi
     const editSpecSoFar = pciApi.editSpecSoFar

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -45,6 +45,16 @@ interface UsePciDeps {
    * questions/marks/rubrics in view. Empty when there's no DMI.
    */
   assessmentMarkingScheme?: string
+  /**
+   * Assessment-only per-type steering for the PCI chat, derived from the DMI
+   * question mix + documentKind. Forwarded to the server as `context.variant`
+   * to tailor the marking-policy interview (objective / free-response / mixed,
+   * plus a study-material note). Omitted/undefined → base prompt, unchanged.
+   */
+  assessmentPciVariant?: {
+    composition?: 'objective' | 'free_response' | 'mixed'
+    documentKind?: 'question_paper' | 'study_material'
+  }
   /** Writes the finalized rubric to the active task/assessment PCI field. */
   setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
@@ -234,6 +244,9 @@ export function usePci(deps: UsePciDeps) {
                 !isTask && deps.assessmentMarkingScheme
                   ? deps.assessmentMarkingScheme.slice(0, 12000)
                   : undefined,
+              // Per-type steering (assessment only) — selects the prompt
+              // addendum for this assessment's question mix / source.
+              variant: !isTask ? deps.assessmentPciVariant : undefined,
             },
             pdfPages,
           }),

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -74,6 +74,15 @@ const PciMasterRequestSchema = z.object({
       // Assessment DMI digest (per-question marks + rubric, no answers) so the
       // marking policy is built with the real questions/marks/rubrics in view.
       markingScheme: z.string().max(16000).optional(),
+      // Assessment-only: the resolved PCI-chat variant (derived client-side from
+      // the DMI question mix + documentKind). Selects per-type steering appended
+      // to the assessment prompt. Ignored for tasks.
+      variant: z
+        .object({
+          composition: z.enum(['objective', 'free_response', 'mixed']).optional(),
+          documentKind: z.enum(['question_paper', 'study_material']).optional(),
+        })
+        .optional(),
     })
     .optional(),
   // Rendered page images (data URLs) of an attached PDF, so the model can SEE the
@@ -169,7 +178,7 @@ export async function POST(request: NextRequest) {
     // Socratic prompt. Enforcement is warn-only — see the validator pass below.
     const guardrailDomain = context?.type
     const activeSystemPrompt = guardrailDomain
-      ? guardrailSystemPrompt(guardrailDomain)
+      ? guardrailSystemPrompt(guardrailDomain, context?.variant)
       : SYSTEM_PROMPT
     const activeTemperature = guardrailDomain ? GUARDRAILED_TEMPERATURE : 0.7
 

--- a/tutorme-app/src/lib/ai/guardrails/index.ts
+++ b/tutorme-app/src/lib/ai/guardrails/index.ts
@@ -41,8 +41,17 @@ export {
 
 export { stripEvaluationLayer, findEvaluationLeaks } from './serialize'
 
+export {
+  resolvePciComposition,
+  assessmentVariantAddendum,
+  type PciComposition,
+  type PciDocumentKind,
+  type PciVariant,
+} from './variants'
+
 import { TASK_PCI_SYSTEM_PROMPT } from './task-pci'
 import { ASSESSMENT_SYSTEM_PROMPT } from './assessment'
+import { assessmentVariantAddendum, type PciVariant } from './variants'
 import {
   validateTaskPciOutput,
   validateAssessmentOutput,
@@ -53,9 +62,19 @@ import {
 
 export type GuardrailDomain = 'task' | 'assessment'
 
-/** Return the canonical guardrail system prompt for a given PCI domain. */
-export function guardrailSystemPrompt(domain: GuardrailDomain): string {
-  return domain === 'assessment' ? ASSESSMENT_SYSTEM_PROMPT : TASK_PCI_SYSTEM_PROMPT
+/**
+ * Return the canonical guardrail system prompt for a given PCI domain.
+ *
+ * For assessments, an optional `variant` appends per-type steering (objective /
+ * free-response / mixed question mix, and a study-material source note) AFTER
+ * the base prompt — additive only, so no guardrail is ever dropped. Tasks have
+ * no sub-variants yet; the variant is ignored for `domain === 'task'`.
+ */
+export function guardrailSystemPrompt(domain: GuardrailDomain, variant?: PciVariant): string {
+  if (domain === 'assessment') {
+    return ASSESSMENT_SYSTEM_PROMPT + assessmentVariantAddendum(variant)
+  }
+  return TASK_PCI_SYSTEM_PROMPT
 }
 
 /**

--- a/tutorme-app/src/lib/ai/guardrails/variants.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolvePciComposition,
+  assessmentVariantAddendum,
+  guardrailSystemPrompt,
+  ASSESSMENT_SYSTEM_PROMPT,
+  ASSESSMENT_GUARDRAILS,
+  TASK_PCI_SYSTEM_PROMPT,
+} from './index'
+
+describe('resolvePciComposition', () => {
+  it('returns undefined when there are no typed questions', () => {
+    expect(resolvePciComposition([])).toBeUndefined()
+    expect(resolvePciComposition([null, undefined])).toBeUndefined()
+  })
+
+  it('classifies an all-closed set as objective', () => {
+    expect(resolvePciComposition(['mcq', 'true_false', 'fill_blank', 'matching'])).toBe('objective')
+  })
+
+  it('classifies an all-open set as free_response', () => {
+    expect(resolvePciComposition(['short', 'long', 'long'])).toBe('free_response')
+  })
+
+  it('applies the 80% closed threshold for objective', () => {
+    // 4 closed + 1 open = 80% closed → objective
+    expect(resolvePciComposition(['mcq', 'mcq', 'mcq', 'mcq', 'long'])).toBe('objective')
+    // 3 closed + 1 open = 75% closed → not objective (and open 25% < 60%) → mixed
+    expect(resolvePciComposition(['mcq', 'mcq', 'mcq', 'long'])).toBe('mixed')
+  })
+
+  it('applies the 60% open threshold for free_response', () => {
+    // 3 open + 2 closed = 60% open → free_response
+    expect(resolvePciComposition(['long', 'short', 'long', 'mcq', 'mcq'])).toBe('free_response')
+  })
+
+  it('classifies a balanced mix as mixed', () => {
+    expect(resolvePciComposition(['mcq', 'long'])).toBe('mixed')
+  })
+
+  it('ignores null/undefined entries when computing ratios', () => {
+    expect(resolvePciComposition(['mcq', null, 'mcq', undefined, 'mcq', 'mcq'])).toBe('objective')
+  })
+})
+
+describe('assessmentVariantAddendum', () => {
+  it('is empty for no variant / empty variant', () => {
+    expect(assessmentVariantAddendum()).toBe('')
+    expect(assessmentVariantAddendum({})).toBe('')
+    expect(assessmentVariantAddendum({ documentKind: 'question_paper' })).toBe('')
+  })
+
+  it('includes a composition block when composition is set', () => {
+    expect(assessmentVariantAddendum({ composition: 'objective' })).toContain('OBJECTIVE-HEAVY')
+    expect(assessmentVariantAddendum({ composition: 'free_response' })).toContain('FREE-RESPONSE')
+    expect(assessmentVariantAddendum({ composition: 'mixed' })).toContain('MIXED assessment')
+  })
+
+  it('adds the study-material note only for study_material', () => {
+    expect(assessmentVariantAddendum({ composition: 'objective' })).not.toContain('GENERATED from')
+    expect(
+      assessmentVariantAddendum({ composition: 'objective', documentKind: 'study_material' })
+    ).toContain('GENERATED from')
+  })
+
+  it('marks the block as steering-only so it cannot read as a new rule', () => {
+    expect(assessmentVariantAddendum({ composition: 'mixed' })).toContain('steering only')
+  })
+})
+
+describe('guardrailSystemPrompt with variants', () => {
+  const variants = [
+    undefined,
+    { composition: 'objective' as const },
+    { composition: 'free_response' as const },
+    { composition: 'mixed' as const },
+    { composition: 'free_response' as const, documentKind: 'study_material' as const },
+  ]
+
+  it('never drops a guardrail rule for any assessment variant (additive only)', () => {
+    for (const v of variants) {
+      const prompt = guardrailSystemPrompt('assessment', v)
+      // the full base prompt is always a prefix
+      expect(prompt.startsWith(ASSESSMENT_SYSTEM_PROMPT)).toBe(true)
+      // every ASMT rule id survives
+      for (const rule of ASSESSMENT_GUARDRAILS) {
+        expect(prompt).toContain(rule.id)
+      }
+    }
+  })
+
+  it('returns the base assessment prompt verbatim when no variant is given', () => {
+    expect(guardrailSystemPrompt('assessment')).toBe(ASSESSMENT_SYSTEM_PROMPT)
+  })
+
+  it('appends the matching addendum for a variant', () => {
+    expect(guardrailSystemPrompt('assessment', { composition: 'objective' })).toContain(
+      'OBJECTIVE-HEAVY'
+    )
+  })
+
+  it('ignores the variant for tasks (no sub-variants yet)', () => {
+    expect(guardrailSystemPrompt('task', { composition: 'objective' })).toBe(TASK_PCI_SYSTEM_PROMPT)
+  })
+})

--- a/tutorme-app/src/lib/ai/guardrails/variants.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.ts
@@ -1,0 +1,76 @@
+/**
+ * PCI-chat prompt variants — per-assessment-type steering appended to the base
+ * ASSESSMENT_SYSTEM_PROMPT.
+ *
+ * These are PROMPT-LAYER nudges only: they tailor the marking-policy interview
+ * to what's actually being marked (objective vs free-response question mix, and
+ * whether the questions were extracted from an exam or generated from study
+ * material). They never introduce or relax a guardrail — the base prompt (which
+ * embeds ASSESSMENT_GUARDRAILS), the validators, and the state machine remain
+ * the binding rules. See docs/guardrails/assessments.md → "Prompt variants".
+ *
+ * Tasks intentionally have no sub-variants yet; `guardrailSystemPrompt('task')`
+ * ignores any variant. The classifier + addenda live here (not in assessment.ts)
+ * so the canonical rule module stays the single source of the rules.
+ */
+
+import { OPEN_DMI_TYPES, type DmiQuestionType } from '@/lib/assessment/question-types'
+
+/** How the assessment's question mix skews (drives the interview shape). */
+export type PciComposition = 'objective' | 'free_response' | 'mixed'
+
+/** Where the questions came from (modifier on top of composition). */
+export type PciDocumentKind = 'question_paper' | 'study_material'
+
+export interface PciVariant {
+  composition?: PciComposition
+  documentKind?: PciDocumentKind
+}
+
+/** ≥80% closed questions → treat as objective (mostly exact right/wrong). */
+const OBJECTIVE_THRESHOLD = 0.8
+/** ≥60% open (short/long) questions → treat as free-response (rubric-driven). */
+const FREE_RESPONSE_THRESHOLD = 0.6
+
+/**
+ * Classify an assessment's question mix into a PCI-chat composition variant.
+ * Open = short/long (`OPEN_DMI_TYPES`); everything else is closed/auto-graded.
+ * Returns `undefined` when there are no typed questions (→ no addendum, base
+ * prompt behaves exactly as before).
+ */
+export function resolvePciComposition(
+  questionTypes: ReadonlyArray<string | null | undefined>
+): PciComposition | undefined {
+  const types = questionTypes.filter((t): t is string => !!t)
+  if (types.length === 0) return undefined
+  const open = types.filter(t => OPEN_DMI_TYPES.has(t as DmiQuestionType)).length
+  const openRatio = open / types.length
+  const closedRatio = 1 - openRatio
+  if (closedRatio >= OBJECTIVE_THRESHOLD) return 'objective'
+  if (openRatio >= FREE_RESPONSE_THRESHOLD) return 'free_response'
+  return 'mixed'
+}
+
+const COMPOSITION_ADDENDA: Record<PciComposition, string> = {
+  objective: `- OBJECTIVE-HEAVY assessment (mostly closed questions — MCQ, true/false, multiple-response, fill-in, matching). Marking is largely exact right/wrong, so keep the interview SHORT: ask only about (a) partial credit for multiple-response questions, (b) negative marking, (c) numeric/fill-in tolerance (units, rounding, spelling/case leniency), and (d) how to treat blank answers. Do NOT walk through rubrics for closed questions — they auto-grade. Only raise a rubric if a specific question is actually open.`,
+  free_response: `- FREE-RESPONSE assessment (mostly open short/long written answers). Marking is rubric-driven, so focus the policy on: awarding by method vs final answer, partial-credit bands, accepting equivalent/alternative reasoning, the key points required for full marks, how to treat blank or off-topic answers, and the depth/tone of written feedback. Confirm every open question has a rubric pathway before finalizing (ASMT-8); rubric criteria must sum to the question's marks (ASMT-9).`,
+  mixed: `- MIXED assessment (both closed and open questions). First ask ONE question: does a single marking policy apply to the whole paper, or should the closed (auto-graded) and written (rubric-graded) parts be handled differently? Then branch — keep closed-question rules brief and spend the interview on the written parts' rubrics.`,
+}
+
+const STUDY_MATERIAL_NOTE = `- SOURCE: these questions were GENERATED from the tutor's study material, not extracted from an existing exam (answer provenance: llm_inferred). On your FIRST turn, before any marking policy, briefly confirm the generated questions cover what the tutor wants at the right difficulty and invite them to adjust the set; only once they are happy with the questions, move on to the marking policy.`
+
+/**
+ * Build the assessment-prompt addendum for a resolved variant. Returns '' when
+ * there's nothing to add (so the base prompt is used verbatim). The header makes
+ * explicit that this is steering, not a new rule — the guardrails still bind.
+ */
+export function assessmentVariantAddendum(variant?: PciVariant): string {
+  if (!variant) return ''
+  const parts: string[] = []
+  if (variant.composition) parts.push(COMPOSITION_ADDENDA[variant.composition])
+  if (variant.documentKind === 'study_material') parts.push(STUDY_MATERIAL_NOTE)
+  if (parts.length === 0) return ''
+  return `\n\nAssessment-type guidance (steering only — every guardrail above still binds; never use this to invent, relax, or skip a rule):\n${parts.join(
+    '\n'
+  )}`
+}


### PR DESCRIPTION
Implements the per-type PCI-chat specialization plan (Phases 1 + 2). The PCI chat used one generic assessment prompt for everything; this tailors the marking-policy interview to what's actually being marked — **without weakening any guardrail**.

## What it does
The chat's assessment prompt now gets a short **steering addendum** chosen from the DMI:

- **Composition** (from the DMI question mix; open = `short`/`long`):
  - `objective` (≥80% closed) → short interview: partial credit for multiple-response, negative marking, numeric/fill-in tolerance, blanks; no rubric walk-throughs for auto-graded questions.
  - `free_response` (≥60% open) → rubric-centric: method vs answer, partial-credit bands, equivalent reasoning, key points, feedback tone; enforces the ASMT-8 rubric pathway + ASMT-9 mark-sum.
  - `mixed` → asks whether one policy covers all or closed/written differ, then branches.
- **Source** (`documentKind`): a `study_material` note tells the model the questions were *generated* (provenance `llm_inferred`) and to confirm coverage/difficulty first.

Tasks keep a single variant (the variant is ignored for `domain === 'task'`).

## Guardrail-safe by construction
- Addenda are appended **after** the full `ASSESSMENT_SYSTEM_PROMPT` (which embeds all 15 rules) → the base is always a prefix, so **no rule is ever dropped or relaxed**. A test asserts every `ASMT-*` id survives in every variant prompt.
- Validators, `canTransition`, and `stripEvaluationLayer` are untouched — this is prompt-layer steering only.
- Documented in `docs/guardrails/assessments.md` → "Prompt variants" to keep the source-of-truth doc in sync with the module (per the pci-guardrails rules).

## Where the signal comes from
Already-available data — no new persistence: `resolvePciComposition(assessmentDmiItems.map(q => q.questionType))` + `dmiDocumentKind.assessment`, derived client-side and sent as `context.variant`. Backward-compatible: absent variant → base prompt, behaves exactly as before.

## Files
- `guardrails/variants.ts` (+ `variants.test.ts`) — classifier + addenda
- `guardrails/index.ts` — `guardrailSystemPrompt(domain, variant?)`
- `api/ai/pci-master/route.ts` — `context.variant` schema + wiring
- `hooks/use-pci.ts`, `CourseBuilder.tsx` — derive + forward the variant
- `docs/guardrails/assessments.md` — "Prompt variants" section

## Testing
- New `variants.test.ts` (24 cases): classifier thresholds/edge cases + guardrail-integrity across all variants. Existing `pci-master` route tests still pass (7). Prettier/eslint clean (0 errors); typecheck clean.
- Behavioural change is prompt-only — worth a manual smoke test after deploy: open an MCQ-heavy assessment's PCI tab (short interview), a written-heavy one (rubric-focused), and a study-material-generated one (coverage check first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)