### PR TITLE
feat(pci): backfill documentKind from answer provenance for pre-fix DMIs

### DIFF
--- a/docs/guardrails/assessments.md
+++ b/docs/guardrails/assessments.md
@@ -85,7 +85,11 @@ The variant is derived client-side from the DMI and passed as `context.variant`:
     parts differ, then branch.
 - **Source** (`documentKind`): a `study_material` note tells the model the
   questions were generated (provenance `llm_inferred`) and to confirm coverage /
-  difficulty before building the policy.
+  difficulty before building the policy. `documentKind` is persisted with the DMI
+  (survives reload); for DMIs generated before it was persisted,
+  `inferDocumentKindFromProvenance` backfills it conservatively at load time
+  (only all-`llm_inferred` answers → `study_material`; any answer-sheet/tutor
+  source → left unset, so a real paper is never mislabelled).
 
 Tasks use the same mechanism but only the **source** modifier: a `study_material`
 note (composition does not apply — task answering is free-form chat). See

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -209,7 +209,7 @@ import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
 import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
 import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
 import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
-import { resolvePciComposition } from '@/lib/ai/guardrails'
+import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -2048,7 +2048,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         setTaskDmiItems(task.dmiItems || [])
         // Rehydrate the DMI source kind so the PCI-chat study-material variant
         // applies for a returning tutor, not just in the generation session.
-        setDmiDocumentKind(prev => ({ ...prev, task: task.documentKind }))
+        setDmiDocumentKind(prev => ({
+          ...prev,
+          // Backfill pre-fix DMIs (no saved kind) from answer provenance.
+          task:
+            task.documentKind ??
+            inferDocumentKindFromProvenance((task.dmiItems ?? []).map(i => i.answerProvenance)),
+        }))
         // Normalize persisted versions so `items` is always an array — a legacy /
         // partially-saved version with a missing items array would otherwise crash
         // the DMI version-list / preview dialogs (rendered at the root, outside the
@@ -2098,7 +2104,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setAssessmentDmiItems(assessment.dmiItems || [])
       // Rehydrate the DMI source kind so the PCI-chat study-material variant
       // applies for a returning tutor, not just in the generation session.
