### PR TITLE
fix(course-details): stronger hover state on back button for visibility

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -695,7 +695,7 @@ export default function TutorCoursePage() {
               <button
                 type="button"
                 onClick={() => router.push(`/tutor/insights?tab=builder&courseId=${id}&mode=edit`)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-white transition-colors hover:bg-white/20"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-white transition-colors hover:bg-white/30 hover:text-white"
                 aria-label="Go back"
               >
                 <ArrowLeft className="h-5 w-5" style={{ color: 'white' }} />


### PR DESCRIPTION
## Problem
The tutor course details back button uses hover:bg-white/20 on a dark metallic header, which is barely visible. The student classroom back button (using shadcn Button ghost variant) shows a clear gray hover state.

## Fix
- Increase hover background from white/20 to white/30 for better visibility
- Add explicit hover:text-white to ensure text stays white on hover

## Before
hover:bg-white/20 — very subtle, almost invisible on dark gradient

## After  
hover:bg-white/30 — more noticeable white tint on hover

## Testing
- TypeScript compiles without errors
- Prettier formatted