### PR TITLE
fix(security): close SSRF bypass via IPv4-mapped/bracketed IPv6 (proxy-url)

### DIFF
--- a/tutorme-app/src/lib/security/proxy-url.test.ts
+++ b/tutorme-app/src/lib/security/proxy-url.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { assertSafeProxyUrl } from './proxy-url'
+
+// IP-literal hosts skip DNS resolution, so these assertions are deterministic.
+describe('assertSafeProxyUrl', () => {
+  const blocked = [
+    'http://127.0.0.1/',
+    'http://10.0.0.1/',
+    'http://192.168.1.1/',
+    'http://172.16.0.1/',
+    'http://169.254.169.254/latest/meta-data/', // cloud metadata
+    'http://100.64.0.1/',
+    'http://[::1]/',
+    'http://[::ffff:169.254.169.254]/', // IPv4-mapped IPv6 — the bypass this fixes
+    'http://[::ffff:127.0.0.1]/',
+    'http://[::ffff:a9fe:a9fe]/', // hex-encoded mapped metadata IP
+    'http://[fe80::1]/',
+    'http://[fc00::1]/',
+    'http://localhost/',
+    'http://foo.localhost/',
+    'ftp://example.com/', // disallowed protocol
+    'file:///etc/passwd',
+  ]
+
+  const allowed = ['http://8.8.8.8/', 'http://1.1.1.1/', 'http://[2606:4700:4700::1111]/']
+
+  for (const url of blocked) {
+    it(`blocks ${url}`, async () => {
+      await expect(assertSafeProxyUrl(url)).rejects.toThrow()
+    })
+  }
+
+  for (const url of allowed) {
+    it(`allows ${url}`, async () => {
+      await expect(assertSafeProxyUrl(url)).resolves.toBeInstanceOf(URL)
+    })
+  }
+})

--- a/tutorme-app/src/lib/security/proxy-url.ts
+++ b/tutorme-app/src/lib/security/proxy-url.ts
@@ -3,21 +3,56 @@ import net from 'net'
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
 
-function isPrivateIp(ip: string): boolean {
-  if (ip === '::1') return true
-  if (ip.startsWith('fe80:') || ip.startsWith('fc') || ip.startsWith('fd')) return true
-
+function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
-  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part))) return false
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    // Not a well-formed dotted-quad — treat as unsafe rather than "public".
+    return true
+  }
   const [a, b] = parts
   return (
     a === 10 ||
     a === 127 ||
     a === 0 ||
-    (a === 169 && b === 254) ||
+    (a === 169 && b === 254) || // link-local / cloud metadata (169.254.169.254)
     (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) // carrier-grade NAT (100.64.0.0/10)
   )
+}
+
+/**
+ * Classify an IP literal as private/loopback/link-local. Handles IPv4, IPv6, and
+ * — critically — IPv4-mapped IPv6 (`::ffff:169.254.169.254` and its hex form
+ * `::ffff:a9fe:a9fe`), which otherwise bypass a naive IPv4-only check and reach
+ * the cloud-metadata endpoint.
+ */
+function isPrivateIp(ip: string): boolean {
+  // Strip an IPv6 zone id, e.g. fe80::1%eth0
+  const lower = ip.split('%')[0].toLowerCase()
+
+  if (net.isIPv4(lower)) return isPrivateIpv4(lower)
+
+  // IPv4-mapped / IPv4-compatible IPv6 → extract and classify the embedded IPv4.
+  if (lower.startsWith('::ffff:') || lower.startsWith('::')) {
+    const rest = lower.replace(/^::(ffff:)?/, '')
+    if (rest.includes('.') && net.isIPv4(rest)) return isPrivateIpv4(rest)
+    // Hex-encoded mapped form: ::ffff:a9fe:a9fe
+    const groups = rest.split(':')
+    if (groups.length === 2 && groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) {
+      const hi = parseInt(groups[0], 16)
+      const lo = parseInt(groups[1], 16)
+      const v4 = [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255].join('.')
+      return isPrivateIpv4(v4)
+    }
+  }
+
+  // Native IPv6 ranges.
+  if (lower === '::1') return true // loopback
+  if (lower === '::' || lower === '::0') return true // unspecified
+  if (/^fe[89ab]/.test(lower)) return true // link-local fe80::/10
+  if (/^f[cd]/.test(lower)) return true // unique local fc00::/7
+  return false
 }
 
 export async function assertSafeProxyUrl(rawUrl: string): Promise<URL> {
@@ -32,7 +67,9 @@ export async function assertSafeProxyUrl(rawUrl: string): Promise<URL> {
     throw new Error('Unsupported protocol')
   }
 
-  const hostname = parsed.hostname.toLowerCase()
+  // URL.hostname keeps the surrounding brackets on IPv6 literals (e.g. "[::1]"),
+  // which would make net.isIP() return 0 and skip IP classification entirely.
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     throw new Error('Local hosts are not allowed')
   }
@@ -42,8 +79,11 @@ export async function assertSafeProxyUrl(rawUrl: string): Promise<URL> {
     return parsed
   }
 
+  // NOTE: the hostname is resolved and vetted here, but the subsequent fetch
+  // re-resolves it, leaving a DNS-rebinding window. Callers should also validate
+  // every redirect hop; pinning the vetted IP into the connection is a follow-up.
   const addresses = await dns.lookup(hostname, { all: true, verbatim: true })
-  if (addresses.length === 0 || addresses.some(address => isPrivateIp(address.address))) {
+  if (addresses.length === 0 || addresses.some((address) => isPrivateIp(address.address))) {
     throw new Error('Private network URLs are not allowed')
   }
 


### PR DESCRIPTION
## Problem (Critical, verified)
`assertSafeProxyUrl` is the SSRF guard for server-side proxy/fetch. Two gaps let an attacker reach internal/metadata endpoints:
1. `isPrivateIp` only parsed dotted-quad IPv4 → an **IPv4-mapped IPv6** literal `http://[::ffff:169.254.169.254]/` (which `URL` even normalizes to the hex form `::ffff:a9fe:a9fe`) classified as **public** and reached the cloud-metadata endpoint.
2. `URL.hostname` keeps brackets on IPv6 literals (`[::1]`), so `net.isIP()` returned 0 and IP classification was **skipped for every IPv6 literal**.

## Fix
- Strip surrounding brackets before classification.
- Normalize IPv4-mapped/compat IPv6 (dotted **and** hex) to the embedded IPv4 and classify that.
- Add IPv6 loopback / unspecified / link-local (`fe80::/10`) / ULA (`fc00::/7`).
- Treat malformed dotted-quads as unsafe (fail closed); add CGNAT `100.64.0.0/10`.
- **New `proxy-url.test.ts`** — 19 cases including the metadata bypasses; all green.

## Not covered (follow-up)
DNS-rebinding: the vetted hostname is re-resolved by the subsequent `fetch`. The `proxy-file` route already re-validates redirect hops; pinning the resolved IP into the connection is a separate change.

Part of the post-review fix track (security Critical). Independent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)