### PR TITLE
feat(classroom): chat-style interface for Test mode

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -20,12 +20,14 @@ import { Send, Loader2, CheckCircle2, Sparkles, FileText, X, ImageIcon } from 'l
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
+import { ChatMessageBubble } from '@/components/classroom/chat-message-bubble'
 import { toast } from 'sonner'
 
 export interface TestTaskChatMsg {
-  role: 'student' | 'ai'
+  role: 'student' | 'ai' | 'tutor'
   content: string
   re?: string
+  timestamp?: number
 }
 
 export interface TestTaskChatState {
@@ -105,7 +107,7 @@ export function TestTaskChat({
   const addAnswer = () => {
     const a = draft.trim()
     if (!a || busy) return
-    setMessages(prev => [...prev, { role: 'student', content: a }])
+    setMessages(prev => [...prev, { role: 'student', content: a, timestamp: Date.now() }])
     setDraft('')
   }
 
@@ -118,7 +120,7 @@ export function TestTaskChat({
       return
     }
     if (pending) {
-      setMessages(prev => [...prev, { role: 'student', content: pending }])
+      setMessages(prev => [...prev, { role: 'student', content: pending, timestamp: Date.now() }])
       setDraft('')
     }
     setBusy(true)
@@ -131,7 +133,12 @@ export function TestTaskChat({
         : []
       setMessages(prev => [
         ...prev,
-        ...responses.map(r => ({ role: 'ai' as const, content: r.response, re: r.answer })),
+        ...responses.map(r => ({
+          role: 'ai' as const,
+          content: r.response,
+          re: r.answer,
+          timestamp: Date.now(),
+        })),
       ])
       setCompleted(true)
     } catch (e) {
@@ -144,7 +151,7 @@ export function TestTaskChat({
   const ask = async () => {
     const q = draft.trim()
     if (!q || busy) return
-    setMessages(prev => [...prev, { role: 'student', content: q }])
+    setMessages(prev => [...prev, { role: 'student', content: q, timestamp: Date.now() }])
     setDraft('')
     setBusy(true)
     try {
@@ -154,11 +161,18 @@ export function TestTaskChat({
       const res = await post({ question: q, history, answers: studentAnswers })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(data?.error || 'Failed to answer')
-      setMessages(prev => [...prev, { role: 'ai', content: data.answer || '…' }])
+      setMessages(prev => [
+        ...prev,
+        { role: 'ai', content: data.answer || '…', timestamp: Date.now() },
+      ])
     } catch {
       setMessages(prev => [
         ...prev,
-        { role: 'ai', content: 'Sorry — I could not answer that. Please try again.' },
+        {
+          role: 'ai',
+          content: 'Sorry — I could not answer that. Please try again.',
+          timestamp: Date.now(),
+        },
       ])
     } finally {
       setBusy(false)
@@ -211,46 +225,18 @@ export function TestTaskChat({
       </div>
 
       {/* Unified chat stream — document thumbnail + messages scroll together */}
-      <div ref={scrollRef} className="relative min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
-        {/* Document thumbnail — persistent first message in the stream */}
+      <div ref={scrollRef} className="relative min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+        {/* Document as first tutor message */}
         {sourceDocument && !pdfPopupOpen && (
-          <div className="flex items-start">
-            <button
-              type="button"
-              onClick={() => loadable && setPdfPopupOpen(true)}
-              disabled={!loadable}
-              className="max-w-[85%] cursor-pointer rounded-xl border border-violet-200 bg-violet-50/50 px-3 py-3 text-left transition-colors hover:border-violet-300 hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <div className="flex items-center gap-3">
-                {/* PDF Thumbnail preview */}
-                {isPdf && loadable ? (
-                  <div className="shrink-0 overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm">
-                    <PDFThumbnail
-                      fileUrl={docUrl}
-                      fileKey={sourceDocument?.fileKey ?? undefined}
-                      width={100}
-                    />
-                  </div>
-                ) : isImage ? (
-                  <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
-                    <ImageIcon className="h-5 w-5 text-gray-400" />
-                  </div>
-                ) : (
-                  <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
-                    <FileText className="h-5 w-5 text-gray-400" />
-                  </div>
-                )}
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-gray-800">{docName}</p>
-                  <p className="text-xs text-gray-500">
-                    {loadable
-                      ? 'Click to view document'
-                      : 'This document is unavailable. Re-upload it.'}
-                  </p>
-                </div>
-              </div>
-            </button>
-          </div>
+          <ChatMessageBubble
+            sender="tutor"
+            name="Tutor"
+            content=""
+            isDocument
+            document={sourceDocument}
+            onDocumentClick={() => loadable && setPdfPopupOpen(true)}
+            isClassroom={isClassroom}
+          />
         )}
 
         {/* PDF Popup — overlay within chat panel, no header, X on right */}
@@ -303,28 +289,17 @@ export function TestTaskChat({
         )}
 
         {/* Chat messages */}
-        {messages.map((m, i) =>
-          m.role === 'student' ? (
-            <div key={i} className="flex justify-end">
-              <span
-                className={`max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-sm ${sendButtonBg} px-3 py-2 text-sm text-white`}
-              >
-                {m.content}
-              </span>
-            </div>
-          ) : (
-            <div key={i} className="flex flex-col items-start">
-              {m.re && (
-                <span className="mb-0.5 max-w-[85%] truncate rounded-md bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
-                  Re: {m.re}
-                </span>
-              )}
-              <span className="max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-bl-sm border border-gray-200 bg-gray-50 px-3 py-2 text-sm leading-relaxed text-gray-800">
-                {m.content}
-              </span>
-            </div>
-          )
-        )}
+        {messages.map((m, i) => (
+          <ChatMessageBubble
+            key={i}
+            sender={m.role}
+            name={m.role === 'student' ? 'Student' : m.role === 'ai' ? 'Tutor' : 'Tutor'}
+            content={m.content}
+            re={m.re}
+            timestamp={m.timestamp ? new Date(m.timestamp) : undefined}
+            isClassroom={isClassroom}
+          />
+        ))}
 
         {busy && (
           <div className="flex items-center gap-1.5 text-xs text-gray-400">

--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { resolvePublicUrl } from '@/lib/utils'
+import { FileText, ImageIcon } from 'lucide-react'
+import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
+import { cn } from '@/lib/utils'
+
+export type ChatMessageSender = 'tutor' | 'ai' | 'student'
+
+export interface ChatMessageBubbleProps {
+  sender: ChatMessageSender
+  name: string
+  content: string
+  avatarUrl?: string | null
+  timestamp?: Date | string
+  isDocument?: boolean
+  document?: {
+    fileName?: string | null
+    fileUrl?: string | null
+    fileKey?: string | null
+    mimeType?: string | null
+  } | null
+  onDocumentClick?: () => void
+  re?: string
+  isClassroom?: boolean
+}
+
+export function ChatMessageBubble({
+  sender,
+  name,
+  content,
+  avatarUrl,
+  timestamp,
+  isDocument,
+  document,
+  onDocumentClick,
+  re,
+  isClassroom = false,
+}: ChatMessageBubbleProps) {
+  const isRight = sender === 'tutor' || sender === 'ai'
+  const isStudent = sender === 'student'
+  const showAvatar = !!avatarUrl || !!name
+
+  const resolvedAvatar = resolvePublicUrl(avatarUrl)
+  const initial = name.charAt(0).toUpperCase()
+
+  // Document card rendering
+  if (isDocument && document) {
+    const rawUrl = document.fileUrl || ''
+    const docUrl = document.fileKey
+      ? `/api/proxy-file?key=${encodeURIComponent(document.fileKey)}`
+      : rawUrl
+    const loadable =
+      !!document.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:') && rawUrl.length > 0)
+    const docName = document.fileName || 'Task document'
+    const isPdf =
+      document.mimeType === 'application/pdf' ||
+      (!document.mimeType && /\.pdf($|\?|#)/i.test(document.fileName || rawUrl))
+    const isImage = !!document.mimeType?.startsWith('image/')
+
+    return (
+      <div className="flex items-start">
+        <button
+          type="button"
+          onClick={() => loadable && onDocumentClick?.()}
+          disabled={!loadable}
+          className={cn(
+            'max-w-[85%] cursor-pointer rounded-xl border px-3 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+            isClassroom
+              ? 'border-orange-200 bg-orange-50/50 hover:border-orange-300 hover:bg-orange-50'
+              : 'border-violet-200 bg-violet-50/50 hover:border-violet-300 hover:bg-violet-50'
+          )}
+        >
+          <div className="flex items-center gap-3">
+            {isPdf && loadable ? (
+              <div className="shrink-0 overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm">
+                <PDFThumbnail
+                  fileUrl={docUrl}
+                  fileKey={document.fileKey ?? undefined}
+                  width={100}
+                />
+              </div>
+            ) : isImage ? (
+              <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
+                <ImageIcon className="h-5 w-5 text-gray-400" />
+              </div>
+            ) : (
+              <div className="flex h-[70px] w-[100px] shrink-0 items-center justify-center rounded-md border border-gray-200 bg-gray-100">
+                <FileText className="h-5 w-5 text-gray-400" />
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-gray-800">{docName}</p>
+              <p className="text-xs text-gray-500">
+                {loadable
+                  ? 'Click to view document'
+                  : 'This document is unavailable. Re-upload it.'}
+              </p>
+            </div>
+          </div>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex gap-2',
+        isRight ? 'flex-row-reverse justify-end' : 'flex-row justify-start'
+      )}
+    >
+      {/* Avatar */}
+      {showAvatar && (
+        <div className="flex flex-col items-center gap-1">
+          <Avatar className="h-8 w-8 shrink-0">
+            {resolvedAvatar && <AvatarImage src={resolvedAvatar} alt={name} />}
+            <AvatarFallback
+              className={cn(
+                'text-xs font-medium',
+                isStudent
+                  ? 'border border-slate-200 bg-white text-slate-600'
+                  : isClassroom
+                    ? 'bg-orange-100 text-orange-700'
+                    : 'bg-violet-100 text-violet-700'
+              )}
+            >
+              {initial}
+            </AvatarFallback>
+          </Avatar>
+          {sender === 'ai' && <span className="text-[9px] font-medium text-gray-400">AI</span>}
+        </div>
+      )}
+
+      {/* Bubble + metadata */}
+      <div className={cn('flex max-w-[80%] flex-col', isRight ? 'items-end' : 'items-start')}>
+        {/* Name label */}
+        <span className="mb-0.5 text-[10px] font-medium text-gray-400">{name}</span>
+
+        {/* Re: reference */}
+        {re && (
+          <span className="mb-0.5 max-w-full truncate rounded-md bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+            Re: {re}
+          </span>
+        )}
+
+        {/* Message bubble */}
+        <div
+          className={cn(
+            'whitespace-pre-wrap rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed',
+            isStudent
+              ? 'rounded-tl-sm border border-slate-200 bg-white text-slate-800 shadow-sm'
+              : isClassroom
+                ? 'rounded-br-sm bg-[#F17623] text-white'
+                : 'rounded-br-sm bg-violet-600 text-white'
+          )}
+        >
+          {content}
+        </div>
+
+        {/* Timestamp */}
+        {timestamp && (
+          <span className="mt-0.5 text-[10px] text-gray-400">
+            {typeof timestamp === 'string'
+              ? timestamp
+              : timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Introduces a chat-style interface for the Test mode classroom, replacing simple text bubbles with a full LLM-style chat experience.

### New Component: `ChatMessageBubble`
**File:** `src/components/classroom/chat-message-bubble.tsx`

Reusable chat bubble supporting:
- **Tutor/AI messages** — right-aligned, colored bubble (orange for classroom, violet for test), avatar on right
- **Student messages** — left-aligned, white bubble with border, avatar on left  
- **Document messages** — special card-style bubble with PDF thumbnail preview, clickable to open popup
- **Avatars** — uses shadcn/ui `Avatar` with `AvatarImage` + `AvatarFallback` (initials)
- **AI badge** — small "AI" label below avatar to distinguish AI responses from tutor
- **Timestamps** — on each message

### Refactored: `TestTaskChat`
**File:** `src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx`

- Replaced inline bubble rendering with `ChatMessageBubble` for all messages
- Document card now appears as **first message** in chat flow (from "Tutor")
- Added timestamps to all new messages (`Date.now()`)
- Preserved existing behavior: auto-scroll, Task Complete flow, PDF popup, state persistence

### Layout
```
[Student View — Test Student 1]
[Left]  [Avatar] [Student msg]     [white bubble]
[Right]              [Tutor msg] [Avatar] [orange/violet bubble]
[Right]              [AI msg] [Avatar] "AI" [orange/violet bubble]
[Left]  [Avatar] [Student msg]     [white bubble]
```

Messages flow from the bottom (newest at bottom), scroll up for history.

### Verification
- TypeScript: clean (`tsc --noEmit`)
- Tests: 556/556 pass
- Prettier: clean

---

**Files changed:** 2 (+216/-68 lines)
