### PR TITLE
fix(courses): center the Board·category·country identity with the course name

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -964,6 +964,19 @@ function CourseBuilderInsightsRouteInner({
                           {currentCourse.name}
                         </span>
                       )}
+                      {/* Full identity next to the name: Board (derived) · category ·
+                          country (country appears once published, from the variant). */}
+                      {(currentCourse as any)?.categories?.length > 0 && (
+                        <span className="bg-muted text-muted-foreground inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
+                          {[
+                            getCategoryBoard((currentCourse as any).categories[0]),
+                            (currentCourse as any).categories.join(', '),
+                            (currentCourse as any).nationality,
+                          ]
+                            .filter(Boolean)
+                            .join(' · ')}
+                        </span>
+                      )}
                     </h1>
                   )}
                   {activeMainTab === 'live' && (
@@ -1012,22 +1025,6 @@ function CourseBuilderInsightsRouteInner({
                             : sessionCategory || sessionNationality}
                       </span>
                     )}
-                  {activeMainTab !== 'live' &&
-                  activeMainTab !== 'test-pci' &&
-                  currentCourse &&
-                  (currentCourse as any).categories?.length > 0 ? (
-                    <span className="bg-muted text-muted-foreground ml-2 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium">
-                      {/* Full identity: Board (derived) · category · country
-                          (country appears once published, from the variant). */}
-                      {[
-                        getCategoryBoard((currentCourse as any).categories[0]),
-                        (currentCourse as any).categories.join(', '),
-                        (currentCourse as any).nationality,
-                      ]
-                        .filter(Boolean)
-                        .join(' · ')}
-                    </span>
-                  ) : null}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Follow-up to #905 — you QA'd it and the header looked off.

## Cause
The `Board · category · country` pill was rendered in the header's **left cluster** (next to the course-selector dropdown), but the course **name** is an **absolutely-centered `<h1>`**. So the identity pill floated off to the left, disconnected from the centered name — the header read as unbalanced.

## Fix
Move the pill **into the centered name `<h1>`**, so it reads as one centered unit:

> **Course Name**  ·  `Board · category · country`

No content change — same derived Board, category, and (once-published) country; just correct placement.

## Testing
- Typecheck + eslint clean (0 errors); small presentational JSX move.
- **Please re-check after deploy** — if the "off" you saw was something else (e.g. wrapping on a long name, or overlap with the side controls), a quick screenshot would let me pin it exactly, since I can't render it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)