### PR TITLE
fix(security): socket feedback identity from session, not client (room-authz Critical)

### DIFF
--- a/tutorme-app/src/lib/socket/handlers/feedback.ts
+++ b/tutorme-app/src/lib/socket/handlers/feedback.ts
@@ -13,16 +13,22 @@ import {
 import { deployedTasks, feedbackPolls, feedbackQuestions } from '@/lib/socket'
 
 export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
-  // Student joins feedback room
-  socket.on('student_feedback_join', (data: { studentId: string }) => {
-    socket.join(`feedback:student:${data.studentId}`)
-    socket.data.feedbackStudentId = data.studentId
+  // Student joins their OWN feedback room. The room id is derived from the
+  // authenticated socket, never a client-supplied studentId — otherwise any user
+  // could subscribe to another student's private feedback stream.
+  socket.on('student_feedback_join', () => {
+    const studentId = socket.data.userId
+    if (!studentId) return
+    socket.join(`feedback:student:${studentId}`)
+    socket.data.feedbackStudentId = studentId
   })
 
-  // Tutor joins insights room
-  socket.on('tutor_insights_join', (data: { tutorId: string }) => {
-    socket.join(`insights:tutor:${data.tutorId}`)
-    socket.data.insightsTutorId = data.tutorId
+  // Tutor joins their OWN insights room (tutors only, id from the session).
+  socket.on('tutor_insights_join', () => {
+    if (socket.data.role !== 'tutor' || !socket.data.userId) return
+    const tutorId = socket.data.userId
+    socket.join(`insights:tutor:${tutorId}`)
+    socket.data.insightsTutorId = tutorId
   })
 
   // Tutor deploys a task
@@ -81,7 +87,10 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
       tutorId: string
       tutorName: string
     }) => {
-      if (socket.data.role !== 'tutor') return
+      if (socket.data.role !== 'tutor' || !socket.data.userId) return
+      // Attribute the poll to the authenticated tutor, not a client-supplied id
+      // (which was previously written straight into the DB poll row).
+      const tutorId = socket.data.userId
 
       const poll = {
         id: data.id,
@@ -91,7 +100,7 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
         responses: new Map<string, number>(),
         isActive: true,
         sentAt: data.sentAt,
-        tutorId: data.tutorId,
+        tutorId,
       }
 
       feedbackPolls.set(data.id, poll)
@@ -116,7 +125,7 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
             await db.insert(dbPoll).values({
               pollId: data.id,
               sessionId: roomId,
-              tutorId: data.tutorId,
+              tutorId,
               question: data.question,
               type: 'RATING',
               isAnonymous: false,
@@ -187,19 +196,22 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
   socket.on(
     'poll_response',
     (data: { pollId: string; studentId: string; option: number; taskId?: string }) => {
-      if (socket.data.role !== 'student') return
+      if (socket.data.role !== 'student' || !socket.data.userId) return
+      // Identity comes from the authenticated socket, not the client payload,
+      // which could otherwise submit or overwrite another student's response.
+      const studentId = socket.data.userId
 
       const poll = feedbackPolls.get(data.pollId)
       if (!poll || !poll.isActive) return
 
       // Store response
-      poll.responses.set(data.studentId, data.option)
+      poll.responses.set(studentId, data.option)
 
       // Notify tutor
       io.to(`insights:tutor:${poll.tutorId}`).emit('poll_response_received', {
         pollId: data.pollId,
         response: {
-          studentId: data.studentId,
+          studentId,
           option: data.option,
           respondedAt: new Date().toISOString(),
         },
@@ -225,13 +237,13 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
             .where(
               and(
                 eq(dbPollResponse.pollId, data.pollId),
-                eq(dbPollResponse.studentId, data.studentId)
+                eq(dbPollResponse.studentId, studentId)
               )
             )
           await db.insert(dbPollResponse).values({
             responseId: crypto.randomUUID(),
             pollId: data.pollId,
-            studentId: data.studentId,
+            studentId,
             optionIds: [],
             rating: data.option,
           })


### PR DESCRIPTION
## Problem (Critical, verified)
The realtime feedback channel (`socket/handlers/feedback.ts`) trusted client-supplied ids:
- `student_feedback_join { studentId }` and `tutor_insights_join { tutorId }` joined the room named by the **payload** id, with no check against the authenticated socket. Any student could `student_feedback_join` with a victim's id and receive their private task/poll/homework feed; any user could subscribe to a tutor's live insights.
- `send_poll` persisted a `poll` DB row with a **client-supplied** `tutorId` (impersonation).
- `poll_response` stored/persisted the vote under a **client-supplied** `studentId` (a student could submit/overwrite another student's response).

`socket.data.userId` / `socket.data.role` are set at authentication time (`socket/socket-auth.ts`), so identity is available server-side.

## Fix (this PR — self-contained in feedback.ts)
- Both join handlers derive the room from `socket.data.userId` and ignore the payload; `tutor_insights_join` also requires `role === 'tutor'`.
- `send_poll` attributes the poll to `socket.data.userId`.
- `poll_response` takes the responder id from `socket.data.userId`.

## Follow-up (separate PR — deliberately out of scope)
Needs careful review of the large `socket-server-enhanced.ts`:
- `deploy_task` still targets a client-supplied `studentIds[]` (post-fix this is spam-only, since students can only join their own room — but should be roster-validated).
- `poll_updated` / `feedback_chat_received` use global `io.emit` → should scope to the session room.
- `join_class`: joins the room before the enrollment check, doesn't `leave` on rejection, and skips the check when `courseId` is null; `chat_message` / `insight:respond` lack room-membership checks.

## Testing
`npm run typecheck` clean (0 source errors); socket unit tests pass.

Part of the post-review fix track (security Critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)