### PR TITLE
fix(courses): reset the Create New Course dialog on cancel

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -490,6 +490,14 @@ function CourseBuilderInsightsRouteInner({
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false)
   // Two-step create flow: name → category (category is required at creation).
   const [createStep, setCreateStep] = useState<'name' | 'category'>('name')
+  // Close + clear the create dialog so a cancelled attempt doesn't leave a stale
+  // name/category on the next open. (Successful create clears via its own handler.)
+  const closeCreateDialog = () => {
+    setCreateStep('name')
+    setNewCourseName?.('')
+    setNewCourseCategories?.([])
+    setIsCreateDialogOpen?.(false)
+  }
   const [goLiveDialogOpen, setGoLiveDialogOpen] = useState(false)
   const [renameValue, setRenameValue] = useState('')
   const [leftPanelHidden, setLeftPanelHidden] = useState(false)
@@ -1159,10 +1167,7 @@ function CourseBuilderInsightsRouteInner({
       {/* Create Course Dialog — step 1: name, step 2: category (required) */}
       <Dialog
         open={isCreateDialogOpen}
-        onOpenChange={next => {
-          setCreateStep('name')
-          setIsCreateDialogOpen?.(next)
-        }}
+        onOpenChange={next => (next ? setIsCreateDialogOpen?.(true) : closeCreateDialog())}
       >
         <DialogContent
           className={
@@ -1228,10 +1233,7 @@ function CourseBuilderInsightsRouteInner({
           <DialogFooter className="gap-3">
             {createStep === 'name' ? (
               <>
-                <Button
-                  variant="modal-secondary-dark"
-                  onClick={() => setIsCreateDialogOpen?.(false)}
-                >
+                <Button variant="modal-secondary-dark" onClick={closeCreateDialog}>
                   Cancel
                 </Button>
                 <Button


### PR DESCRIPTION
Final tidy-up on the category-at-creation feature.

The builder's Create New Course dialog cleared the name/category only on a **successful** create, so cancelling (Cancel button, Escape, backdrop click, or X) and reopening left the previous name and selected category lingering — a stale form.

Fix: a single `closeCreateDialog` that resets step → name → category, wired into **both** the Cancel button and the dialog's close path (`onOpenChange(false)`, which covers Escape/backdrop/X). A fresh open now always starts clean. Successful create still clears via its own handler (unchanged).

## Testing
- Typecheck + eslint clean (0 errors). One-file, presentational change.
- Quick check after deploy: **+** → type a name / pick a category → **Cancel** (or Esc) → reopen → fields are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)