### PR TITLE
fix(deploy): stop answer key leaking to students + restore grading

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -203,10 +203,12 @@ import {
 } from '@/lib/assessment/question-types'
 import { deriveExamContext } from '@/lib/assessment/marking-scheme'
 import { getAllCourseCategoryOptions } from '@/lib/data/all-categories'
-import { reverifyAssessment } from '@/lib/assessment/assessment-gates'
 import { deriveSections, deriveTotalMarks } from '@/lib/assessment/sections'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
-import { findEvaluationLeaks, resolvePciComposition } from '@/lib/ai/guardrails'
+import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
+import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
+import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
+import { resolvePciComposition } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -515,56 +517,6 @@ const pdfPageCache = new Map<string, string[]>()
 // Collapsible explainer at the top of a PCI tab. PCI ("how to mark this") is easy
 // to confuse with the question content, so this spells out what it is, the flow,
 // and concrete things worth telling the assistant — to point tutors the right way.
-// --- MCQ answer-key helpers (DMI editor) ------------------------------------
-// Choice options are labelled A, B, C… and the answer key stores those letters.
-// These map an option index to its letter and read which letters an item's
-// free-text `answer` currently marks as correct (tolerant of "A", "A, C",
-// "A C", or the option's exact text).
-function dmiOptionLetter(index: number): string {
-  return String.fromCharCode(65 + index)
-}
-function dmiSelectedOptionLetters(
-  answer: string | undefined,
-  options: readonly string[]
-): Set<string> {
-  const selected = new Set<string>()
-  const ans = (answer ?? '').trim()
-  if (!ans) return selected
-  const tokens = ans
-    .toUpperCase()
-    .split(/[^A-Z0-9]+/)
-    .filter(Boolean)
-  options.forEach((opt, i) => {
-    const letter = dmiOptionLetter(i)
-    const text = (opt ?? '').trim().toLowerCase()
-    if (tokens.includes(letter) || (text && ans.toLowerCase() === text)) selected.add(letter)
-  })
-  return selected
-}
-
-// Map the tutor's free-text PCI answer-reveal policy to a deploy reveal mode, so
-// the Deploy dialog can default to what they already said (they can still change
-// it). Returns null when the policy doesn't clearly map to a mode.
-function revealPolicyToDeployMode(
-  policy?: string
-): 'instant' | 'after_submit' | 'hidden' | 'student_choice' | null {
-  const p = (policy ?? '').toLowerCase().trim()
-  if (!p) return null
-  if (/\bnever\b|\bhidden\b|do ?n'?t reveal|do not reveal|no reveal|withhold|keep hidden/.test(p))
-    return 'hidden'
-  if (/student'?s? choice|let (the )?student|on request|when they (want|choose)|optional/.test(p))
-    return 'student_choice'
-  if (
-    /after (the )?(final|last|submit|submission|attempt|answer|test|quiz)|once (they|the student|submitted)|on (the )?results|end of/.test(
-      p
-    )
-  )
-    return 'after_submit'
-  if (/instant|immediately|right away|straight away|as soon as|show (the )?answer/.test(p))
-    return 'instant'
-  return null
-}
-
 // Remember the tutor's assessment DMI response-format choice per course, so the
 // chooser doesn't re-prompt on every paper in a course that's all one format.
 type DmiFormat = 'free_response' | 'multiple_choice'
@@ -1448,8 +1400,28 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           }
           if (srcLessonId) break
         }
+        // Deploy-safety: strip the answer key out of the student-facing dmiItems
+        // and carry it separately as `answerKey` (server-only, for grading). Every
+        // deploy path routes through here, so this is the single guarantee that
+        // answers/rubrics never reach students. Block if anything still leaks.
+        const {
+          dmiItems: safeDmiItems,
+          answerKey,
+          leaks,
+        } = buildStudentDeployPayload(
+          payload.dmiItems as unknown as RawDeployDmiItem[] | undefined,
+          payload.answerKey
+        )
+        if (leaks.length > 0) {
+          console.error('[deploy] evaluation-layer leak blocked:', leaks)
+          toast.error('Answer data was present in the student view. Deploy blocked.')
+          return
+        }
+
         const enriched: LiveTask = {
           ...payload,
+          dmiItems: safeDmiItems,
+          answerKey,
           pci:
             payload.pci ?? (typeof src?.instructions === 'string' ? src.instructions : undefined),
           pciSpec: payload.pciSpec ?? src?.pciSpec,
@@ -3817,101 +3789,6 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         setAssessmentDmiVersions(prev => prev.filter(v => v.id !== versionId))
       }
     }
