### PR TITLE
chore(ci): drop stale `port` input from the ADK Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -162,7 +162,6 @@ jobs:
             --memory=1Gi
             --min-instances=0
             --max-instances=10
-          port: 8080
           env_vars: NODE_ENV=production,ADK_PUBLIC_HEALTH=true,ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }},KIMI_API_KEY=${{ secrets.KIMI_API_KEY }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
 
       - name: Run migrations (inline docker)


### PR DESCRIPTION
`google-github-actions/deploy-cloudrun@v2` no longer accepts a `port` input, so the ADK deploy step logged **`! Unexpected input(s) 'port'`** on every production deploy and **ignored the value**.

Removed `port: 8080` from the ADK deploy step (the prod step never had it). Since the input was already ignored, this is functionally a no-op — Cloud Run defaults the container port to 8080 and the ADK service listens on `$PORT` — it just clears the warning.

## Verification
- `python3 -c 'yaml.safe_load(...)'` → YAML OK.
- No remaining `port:` inputs in the workflow.
- The deploy triggered by merging this PR will run the updated workflow, confirming the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)