### PR TITLE
feat(test-task): embed PDF as inline thumbnail in chat stream with full-screen viewer

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -6,15 +6,19 @@
  * student gets: chat answers → "Task complete" → the AI responds to each answer
  * per the PCI → ask follow-ups.
  *
+ * The task document (PDF/image) is shown as a thumbnail card inside the chat
+ * stream, like an uploaded document in an LLM chat. Clicking it opens a full-
+ * screen viewer with fit-to-screen scaling.
+ *
  * State can be persisted by the parent: pass `initialState` to seed the chat and
  * `onPersist` to mirror every change into a store, so switching Test-tab
  * students (which remounts this component) doesn't lose the conversation.
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { Send, Loader2, CheckCircle2, Sparkles } from 'lucide-react'
+import { Send, Loader2, CheckCircle2, Sparkles, FileText, X, ImageIcon } from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
-import { TaskDocumentCard, type TaskDocumentSource } from '@/components/task/TaskDocumentCard'
+import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { toast } from 'sonner'
 
 export interface TestTaskChatMsg {
@@ -31,6 +35,13 @@ export interface TestTaskChatState {
 
 type ChatMsg = TestTaskChatMsg
 
+export interface TaskDocumentSource {
+  fileName?: string | null
+  fileUrl?: string | null
+  fileKey?: string | null
+  mimeType?: string | null
+}
+
 export function TestTaskChat({
   pci,
   pciSpec,
@@ -42,8 +53,7 @@ export function TestTaskChat({
   pci?: string
   pciSpec?: unknown
   questionText?: string
-  /** The task's document — previewed inline exactly as students see it (full
-   *  until the first sample answer, then a collapsed, re-expandable card). */
+  /** The task's document — shown as a thumbnail in the chat stream. */
   sourceDocument?: TaskDocumentSource | null
   initialState?: TestTaskChatState
   onPersist?: (state: TestTaskChatState) => void
@@ -52,6 +62,7 @@ export function TestTaskChat({
   const [draft, setDraft] = useState(initialState?.draft ?? '')
   const [completed, setCompleted] = useState(initialState?.completed ?? false)
   const [busy, setBusy] = useState(false)
+  const [pdfFullscreen, setPdfFullscreen] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -66,6 +77,19 @@ export function TestTaskChat({
   }, [messages, draft, completed, onPersist])
 
   const studentAnswers = messages.filter(m => m.role === 'student').map(m => m.content)
+
+  // Build the proxied document URL (same logic as TaskDocumentCard)
+  const rawUrl = sourceDocument?.fileUrl || ''
+  const docUrl = sourceDocument?.fileKey
+    ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
+    : rawUrl
+  const loadable =
+    !!sourceDocument?.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:') && rawUrl.length > 0)
+  const docName = sourceDocument?.fileName || 'Task document'
+  const isPdf =
+    sourceDocument?.mimeType === 'application/pdf' ||
+    (!sourceDocument?.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument?.fileName || rawUrl))
+  const isImage = !!sourceDocument?.mimeType?.startsWith('image/')
 
   const post = (extra: Record<string, unknown>) =>
     fetchWithCsrf('/api/tutor/test-grade', {
@@ -147,6 +171,7 @@ export function TestTaskChat({
 
   return (
     <div className="flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl border border-violet-300 bg-white">
+      {/* Header bar */}
       <div className="flex items-center gap-2 border-b border-violet-100 bg-violet-50/60 px-4 py-2">
         <Sparkles className="h-4 w-4 text-violet-600" />
         <span className="text-sm font-semibold text-gray-800">
@@ -170,15 +195,37 @@ export function TestTaskChat({
         </span>
       </div>
 
-      {/* Document preview — mirrors the student flow: full until the first sample
-          answer, then a pinned, re-expandable card. */}
-      <TaskDocumentCard
-        sourceDocument={sourceDocument}
-        autoOpen={!studentAnswers.length}
-        accent="violet"
-      />
-
+      {/* Unified chat stream — document thumbnail + messages scroll together */}
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+        {/* Document thumbnail — persistent first message in the stream */}
+        {sourceDocument && (
+          <div className="flex items-start">
+            <button
+              type="button"
+              onClick={() => loadable && setPdfFullscreen(true)}
+              disabled={!loadable}
+              className="max-w-[85%] cursor-pointer rounded-xl border border-violet-200 bg-violet-50/50 px-4 py-3 text-left transition-colors hover:border-violet-300 hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <div className="flex items-center gap-2.5">
+                {isImage ? (
+                  <ImageIcon className="h-5 w-5 shrink-0 text-violet-600" />
+                ) : (
+                  <FileText className="h-5 w-5 shrink-0 text-violet-600" />
+                )}
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-800">{docName}</p>
+                  <p className="text-xs text-gray-500">
+                    {loadable
+                      ? 'Click to view full document'
+                      : 'This document is unavailable. Re-upload it.'}
+                  </p>
+                </div>
+              </div>
+            </button>
+          </div>
+        )}
+
+        {/* Empty state — shown when no messages yet */}
         {messages.length === 0 && (
           <p className="text-sm leading-relaxed text-gray-500">
             This is exactly what students see for a task. Chat sample answers, click{' '}
@@ -186,6 +233,8 @@ export function TestTaskChat({
             to each answer using your PCI — then ask a follow-up to check how it explains mistakes.
           </p>
         )}
+
+        {/* Chat messages */}
         {messages.map((m, i) =>
           m.role === 'student' ? (
             <div key={i} className="flex justify-end">
@@ -206,6 +255,7 @@ export function TestTaskChat({
             </div>
           )
         )}
+
         {busy && (
           <div className="flex items-center gap-1.5 text-xs text-gray-400">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -214,6 +264,7 @@ export function TestTaskChat({
         )}
       </div>
 
+      {/* Input area */}
       <div className="border-t border-gray-100 p-2">
         <div className="flex items-end gap-2">
           <textarea
@@ -256,6 +307,61 @@ export function TestTaskChat({
           </button>
         )}
       </div>
+
+      {/* Full-screen PDF viewer overlay */}
+      {pdfFullscreen && loadable && (
+        <div className="fixed inset-0 z-50 bg-black/80">
+          <div className="fixed inset-4 z-50 flex flex-col overflow-hidden rounded-xl bg-white">
+            {/* Overlay header */}
+            <div className="flex items-center gap-3 border-b px-4 py-2">
+              <button
+                type="button"
+                onClick={() => setPdfFullscreen(false)}
+                className="grid h-8 w-8 place-items-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100"
+                aria-label="Close document viewer"
+              >
+                <X className="h-5 w-5" />
+              </button>
+              <FileText className="h-4 w-4 text-violet-600" />
+              <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">
+                {docName}
+              </span>
+            </div>
+            {/* PDF viewer — fit to screen */}
+            <div className="flex-1 overflow-hidden">
+              {isPdf ? (
+                <PDFViewer
+                  fileUrl={docUrl}
+                  fileKey={sourceDocument?.fileKey ?? undefined}
+                  fitToScreen
+                  className="h-full w-full"
+                />
+              ) : isImage ? (
+                <div className="flex h-full items-center justify-center bg-gray-100 p-4">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={docUrl}
+                    alt={docName}
+                    className="max-h-full max-w-full object-contain"
+                  />
+                </div>
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-3">
+                  <FileText className="h-12 w-12 text-blue-600" />
+                  <a
+                    href={docUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-sm text-blue-600 underline"
+                  >
+                    Open document
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Transforms the Test mode view from a split-screen layout (PDF panel above, chat below) into a unified chat-stream layout where the PDF appears as a thumbnail message within the chat flow — similar to how LLM chats display uploaded documents.

## Changes
- **Removed** separate  panel above the chat in 
- **Added** PDF thumbnail as a persistent first message in the unified chat stream
  - Shows document icon, filename, and "Click to view full document" hint
  - Styled with violet accent to match the Test tab theme
  - Left-aligned (like AI messages) with 
- **Clicking the thumbnail** opens a full-screen overlay:
  - Dark backdrop ()
  - White rounded container filling most of the viewport ()
  - Header with close (X) button and document filename
  -  with  for proper scaling
  - Supports PDF, image, and other document types
- **Unified scroll area**: document thumbnail, empty state text, and all chat messages scroll together
- **No changes** to  or  — still used by student Classroom view

## Visual Before/After

**Before:**


**After:**


## Testing
- TypeScript compiles without errors
- PDF thumbnail renders when document exists
- Clicking opens full-screen PDF viewer with fit-to-screen
- Zoom slider works in full-screen view
- Close button (X) closes overlay
- Chat messages, empty state, and input all work correctly
- No document: no thumbnail, empty state shows
- Blob URL: shows unavailable message
- Image document: shows image thumbnail and viewer
- Student Classroom view (TaskChatPanel) is NOT affected

## Related
- Reuses existing  component with  prop (from PR #865)
-  remains untouched for student Classroom use