### PR TITLE
fix(pci): persist DMI documentKind so the study-material variant survives reload

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2099,6 +2099,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           activeExtensionId,
         })
         setTaskDmiItems(task.dmiItems || [])
+        // Rehydrate the DMI source kind so the PCI-chat study-material variant
+        // applies for a returning tutor, not just in the generation session.
+        setDmiDocumentKind(prev => ({ ...prev, task: task.documentKind }))
         // Normalize persisted versions so `items` is always an array — a legacy /
         // partially-saved version with a missing items array would otherwise crash
         // the DMI version-list / preview dialogs (rendered at the root, outside the
@@ -2146,6 +2149,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         activeExtensionId: null,
       })
       setAssessmentDmiItems(assessment.dmiItems || [])
+      // Rehydrate the DMI source kind so the PCI-chat study-material variant
+      // applies for a returning tutor, not just in the generation session.
+      setDmiDocumentKind(prev => ({ ...prev, assessment: assessment.documentKind }))
       // Normalize so every version's `items` is an array (see task note above).
       setAssessmentDmiVersions(
         (assessment.dmiVersions || []).map(v => ({
@@ -2321,6 +2327,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   task.instructions === taskBuilder.taskPci &&
                   task.extensions === taskBuilder.extensions &&
                   task.dmiItems === taskDmiItems &&
+                  task.documentKind === (dmiDocumentKind.task ?? task.documentKind) &&
                   task.dmiVersions === taskDmiVersions &&
                   task.activeDmiVersionId === nextActiveDmiVersionId &&
                   task.sourceDocument === taskBuilder.sourceDocument
@@ -2340,6 +2347,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   pciSpec: taskBuilder.pciSpec,
                   extensions: taskBuilder.extensions,
                   dmiItems: taskDmiItems,
+                  // Preserve the persisted kind when the session hasn't set one.
+                  documentKind: dmiDocumentKind.task ?? task.documentKind,
                   dmiVersions: taskDmiVersions,
                   activeDmiVersionId: nextActiveDmiVersionId,
                   sourceDocument: taskBuilder.sourceDocument,
@@ -2361,6 +2370,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       taskBuilder.sourceDocument,
       taskDmiItems,
       taskDmiVersions,
+      dmiDocumentKind.task,
       testPciSource,
       testPciViewMode,
       loadedTaskId,
@@ -2394,6 +2404,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   hw.instructions === assessmentBuilder.taskPci &&
                   hw.pciSpec === assessmentBuilder.pciSpec &&
                   hw.dmiItems === assessmentDmiItems &&
+                  hw.documentKind === (dmiDocumentKind.assessment ?? hw.documentKind) &&
                   hw.dmiVersions === assessmentDmiVersions &&
                   hw.activeDmiVersionId === nextActiveDmiVersionId &&
                   hw.sourceDocument === assessmentBuilder.sourceDocument
@@ -2408,6 +2419,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   instructions: assessmentBuilder.taskPci,
                   pciSpec: assessmentBuilder.pciSpec,
                   dmiItems: assessmentDmiItems,
+                  // Preserve the persisted kind when the session hasn't set one.
+                  documentKind: dmiDocumentKind.assessment ?? hw.documentKind,
                   dmiVersions: assessmentDmiVersions,
                   activeDmiVersionId: nextActiveDmiVersionId,
                   sourceDocument: assessmentBuilder.sourceDocument,
@@ -2428,6 +2441,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       assessmentBuilder.sourceDocument,
       assessmentDmiItems,
       assessmentDmiVersions,
+      dmiDocumentKind.assessment,
       testPciSource,
       testPciViewMode,
       loadedAssessmentId,

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -158,6 +158,9 @@ export interface Task extends WithDifficultyVariants {
   dmiItems?: DMIQuestion[]
   dmiVersions?: DMIVersion[]
   activeDmiVersionId?: string
+  /** How the DMI was sourced — persisted so the PCI-chat study-material variant
+   *  works for a returning tutor (not just in the DMI-generation session). */
+  documentKind?: 'question_paper' | 'study_material'
   estimatedMinutes: number
   points: number
   submissionType: 'text' | 'file' | 'link' | 'none' | 'questions'
@@ -188,6 +191,9 @@ export interface Assessment extends WithDifficultyVariants {
   dmiItems?: DMIQuestion[]
   dmiVersions?: DMIVersion[]
   activeDmiVersionId?: string
+  /** How the DMI was sourced — persisted so the PCI-chat study-material variant
+   *  works for a returning tutor (not just in the DMI-generation session). */
+  documentKind?: 'question_paper' | 'study_material'
   category?: 'assessment' | 'homework'
   difficulty?: string
   dueDate?: string

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -183,6 +183,14 @@ export async function POST(request: NextRequest) {
       : SYSTEM_PROMPT
     const activeTemperature = guardrailDomain ? GUARDRAILED_TEMPERATURE : 0.7
 
+    // Observability: record which per-type variant actually fired, so the
+    // composition thresholds / addendum wording can be tuned from real usage.
+    if (guardrailDomain) {
+      console.log(
+        `[pci-master] domain=${guardrailDomain} composition=${context?.variant?.composition ?? '-'} documentKind=${context?.variant?.documentKind ?? '-'}`
+      )
+    }
+
     const safeMessage = AISecurityManager.sanitizeAiInput(message)
     if (!safeMessage) {
       return NextResponse.json(


### PR DESCRIPTION
Fills the gap I flagged in the per-type PCI feature: the **study-material variant only fired in the same session the DMI was generated**.

## The gap
The study-material steering (assessment Phase 2 / task Phase 3) keys off `dmiDocumentKind`, which was **React session state** set only at DMI-generation time and never persisted (not a DB column, not in builderData). So for a **returning tutor** — page reload, or reopening an assessment/task whose DMI was generated in a prior session — `dmiDocumentKind[source]` was `undefined` and the "these were generated, confirm coverage first" note silently didn't apply.

(The **composition** variant was already robust — it derives from the persisted `dmiItems`, so objective/free-response/mixed steering already survived reloads.)

## Fix
- **Persist** `documentKind` on the Task/Assessment builder record (`builder-types.ts`).
- **Write** it in both auto-save syncs (task + assessment), preserving the stored value when the session hasn't set one (`?? record.documentKind`); added to the change-comparison and effect deps so a manual override via the "Detected as…" banner persists too.
- **Rehydrate** `dmiDocumentKind` from the record in `loadTaskIntoBuilder` / `loadAssessmentIntoBuilder`, so the variant applies on reopen.
- **Observability**: `pci-master` now logs the resolved variant (`domain / composition / documentKind`) so the 80%/60% thresholds and addendum wording can be tuned from real usage.

`documentKind` is source metadata (not answers/rubrics), so it sits outside the evaluation layer — unaffected by `stripEvaluationLayer`.

## Testing
- Guardrail + `pci-master` route tests pass (42). Prettier/eslint clean (0 errors); typecheck clean.
- Manual check worth doing after deploy: generate a DMI from **study material**, reload the page, reopen it → the PCI chat's first turn should still do the coverage check. Then check Cloud Run logs for the `[pci-master] …` line to see the variant firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)