### PR TITLE
feat: PDF thumbnail preview + popup overlay in TestTaskChat

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -7,8 +7,8 @@
  * per the PCI → ask follow-ups.
  *
  * The task document (PDF/image) is shown as a thumbnail card inside the chat
- * stream. Clicking it expands an inline PDF viewer contained within the chat
- * panel (using the same padding as the Task Builder slide view).
+ * stream. Clicking it opens a popup overlay within the chat panel showing the
+ * PDF fit-to-screen with an X close button in the top-right corner.
  *
  * State can be persisted by the parent: pass `initialState` to seed the chat and
  * `onPersist` to mirror every change into a store, so switching Test-tab
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Send, Loader2, CheckCircle2, Sparkles, FileText, X, ImageIcon } from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
+import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
 import { toast } from 'sonner'
 
 export interface TestTaskChatMsg {
@@ -65,13 +66,13 @@ export function TestTaskChat({
   const [draft, setDraft] = useState(initialState?.draft ?? '')
   const [completed, setCompleted] = useState(initialState?.completed ?? false)
   const [busy, setBusy] = useState(false)
-  const [pdfExpanded, setPdfExpanded] = useState(false)
+  const [pdfPopupOpen, setPdfPopupOpen] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
-  }, [messages, busy, pdfExpanded])
+  }, [messages, busy])
 
   // Mirror state to the parent's store so a remount (switching Test students)
   // can rehydrate it. Cheap; runs only when the persisted fields change.
