### PR TITLE
fix(courses): keep the creation-time category when a draft course is saved

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
@@ -10,6 +10,9 @@ export interface SaveCourseOptions {
   draftListStorageKey?: string
   courseName?: string
   courseDescription?: string
+  /** Categories to set when creating a DB course from a draft (chosen at
+   *  creation and held on the local draft). Ignored for updates. */
+  categories?: string[]
   developmentMode?: 'single' | 'multi'
   previewDifficulty?: 'all' | 'beginner' | 'intermediate' | 'advanced'
   isAutoSave?: boolean
@@ -110,6 +113,7 @@ export async function saveCourse(options: SaveCourseOptions): Promise<SaveCourse
     draftListStorageKey,
     courseName,
     courseDescription,
+    categories,
     developmentMode = 'single',
     previewDifficulty = 'all',
     isExistingDbCourse = false,
@@ -171,7 +175,7 @@ export async function saveCourse(options: SaveCourseOptions): Promise<SaveCourse
         body: safeStringify({
           title,
           description: courseDescription || '',
-          categories: [],
+          categories: categories ?? [],
           schedule: [],
           isLiveOnline: false,
         }),

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -350,6 +350,9 @@ function TutorInsightsPageInner() {
         draftListStorageKey: draftStorageKey,
         courseName: options?.courseName,
         courseDescription: options?.courseDescription,
+        // When a draft is first persisted to the DB, carry the category chosen
+        // at creation (drafts hold it locally) so it isn't lost.
+        categories: [...courses, ...draftCourses].find(c => c.id === courseId)?.categories,
         detachedCourseName,
         isAutoSave: options?.isAutoSave,
         propagateToVariants,
@@ -385,7 +388,16 @@ function TutorInsightsPageInner() {
         )
       }
     },
-    [courseId, saveMode, draftStorageKey, isPublishedVariant, detachedCourseName, router]
+    [
+      courseId,
+      saveMode,
+      draftStorageKey,
+      isPublishedVariant,
+      detachedCourseName,
+      router,
+      courses,
+      draftCourses,
+    ]
   )
 
   const handleSave = useCallback(
@@ -415,6 +427,7 @@ function TutorInsightsPageInner() {
       const newCourse = {
         id: `course-${Date.now()}`,
         name: newCourseName.trim(),
+        categories: newCourseCategories,
         modules: [],
         updatedAt: new Date().toISOString(),
       }
@@ -430,7 +443,12 @@ function TutorInsightsPageInner() {
         )
         setDraftCourses(prev => [
           ...prev,
-          { id: newCourse.id, name: newCourse.name, updatedAt: newCourse.updatedAt },
+          {
+            id: newCourse.id,
+            name: newCourse.name,
+            categories: newCourseCategories,
+            updatedAt: newCourse.updatedAt,
+          },
         ])
         setCourseId(newCourse.id)
         setDetachedCourseName(newCourse.name)


### PR DESCRIPTION
Follow-up to #900 — fixes a real gap I found while reviewing that PR.

## Bug
Creating a course in the builder's **draft** mode collected the (now required) category but **dropped it**:
- the local draft object didn't store `categories`, and
- `saveCourse` hard-coded `categories: []` when first persisting a draft to the DB.

So a draft-created course ended up **Uncategorized**, and the tutor had to re-pick the category on the Course Details page — defeating "decide it once at creation" for that path. (The direct DB-create path already persisted the category correctly, so this only affected draft-mode creation.)

## Fix
- Store `categories` on the local draft object and its `draftCourses` entry.
- Thread the draft's categories through `executeSave` → `saveCourse` (`SaveCourseOptions.categories`), used in the create POST (`categories ?? []`).

Now a draft created with a category carries it into the DB course, matching the direct-create path.

## Testing
- `npm run build` passes; typecheck + eslint clean (0 errors).
- Worth a manual pass after deploy: create a course in **draft/edit** mode (pick a category) → build something → save → confirm the resulting DB course has the chosen category (not Uncategorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)