### PR TITLE
feat(courses): Edit Course button + full-name builder header (parts 2 & 3)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -37,6 +37,7 @@ import {
 } from 'lucide-react'
 import { BackButton } from '@/components/navigation/BackButton'
 import { CourseCategoryPicker } from './CourseCategoryPicker'
+import { getCategoryBoard } from '@/lib/data/category-board'
 import {
   Select,
   SelectContent,
@@ -134,6 +135,9 @@ type Props = UseCourseBuilderContentArgs & {
   newCourseCategories?: string[]
   setNewCourseCategories?: (v: string[]) => void
   createStorageUserId?: string
+  /** Persist an edited course name/categories (from the control-panel Edit button). */
+  onUpdateCourse?: (id: string, patch: { name: string; categories: string[] }) => void
+  editStorageUserId?: string
   onCreateNewCourse?: () => void
   isDeleteDialogOpen?: boolean
   setIsDeleteDialogOpen?: (v: boolean) => void
@@ -178,6 +182,7 @@ interface TutorControlsPanelProps {
   onVideo: () => void
   onSync: () => void
   onCreateCourse?: () => void
+  onEditCourse?: () => void
   canDelete: boolean
   canSchedule: boolean
   canGoLive: boolean
@@ -200,6 +205,7 @@ function TutorControlsPanel({
   onVideo,
   onSync,
   onCreateCourse,
+  onEditCourse,
   canDelete,
   canSchedule,
   canGoLive,
@@ -354,6 +360,19 @@ function TutorControlsPanel({
                       <Trash2 className="h-4 w-4" />
                       Delete
                     </button>
+
+                    <button
+                      type="button"
+                      disabled={panelDisabled || mode !== 'build' || !onEditCourse}
+                      onClick={onEditCourse}
+                      className={cn(
+                        actionButtonBase,
+                        'bg-white text-slate-700 hover:bg-slate-50 active:bg-slate-100'
+                      )}
+                    >
+                      <Edit3 className="h-4 w-4" />
+                      Edit Course
+                    </button>
                   </div>
 
                   <div className="flex flex-col gap-2">
@@ -453,6 +472,8 @@ function CourseBuilderInsightsRouteInner({
   newCourseCategories,
   setNewCourseCategories,
   createStorageUserId,
+  onUpdateCourse,
+  editStorageUserId,
   onCreateNewCourse,
   isDeleteDialogOpen,
   setIsDeleteDialogOpen,
@@ -497,6 +518,21 @@ function CourseBuilderInsightsRouteInner({
     setNewCourseName?.('')
     setNewCourseCategories?.([])
     setIsCreateDialogOpen?.(false)
+  }
+  // Edit-course dialog (control-panel Edit button): edit name + category of the
+  // current course. Prefilled from currentCourse; persisted via onUpdateCourse.
+  const [isEditCourseOpen, setIsEditCourseOpen] = useState(false)
+  const [editName, setEditName] = useState('')
+  const [editCategories, setEditCategories] = useState<string[]>([])
+  const openEditCourse = () => {
+    setEditName(currentCourse?.name ?? '')
+    setEditCategories(((currentCourse as { categories?: string[] })?.categories ?? []).slice())
+    setIsEditCourseOpen(true)
+  }
+  const saveEditCourse = () => {
+    if (!courseId || !editName.trim() || editCategories.length === 0) return
+    onUpdateCourse?.(courseId, { name: editName.trim(), categories: editCategories })
+    setIsEditCourseOpen(false)
   }
   const [goLiveDialogOpen, setGoLiveDialogOpen] = useState(false)
   const [renameValue, setRenameValue] = useState('')
@@ -981,7 +1017,15 @@ function CourseBuilderInsightsRouteInner({
                   currentCourse &&
                   (currentCourse as any).categories?.length > 0 ? (
                     <span className="bg-muted text-muted-foreground ml-2 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
-                      {(currentCourse as any).categories.join(', ')}
+                      {/* Full identity: Board (derived) · category · country
+                          (country appears once published, from the variant). */}
+                      {[
+                        getCategoryBoard((currentCourse as any).categories[0]),
+                        (currentCourse as any).categories.join(', '),
+                        (currentCourse as any).nationality,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
                     </span>
                   ) : null}
                 </div>
@@ -1139,6 +1183,7 @@ function CourseBuilderInsightsRouteInner({
               ref?.triggerSync?.()
             }}
             onCreateCourse={onCreateCourse}
+            onEditCourse={courseId ? openEditCourse : undefined}
             canDelete={!!(courseId && courseId !== 'insights-draft' && onDeleteCourse)}
             canSchedule={
               !!(
@@ -1258,6 +1303,51 @@ function CourseBuilderInsightsRouteInner({
                 </Button>
               </>
             )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Course Dialog — control-panel "Edit Course" (name + category) */}
+      <Dialog open={isEditCourseOpen} onOpenChange={setIsEditCourseOpen}>
+        <DialogContent
+          className="max-h-[90vh] max-w-3xl overflow-hidden border border-slate-200 shadow-2xl"
+          aria-describedby={undefined}
+        >
+          <DialogHeader className="text-center">
+            <DialogTitle className="mx-auto text-center text-white">Edit Course</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 px-2 py-2">
+            <div className="space-y-2 px-4">
+              <Label className="text-sm font-medium text-slate-700">Course name</Label>
+              <Input
+                value={editName}
+                onChange={e => e.target.value.length <= 25 && setEditName(e.target.value)}
+                placeholder="Course name"
+                maxLength={25}
+                className="h-11 w-full rounded-lg border border-gray-300 bg-white px-4 text-sm text-gray-900 placeholder:text-gray-400"
+              />
+            </div>
+            <div className="max-h-[55vh] overflow-y-auto rounded-lg bg-white p-4 text-slate-900">
+              <CourseCategoryPicker
+                value={editCategories}
+                onChange={setEditCategories}
+                storageUserId={editStorageUserId}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-3">
+            <Button variant="modal-secondary-dark" onClick={() => setIsEditCourseOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="modal-primary-dark"
+              onClick={saveEditCourse}
+              disabled={!editName.trim() || editCategories.length === 0}
+            >
+              Save
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -491,6 +491,57 @@ function TutorInsightsPageInner() {
     }
   }, [newCourseName, newCourseCategories, saveMode])
 
+  // Persist an edited course name/categories from the control-panel Edit button.
+  const handleUpdateCourse = useCallback(
+    async (id: string, patch: { name: string; categories: string[] }) => {
+      // Optimistic local update so the builder header reflects it immediately.
+      setCourses(prev =>
+        prev.map(c => (c.id === id ? { ...c, name: patch.name, categories: patch.categories } : c))
+      )
+      setDraftCourses(prev =>
+        prev.map(c => (c.id === id ? { ...c, name: patch.name, categories: patch.categories } : c))
+      )
+      if (id === courseId) setDetachedCourseName(patch.name)
+
+      // Drafts live only in localStorage; DB courses persist via PATCH.
+      const isDraft = draftCourses.some(c => c.id === id)
+      if (isDraft) {
+        try {
+          const raw = localStorage.getItem(draftStorageKey)
+          const parsed = raw ? JSON.parse(raw) : []
+          localStorage.setItem(
+            draftStorageKey,
+            JSON.stringify(
+              parsed.map((c: any) =>
+                c.id === id ? { ...c, name: patch.name, categories: patch.categories } : c
+              )
+            )
+          )
+        } catch {
+          // ignore
+        }
+        toast.success('Course updated')
+        return
+      }
+      try {
+        const res = await fetchWithCsrf(`/api/tutor/courses/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: patch.name, categories: patch.categories }),
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          toast.error(data.error || 'Failed to update course')
+          return
+        }
+        toast.success('Course updated')
+      } catch {
+        toast.error('Failed to update course')
+      }
+    },
+    [courseId, draftCourses, draftStorageKey]
+  )
+
   const handleDeleteCourse = useCallback(async () => {
     if (!courseId || courseId === 'insights-draft') return
 
@@ -1322,6 +1373,8 @@ function TutorInsightsPageInner() {
           newCourseCategories={newCourseCategories}
           setNewCourseCategories={setNewCourseCategories}
           createStorageUserId={session?.user?.id}
+          onUpdateCourse={handleUpdateCourse}
+          editStorageUserId={session?.user?.id}
           onCreateNewCourse={handleCreateNewCourse}
           isDeleteDialogOpen={isDeleteDialogOpen}
           setIsDeleteDialogOpen={setIsDeleteDialogOpen}

--- a/tutorme-app/src/lib/data/category-board.ts
+++ b/tutorme-app/src/lib/data/category-board.ts
@@ -1,0 +1,39 @@
+/**
+ * Best-effort exam board for a course category, derived from the static category
+ * datasets (AP / IB / A Level / IGCSE / Global / Languages / Professional /
+ * Universities). Used to show the Board alongside the category in the builder
+ * header. Returns null for national exams or custom categories that have no
+ * fixed board.
+ */
+
+import {
+  GLOBAL_EXAMS_CATEGORIES,
+  AP_CATEGORIES,
+  A_LEVEL_CATEGORIES,
+  IB_CATEGORIES,
+  IGCSE_CATEGORIES,
+  LANGUAGE_CATEGORIES,
+  PROFESSIONAL_CATEGORIES,
+  UNIVERSITY_CATEGORIES,
+  type ExamCategory,
+} from './tutor-categories'
+
+const CATEGORY_BOARD_MAP = new Map<string, string>()
+;(
+  [
+    [GLOBAL_EXAMS_CATEGORIES, 'Global'],
+    [AP_CATEGORIES, 'AP'],
+    [A_LEVEL_CATEGORIES, 'A Level'],
+    [IB_CATEGORIES, 'IB'],
+    [IGCSE_CATEGORIES, 'IGCSE'],
+    [LANGUAGE_CATEGORIES, 'Languages'],
+    [PROFESSIONAL_CATEGORIES, 'Professional'],
+    [UNIVERSITY_CATEGORIES, 'Universities'],
+  ] as [ExamCategory[], string][]
+).forEach(([cats, board]) =>
+  cats.forEach(c => c.exams.forEach(e => CATEGORY_BOARD_MAP.set(e, board)))
+)
+
+export function getCategoryBoard(category: string): string | null {
+  return CATEGORY_BOARD_MAP.get(category) ?? null
+}


### PR DESCRIPTION
Implements requests **#2** (control-panel Edit button for name/category) and **#3** (builder shows full name) from the category-management redesign. Request **#1** (remove the Course Details Category section + rewire VariantManager) follows as a separate PR to keep the risky removal isolated.

Per your answers: **Board is derived from the category**, **country stays a per-variant concept** (shown once published, blank before), and category is set at **creation + this new Edit button**.

## #3 — Full-name header
The builder header pill now reads **`Board · category · country`**:
- **Board** — derived from the chosen category via a new best-effort lookup (`getCategoryBoard`) over the static datasets (AP / IB / A-Level / IGCSE / Global / Languages / Professional / Universities).
- **category** — the course's stored categories.
- **country** — the published variant's nationality (appears once published; blank pre-publish, matching the multi-country model).

## #2 — "Edit Course" button
New button in the builder Controls panel → opens a dialog to edit **name + category** (reuses `CourseCategoryPicker`). On Save: optimistic local update (header reflects it immediately) + `PATCH /api/tutor/courses/[id]` for DB courses, or localStorage for drafts. Save is disabled until a name and category are set.

## Notes
- No API/schema change — `PATCH /api/tutor/courses/[id]` already accepts `name` + `categories`.
- The Course Details Category section is still present (untouched here) — removed in the follow-up PR so publishing (`VariantManager`) can be rewired safely to source category from the course.

## Testing
- `npm run build` passes; typecheck + eslint clean (0 errors).
- **Not visually verified** — after deploy: open a course → header shows `Board · category`; click **Edit Course** → change name/category → Save → header updates; publish → country appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)