@@ -178,13 +179,12 @@ export function TestTaskChat({
   const accentBorder = isClassroom ? 'border-orange-100' : 'border-violet-100'
   const accentBorderStrong = isClassroom ? 'border-[rgba(241,118,35,0.4)]' : 'border-violet-300'
   const sendButtonBg = isClassroom ? 'bg-[#F17623]' : 'bg-violet-600'
-  const sendButtonHover = isClassroom ? 'hover:bg-[#d9631a]' : 'hover:bg-violet-700'
   const taskCompleteBg = isClassroom ? 'bg-[#F17623]' : 'bg-violet-600'
   const taskCompleteHover = isClassroom ? 'hover:bg-[#d9631a]' : 'hover:bg-violet-700'
 
   return (
     <div
-      className={`flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl border ${accentBorderStrong} bg-white`}
+      className={`relative flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl border ${accentBorderStrong} bg-white`}
     >
       {/* Header bar */}
       <div className={`flex items-center gap-2 border-b ${accentBorder} ${accentBg} px-4 py-2`}>
@@ -211,21 +211,34 @@ export function TestTaskChat({
       </div>
 
       {/* Unified chat stream — document thumbnail + messages scroll together */}
-      <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+      <div ref={scrollRef} className="relative min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
         {/* Document thumbnail — persistent first message in the stream */}
-        {sourceDocument && !pdfExpanded && (
+        {sourceDocument && !pdfPopupOpen && (
           <div className="flex items-start">
             <button
               type="button"
-              onClick={() => loadable && setPdfExpanded(true)}
+              onClick={() => loadable && setPdfPopupOpen(true)}
               disabled={!loadable}
-              className="max-w-[85%] cursor-pointer rounded-xl border border-violet-200 bg-violet-50/50 px-4 py-3 text-left transition-colors hover:border-violet-300 hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="max-w-[85%] cursor-pointer rounded-xl border border-violet-200 bg-violet-50/50 px-3 py-3 text-left transition-colors hover:border-violet-300 hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              <div className="flex items-center gap-2.5">
-                {isImage ? (
-                  <ImageIcon className="h-5 w-5 shrink-0 text-violet-600" />
+              <div className="flex items-center gap-3">
+                {/* PDF Thumbnail preview */}
+                {isPdf && loadable ? (
+                  <div className="shrink-0 overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm">
+                    <PDFThumbnail
+                      fileUrl={docUrl}
+                      fileKey={sourceDocument?.fileKey ?? undefined}
+                      width={100}
+                    />
+                  </div>
+                ) : isImage ? (
+                  <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
+                    <ImageIcon className="h-5 w-5 text-gray-400" />
+                  </div>
                 ) : (
-                  <FileText className="h-5 w-5 shrink-0 text-violet-600" />
+                  <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
+                    <FileText className="h-5 w-5 text-gray-400" />
+                  </div>
                 )}
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium text-gray-800">{docName}</p>
@@ -240,35 +253,31 @@ export function TestTaskChat({
           </div>
         )}
 
-        {/* Inline PDF viewer — contained within the chat panel */}
-        {pdfExpanded && loadable && (
-          <div className="flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-            {/* Viewer header */}
-            <div className="flex items-center gap-2 border-b px-3 py-2">
+        {/* PDF Popup — overlay within chat panel, no header, X on right */}
+        {pdfPopupOpen && loadable && (
+          <div className="absolute inset-0 z-10 flex flex-col bg-white">
+            {/* X close button — top right, no header bar */}
+            <div className="flex justify-end px-3 py-2">
               <button
                 type="button"
-                onClick={() => setPdfExpanded(false)}
-                className="grid h-7 w-7 place-items-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100"
-                aria-label="Close document viewer"
+                onClick={() => setPdfPopupOpen(false)}
+                className="grid h-8 w-8 place-items-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100"
+                aria-label="Close document"
               >
-                <X className="h-4 w-4" />
+                <X className="h-5 w-5" />
               </button>
-              <FileText className="h-4 w-4 text-violet-600" />
-              <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">
-                {docName}
-              </span>
             </div>
-            {/* PDF viewer — same padding as Task Builder slide view (px-4, py-4) */}
-            <div className="h-[50vh] min-h-[280px] w-full">
+            {/* PDF viewer — fit to screen, no scrolling needed */}
+            <div className="min-h-0 flex-1 overflow-hidden px-4 pb-4">
               {isPdf ? (
                 <PDFViewer
                   fileUrl={docUrl}
                   fileKey={sourceDocument?.fileKey ?? undefined}
-                  fitToWidth
+                  fitToScreen
                   className="h-full w-full"
                 />
               ) : isImage ? (
-                <div className="flex h-full items-center justify-center bg-gray-100 p-4">
+                <div className="flex h-full items-center justify-center">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={docUrl}

--- a/tutorme-app/src/components/pdf/PDFThumbnail.tsx
+++ b/tutorme-app/src/components/pdf/PDFThumbnail.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
+import 'react-pdf/dist/esm/Page/TextLayer.css'
+
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs'
+
+interface PDFThumbnailProps {
+  fileUrl: string
+  fileKey?: string
+  className?: string
+  width?: number
+  onLoadSuccess?: () => void
+  onLoadError?: () => void
+}
+
+function getProxiedPdfUrl(fileUrl: string, fileKey?: string): string {
+  if (fileKey && /^(documents|assets|resources)\//.test(fileKey)) {
+    return `/api/proxy-file?key=${encodeURIComponent(fileKey)}`
+  }
+  if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
+    return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
+  }
+  return fileUrl
+}
+
+export function PDFThumbnail({
+  fileUrl,
+  fileKey,
+  className = '',
+  width = 120,
+  onLoadSuccess,
+  onLoadError,
+}: PDFThumbnailProps) {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  const handleLoadSuccess = useCallback(() => {
+    setLoading(false)
+    onLoadSuccess?.()
+  }, [onLoadSuccess])
+
+  const handleLoadError = useCallback(() => {
+    setLoading(false)
+    setError(true)
+    onLoadError?.()
+  }, [onLoadError])
+
+  if (!fileUrl && !fileKey) return null
+
+  const proxiedUrl = getProxiedPdfUrl(fileUrl, fileKey)
+
+  return (
+    <div className={`relative overflow-hidden rounded-lg bg-white ${className}`}>
+      {loading && (
+        <div
+          className="flex items-center justify-center bg-gray-100"
+          style={{ width, height: width * 1.4 }}
+        >
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-blue-600" />
+        </div>
+      )}
+      {error ? (
+        <div
+          className="flex items-center justify-center bg-gray-100"
+          style={{ width, height: width * 1.4 }}
+        >
+          <span className="text-xs text-gray-400">PDF</span>
+        </div>
+      ) : (
+        <Document
+          file={proxiedUrl}
+          onLoadSuccess={handleLoadSuccess}
+          onLoadError={handleLoadError}
+          loading={null}
+          error={null}
+        >
+          <Page
+            pageNumber={1}
+            width={width}
+            renderTextLayer={false}
+            renderAnnotationLayer={false}
+            className="shadow-sm"
+          />
+        </Document>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Redesigns the PDF document display in the TestTaskChat component with an actual rendered thumbnail preview and a contained popup overlay.

## Changes

### New Component: PDFThumbnail
- Uses react-pdf to render the first page of a PDF as an actual image preview
- Configurable width (default 120px)
- Shows loading spinner while rendering
- Falls back to generic PDF icon on error

### TestTaskChat.tsx Redesign

#### Document Thumbnail (Before → After)
- **Before**: Generic FileText icon + filename text
- **After**: Actual rendered PDF page thumbnail (100px width) + filename

#### PDF Popup (Before → After)
- **Before**: Inline expandable panel with header bar (FileText icon + filename + X button)
- **After**: Overlay popup within chat container boundaries
  - No header/title bar
  - X close button floating top-right
  - PDF displayed with fitToScreen (whole page visible without scrolling)
  - Absolute positioned within chat panel (not fixed fullscreen)

## Technical Details
- Popup uses  within the relative chat container
- PDFViewer uses  prop for full-page display
- Thumbnail uses  and  for performance

## Testing
- Type check passes
- Prettier formatting applied

## Files Changed
-  (new)
- 