### PR TITLE
fix(courses): show full name (name + category) in the builder before publishing

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -367,9 +367,15 @@ function TutorInsightsPageInner() {
         // If a new course was created (draft sentinel → real DB course),
         // update state + URL so refresh loads the persisted course
         if (result.courseId && result.courseId !== courseId) {
+          // Carry the draft's categories onto the persisted course so the builder
+          // header keeps showing the full name (name + category), not just the name.
+          const draftCategories = [...courses, ...draftCourses].find(
+            c => c.id === courseId
+          )?.categories
           const newCourse = {
             id: result.courseId,
             name: options?.courseName || detachedCourseName || 'Untitled Course',
+            categories: draftCategories,
             updatedAt: new Date().toISOString(),
           }
           setCourses(prev => {
@@ -476,7 +482,16 @@ function TutorInsightsPageInner() {
       const data = await res.json()
       const createdCourse = data.courses?.[0]
       if (res.ok && createdCourse?.id) {
-        setCourses(prev => [...prev, createdCourse])
+        // Ensure the new course carries its category into state so the builder
+        // header shows the full name (name + category) immediately.
+        const withCategories = {
+          ...createdCourse,
+          categories:
+            Array.isArray(createdCourse.categories) && createdCourse.categories.length > 0
+              ? createdCourse.categories
+              : newCourseCategories,
+        }
+        setCourses(prev => [...prev, withCategories])
         setCourseId(createdCourse.id)
         setDetachedCourseName(createdCourse.name)
         setNewCourseName('')


### PR DESCRIPTION
## Report
"After creating a course, the builder should show the **full** course name (name + category) even before publishing — currently only the typed name shows."

## Root cause
The builder header renders `currentCourse.name` **plus a category pill**, but the pill is gated on `currentCourse.categories?.length > 0` (`CourseBuilderInsightsRoute.tsx:982`). `currentCourse` is looked up from `courses`/`draftCourses` state — and a newly-created course's categories weren't reaching that state on every path:
- **`executeSave` (draft → DB):** the new-course state object was `{ id, name, updatedAt }` — **no `categories`**. So the moment a draft was persisted (e.g. auto-save right after creation), `currentCourse` switched to that object and the pill disappeared, leaving just the name. ← the main culprit.
- **DB-create path:** the create route *does* return `categories`, but I also keep the chosen categories on the state object defensively.

The draft-create entry already carried `categories` (from the earlier fix), so this closes the remaining gaps.

## Result
The category pill now shows next to the name **immediately after creation on every create/save path** — the "full name" is visible pre-publish.

## Testing
- Typecheck + eslint clean (0 errors).
- **Not visually verified** (can't render here) — worth a check after deploy: create a course (draft and live), pick a category → the builder header should show name **and** the category pill; save a draft → the pill should persist (not vanish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)