### PR TITLE
feat(pci): task study-material variant + PCI naming cleanup (Phase 3)

### DIFF
--- a/docs/guardrails/assessments.md
+++ b/docs/guardrails/assessments.md
@@ -87,5 +87,6 @@ The variant is derived client-side from the DMI and passed as `context.variant`:
   questions were generated (provenance `llm_inferred`) and to confirm coverage /
   difficulty before building the policy.
 
-Tasks have no sub-variants yet — `guardrailSystemPrompt('task', …)` ignores the
-variant.
+Tasks use the same mechanism but only the **source** modifier: a `study_material`
+note (composition does not apply — task answering is free-form chat). See
+[`tasks-pci.md`](./tasks-pci.md) → "Prompt variants".

--- a/docs/guardrails/tasks-pci.md
+++ b/docs/guardrails/tasks-pci.md
@@ -15,14 +15,14 @@ rules change.
 
 ## Enforcement model
 
-| Layer | Mechanism | Status |
-| --- | --- | --- |
-| Prompt | `TASK_PCI_SYSTEM_PROMPT` injected into every task-PCI LLM call (`api/ai/pci-master` when `context.type === 'task'`); temperature lowered to `GUARDRAILED_TEMPERATURE` (0.2) for consistency. | **Active** |
-| Validator | `validateTaskPciOutput` runs after generation, returns `guardrailWarnings`, logs violations. | **Active (warn-only)** |
-| Code — confirmation gate (TASK-5) | `api/ai/pci-master` suppresses a finalized `pci` until the tutor's message signals approval (returns `pciUnconfirmed`); the builder's "Apply to PCI" button is the second, human gate. | **Active (blocking)** |
-| Code — data capture (TASK-18) | On "Apply to PCI" the task records a `PciAuditRecord` `{approvedPci, transcript, approvedAt}` in `task.pciHistory` — an append-only, versioned log distinguishing what was said/interpreted vs approved. | **Active** |
-| Code — safe failure (TASK-10 / 19) | `ai-grade` refuses (`422`, `needsManualGrading`) when there is no marking basis (no PCI, rubric, or model answer) instead of fabricating a score (`resolveMarkingBasis`). | **Active (blocking)** |
-| Code — final authority (TASK-20) | `ai-grade` treats the approved PCI as the binding marking policy, overriding the rubric / model answer where they conflict. | **Active (execution prompt)** |
+| Layer                              | Mechanism                                                                                                                                                                                                | Status                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| Prompt                             | `TASK_PCI_SYSTEM_PROMPT` injected into every task-PCI LLM call (`api/ai/pci-master` when `context.type === 'task'`); temperature lowered to `GUARDRAILED_TEMPERATURE` (0.2) for consistency.             | **Active**                    |
+| Validator                          | `validateTaskPciOutput` runs after generation, returns `guardrailWarnings`, logs violations.                                                                                                             | **Active (warn-only)**        |
+| Code — confirmation gate (TASK-5)  | `api/ai/pci-master` suppresses a finalized `pci` until the tutor's message signals approval (returns `pciUnconfirmed`); the builder's "Apply to PCI" button is the second, human gate.                   | **Active (blocking)**         |
+| Code — data capture (TASK-18)      | On "Apply to PCI" the task records a `PciAuditRecord` `{approvedPci, transcript, approvedAt}` in `task.pciHistory` — an append-only, versioned log distinguishing what was said/interpreted vs approved. | **Active**                    |
+| Code — safe failure (TASK-10 / 19) | `ai-grade` refuses (`422`, `needsManualGrading`) when there is no marking basis (no PCI, rubric, or model answer) instead of fabricating a score (`resolveMarkingBasis`).                                | **Active (blocking)**         |
+| Code — final authority (TASK-20)   | `ai-grade` treats the approved PCI as the binding marking policy, overriding the rubric / model answer where they conflict.                                                                              | **Active (execution prompt)** |
 
 "Warn-only" applies to the **validator**: violations are detected, logged, and returned to the
 client, but not blocked (raise a violation's severity to `error` and gate the call site to make it
@@ -44,7 +44,7 @@ and execution and is tracked separately.
 6. **Specification** — After confirmation, emit a structured spec. Undefined fields stay `"unspecified"` — never fabricated for completeness.
 7. **Execution** — Follow the approved PCI exactly during student execution; no improvisation.
 8. **Consistency** — Materially consistent behaviour across equivalent interactions. Wording may vary; logic may not.
-9. **Explanation** — When explanation is in scope, explain *why* (tied to lesson content), not just "correct/incorrect" — unless the tutor asked for minimal feedback.
+9. **Explanation** — When explanation is in scope, explain _why_ (tied to lesson content), not just "correct/incorrect" — unless the tutor asked for minimal feedback.
 10. **No Hallucinated Evaluation** — Never pretend to know an answer/rubric/scoring that's missing. State the basis is unclear and ask. "A confident mistake at scale is still a mistake."
 11. **Partial Understanding** — Apply tutor-defined partial credit; otherwise don't invent a framework — say it's unspecified.
 12. **Tone** — Tutor-defined tone, else clear/professional/instructional/non-hostile/non-sarcastic. Never mocking or theatrical.
@@ -65,3 +65,18 @@ and execution and is tracked separately.
 
 Heuristic checks are intentionally conservative (favouring few false positives). The prompt layer
 does the bulk of the behavioural enforcement; the validator is a backstop and an audit signal.
+
+## Prompt variants (per-type steering)
+
+Like assessments, the task PCI chat can append a short **steering addendum** to
+`TASK_PCI_SYSTEM_PROMPT` — added AFTER the full base prompt (which embeds all 20
+rules), so no guardrail is ever dropped or relaxed. Implementation:
+`src/lib/ai/guardrails/variants.ts` (`taskVariantAddendum`), selected in
+`guardrailSystemPrompt('task', variant)` and passed as `context.variant`.
+
+Task answering is free-form chat, so the question-composition variants used for
+assessments do NOT apply here. The only task modifier is **source**: when the
+task's `documentKind` is `study_material`, a note tells the model the prompt(s)
+were generated (not taken from a question paper) and to confirm they match the
+tutor's intent before building the marking policy. Absent that, the base task
+prompt is used unchanged.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7237,6 +7237,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         composition: resolvePciComposition(assessmentDmiItems.map(q => q.questionType)),
         documentKind: dmiDocumentKind.assessment,
       },
