### PR TITLE
ci: run gitleaks CLI instead of the action (fixes org-license failure)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,11 +14,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # gitleaks is more effective with full history
+          # Full history so we can scan the pushed/PR commit range.
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # NOTE: we run the gitleaks CLI directly instead of gitleaks/gitleaks-action@v2.
+      # The action requires a PAID license when the repo lives in a GitHub org
+      # (which this repo now does, under Solocorn-LLC). The CLI is free (MIT).
+      - name: Detect secrets (gitleaks CLI)
+        run: |
+          set -euo pipefail
 
+          # Install the latest gitleaks linux binary from GitHub Releases.
+          url=$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | grep -oE '"browser_download_url": *"[^"]*linux_(x64|amd64)\.tar\.gz"' \
+            | head -1 | sed -E 's/.*"(https[^"]+)".*/\1/')
+          echo "Downloading gitleaks: $url"
+          curl -fsSL "$url" | tar -xz gitleaks
+          ./gitleaks version
+
+          # Scan ONLY the commits introduced by this push/PR — not full history,
+          # which still contains previously-leaked keys (being revoked) and would
+          # otherwise keep this check red forever.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            range="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          else
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || printf '%s' "$before" | grep -qE '^0+$'; then
+              range="HEAD~1..HEAD"
+            else
+              range="${before}..${{ github.sha }}"
+            fi
+          fi
+          echo "Scanning commit range: $range"
+
+          ./gitleaks detect \
+            --source . \
+            --redact \
+            --exit-code 1 \
+            --log-opts="$range" \
+            --verbose


### PR DESCRIPTION
## Problem
`gitleaks/gitleaks-action@v2` requires a **paid `GITLEAKS_LICENSE`** when the repo is in a GitHub **organization** — which started failing (`🛑 missing gitleaks license`) when the repo moved to `Solocorn-LLC`. (The Node 20 lines in the log are just deprecation warnings, not the cause.)

## Fix
Run the **gitleaks CLI** directly instead of the action wrapper. The CLI is free (MIT); only the wrapper charges for orgs. Same tool, same rules, no license.

- Downloads the latest gitleaks linux binary and runs `gitleaks detect`.
- **Scans only the pushed / PR commit range**, not full history — history still contains the previously-leaked keys (being revoked), which would otherwise keep this check red forever. New secrets introduced by a PR are still caught.

This PR self-tests: the `Detect secrets` check on it now runs the CLI path.

> `Detect secrets` is an **advisory** check (not required), so this was red-but-non-blocking — but now it's green and still doing real scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)