-
-    const handleDeployAssessmentDmi = useCallback(
-      (revealArg?: 'instant' | 'after_submit' | 'hidden' | 'student_choice') => {
-        const reveal = revealArg ?? deployAnswerReveal
-        if (!loadedAssessmentId) {
-          toast.error('Select an assessment to deploy')
-          return
-        }
-        if (!insightsProps?.sessionId) {
-          toast.error('Select a course session for insights')
-          return
-        }
-
-        // ASMT-12: re-verify the assessment is internally consistent and fully
-        // gradable before generating the final/deployed DMI. Covers ASMT-8
-        // (open-question rubric), numbering integrity, and answer-key mapping;
-        // blocks deploy on any issue.
-        const reverifyIssues = reverifyAssessment(assessmentDmiItems)
-        if (reverifyIssues.length > 0) {
-          const shown = reverifyIssues
-            .slice(0, 3)
-            .map(i => i.message)
-            .join(' ')
-          const more = reverifyIssues.length > 3 ? ` (+${reverifyIssues.length - 3} more)` : ''
-          toast.error(`Cannot deploy — ${shown}${more}`)
-          return
-        }
-
-        // Student-safe DMI: strips the answer key, including matching `pairs`
-        // and hotspot `regions` (which ARE the answer). See toStudentDmiItem.
-        const studentDmiItems = assessmentDmiItems.map(toStudentDmiItem)
-        // ASMT-10/13: deterministic guarantee the student payload carries no
-        // evaluation data — block deploy if anything leaks through.
-        const leaks = findEvaluationLeaks(studentDmiItems)
-        if (leaks.length > 0) {
-          console.error('[assessment] evaluation-layer leak in student payload:', leaks)
-          toast.error(
-            'Internal error: answer data was present in the student view. Deploy blocked.'
-          )
-          return
-        }
-
-        const task: LiveTask = {
-          id: loadedAssessmentId,
-          title: assessmentBuilder.title || 'Assessment',
-          content: assessmentBuilder.taskContent,
-          source: 'assessment',
-          dmiItems: studentDmiItems,
-          // Answer key + marks for server-side auto-grading. Sent to the server
-          // only — never broadcast to students.
-          answerKey: assessmentDmiItems.map(item => ({
-            id: item.id,
-            answer: item.answer,
-            acceptableVariants: item.acceptableVariants,
-            marks: item.marks,
-          })),
-          answerReveal: reveal,
-          // Tutor's PCI (free-text + structured spec) for server-side use by the
-          // live tutor + grader. Deploy-only; never broadcast to students. The
-          // server persists pciSpec to BuilderTask.pciSpec, mirroring tasks.
-          pci: assessmentBuilder.taskPci || undefined,
-          pciSpec: assessmentBuilder.pciSpec,
-          // The lesson this assessment was deployed from (real lesson, not
-          // "Lesson 1").
-          lessonId: findLessonIdForItem(loadedAssessmentId),
-          deployedAt: Date.now(),
-          polls: [],
-          questions: [],
-          // Reference-only (study-material-derived) documents stay in the
-          // builder for the tutor but are NOT sent to students — they receive
-          // the generated questions as Classroom content instead.
-          sourceDocument:
-            currentAssessmentDocument && !assessmentSourceReferenceOnly
-              ? {
-                  fileName: currentAssessmentDocument.fileName,
-                  fileUrl: currentAssessmentDocument.fileUrl,
-                  fileKey: currentAssessmentDocument.fileKey,
-                  mimeType: currentAssessmentDocument.mimeType,
-                }
-              : undefined,
-        }
-
-        // Success is confirmed by the server's task:deployed broadcast (handled in
-        // insights/page.tsx), not optimistically here.
-        insightsProps.onDeployTask?.(task)
-      },
-      [
-        assessmentBuilder,
-        assessmentDmiItems,
-        assessmentSourceReferenceOnly,
-        insightsProps,
-        loadedAssessmentId,
-        deployAnswerReveal,
-      ]
-    )
 
     useEffect(() => {
       return () => {

--- a/tutorme-app/src/lib/assessment/deploy-safety.test.ts
+++ b/tutorme-app/src/lib/assessment/deploy-safety.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { buildStudentDeployPayload, type RawDeployDmiItem } from './deploy-safety'
+
+const rawItem = (over: Partial<RawDeployDmiItem> = {}): RawDeployDmiItem => ({
+  id: 'q1',
+  questionNumber: 1,
+  questionText: 'What is 2 + 2?',
+  questionType: 'mcq',
+  options: ['3', '4', '5', '6'],
+  marks: 1,
+  answer: 'B',
+  acceptableVariants: ['b', 'four'],
+  rubric: 'Award 1 for B.',
+  ...over,
+})
+
+describe('buildStudentDeployPayload', () => {
+  it('strips the answer key from the student dmiItems', () => {
+    const { dmiItems } = buildStudentDeployPayload([rawItem()])
+    const item = dmiItems[0] as Record<string, unknown>
+    expect(item.answer).toBeUndefined()
+    expect(item.rubric).toBeUndefined()
+    expect(item.acceptableVariants).toBeUndefined()
+    // ...but keeps the student-facing fields.
+    expect(item.questionText).toBe('What is 2 + 2?')
+    expect(item.options).toEqual(['3', '4', '5', '6'])
+  })
+
+  it('derives the server-only answerKey from the raw items', () => {
+    const { answerKey } = buildStudentDeployPayload([rawItem()])
+    expect(answerKey).toEqual([
+      { id: 'q1', answer: 'B', acceptableVariants: ['b', 'four'], marks: 1 },
+    ])
+  })
+
+  it('reports NO leaks in the produced student payload', () => {
+    const { leaks } = buildStudentDeployPayload([
+      rawItem(),
+      rawItem({ id: 'q2', answer: 'A', questionText: 'Pick A' }),
+    ])
+    expect(leaks).toEqual([])
+  })
+
+  it('strips matching/hotspot answer keys (pairs/regions) from the student view', () => {
+    const { dmiItems, leaks } = buildStudentDeployPayload([
+      {
+        id: 'm1',
+        questionNumber: 1,
+        questionText: 'Match them',
+        questionType: 'matching',
+        pairs: [
+          { left: 'A', right: '1' },
+          { left: 'B', right: '2' },
+        ],
+      } as RawDeployDmiItem,
+    ])
+    const item = dmiItems[0] as Record<string, unknown>
+    expect(item.pairs).toBeUndefined()
+    // The prompt is shown; the correct pairing is not.
+    expect(item.matchPrompts).toEqual(['A', 'B'])
+    expect(leaks).toEqual([])
+  })
+
+  it('uses a provided answerKey as-is (already-stripped paths)', () => {
+    const provided = [{ id: 'q1', answer: 'B', marks: 1 }]
+    const { answerKey } = buildStudentDeployPayload([rawItem({ answer: undefined })], provided)
+    expect(answerKey).toBe(provided)
+  })
+
+  it('handles empty / undefined input', () => {
+    expect(buildStudentDeployPayload(undefined)).toEqual({ dmiItems: [], answerKey: [], leaks: [] })
+    expect(buildStudentDeployPayload([])).toEqual({ dmiItems: [], answerKey: [], leaks: [] })
+  })
+})

--- a/tutorme-app/src/lib/assessment/deploy-safety.ts
+++ b/tutorme-app/src/lib/assessment/deploy-safety.ts
@@ -1,0 +1,65 @@
+/**
+ * Deploy-safety — the single guarantee point for every deploy path (task /
+ * assessment / homework).
+ *
+ * The builder holds DMI items that carry the answer key (`answer`, `rubric`,
+ * `acceptableVariants`, and the correct `pairs`/`regions` for matching/hotspot).
+ * Two things must happen before a deploy reaches students:
+ *   1. the student-facing `dmiItems` must be stripped of all of that
+ *      (`toStudentDmiItem`), and
+ *   2. the answer key must be carried separately as `answerKey` — sent to the
+ *      server for grading, NEVER broadcast to students.
+ * Sending raw items leaks answers; sending no answer key breaks auto-grading.
+ * `buildStudentDeployPayload` does both and returns a leak backstop.
+ */
+
+import { toStudentDmiItem, type DeployableDmiItem, type StudentDmiItem } from './student-dmi'
+import { findEvaluationLeaks } from '@/lib/ai/guardrails'
+
+/** A DMI item as held in the builder — the answer-bearing (evaluation) shape. */
+export type RawDeployDmiItem = DeployableDmiItem & {
+  answer?: string
+  acceptableVariants?: string[]
+  rubric?: string
+}
+
+/** Per-question answer key sent to the server for grading (never to students). */
+export interface DeployAnswerKeyEntry {
+  id: string
+  answer?: string
+  acceptableVariants?: string[]
+  marks?: number
+}
+
+export interface StudentDeployPayload {
+  /** Answer-stripped items, safe to broadcast to students. */
+  dmiItems: StudentDmiItem[]
+  /** Server-only answer key for grading. */
+  answerKey: DeployAnswerKeyEntry[]
+  /** Residual evaluation-layer leaks found in `dmiItems` — MUST be empty; a
+   *  non-empty result means the deploy should be blocked. */
+  leaks: string[]
+}
+
+/**
+ * Produce the student-safe payload from the tutor's raw DMI items. When the
+ * caller already supplies an `answerKey` (e.g. a path that pre-stripped its
+ * items), it is used as-is; otherwise the key is derived from the raw items.
+ */
+export function buildStudentDeployPayload(
+  rawItems: ReadonlyArray<RawDeployDmiItem> | undefined,
+  providedAnswerKey?: DeployAnswerKeyEntry[]
+): StudentDeployPayload {
+  const items = rawItems ?? []
+  const dmiItems = items.map(it => toStudentDmiItem(it))
+  const answerKey =
+    providedAnswerKey ??
+    items.map(it => ({
+      id: it.id,
+      answer: typeof it.answer === 'string' ? it.answer : undefined,
+      acceptableVariants: Array.isArray(it.acceptableVariants) ? it.acceptableVariants : undefined,
+      marks: typeof it.marks === 'number' ? it.marks : undefined,
+    }))
+  const leaks = findEvaluationLeaks(dmiItems)
+  return { dmiItems, answerKey, leaks }
+}

--- a/tutorme-app/src/lib/assessment/mcq-answer.test.ts
+++ b/tutorme-app/src/lib/assessment/mcq-answer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { dmiOptionLetter, dmiSelectedOptionLetters } from './mcq-answer'
+
+const OPTS = ['alpha', 'beta', 'gamma', 'delta']
+
+describe('dmiOptionLetter', () => {
+  it('maps index → A, B, C, D', () => {
+    expect([0, 1, 2, 3].map(dmiOptionLetter)).toEqual(['A', 'B', 'C', 'D'])
+  })
+})
+
+describe('dmiSelectedOptionLetters', () => {
+  it('reads a single letter (any case)', () => {
+    expect([...dmiSelectedOptionLetters('B', OPTS)]).toEqual(['B'])
+    expect([...dmiSelectedOptionLetters('b', OPTS)]).toEqual(['B'])
+  })
+
+  it('reads multiple letters separated by commas or spaces', () => {
+    expect([...dmiSelectedOptionLetters('A, C', OPTS)].sort()).toEqual(['A', 'C'])
+    expect([...dmiSelectedOptionLetters('A C', OPTS)].sort()).toEqual(['A', 'C'])
+    expect([...dmiSelectedOptionLetters('a,d', OPTS)].sort()).toEqual(['A', 'D'])
+  })
+
+  it('matches by exact option text', () => {
+    expect([...dmiSelectedOptionLetters('gamma', OPTS)]).toEqual(['C'])
+    expect([...dmiSelectedOptionLetters('GAMMA', OPTS)]).toEqual(['C'])
+  })
+
+  it('returns empty for blank / unmatched answers', () => {
+    expect([...dmiSelectedOptionLetters('', OPTS)]).toEqual([])
+    expect([...dmiSelectedOptionLetters(undefined, OPTS)]).toEqual([])
+    expect([...dmiSelectedOptionLetters('Z', OPTS)]).toEqual([])
+  })
+
+  it('does not select a letter beyond the option count', () => {
+    // Only 2 options → only A/B are valid even if the answer says "C".
+    expect([...dmiSelectedOptionLetters('C', ['x', 'y'])]).toEqual([])
+  })
+})

--- a/tutorme-app/src/lib/assessment/mcq-answer.ts
+++ b/tutorme-app/src/lib/assessment/mcq-answer.ts
@@ -1,0 +1,29 @@
+/**
+ * MCQ answer-key helpers for the DMI editor. Choice options are labelled A, B,
+ * C… and the answer key stores those letters. These map an option index to its
+ * letter and read which letters an item's free-text `answer` currently marks as
+ * correct — tolerant of "A", "A, C", "A C", or the option's exact text.
+ */
+
+export function dmiOptionLetter(index: number): string {
+  return String.fromCharCode(65 + index)
+}
+
+export function dmiSelectedOptionLetters(
+  answer: string | undefined,
+  options: readonly string[]
+): Set<string> {
+  const selected = new Set<string>()
+  const ans = (answer ?? '').trim()
+  if (!ans) return selected
+  const tokens = ans
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter(Boolean)
+  options.forEach((opt, i) => {
+    const letter = dmiOptionLetter(i)
+    const text = (opt ?? '').trim().toLowerCase()
+    if (tokens.includes(letter) || (text && ans.toLowerCase() === text)) selected.add(letter)
+  })
+  return selected
+}

--- a/tutorme-app/src/lib/assessment/reveal-policy.test.ts
+++ b/tutorme-app/src/lib/assessment/reveal-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { revealPolicyToDeployMode } from './reveal-policy'
+
+describe('revealPolicyToDeployMode', () => {
+  it('maps hidden / never phrasings', () => {
+    expect(revealPolicyToDeployMode('Never reveal the answer')).toBe('hidden')
+    expect(revealPolicyToDeployMode('Keep the answer hidden')).toBe('hidden')
+    expect(revealPolicyToDeployMode("Don't reveal answers")).toBe('hidden')
+  })
+
+  it('maps after-submit / after-attempt phrasings', () => {
+    expect(revealPolicyToDeployMode('Reveal after the final attempt')).toBe('after_submit')
+    expect(revealPolicyToDeployMode('Show it once they submit')).toBe('after_submit')
+    expect(revealPolicyToDeployMode('Only on the results screen')).toBe('after_submit')
+  })
+
+  it('maps instant phrasings', () => {
+    expect(revealPolicyToDeployMode('Show the answer immediately')).toBe('instant')
+    expect(revealPolicyToDeployMode('Reveal right away')).toBe('instant')
+  })
+
+  it('maps student-choice phrasings', () => {
+    expect(revealPolicyToDeployMode("Student's choice")).toBe('student_choice')
+    expect(revealPolicyToDeployMode('Let the student decide when to see it')).toBe('student_choice')
+  })
+
+  it('returns null for empty or unmappable policies', () => {
+    expect(revealPolicyToDeployMode('')).toBeNull()
+    expect(revealPolicyToDeployMode(undefined)).toBeNull()
+    expect(revealPolicyToDeployMode('Mark strictly to the rubric')).toBeNull()
+  })
+
+  it('prioritizes hidden over after-submit when both are implied', () => {
+    // "never" wins even if "after" appears.
+    expect(revealPolicyToDeployMode('Never reveal, not even after submit')).toBe('hidden')
+  })
+})

--- a/tutorme-app/src/lib/assessment/reveal-policy.ts
+++ b/tutorme-app/src/lib/assessment/reveal-policy.ts
@@ -1,0 +1,25 @@
+/**
+ * Map the tutor's free-text PCI answer-reveal policy to a deploy reveal mode, so
+ * the Deploy dialog can default to what they already said (they can still change
+ * it). Returns null when the policy doesn't clearly map to a mode.
+ */
+
+export type DeployAnswerReveal = 'instant' | 'after_submit' | 'hidden' | 'student_choice'
+
+export function revealPolicyToDeployMode(policy?: string): DeployAnswerReveal | null {
+  const p = (policy ?? '').toLowerCase().trim()
+  if (!p) return null
+  if (/\bnever\b|\bhidden\b|do ?n'?t reveal|do not reveal|no reveal|withhold|keep hidden/.test(p))
+    return 'hidden'
+  if (/student'?s? choice|let (the )?student|on request|when they (want|choose)|optional/.test(p))
+    return 'student_choice'
+  if (
+    /after (the )?(final|last|submit|submission|attempt|answer|test|quiz)|once (they|the student|submitted)|on (the )?results|end of/.test(
+      p
+    )
+  )
+    return 'after_submit'
+  if (/instant|immediately|right away|straight away|as soon as|show (the )?answer/.test(p))
+    return 'instant'
+  return null
+}


### PR DESCRIPTION
## ⚠️ Security: answer key leaked to students on deploy

Deploying a **task** or **assessment** via the "Deploy" menu sent the **raw** DMI items to students — including `answer`, `rubric`, `acceptableVariants`, and the correct `pairs`/`regions` for matching/hotspot questions.

The student broadcast is supposed to be **stripped** (`toStudentDmiItem`), with the answer key carried separately as the **server-only** `answerKey` (both `LiveTaskDmiItem` and `LiveTask.answerKey` document this explicitly). But the correct logic lived only in `handleDeployAssessmentDmi`, which was **dead code** (unused — flagged in `lint.txt`). The live path — the deploy buttons → `deployTaskWithDialog` → `handleDeployTask` emit → server `normalizedTask.dmiItems = task.dmiItems` — stripped **nothing**.

**Two consequences:**
1. **Leak** — students received the answers in the deployed payload (inspectable client-side), and
2. **Broken grading** — no `answerKey` was sent, so server-side auto-grading had no key.

Only the homework path stripped correctly. Traced through client + server to confirm neither stripped.

## Fix
At the single deploy chokepoint (`deployTaskWithDialog`), so **every** path (task/assessment/homework) is covered:
- Strip `dmiItems` via `toStudentDmiItem` and derive the server-only `answerKey` from the raw items — extracted into a pure, tested `buildStudentDeployPayload`.
- Re-instate the `findEvaluationLeaks` backstop — **block** the deploy if any evaluation data remains in the student payload.
- Remove the dead `handleDeployAssessmentDmi` and its now-unused imports.

## Also (from the "anything to improve?" list) — extracted + unit-tested the error-prone helpers
- `deploy-safety.ts` (`buildStudentDeployPayload`) + tests — **verifies the leak is closed**
- `reveal-policy.ts` (`revealPolicyToDeployMode`) + tests
- `mcq-answer.ts` (option-letter parsing) + tests

## Verification
- **119 assessment unit tests pass** (18 new). `deploy-safety.test.ts` asserts answers are stripped, `answerKey` is derived, matching pairs are stripped, and `findEvaluationLeaks` reports **no leaks**.
- `tsc` clean · `eslint` 0 errors · `prettier`/`format:check` clean.

## Follow-up (not in this PR)
The ASMT-12 `reverifyAssessment` gradability gate was *also* only in the dead function, so it hasn't been running on deploys. Left un-wired here to keep this a focused security fix; re-instating it (assessment-only, on raw items) is a separate change since it changes which deploys are allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)