### PR TITLE
fix(security): require TUTOR role on answer/marking-scheme AI endpoints

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -454,6 +454,10 @@ export async function POST(request: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+    // Tutor-only: this returns generated answers + rubrics for an assessment.
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
 
     const body = await request.json().catch(() => null)
     const parsed = GenerateDmiRequestSchema.safeParse(body)

--- a/tutorme-app/src/app/api/ai/parse-marking-scheme/route.test.ts
+++ b/tutorme-app/src/app/api/ai/parse-marking-scheme/route.test.ts
@@ -61,7 +61,7 @@ const baseBody = {
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.withRateLimitPreset.mockResolvedValue({ response: null })
-  mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+  mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
   mocks.getServerSession.mockResolvedValue(null)
   mocks.validateAiResponse.mockResolvedValue({ isValid: true, severity: 'LOW' })
   mocks.runAssessmentGuardrails.mockReturnValue({ violations: [] })

--- a/tutorme-app/src/app/api/ai/parse-marking-scheme/route.ts
+++ b/tutorme-app/src/app/api/ai/parse-marking-scheme/route.ts
@@ -122,6 +122,12 @@ export async function POST(request: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+    // Tutor-only: this returns model-extracted answer keys / rubrics. Do not fall
+    // back to a generic session role — the realm cookie only selects which token
+    // is read, it does not enforce that the caller is actually a tutor.
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
 
     const body = await request.json().catch(() => null)
     const parsed = RequestSchema.safeParse(body)

--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -67,7 +67,7 @@ describe('/api/ai/pci-master', () => {
   })
 
   it('uses tutor realm session when available', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.getServerSession.mockResolvedValue(null)
 
     const req = new Request('http://localhost/api/ai/pci-master', {
@@ -110,7 +110,7 @@ describe('/api/ai/pci-master', () => {
   }
 
   it('task domain: extracts {reply,pci,spec} — reply, finalized rubric, and structured spec (on approval)', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response:
         '{"reply":"What counts as a correct answer?","pci":"FINAL RUBRIC TEXT","spec":{"evaluationLogic":"Exact match","retryPolicy":"unspecified","instructionalTone":"Encouraging"}}',
@@ -135,7 +135,7 @@ describe('/api/ai/pci-master', () => {
   })
 
   it('task domain: offers the rubric but flags it unconfirmed until the tutor applies (TASK-5)', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: '{"reply":"Here is the finalized rubric.","pci":"FINAL RUBRIC TEXT"}',
       conversationId: 'c1',
@@ -153,7 +153,7 @@ describe('/api/ai/pci-master', () => {
   })
 
   it('task domain: empty pci until finalized (no draft surfaced)', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: '{"reply":"Here is the summary, is it right?","pci":""}',
       conversationId: 'c1',
@@ -168,7 +168,7 @@ describe('/api/ai/pci-master', () => {
   })
 
   it('task domain: falls back gracefully when the model ignores the envelope', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: 'Just plain prose, no JSON at all.',
       conversationId: 'c1',
@@ -183,7 +183,7 @@ describe('/api/ai/pci-master', () => {
   })
 
   it('non-guardrail domain: no pciDraft extraction', async () => {
-    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1' } })
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({
       response: 'ok',
       conversationId: 'c1',

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -155,6 +155,10 @@ export async function POST(request: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+    // Tutor-only course-builder PCI chat.
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
 
     // Rate-limit per authenticated user, not per IP, so co-located tutors behind
     // one NAT/proxy don't share a single AI quota.

--- a/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-spec-suggest/route.ts
@@ -54,6 +54,10 @@ export async function POST(request: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+    // Tutor-only course-builder tooling.
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
 
     const { response: rateLimitResponse } = await withRateLimitPreset(
       request,


### PR DESCRIPTION
## Problem (High, verified — answer leakage)
Four AI endpoints that return answer keys / rubrics gated only on `session.user.id`:
`parse-marking-scheme`, `generate-dmi`, `pci-spec-suggest`, `pci-master`.

`getSessionForRealm(request,'tutor')` only chooses *which cookie* to read and returns `role` straight from the token (defaults to `STUDENT`); the `?? getServerSession(...)` fallback returns **any** logged-in user. So a logged-in **student** could POST their own copy of a paper to `parse-marking-scheme` / `generate-dmi` and get model-extracted answers + rubrics back. This is the most concrete answer-leak vector from the review.

## Fix
Explicit `TUTOR`/`ADMIN` role check (→ 403) after the id check on all four routes.

## Testing
`npm run typecheck` passes. `session.user.role` is already the typed field used elsewhere (e.g. the refund route).

Complements the guardrails work — this closes the direct-extraction path. Part of the post-review fix track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)