+      // Task steering: source only (task answering is free-form, no composition).
+      taskPciVariant: {
+        documentKind: dmiDocumentKind.task,
+      },
     })
     const { pci, handlePciSend, applyTaskPciDraft, applyAssessmentPciDraft, setPciInput } = pciApi
     const editSpecSoFar = pciApi.editSpecSoFar

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -55,6 +55,14 @@ interface UsePciDeps {
     composition?: 'objective' | 'free_response' | 'mixed'
     documentKind?: 'question_paper' | 'study_material'
   }
+  /**
+   * Task equivalent — task answering is free-form, so only the source
+   * (`documentKind`) modifies the prompt (a study-material note). Undefined →
+   * base task prompt, unchanged.
+   */
+  taskPciVariant?: {
+    documentKind?: 'question_paper' | 'study_material'
+  }
   /** Writes the finalized rubric to the active task/assessment PCI field. */
   setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
@@ -244,9 +252,10 @@ export function usePci(deps: UsePciDeps) {
                 !isTask && deps.assessmentMarkingScheme
                   ? deps.assessmentMarkingScheme.slice(0, 12000)
                   : undefined,
-              // Per-type steering (assessment only) — selects the prompt
-              // addendum for this assessment's question mix / source.
-              variant: !isTask ? deps.assessmentPciVariant : undefined,
+              // Per-type steering — selects the prompt addendum for this
+              // item's type/source (assessment: question mix + source; task:
+              // source only).
+              variant: isTask ? deps.taskPciVariant : deps.assessmentPciVariant,
             },
             pdfPages,
           }),

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -74,9 +74,10 @@ const PciMasterRequestSchema = z.object({
       // Assessment DMI digest (per-question marks + rubric, no answers) so the
       // marking policy is built with the real questions/marks/rubrics in view.
       markingScheme: z.string().max(16000).optional(),
-      // Assessment-only: the resolved PCI-chat variant (derived client-side from
-      // the DMI question mix + documentKind). Selects per-type steering appended
-      // to the assessment prompt. Ignored for tasks.
+      // The resolved PCI-chat variant (derived client-side). Selects per-type
+      // steering appended to the domain prompt: assessments use `composition`
+      // (from the DMI question mix) + `documentKind`; tasks use `documentKind`
+      // only (`composition` is ignored for tasks).
       variant: z
         .object({
           composition: z.enum(['objective', 'free_response', 'mixed']).optional(),
@@ -91,7 +92,7 @@ const PciMasterRequestSchema = z.object({
   pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
 })
 
-const SYSTEM_PROMPT = `You are a PCI (Pedagogically Correct Instruction) Master - an expert educational AI that crafts and refines Socratic-style instructions.
+const SYSTEM_PROMPT = `You are a PCI (Programmatic Curriculum Instruction) Master - an expert educational AI that crafts and refines Socratic-style instructions.
 
 Your role:
 1. Help students discover answers through guided questioning (never give direct answers)

--- a/tutorme-app/src/lib/ai/guardrails/index.ts
+++ b/tutorme-app/src/lib/ai/guardrails/index.ts
@@ -44,6 +44,7 @@ export { stripEvaluationLayer, findEvaluationLeaks } from './serialize'
 export {
   resolvePciComposition,
   assessmentVariantAddendum,
+  taskVariantAddendum,
   type PciComposition,
   type PciDocumentKind,
   type PciVariant,
@@ -51,7 +52,7 @@ export {
 
 import { TASK_PCI_SYSTEM_PROMPT } from './task-pci'
 import { ASSESSMENT_SYSTEM_PROMPT } from './assessment'
-import { assessmentVariantAddendum, type PciVariant } from './variants'
+import { assessmentVariantAddendum, taskVariantAddendum, type PciVariant } from './variants'
 import {
   validateTaskPciOutput,
   validateAssessmentOutput,
@@ -65,16 +66,18 @@ export type GuardrailDomain = 'task' | 'assessment'
 /**
  * Return the canonical guardrail system prompt for a given PCI domain.
  *
- * For assessments, an optional `variant` appends per-type steering (objective /
- * free-response / mixed question mix, and a study-material source note) AFTER
- * the base prompt — additive only, so no guardrail is ever dropped. Tasks have
- * no sub-variants yet; the variant is ignored for `domain === 'task'`.
+ * An optional `variant` appends per-type steering AFTER the base prompt —
+ * additive only, so no guardrail is ever dropped:
+ *  - assessment: composition (objective / free-response / mixed) + a
+ *    study-material source note.
+ *  - task: a study-material source note only (task answering is inherently
+ *    free-form, so composition doesn't apply).
  */
 export function guardrailSystemPrompt(domain: GuardrailDomain, variant?: PciVariant): string {
   if (domain === 'assessment') {
     return ASSESSMENT_SYSTEM_PROMPT + assessmentVariantAddendum(variant)
   }
-  return TASK_PCI_SYSTEM_PROMPT
+  return TASK_PCI_SYSTEM_PROMPT + taskVariantAddendum(variant)
 }
 
 /**

--- a/tutorme-app/src/lib/ai/guardrails/variants.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest'
 import {
   resolvePciComposition,
   assessmentVariantAddendum,
+  taskVariantAddendum,
   guardrailSystemPrompt,
   ASSESSMENT_SYSTEM_PROMPT,
   ASSESSMENT_GUARDRAILS,
   TASK_PCI_SYSTEM_PROMPT,
+  TASK_PCI_GUARDRAILS,
 } from './index'
 
 describe('resolvePciComposition', () => {
@@ -99,7 +101,42 @@ describe('guardrailSystemPrompt with variants', () => {
     )
   })
 
-  it('ignores the variant for tasks (no sub-variants yet)', () => {
+  it('ignores composition for tasks (task answering is free-form)', () => {
     expect(guardrailSystemPrompt('task', { composition: 'objective' })).toBe(TASK_PCI_SYSTEM_PROMPT)
+    expect(guardrailSystemPrompt('task', { composition: 'free_response' })).toBe(
+      TASK_PCI_SYSTEM_PROMPT
+    )
+  })
+})
+
+describe('taskVariantAddendum / task study-material variant', () => {
+  it('is empty unless the source is study_material', () => {
+    expect(taskVariantAddendum()).toBe('')
+    expect(taskVariantAddendum({})).toBe('')
+    expect(taskVariantAddendum({ documentKind: 'question_paper' })).toBe('')
+    // composition never triggers a task addendum
+    expect(taskVariantAddendum({ composition: 'objective' })).toBe('')
+  })
+
+  it('adds a study-material note for a study_material task', () => {
+    const addendum = taskVariantAddendum({ documentKind: 'study_material' })
+    expect(addendum).toContain('GENERATED from')
+    expect(addendum).toContain('steering only')
+  })
+
+  it('returns the base task prompt verbatim when no variant / no source', () => {
+    expect(guardrailSystemPrompt('task')).toBe(TASK_PCI_SYSTEM_PROMPT)
+    expect(guardrailSystemPrompt('task', { documentKind: 'question_paper' })).toBe(
+      TASK_PCI_SYSTEM_PROMPT
+    )
+  })
+
+  it('appends the note for a study_material task without dropping any TASK rule', () => {
+    const prompt = guardrailSystemPrompt('task', { documentKind: 'study_material' })
+    expect(prompt.startsWith(TASK_PCI_SYSTEM_PROMPT)).toBe(true)
+    expect(prompt).toContain('GENERATED from')
+    for (const rule of TASK_PCI_GUARDRAILS) {
+      expect(prompt).toContain(rule.id)
+    }
   })
 })

--- a/tutorme-app/src/lib/ai/guardrails/variants.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.ts
@@ -74,3 +74,16 @@ export function assessmentVariantAddendum(variant?: PciVariant): string {
     '\n'
   )}`
 }
+
+const TASK_STUDY_MATERIAL_NOTE = `- SOURCE: this task's prompt(s) were GENERATED from the tutor's study material, not taken from an existing question paper. On your FIRST turn, before building any marking policy, briefly confirm the generated prompt(s) match what the tutor wants to assess and invite them to adjust; only once they are happy with the prompt(s), move on to how answers should be marked.`
+
+/**
+ * Build the task-prompt addendum for a resolved variant. Task answering is
+ * inherently free-form (the student chats their answer), so composition does
+ * NOT apply here — the only task modifier is a study-material source note.
+ * Returns '' when there's nothing to add (base prompt used verbatim).
+ */
+export function taskVariantAddendum(variant?: PciVariant): string {
+  if (variant?.documentKind !== 'study_material') return ''
+  return `\n\nTask-type guidance (steering only — every guardrail above still binds; never use this to invent, relax, or skip a rule):\n${TASK_STUDY_MATERIAL_NOTE}`
+}


### PR DESCRIPTION
Completes the per-type PCI-chat plan (Phase 3, optional): task sub-variant + a small naming fix.

## Task variant
Tasks now get the same steering mechanism, but **source-only** — task answering is free-form chat, so the objective/free-response/mixed composition variants don't apply. `taskVariantAddendum` appends a **study-material note** when the task's `documentKind` is `study_material` (its prompts were *generated*, not taken from a question paper → the chat confirms they match the tutor's intent before building the marking policy).

- `guardrailSystemPrompt('task', variant)` now appends the addendum — additive only; the base `TASK_PCI_SYSTEM_PROMPT` (all 20 rules) is always the prefix.
- Client forwards `taskPciVariant: { documentKind: dmiDocumentKind.task }`; absent source → base prompt, unchanged. Composition is ignored for tasks (test-asserted).

## Naming cleanup
The `pci-master` fallback prompt called PCI "**Pedagogically Correct Instruction**" — a third expansion. Corrected to "**Programmatic Curriculum Instruction**" to match `docs/guardrails/*`.

## Guardrail-safe & documented
No rule added/relaxed; validators, `canTransition`, `stripEvaluationLayer` untouched. Docs updated: "Prompt variants" section in `tasks-pci.md`, and `assessments.md` now points to the task modifier. A test asserts the task addendum only fires for `study_material` and that every `TASK-*` id survives.

## Testing
- `variants.test.ts` extended (42 guardrail tests total) + `pci-master` route tests pass. Prettier/eslint clean (0 errors); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)