### PR TITLE
feat(1-on-1): reviews & tutor ratings

### DIFF
--- a/tutorme-app/drizzle/0071_one_on_one_review.sql
+++ b/tutorme-app/drizzle/0071_one_on_one_review.sql
@@ -1,0 +1,13 @@
+-- Student reviews of completed 1-on-1 sessions (one per booking).
+CREATE TABLE IF NOT EXISTS "OneOnOneReview" (
+  "id" text PRIMARY KEY NOT NULL,
+  "requestId" text NOT NULL REFERENCES "OneOnOneBookingRequest"("id") ON DELETE CASCADE,
+  "tutorId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "studentId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "rating" integer NOT NULL,
+  "comment" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now(),
+  "updatedAt" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneReview_requestId_key" ON "OneOnOneReview" ("requestId");
+CREATE INDEX IF NOT EXISTS "OneOnOneReview_tutorId_idx" ON "OneOnOneReview" ("tutorId");

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/app/[locale]/tutor/dashboard/components/InteractiveCalendar'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { Badge } from '@/components/ui/badge'
-import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2 } from 'lucide-react'
+import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2, Star } from 'lucide-react'
+import { OneOnOneReviewDialog } from '@/components/booking/one-on-one-review-dialog'
 import { cn } from '@/lib/utils'
 
 export interface CalendarEvent {
@@ -29,6 +30,7 @@ export interface CalendarEvent {
   courseDescription?: string | null
   meetingUrl?: string | null
   status?: string
+  requestId?: string | null
 }
 
 interface DashboardCalendarProps {
@@ -101,6 +103,7 @@ export function DashboardCalendar({
   const [month, setMonth] = useState<Date>(() => new Date())
   const [events, setEvents] = useState<CalendarEvent[]>(initialEvents ?? [])
   const [loading, setLoading] = useState(!initialEvents?.length)
+  const [reviewRequestId, setReviewRequestId] = useState<string | null>(null)
   const monthStart = useMemo(() => new Date(month.getFullYear(), month.getMonth(), 1), [month])
   const monthEnd = useMemo(
     () => new Date(month.getFullYear(), month.getMonth() + 1, 0, 23, 59, 59),
@@ -218,218 +221,238 @@ export function DashboardCalendar({
   )
 
   return (
-    <SessionCalendarPanel
-      value={activeTab}
-      onValueChange={setActiveTab}
-      tabs={[
-        { value: 'classes', label: 'Sessions' },
-        { value: 'calendar', label: 'Calendar' },
-        { value: 'bookings', label: 'Bookings' },
-      ]}
-      showCalendarControls={activeTab === 'calendar'}
-      calendarView={calendarView}
-      onCalendarViewChange={setCalendarView}
-      timezone={timezone}
-      onTimezoneChange={setTimezone}
-      variant="orange"
-    >
-      {/* My Calendar Tab */}
-      <TabsContent value="calendar" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
-        <InteractiveCalendar
-          events={interactiveEvents}
-          loading={loading}
-          mode="student"
-          embedded
-          initialView="day"
-          timezone={timezone}
-          onTimezoneChange={setTimezone}
-          view={calendarView}
-          onViewChange={setCalendarView}
-        />
-      </TabsContent>
+    <>
+      <SessionCalendarPanel
+        value={activeTab}
+        onValueChange={setActiveTab}
+        tabs={[
+          { value: 'classes', label: 'Sessions' },
+          { value: 'calendar', label: 'Calendar' },
+          { value: 'bookings', label: 'Bookings' },
+        ]}
+        showCalendarControls={activeTab === 'calendar'}
+        calendarView={calendarView}
+        onCalendarViewChange={setCalendarView}
+        timezone={timezone}
+        onTimezoneChange={setTimezone}
+        variant="orange"
+      >
+        {/* My Calendar Tab */}
+        <TabsContent value="calendar" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+          <InteractiveCalendar
+            events={interactiveEvents}
+            loading={loading}
+            mode="student"
+            embedded
+            initialView="day"
+            timezone={timezone}
+            onTimezoneChange={setTimezone}
+            view={calendarView}
+            onViewChange={setCalendarView}
+          />
+        </TabsContent>
 
-      {/* Bookings Tab */}
-      <TabsContent value="bookings" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="grid h-full grid-cols-2 gap-4 overflow-hidden">
-          {/* Left column - 1 on 1 Sessions */}
-          <div className="flex min-h-0 flex-col overflow-hidden rounded-[14px] border border-gray-400 bg-white p-4 shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
-            <h3 className="mb-1 text-base font-semibold text-[#1F2933]">1-on-1 Sessions</h3>
-            <p className="mb-4 text-xs text-gray-500">Upcoming private tutoring sessions.</p>
-            <div className="flex-1 overflow-y-auto pr-1">
-              {oneOnOneSessions.length === 0 ? (
+        {/* Bookings Tab */}
+        <TabsContent value="bookings" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="grid h-full grid-cols-2 gap-4 overflow-hidden">
+            {/* Left column - 1 on 1 Sessions */}
+            <div className="flex min-h-0 flex-col overflow-hidden rounded-[14px] border border-gray-400 bg-white p-4 shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
+              <h3 className="mb-1 text-base font-semibold text-[#1F2933]">1-on-1 Sessions</h3>
+              <p className="mb-4 text-xs text-gray-500">Upcoming private tutoring sessions.</p>
+              <div className="flex-1 overflow-y-auto pr-1">
+                {oneOnOneSessions.length === 0 ? (
+                  <div className="rounded-[12px] border border-dashed border-gray-200 bg-gray-50/60 py-10 text-center">
+                    <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
+                    <p className="text-muted-foreground text-sm">No 1-on-1 sessions booked yet.</p>
+                    <p className="text-muted-foreground/70 mt-1 text-xs">
+                      Your upcoming private sessions will appear here.
+                    </p>
+                  </div>
+                ) : (
+                  <ul className="space-y-2">
+                    {oneOnOneSessions.map(s => {
+                      const isLive = s.status === 'live' || s.status === 'active'
+                      return (
+                        <li
+                          key={s.id}
+                          className="flex items-center justify-between gap-3 rounded-[12px] border border-gray-200 bg-white p-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-[#1F2933]">
+                              {s.title}
+                              {s.tutorName ? (
+                                <span className="font-normal text-gray-400"> · {s.tutorName}</span>
+                              ) : null}
+                            </p>
+                            <p className="mt-0.5 text-xs text-gray-500">
+                              {formatDate(s.start)} · {formatEventTime(s.start)}
+                            </p>
+                          </div>
+                          {s.type === 'one-on-one' &&
+                          s.requestId &&
+                          new Date(s.end).getTime() < Date.now() ? (
+                            <button
+                              type="button"
+                              onClick={() => setReviewRequestId(s.requestId ?? null)}
+                              className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600"
+                            >
+                              <Star className="h-3.5 w-3.5" />
+                              Rate
+                            </button>
+                          ) : s.meetingUrl ? (
+                            <a
+                              href={s.meetingUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={cn(
+                                'inline-flex shrink-0 items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
+                                isLive
+                                  ? 'bg-emerald-600 hover:bg-emerald-700'
+                                  : 'bg-blue-600 hover:bg-blue-700'
+                              )}
+                            >
+                              <Video className="h-3.5 w-3.5" />
+                              {isLive ? 'Join now' : 'Join'}
+                            </a>
+                          ) : (
+                            <span className="shrink-0 text-xs text-gray-400">Scheduled</span>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            {/* Right column - Tutor Info */}
+            <div className="flex min-h-0 flex-col overflow-hidden rounded-[14px] border border-gray-400 bg-white p-4 shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
+              <h3 className="mb-1 text-base font-semibold text-[#1F2933]">Tutor Info</h3>
+              <p className="mb-4 text-xs text-gray-500">Details about your assigned tutor.</p>
+              <div className="flex-1 overflow-y-auto pr-1">
                 <div className="rounded-[12px] border border-dashed border-gray-200 bg-gray-50/60 py-10 text-center">
-                  <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
-                  <p className="text-muted-foreground text-sm">No 1-on-1 sessions booked yet.</p>
+                  <Users className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
+                  <p className="text-muted-foreground text-sm">No tutor selected.</p>
                   <p className="text-muted-foreground/70 mt-1 text-xs">
-                    Your upcoming private sessions will appear here.
+                    Tutor information will appear here once a session is booked.
                   </p>
                 </div>
-              ) : (
-                <ul className="space-y-2">
-                  {oneOnOneSessions.map(s => {
-                    const isLive = s.status === 'live' || s.status === 'active'
-                    return (
-                      <li
-                        key={s.id}
-                        className="flex items-center justify-between gap-3 rounded-[12px] border border-gray-200 bg-white p-3"
-                      >
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold text-[#1F2933]">
-                            {s.title}
-                            {s.tutorName ? (
-                              <span className="font-normal text-gray-400"> · {s.tutorName}</span>
-                            ) : null}
-                          </p>
-                          <p className="mt-0.5 text-xs text-gray-500">
-                            {formatDate(s.start)} · {formatEventTime(s.start)}
-                          </p>
-                        </div>
-                        {s.meetingUrl ? (
-                          <a
-                            href={s.meetingUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={cn(
-                              'inline-flex shrink-0 items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
-                              isLive
-                                ? 'bg-emerald-600 hover:bg-emerald-700'
-                                : 'bg-blue-600 hover:bg-blue-700'
-                            )}
-                          >
-                            <Video className="h-3.5 w-3.5" />
-                            {isLive ? 'Join now' : 'Join'}
-                          </a>
-                        ) : (
-                          <span className="shrink-0 text-xs text-gray-400">Scheduled</span>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              )}
-            </div>
-          </div>
-
-          {/* Right column - Tutor Info */}
-          <div className="flex min-h-0 flex-col overflow-hidden rounded-[14px] border border-gray-400 bg-white p-4 shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
-            <h3 className="mb-1 text-base font-semibold text-[#1F2933]">Tutor Info</h3>
-            <p className="mb-4 text-xs text-gray-500">Details about your assigned tutor.</p>
-            <div className="flex-1 overflow-y-auto pr-1">
-              <div className="rounded-[12px] border border-dashed border-gray-200 bg-gray-50/60 py-10 text-center">
-                <Users className="text-muted-foreground/60 mx-auto mb-3 h-10 w-10" />
-                <p className="text-muted-foreground text-sm">No tutor selected.</p>
-                <p className="text-muted-foreground/70 mt-1 text-xs">
-                  Tutor information will appear here once a session is booked.
-                </p>
               </div>
             </div>
           </div>
-        </div>
-      </TabsContent>
+        </TabsContent>
 
-      {/* My Classes Tab */}
-      <TabsContent value="classes" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="h-full overflow-y-auto">
-          {loading ? (
-            <div className="py-8 text-center">
-              <p className="text-muted-foreground text-sm">Loading your classes...</p>
-            </div>
-          ) : classes.length === 0 ? (
-            <div className="rounded-[14px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] py-12 text-center shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
-              <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-12 w-12" />
-              <p className="text-muted-foreground">There are no upcoming sessions.</p>
-            </div>
-          ) : (
-            <div className="space-y-3 pr-2">
-              {classes.map(cls => (
-                <div
-                  key={cls.id}
-                  className="flex items-center gap-3 rounded-[14px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] p-3 shadow-[0_4px_14px_rgba(0,0,0,0.08)] transition-colors hover:bg-slate-50"
-                >
-                  {cls.tutorAvatarUrl ? (
-                    <img
-                      src={cls.tutorAvatarUrl}
-                      alt={cls.tutorName}
-                      className="h-10 w-10 shrink-0 rounded-full object-cover"
-                    />
-                  ) : (
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-500">
-                      {cls.tutorName.charAt(0).toUpperCase()}
+        {/* My Classes Tab */}
+        <TabsContent value="classes" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="h-full overflow-y-auto">
+            {loading ? (
+              <div className="py-8 text-center">
+                <p className="text-muted-foreground text-sm">Loading your classes...</p>
+              </div>
+            ) : classes.length === 0 ? (
+              <div className="rounded-[14px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] py-12 text-center shadow-[0_4px_14px_rgba(0,0,0,0.08)]">
+                <BookOpen className="text-muted-foreground/60 mx-auto mb-3 h-12 w-12" />
+                <p className="text-muted-foreground">There are no upcoming sessions.</p>
+              </div>
+            ) : (
+              <div className="space-y-3 pr-2">
+                {classes.map(cls => (
+                  <div
+                    key={cls.id}
+                    className="flex items-center gap-3 rounded-[14px] border border-[rgba(0,0,0,0.04)] bg-[#FFFFFF] p-3 shadow-[0_4px_14px_rgba(0,0,0,0.08)] transition-colors hover:bg-slate-50"
+                  >
+                    {cls.tutorAvatarUrl ? (
+                      <img
+                        src={cls.tutorAvatarUrl}
+                        alt={cls.tutorName}
+                        className="h-10 w-10 shrink-0 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-500">
+                        {cls.tutorName.charAt(0).toUpperCase()}
+                      </div>
+                    )}
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <h4 className="truncate font-medium text-gray-900">
+                          {cls.courseName || cls.title}
+                        </h4>
+                        <Badge
+                          variant="secondary"
+                          className={cn(
+                            'text-[10px]',
+                            cls.status === 'live'
+                              ? 'animate-pulse gap-1 bg-emerald-100 text-emerald-700'
+                              : 'bg-blue-100 text-blue-700'
+                          )}
+                        >
+                          {cls.status === 'live' && (
+                            <span className="inline-block h-1.5 w-1.5 animate-ping rounded-full bg-emerald-500" />
+                          )}
+                          {cls.status === 'live' ? 'Live' : 'Scheduled'}
+                        </Badge>
+                      </div>
+                      <p className="text-muted-foreground text-xs">
+                        {cls.courseName ? cls.title : cls.subject}
+                      </p>
+
+                      <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                        <span className="flex items-center gap-1">
+                          <CalendarDays className="h-3 w-3" />
+                          {formatDate(cls.scheduledAt)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {formatEventTime(cls.scheduledAt)}
+                        </span>
+                        <span className={cn('flex items-center gap-1', 'text-primary')}>
+                          {cls.type === 'online' ? (
+                            <Video className="h-3 w-3" />
+                          ) : (
+                            <MapPin className="h-3 w-3" />
+                          )}
+                          {cls.type === 'online' ? 'Online' : 'In-Person'}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Users className="h-3 w-3" />
+                          {cls.students}/{cls.maxStudents} students
+                        </span>
+                        <span>Tutor: {cls.tutorName}</span>
+                      </div>
                     </div>
-                  )}
 
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <h4 className="truncate font-medium text-gray-900">
-                        {cls.courseName || cls.title}
-                      </h4>
-                      <Badge
-                        variant="secondary"
-                        className={cn(
-                          'text-[10px]',
-                          cls.status === 'live'
-                            ? 'animate-pulse gap-1 bg-emerald-100 text-emerald-700'
-                            : 'bg-blue-100 text-blue-700'
-                        )}
+                    <div className="line-clamp-3 hidden w-1/3 shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs text-gray-600 sm:block">
+                      {cls.courseDescription || 'No description available.'}
+                    </div>
+
+                    {cls.sessionId ? (
+                      <Button
+                        size="sm"
+                        className="shrink-0 bg-emerald-600 text-white hover:bg-emerald-500"
+                        onClick={() => router.push(`/student/feedback?sessionId=${cls.sessionId}`)}
                       >
-                        {cls.status === 'live' && (
-                          <span className="inline-block h-1.5 w-1.5 animate-ping rounded-full bg-emerald-500" />
-                        )}
-                        {cls.status === 'live' ? 'Live' : 'Scheduled'}
-                      </Badge>
-                    </div>
-                    <p className="text-muted-foreground text-xs">
-                      {cls.courseName ? cls.title : cls.subject}
-                    </p>
-
-                    <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-                      <span className="flex items-center gap-1">
-                        <CalendarDays className="h-3 w-3" />
-                        {formatDate(cls.scheduledAt)}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Clock className="h-3 w-3" />
-                        {formatEventTime(cls.scheduledAt)}
-                      </span>
-                      <span className={cn('flex items-center gap-1', 'text-primary')}>
-                        {cls.type === 'online' ? (
-                          <Video className="h-3 w-3" />
-                        ) : (
-                          <MapPin className="h-3 w-3" />
-                        )}
-                        {cls.type === 'online' ? 'Online' : 'In-Person'}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Users className="h-3 w-3" />
-                        {cls.students}/{cls.maxStudents} students
-                      </span>
-                      <span>Tutor: {cls.tutorName}</span>
-                    </div>
+                        {cls.status === 'live' ? 'Join' : 'Enter'}
+                      </Button>
+                    ) : (
+                      <Button size="sm" variant="outline" className="shrink-0" asChild>
+                        <Link href={`/student/courses/${cls.id}`}>Details</Link>
+                      </Button>
+                    )}
                   </div>
-
-                  <div className="line-clamp-3 hidden w-1/3 shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-2 text-xs text-gray-600 sm:block">
-                    {cls.courseDescription || 'No description available.'}
-                  </div>
-
-                  {cls.sessionId ? (
-                    <Button
-                      size="sm"
-                      className="shrink-0 bg-emerald-600 text-white hover:bg-emerald-500"
-                      onClick={() => router.push(`/student/feedback?sessionId=${cls.sessionId}`)}
-                    >
-                      {cls.status === 'live' ? 'Join' : 'Enter'}
-                    </Button>
-                  ) : (
-                    <Button size="sm" variant="outline" className="shrink-0" asChild>
-                      <Link href={`/student/courses/${cls.id}`}>Details</Link>
-                    </Button>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </TabsContent>
-    </SessionCalendarPanel>
+                ))}
+              </div>
+            )}
+          </div>
+        </TabsContent>
+      </SessionCalendarPanel>
+      {reviewRequestId && (
+        <OneOnOneReviewDialog
+          requestId={reviewRequestId}
+          open
+          onOpenChange={o => !o && setReviewRequestId(null)}
+        />
+      )}
+    </>
   )
 }

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -74,6 +74,8 @@ interface PublicTutorResponse {
     specialties: string[]
     credentials: string
     hourlyRate: number | null
+    oneOnOneRating?: number | null
+    oneOnOneReviewCount?: number | null
     tutorSince?: string | null
     country?: string | null
     activeCourses?: number | null
@@ -1294,6 +1296,13 @@ export default function PublicTutorPage() {
               </div>
 
               <div className="flex w-full max-w-md flex-col gap-4 rounded-2xl bg-white/10 p-4 ring-1 ring-white/10 lg:w-auto">
+                {tutor.oneOnOneRating != null && (tutor.oneOnOneReviewCount ?? 0) > 0 && (
+                  <StarRating
+                    rating={tutor.oneOnOneRating}
+                    count={tutor.oneOnOneReviewCount ?? 0}
+                    className="text-white/90"
+                  />
+                )}
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Button
                     size="lg"

--- a/tutorme-app/src/app/api/one-on-one/review/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/review/route.ts
@@ -1,0 +1,113 @@
+/**
+ * 1-on-1 reviews.
+ *
+ * GET  ?requestId=…  → the caller's review for that booking (or null) + whether
+ *                      it's reviewable yet.
+ * POST { requestId, rating, comment? } → student submits/updates their review of
+ *                      a completed, paid session (one per booking).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest, oneOnOneReview } from '@/lib/db/schema'
+import { nanoid } from 'nanoid'
+
+const postSchema = z.object({
+  requestId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(1000).optional(),
+})
+
+/** A booking is reviewable once it's paid and its scheduled end has passed. */
+function isReviewable(booking: { status: string; requestedDate: Date; endTime: string }): boolean {
+  if (booking.status !== 'PAID') return false
+  const date = booking.requestedDate.toISOString().split('T')[0]
+  const end = new Date(`${date}T${booking.endTime}:00`)
+  return Number.isFinite(end.getTime()) && end.getTime() < Date.now()
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions, req)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const requestId = new URL(req.url).searchParams.get('requestId')
+  if (!requestId) return NextResponse.json({ error: 'requestId required' }, { status: 400 })
+
+  const booking = await drizzleDb.query.oneOnOneBookingRequest.findFirst({
+    where: eq(oneOnOneBookingRequest.requestId, requestId),
+  })
+  if (!booking || (booking.studentId !== session.user.id && booking.tutorId !== session.user.id)) {
+    return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
+  }
+
+  const [review] = await drizzleDb
+    .select()
+    .from(oneOnOneReview)
+    .where(eq(oneOnOneReview.requestId, requestId))
+    .limit(1)
+
+  return NextResponse.json({
+    review: review ?? null,
+    reviewable: booking.studentId === session.user.id && isReviewable(booking),
+  })
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions, req)
+    if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const { requestId, rating, comment } = postSchema.parse(await req.json())
+
+    const booking = await drizzleDb.query.oneOnOneBookingRequest.findFirst({
+      where: eq(oneOnOneBookingRequest.requestId, requestId),
+    })
+    if (!booking) return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
+    if (booking.studentId !== session.user.id) {
+      return NextResponse.json(
+        { error: 'Only the student can review this session' },
+        { status: 403 }
+      )
+    }
+    if (!isReviewable(booking)) {
+      return NextResponse.json(
+        { error: 'You can review a session once it has been paid and has taken place.' },
+        { status: 400 }
+      )
+    }
+
+    // Upsert — one review per booking; a student can update their own.
+    const [existing] = await drizzleDb
+      .select({ reviewId: oneOnOneReview.reviewId })
+      .from(oneOnOneReview)
+      .where(eq(oneOnOneReview.requestId, requestId))
+      .limit(1)
+
+    if (existing) {
+      await drizzleDb
+        .update(oneOnOneReview)
+        .set({ rating, comment: comment ?? null, updatedAt: new Date() })
+        .where(eq(oneOnOneReview.reviewId, existing.reviewId))
+    } else {
+      await drizzleDb.insert(oneOnOneReview).values({
+        reviewId: nanoid(),
+        requestId,
+        tutorId: booking.tutorId,
+        studentId: booking.studentId,
+        rating,
+        comment: comment ?? null,
+      })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid review (rating must be 1–5)' }, { status: 400 })
+    }
+    console.error('review submit failed:', err)
+    return NextResponse.json({ error: 'Failed to submit review' }, { status: 500 })
+  }
+}

--- a/tutorme-app/src/app/api/public/tutors/[username]/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/[username]/route.ts
@@ -14,6 +14,7 @@ import {
   tutorApplication,
 } from '@/lib/db/schema'
 import { eq, and, inArray } from 'drizzle-orm'
+import { getTutorRating } from '@/lib/one-on-one/reviews'
 
 export async function GET(
   request: NextRequest,
@@ -180,6 +181,7 @@ export async function GET(
     }
 
     // Build tutor response
+    const oneOnOneRating = await getTutorRating(tutorId)
     const tutorResponse = {
       id: tutorId,
       name: profileData.name || 'Anonymous Tutor',
@@ -190,6 +192,8 @@ export async function GET(
       credentials: profileData.credentials || '',
       hourlyRate: profileData.hourlyRate,
       oneOnOneEnabled: profileData.oneOnOneEnabled ?? true,
+      oneOnOneRating: oneOnOneRating.average,
+      oneOnOneReviewCount: oneOnOneRating.count,
       tutorSince: tutorUser[0].createdAt?.toISOString() || null,
       country: tutorApp?.countryOfResidence || null,
       activeCourses: publishedCourses.length,

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -139,6 +139,7 @@ export const GET = withAuth(
         tutorId: calendarEvent.tutorId,
         externalId: calendarEvent.externalId,
         sessionStatus: liveSession.status,
+        requestId: oneOnOneBookingRequest.requestId,
       })
       .from(calendarEvent)
       .innerJoin(
@@ -199,6 +200,7 @@ export const GET = withAuth(
         id: e.eventId,
         sessionId: e.externalId,
         bookingId: e.eventId,
+        requestId: e.requestId as string | null,
         title: e.title || '1-on-1 Session',
         subject: e.description || '1-on-1 tutoring session',
         start: e.startTime?.toISOString() ?? new Date().toISOString(),

--- a/tutorme-app/src/components/booking/one-on-one-review-dialog.tsx
+++ b/tutorme-app/src/components/booking/one-on-one-review-dialog.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * Dialog for a student to rate a completed 1-on-1 session (1–5 stars + optional
+ * comment). Loads any existing review on open so it can be edited. Posts to
+ * /api/one-on-one/review.
+ */
+
+import { useEffect, useState } from 'react'
+import { Star, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface OneOnOneReviewDialogProps {
+  requestId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmitted?: () => void
+}
+
+export function OneOnOneReviewDialog({
+  requestId,
+  open,
+  onOpenChange,
+  onSubmitted,
+}: OneOnOneReviewDialogProps) {
+  const [rating, setRating] = useState(0)
+  const [hover, setHover] = useState(0)
+  const [comment, setComment] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setLoading(true)
+    fetch(`/api/one-on-one/review?requestId=${encodeURIComponent(requestId)}`, {
+      credentials: 'include',
+    })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (data?.review) {
+          setRating(data.review.rating ?? 0)
+          setComment(data.review.comment ?? '')
+        } else {
+          setRating(0)
+          setComment('')
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [open, requestId])
+
+  const submit = async () => {
+    if (rating < 1) {
+      toast.error('Pick a star rating first')
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch('/api/one-on-one/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId, rating, comment: comment.trim() || undefined }),
+      })
+      if (res.ok) {
+        toast.success('Thanks for your review!')
+        onSubmitted?.()
+        onOpenChange(false)
+      } else {
+        const d = await res.json().catch(() => ({}))
+        toast.error(d.error || 'Could not submit your review')
+      }
+    } catch {
+      toast.error('Could not submit your review')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Rate your session</DialogTitle>
+          <DialogDescription>How was your 1-on-1 session with your tutor?</DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex justify-center py-6">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+        ) : (
+          <div className="space-y-4 py-2">
+            <div className="flex justify-center gap-1">
+              {[1, 2, 3, 4, 5].map(n => (
+                <button
+                  key={n}
+                  type="button"
+                  aria-label={`${n} star${n === 1 ? '' : 's'}`}
+                  onMouseEnter={() => setHover(n)}
+                  onMouseLeave={() => setHover(0)}
+                  onClick={() => setRating(n)}
+                  className="p-1"
+                >
+                  <Star
+                    className={cn(
+                      'h-8 w-8 transition-colors',
+                      (hover || rating) >= n ? 'fill-amber-400 text-amber-400' : 'text-gray-300'
+                    )}
+                  />
+                </button>
+              ))}
+            </div>
+            <textarea
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              placeholder="Share a little about your experience (optional)…"
+              maxLength={1000}
+              className="min-h-[90px] w-full resize-y rounded-md border border-gray-300 p-2 text-sm text-gray-900"
+            />
+          </div>
+        )}
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={saving || loading}>
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Submit review
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -263,3 +263,35 @@ export const oneOnOneBookingRequest = pgTable(
     ).on(table.tutorId, table.studentId, table.status),
   })
 )
+
+/**
+ * A student's review of a completed 1-on-1 session — one per booking. Drives the
+ * tutor's average rating shown on their public profile.
+ */
+export const oneOnOneReview = pgTable(
+  'OneOnOneReview',
+  {
+    reviewId: text('id').primaryKey().notNull(),
+    requestId: text('requestId')
+      .notNull()
+      .references(() => oneOnOneBookingRequest.requestId, { onDelete: 'cascade' }),
+    tutorId: text('tutorId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    rating: integer('rating').notNull(), // 1–5
+    comment: text('comment'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  table => ({
+    // One review per booking (a student can edit theirs, not create duplicates).
+    OneOnOneReview_requestId_key: uniqueIndex('OneOnOneReview_requestId_key').on(table.requestId),
+    OneOnOneReview_tutorId_idx: index('OneOnOneReview_tutorId_idx').on(table.tutorId),
+  })
+)

--- a/tutorme-app/src/lib/one-on-one/reviews.ts
+++ b/tutorme-app/src/lib/one-on-one/reviews.ts
@@ -1,0 +1,27 @@
+/**
+ * 1-on-1 review helpers — the tutor's aggregate rating shown on their profile.
+ */
+
+import { eq, sql } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneReview } from '@/lib/db/schema'
+
+export interface TutorRating {
+  /** Mean rating (1–5) rounded to 1 dp, or null when there are no reviews. */
+  average: number | null
+  count: number
+}
+
+export async function getTutorRating(tutorId: string): Promise<TutorRating> {
+  const [row] = await drizzleDb
+    .select({
+      avg: sql<number>`avg(${oneOnOneReview.rating})`,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(oneOnOneReview)
+    .where(eq(oneOnOneReview.tutorId, tutorId))
+
+  const count = Number(row?.count ?? 0)
+  if (count === 0) return { average: null, count: 0 }
+  return { average: Math.round(Number(row.avg) * 10) / 10, count }
+}


### PR DESCRIPTION
Students can rate a completed 1-on-1; the tutor's average rating shows on their public profile.

## Backend
- **Schema:** `OneOnOneReview` (one per booking, FK to booking/tutor/student) + migration `0071_one_on_one_review.sql`.
- **`POST/GET /api/one-on-one/review`** — a student submits/edits their review once the session is **paid** and its **scheduled end has passed** (upsert — one per booking; students can edit theirs).
- **`getTutorRating()`** aggregate (average to 1dp + count).

## Surfaces
- **Public profile:** `/api/public/tutors/[username]` now returns `oneOnOneRating` + `oneOnOneReviewCount`, and the profile renders a `StarRating` next to **Book 1-on-1** (hidden until there are reviews).
- **Student:** the calendar events API exposes the booking `requestId` for 1-on-1s; the **Bookings** tab shows a **Rate** button on past sessions → opens a reusable `OneOnOneReviewDialog` (stars + comment).

## Verification
- `tsc` clean · `eslint` 0 errors · `prettier`/`format:check` clean.
- Migration is an additive `CREATE TABLE IF NOT EXISTS` (safe).

## Remaining gap
Only **automated 15%-fee refunds** left. Before building it I'll check whether `HitpayGateway`/`AirwallexGateway` expose refund methods (or need implementing) — and it'll need your gateway **sandbox** to verify a real refund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)