### PR TITLE
fix(poll): use mode-specific default text instead of hardcoded question

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1829,13 +1829,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const setShowAIQuestion = (val: boolean) =>
       setShowAIQuestionMap(prev => ({ ...prev, [currentInsightsId]: val }))
 
-    const pollPrompt = pollPromptMap[currentInsightsId] ?? 'Did you find this task difficult'
-    const setPollPrompt = (val: string) =>
-      setPollPromptMap(prev => ({ ...prev, [currentInsightsId]: val }))
-
     const pollOptionMode = pollOptionModeMap[currentInsightsId] ?? '1-10'
     const setPollOptionMode = (val: '1-10' | 'likert' | 'ae' | 'tf' | 'yn') =>
       setPollOptionModeMap(prev => ({ ...prev, [currentInsightsId]: val }))
+
+    const pollPrompt = pollPromptMap[currentInsightsId] ?? getPollPlaceholder(pollOptionMode)
+    const setPollPrompt = (val: string) =>
+      setPollPromptMap(prev => ({ ...prev, [currentInsightsId]: val }))
     const pollCustomOptions = pollCustomOptionsMap[currentInsightsId] ?? ''
     const setPollCustomOptions = (val: string) =>
       setPollCustomOptionsMap(prev => ({ ...prev, [currentInsightsId]: val }))


### PR DESCRIPTION
## Problem
The poll composer was showing 'Did you find this task difficult?' as the pre-filled default text regardless of the selected poll type (1-10, Likert, True/False, Yes/No). The placeholder function (getPollPlaceholder) was correct, but the actual default value was hardcoded.

## Fix
Changed the pollPrompt default from a hardcoded string to use getPollPlaceholder(pollOptionMode), so the default text matches the selected poll mode:
- 1-10: 'On a scale of 1 to 10, how difficult did you find this task?'
- likert: 'Did you find this task difficult?'
- tf: 'The explanation to your answer was clear and concise?'
- yn: 'Did you complete all your homework tasks?'

## Testing
- TypeScript compiles without errors
- Reordered pollOptionMode definition before pollPrompt so the mode is available when computing the default