### PR TITLE
style: prettier-format recently-merged files (clears the red Format check)

### DIFF
--- a/tutorme-app/src/app/api/polls/[pollId]/route.ts
+++ b/tutorme-app/src/app/api/polls/[pollId]/route.ts
@@ -62,9 +62,7 @@ export async function GET(
     const formattedPoll = {
       ...pollRow,
       options,
-      responses: hideStudentIds
-        ? responses.map(r => ({ ...r, studentId: undefined }))
-        : responses,
+      responses: hideStudentIds ? responses.map(r => ({ ...r, studentId: undefined })) : responses,
       totalResponses: responses.length,
     }
 

--- a/tutorme-app/src/lib/db/drizzle.ts
+++ b/tutorme-app/src/lib/db/drizzle.ts
@@ -43,7 +43,7 @@ export function getPool(): Pool {
   // An idle client can emit 'error' (e.g. DB restart, network blip). Without a
   // listener, pg re-emits it as an uncaught exception that crashes the process —
   // a single transient blip would take down the whole instance under load.
-  pool.on('error', (err) => {
+  pool.on('error', err => {
     console.error('[db] idle pool client error:', err.message)
   })
 

--- a/tutorme-app/src/lib/security/proxy-url.ts
+++ b/tutorme-app/src/lib/security/proxy-url.ts
@@ -5,7 +5,7 @@ const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
 
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
     // Not a well-formed dotted-quad — treat as unsafe rather than "public".
     return true
   }
@@ -39,7 +39,7 @@ function isPrivateIp(ip: string): boolean {
     if (rest.includes('.') && net.isIPv4(rest)) return isPrivateIpv4(rest)
     // Hex-encoded mapped form: ::ffff:a9fe:a9fe
     const groups = rest.split(':')
-    if (groups.length === 2 && groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))) {
+    if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
       const hi = parseInt(groups[0], 16)
       const lo = parseInt(groups[1], 16)
       const v4 = [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255].join('.')
@@ -83,7 +83,7 @@ export async function assertSafeProxyUrl(rawUrl: string): Promise<URL> {
   // re-resolves it, leaving a DNS-rebinding window. Callers should also validate
   // every redirect hop; pinning the vetted IP into the connection is a follow-up.
   const addresses = await dns.lookup(hostname, { all: true, verbatim: true })
-  if (addresses.length === 0 || addresses.some((address) => isPrivateIp(address.address))) {
+  if (addresses.length === 0 || addresses.some(address => isPrivateIp(address.address))) {
     throw new Error('Private network URLs are not allowed')
   }
 

--- a/tutorme-app/src/lib/socket/handlers/feedback.ts
+++ b/tutorme-app/src/lib/socket/handlers/feedback.ts
@@ -235,10 +235,7 @@ export function initFeedbackHandlers(io: SocketIOServer, socket: Socket) {
           await db
             .delete(dbPollResponse)
             .where(
-              and(
-                eq(dbPollResponse.pollId, data.pollId),
-                eq(dbPollResponse.studentId, studentId)
-              )
+              and(eq(dbPollResponse.pollId, data.pollId), eq(dbPollResponse.studentId, studentId))
             )
           await db.insert(dbPollResponse).values({
             responseId: crypto.randomUUID(),


### PR DESCRIPTION
The advisory **Format** check was going red on **my** recently-merged files — I skipped `npm run format` before pushing them. This formats them so the check goes green.

**Cosmetic only** (verified): arrow-param parens (`(x) =>` → `x =>`, repo uses `arrowParens: avoid`) and a few lines un-wrapped to width 100. No logic changes. `npm run format:check` now passes clean.

Files: `polls/[pollId]/route.ts`, `db/drizzle.ts`, `security/proxy-url.ts`, `socket/handlers/feedback.ts`.

To stop this recurring, each dev's assistant should run `npm run format` before pushing (or add a pre-commit hook / make Format a required check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)