### PR TITLE
feat(deploy): re-instate ASMT-12 gradability gate + answer-leak audit script

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -204,6 +204,7 @@ import {
 import { deriveExamContext } from '@/lib/assessment/marking-scheme'
 import { getAllCourseCategoryOptions } from '@/lib/data/all-categories'
 import { deriveSections, deriveTotalMarks } from '@/lib/assessment/sections'
+import { reverifyAssessment, type ReverifyItem } from '@/lib/assessment/assessment-gates'
 import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
 import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
 import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
@@ -1404,6 +1405,26 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         // and carry it separately as `answerKey` (server-only, for grading). Every
         // deploy path routes through here, so this is the single guarantee that
         // answers/rubrics never reach students. Block if anything still leaks.
+
+        // ASMT-12 gradability gate (assessment-only): the assessment must be
+        // internally consistent and fully gradable before deploy — no duplicate
+        // question numbers, every open (short/long) question has a rubric
+        // pathway, and every closed (mcq/…) question has an answer key. Runs on
+        // the RAW items (which still carry answers/rubrics). This blocks, e.g.,
+        // deploying a configured MCQ paper before all correct options are set.
+        if (payload.source === 'assessment') {
+          const issues = reverifyAssessment((payload.dmiItems ?? []) as unknown as ReverifyItem[])
+          if (issues.length > 0) {
+            const shown = issues
+              .slice(0, 3)
+              .map(i => i.message)
+              .join(' ')
+            const more = issues.length > 3 ? ` (+${issues.length - 3} more)` : ''
+            toast.error(`Cannot deploy — ${shown}${more}`)
+            return
+          }
+        }
+
         const {
           dmiItems: safeDmiItems,
           answerKey,

--- a/tutorme-app/src/scripts/audit-deployed-answer-leaks.ts
+++ b/tutorme-app/src/scripts/audit-deployed-answer-leaks.ts
@@ -1,0 +1,81 @@
+/**
+ * READ-ONLY audit for the deploy answer-key leak fixed in #874.
+ *
+ * Before the fix, deploying a task/assessment stored the raw DMI items (with
+ * `answer`/`rubric`/`acceptableVariants`/matching `pairs`/hotspot `regions`) in
+ * `deployedMaterial.content` — the student-facing snapshot. This scans every
+ * deployedMaterial row with `findEvaluationLeaks` and reports which sessions,
+ * courses, and items exposed answer data, so the exposure can be assessed.
+ *
+ * Makes NO writes (pure SELECT). Run against the target database:
+ *   DATABASE_URL=... npx tsx src/scripts/audit-deployed-answer-leaks.ts
+ */
+
+import { drizzleDb } from '@/lib/db/drizzle'
+import { deployedMaterial } from '@/lib/db/schema'
+import { findEvaluationLeaks } from '@/lib/ai/guardrails'
+
+export interface DeployLeakRow {
+  id: string
+  sessionId: string
+  courseId: string
+  type: string
+  itemId: string
+  title: string
+  deployedAt: Date | null
+  leaks: string[]
+}
+
+/** Returns the deployed-material rows whose stored content still carries answer
+ *  data. Empty array = clean. */
+export async function auditDeployedAnswerLeaks(): Promise<DeployLeakRow[]> {
+  const rows = await drizzleDb.select().from(deployedMaterial)
+  const affected: DeployLeakRow[] = []
+  for (const row of rows) {
+    if (!row.content) continue
+    const leaks = findEvaluationLeaks(row.content)
+    if (leaks.length > 0) {
+      affected.push({
+        id: row.id,
+        sessionId: row.sessionId,
+        courseId: row.courseId,
+        type: row.type,
+        itemId: row.itemId,
+        title: row.title,
+        deployedAt: row.deployedAt ?? null,
+        leaks,
+      })
+    }
+  }
+  return affected
+}
+
+if (require.main === module) {
+  auditDeployedAnswerLeaks()
+    .then(affected => {
+      if (affected.length === 0) {
+        console.log('✓ No answer-key leaks found in any deployed material.')
+        return process.exit(0)
+      }
+      console.log(`⚠️  ${affected.length} deployed material(s) contain leaked answer data:\n`)
+      const leakedFields = new Set<string>()
+      for (const r of affected) {
+        r.leaks.forEach(path => leakedFields.add(path.split('.').pop() || path))
+        console.log(
+          `- ${r.deployedAt?.toISOString() ?? '?'} | course=${r.courseId} session=${r.sessionId} | ` +
+            `${r.type} "${r.title}" (item=${r.itemId}) — ${r.leaks.length} leak field(s)`
+        )
+      }
+      console.log(`\nLeaked field types: ${[...leakedFields].sort().join(', ')}`)
+      console.log(
+        '\nThese were deployed before the #874 fix and exposed answer data in the student ' +
+          'snapshot. New deploys are stripped; consider whether these historical rows need ' +
+          'redaction.'
+      )
+      return process.exit(0)
+    })
+    .catch(err => {
+      console.error('audit failed:', err)
+      process.exit(1)
+    })
+}


### PR DESCRIPTION
The two follow-ups to the #874 answer-leak fix.

## 1. Re-instate the ASMT-12 gradability gate
`reverifyAssessment` is re-wired into the deploy chokepoint (`deployTaskWithDialog`, **assessment-only**, run on the raw items). It blocks deploying an assessment that isn't fully gradable:
- duplicate question numbers (breaks answer/grade mapping),
- an open (`short`/`long`) question with **no rubric** pathway (a "manual marking" note counts),
- a closed (`mcq`/…) question with **no answer key**.

This gate lived only in the dead `handleDeployAssessmentDmi` (removed in #874), so it **hadn't been running** on deploys.

⚠️ **Behaviour change:** assessments with these issues will now be blocked with `Cannot deploy — …` instead of deploying in a broken/ungradable state. In particular, a configured MCQ paper can't be deployed until every correct option is set — which is the intended safety.

## 2. Read-only answer-leak audit script
`src/scripts/audit-deployed-answer-leaks.ts` scans every `deployedMaterial.content` with `findEvaluationLeaks` and reports which sessions/courses/items exposed answer data before the fix (with timestamps and the leaked field types). **Pure SELECT — makes no writes.**

Run it against the target database:
```
DATABASE_URL=... npx tsx src/scripts/audit-deployed-answer-leaks.ts
```
Output is either "✓ No answer-key leaks found" or a dated list of affected deploys so you can assess exposure and decide whether historical rows need redaction.

## Verification
- `tsc` clean · `eslint` 0 errors · `prettier`/`format:check` clean.
- `assessment-gates` (reverify) unit tests pass; `findEvaluationLeaks` (audit's core) is already unit-tested.
- The audit is read-only and safe to run against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)