-      setDmiDocumentKind(prev => ({ ...prev, assessment: assessment.documentKind }))
+      setDmiDocumentKind(prev => ({
+        ...prev,
+        // Backfill pre-fix DMIs (no saved kind) from answer provenance.
+        assessment:
+          assessment.documentKind ??
+          inferDocumentKindFromProvenance((assessment.dmiItems ?? []).map(i => i.answerProvenance)),
+      }))
       // Normalize so every version's `items` is an array (see task note above).
       setAssessmentDmiVersions(
         (assessment.dmiVersions || []).map(v => ({

--- a/tutorme-app/src/lib/ai/guardrails/index.ts
+++ b/tutorme-app/src/lib/ai/guardrails/index.ts
@@ -43,6 +43,7 @@ export { stripEvaluationLayer, findEvaluationLeaks } from './serialize'
 
 export {
   resolvePciComposition,
+  inferDocumentKindFromProvenance,
   assessmentVariantAddendum,
   taskVariantAddendum,
   type PciComposition,

--- a/tutorme-app/src/lib/ai/guardrails/variants.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   resolvePciComposition,
+  inferDocumentKindFromProvenance,
   assessmentVariantAddendum,
   taskVariantAddendum,
   guardrailSystemPrompt,
@@ -42,6 +43,36 @@ describe('resolvePciComposition', () => {
 
   it('ignores null/undefined entries when computing ratios', () => {
     expect(resolvePciComposition(['mcq', null, 'mcq', undefined, 'mcq', 'mcq'])).toBe('objective')
+  })
+})
+
+describe('inferDocumentKindFromProvenance (pre-fix backfill)', () => {
+  it('returns undefined with no provenance signal', () => {
+    expect(inferDocumentKindFromProvenance([])).toBeUndefined()
+    expect(inferDocumentKindFromProvenance([null, undefined])).toBeUndefined()
+  })
+
+  it('infers study_material when every known answer is llm_inferred', () => {
+    expect(inferDocumentKindFromProvenance(['llm_inferred', 'llm_inferred'])).toBe('study_material')
+    // undefined entries are ignored, not disqualifying
+    expect(inferDocumentKindFromProvenance(['llm_inferred', undefined, 'llm_inferred'])).toBe(
+      'study_material'
+    )
+  })
+
+  it('never labels study_material when a real answer source is present (avoids mislabelling papers)', () => {
+    expect(
+      inferDocumentKindFromProvenance(['llm_inferred', 'answer_sheet_extracted'])
+    ).toBeUndefined()
+    expect(inferDocumentKindFromProvenance(['tutor_provided'])).toBeUndefined()
+    expect(inferDocumentKindFromProvenance(['llm_inferred', 'tutor_edited'])).toBeUndefined()
+  })
+
+  it('never returns question_paper (undefined is the safe no-note default)', () => {
+    // A wrong guess can only withhold the note, never fabricate a classification.
+    const result = inferDocumentKindFromProvenance(['answer_sheet_extracted'])
+    expect(result).not.toBe('question_paper')
+    expect(result).toBeUndefined()
   })
 })
 

--- a/tutorme-app/src/lib/ai/guardrails/variants.ts
+++ b/tutorme-app/src/lib/ai/guardrails/variants.ts
@@ -9,9 +9,10 @@
  * embeds ASSESSMENT_GUARDRAILS), the validators, and the state machine remain
  * the binding rules. See docs/guardrails/assessments.md → "Prompt variants".
  *
- * Tasks intentionally have no sub-variants yet; `guardrailSystemPrompt('task')`
- * ignores any variant. The classifier + addenda live here (not in assessment.ts)
- * so the canonical rule module stays the single source of the rules.
+ * Tasks use the source modifier only (a study-material note) — composition does
+ * not apply to free-form chat answering. The classifier + addenda live here (not
+ * in assessment.ts) so the canonical rule module stays the single source of the
+ * rules.
  */
 
 import { OPEN_DMI_TYPES, type DmiQuestionType } from '@/lib/assessment/question-types'
@@ -49,6 +50,34 @@ export function resolvePciComposition(
   if (closedRatio >= OBJECTIVE_THRESHOLD) return 'objective'
   if (openRatio >= FREE_RESPONSE_THRESHOLD) return 'free_response'
   return 'mixed'
+}
+
+/**
+ * Best-effort backfill of `documentKind` for DMIs generated BEFORE it was
+ * persisted, inferred from answer provenance (ASMT-5). Deliberately CONSERVATIVE
+ * to avoid mislabelling a real question paper as study material:
+ *  - any answer from a real source (answer sheet / tutor) → NOT study material
+ *    (returns undefined → base prompt, treated as a question paper);
+ *  - only when every known answer is `llm_inferred` (the signature of AI-
+ *    generated study-material questions) do we infer `study_material`.
+ * It never returns `question_paper` (undefined already means "no note"), so a
+ * wrong guess can only ever WITHHOLD the study-material note, never fabricate a
+ * question-paper classification. A regenerated DMI persists the real value and
+ * supersedes this inference.
+ */
+export function inferDocumentKindFromProvenance(
+  provenances: ReadonlyArray<string | null | undefined>
+): 'study_material' | undefined {
+  const known = provenances.filter((p): p is string => !!p)
+  if (known.length === 0) return undefined
+  if (
+    known.some(
+      p => p === 'answer_sheet_extracted' || p === 'tutor_provided' || p === 'tutor_edited'
+    )
+  ) {
+    return undefined
+  }
+  return known.every(p => p === 'llm_inferred') ? 'study_material' : undefined
 }
 
 const COMPOSITION_ADDENDA: Record<PciComposition, string> = {


### PR DESCRIPTION
Follow-up to #875. DMIs generated **before** `documentKind` was persisted have no saved kind, so a returning tutor wouldn't get the study-material variant until regenerating. This backfills it — as a **safe load-time fallback**, not a DB migration.

## Approach
`inferDocumentKindFromProvenance` infers the source from answer provenance (ASMT-5), **conservatively**:
- Any answer from a real source (`answer_sheet_extracted` / `tutor_provided` / `tutor_edited`) → **not** study material (a real paper is never mislabelled).
- Only when **every** known answer is `llm_inferred` (the signature of AI-generated study-material questions) → `study_material`.
- **Never returns `question_paper`** — a wrong guess can only *withhold* the note, never fabricate a classification.

Used as `record.documentKind ?? infer(...)` in `loadTaskIntoBuilder` / `loadAssessmentIntoBuilder`; the inferred value then persists on the next auto-save (self-healing). A regenerated DMI writes the real value and supersedes the guess.

## Why a fallback, not a migration
No mass JSONB mutation, no risk to existing course data, self-heals on load, and the classification can only ever be withheld (never wrong-and-persisted-as-question_paper). This directly addresses the caveat I flagged: old study-material assessments now get the coverage-check note too.

## Testing
- New inference tests (all-`llm_inferred` → study_material; any real source → unset; never `question_paper`) + existing variant tests: 39 guardrail tests pass. Prettier/eslint clean (0 errors); typecheck clean.
- Also refreshed a stale `variants.ts` header comment (tasks now have a source variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)