### PR TITLE
fix(db): cache pg pool in production (scale) + pool error handler

### DIFF
--- a/tutorme-app/src/lib/db/drizzle.ts
+++ b/tutorme-app/src/lib/db/drizzle.ts
@@ -22,22 +22,32 @@ export function getPool(): Pool {
     )
   }
 
-  const isPgBouncer = connectionString.includes('pgbouncer') || process.env.PGBOUNCER === 'true'
-  const pool =
-    globalForDrizzle.drizzlePool ??
-    new Pool({
-      connectionString,
-      max: process.env.NODE_ENV === 'production' ? 50 : 5,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 5000,
-      allowExitOnIdle: true,
-      ...(isPgBouncer && { prepare: false }),
-    })
-
-  if (process.env.NODE_ENV !== 'production') {
-    globalForDrizzle.drizzlePool = pool
+  // Reuse the cached pool in ALL environments. This must be cached in production
+  // too: any code path that calls getPool() directly (not via the memoized
+  // getDrizzleDb) would otherwise construct a brand-new Pool — each up to `max`
+  // connections — on every call, exhausting Postgres/PgBouncer under load.
+  if (globalForDrizzle.drizzlePool) {
+    return globalForDrizzle.drizzlePool
   }
 
+  const isPgBouncer = connectionString.includes('pgbouncer') || process.env.PGBOUNCER === 'true'
+  const pool = new Pool({
+    connectionString,
+    max: process.env.NODE_ENV === 'production' ? 50 : 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 5000,
+    allowExitOnIdle: true,
+    ...(isPgBouncer && { prepare: false }),
+  })
+
+  // An idle client can emit 'error' (e.g. DB restart, network blip). Without a
+  // listener, pg re-emits it as an uncaught exception that crashes the process —
+  // a single transient blip would take down the whole instance under load.
+  pool.on('error', (err) => {
+    console.error('[db] idle pool client error:', err.message)
+  })
+
+  globalForDrizzle.drizzlePool = pool
   return pool
 }
 


### PR DESCRIPTION
## Problem
`getPool()` only cached the pool on `globalThis` when `NODE_ENV !== 'production'` — the guard is inverted for a singleton. In production, any code path calling `getPool()` directly (not via the memoized `getDrizzleDb`) constructed a **new `Pool` of up to `max=50` connections on every call**, which exhausts Postgres/PgBouncer under load. This is a top risk for the 1000+ concurrent-user target.

## Fix
- Cache the pool in **all** environments (return the cached instance if present).
- Register a `pool.on('error', …)` handler — an idle client error (DB restart / network blip) is otherwise re-emitted as an uncaught exception that crashes the whole instance.

## Risk / testing
- Behavior-preserving for the common `drizzleDb` path (already memoized via `getDrizzleDb`).
- `npm run typecheck` passes.
- No schema/API changes.

Part of the post-review fix track (scale). Independent of the adk extraction (#880).

🤖 Generated with [Claude Code](https://claude.com/claude-code)