### PR TITLE
feat(1-on-1): automated cancellation refunds (85% / 15% fee) + disclosure

### DIFF
--- a/tutorme-app/src/app/[locale]/payment/page.tsx
+++ b/tutorme-app/src/app/[locale]/payment/page.tsx
@@ -253,6 +253,11 @@ function PaymentPageInner() {
               <p className="text-4xl font-bold text-gray-900">
                 {formatCurrency(displayAmount, displayCurrency)}
               </p>
+              {requestId && (
+                <p className="mt-2 text-xs text-gray-500">
+                  Cancellations are refundable at any time, minus a 15% cancellation fee.
+                </p>
+              )}
             </div>
 
             {/* Payment Method Selection */}

--- a/tutorme-app/src/app/api/one-on-one/cancel/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/cancel/route.ts
@@ -4,6 +4,7 @@ import { eq, and, ne } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, calendarEvent, liveSession } from '@/lib/db/schema'
 import { notify } from '@/lib/notifications/notify'
+import { refundPaidOneOnOne, type RefundOutcome } from '@/lib/payments/refund-one-on-one'
 import { z } from 'zod'
 
 const cancelSchema = z.object({
@@ -103,27 +104,58 @@ export async function PATCH(request: NextRequest) {
       actionUrl: isStudent ? '/tutor/dashboard' : '/student/dashboard',
     }).catch(console.error)
 
-    // A paid booking that's cancelled owes the student a refund. Flag the tutor
-    // to process it via the standard refund flow (automated gateway refunds for
-    // 1-on-1 are not yet wired, so this stays a deliberate human step).
+    // A paid booking cancelled at any time is refunded automatically through the
+    // original gateway, minus a fixed 15% cancellation fee (student gets 85%).
+    let refundResult: RefundOutcome | null = null
     if (wasPaid) {
-      notify({
-        userId: existingRequest.tutorId,
-        type: 'class',
-        title: 'Refund required — 1-on-1 cancelled',
-        message: `A paid 1-on-1 session was cancelled. Please issue a refund of ${existingRequest.costPerSession} to the student.`,
-        data: {
-          requestId: updatedRequest[0].requestId,
-          type: 'one-on-one-refund-required',
-          amount: existingRequest.costPerSession,
-        },
-        actionUrl: '/tutor/dashboard',
-      }).catch(console.error)
+      refundResult = await refundPaidOneOnOne(
+        existingRequest.requestId,
+        `Cancelled by ${isStudent ? 'student' : 'tutor'}`
+      )
+      if (refundResult.refunded) {
+        const amt = `${refundResult.amount}${refundResult.currency ? ' ' + refundResult.currency : ''}`
+        notify({
+          userId: existingRequest.studentId,
+          type: 'class',
+          title: 'Refund issued',
+          message: `Your 1-on-1 was cancelled — ${amt} has been refunded (a 15% cancellation fee of ${refundResult.fee} was applied).`,
+          data: {
+            requestId: updatedRequest[0].requestId,
+            type: 'one-on-one-refunded',
+            amount: refundResult.amount,
+            fee: refundResult.fee,
+          },
+        }).catch(console.error)
+        notify({
+          userId: existingRequest.tutorId,
+          type: 'class',
+          title: '1-on-1 refunded',
+          message: `The cancelled session was refunded to the student (${amt}, after a 15% fee).`,
+          data: { requestId: updatedRequest[0].requestId, type: 'one-on-one-refunded' },
+        }).catch(console.error)
+      } else {
+        // Automated refund failed — flag it so the owed amount isn't lost.
+        notify({
+          userId: existingRequest.tutorId,
+          type: 'class',
+          title: 'Refund needs attention — 1-on-1 cancelled',
+          message: `The automatic refund failed (${refundResult.error ?? 'unknown error'}). Please refund ${refundResult.amount ?? existingRequest.costPerSession} to the student manually.`,
+          data: {
+            requestId: updatedRequest[0].requestId,
+            type: 'one-on-one-refund-required',
+            amount: refundResult.amount ?? existingRequest.costPerSession,
+          },
+          actionUrl: '/tutor/dashboard',
+        }).catch(console.error)
+      }
     }
 
     return NextResponse.json({
       success: true,
-      refundRequired: wasPaid,
+      refunded: refundResult?.refunded ?? false,
+      refundAmount: refundResult?.amount,
+      refundFee: refundResult?.fee,
+      refundRequired: wasPaid && !refundResult?.refunded,
       request: updatedRequest[0],
     })
   } catch (error) {

--- a/tutorme-app/src/lib/payments/refund-one-on-one.test.ts
+++ b/tutorme-app/src/lib/payments/refund-one-on-one.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { computeOneOnOneRefund, ONE_ON_ONE_CANCELLATION_FEE_RATE } from './refund-one-on-one'
+
+describe('computeOneOnOneRefund', () => {
+  it('keeps a 15% fee and refunds 85%', () => {
+    expect(ONE_ON_ONE_CANCELLATION_FEE_RATE).toBe(0.15)
+    expect(computeOneOnOneRefund(100)).toEqual({ amount: 85, fee: 15 })
+    expect(computeOneOnOneRefund(50)).toEqual({ amount: 42.5, fee: 7.5 })
+  })
+
+  it('rounds to 2 decimal places', () => {
+    // 33.33 * 0.15 = 4.9995 → 5.00 fee; 33.33 - 5.00 = 28.33
+    expect(computeOneOnOneRefund(33.33)).toEqual({ amount: 28.33, fee: 5 })
+    // 19.99 * 0.15 = 2.9985 → 3.00 fee; 19.99 - 3.00 = 16.99
+    expect(computeOneOnOneRefund(19.99)).toEqual({ amount: 16.99, fee: 3 })
+  })
+
+  it('handles zero', () => {
+    expect(computeOneOnOneRefund(0)).toEqual({ amount: 0, fee: 0 })
+  })
+
+  it('amount + fee always reconstructs the paid total (to cents)', () => {
+    for (const paid of [12.5, 47.7, 199.99, 1, 0.99]) {
+      const { amount, fee } = computeOneOnOneRefund(paid)
+      expect(Math.round((amount + fee) * 100) / 100).toBe(Math.round(paid * 100) / 100)
+    }
+  })
+})

--- a/tutorme-app/src/lib/payments/refund-one-on-one.ts
+++ b/tutorme-app/src/lib/payments/refund-one-on-one.ts
@@ -1,0 +1,92 @@
+/**
+ * Automated refund for a cancelled, paid 1-on-1 booking.
+ *
+ * Policy: a cancellation is refundable at any time, minus a fixed 15% fee (the
+ * student receives 85% of what they paid; the platform/tutor keeps 15%). The
+ * refund is issued through the SAME gateway the student paid with, recorded in
+ * the `refund` table, and flips the `payment` to REFUNDED on success.
+ */
+
+import { and, eq, sql } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { payment, refund } from '@/lib/db/schema'
+import { getPaymentGateway, type GatewayName } from './factory'
+
+/** Fee retained on any 1-on-1 cancellation refund. */
+export const ONE_ON_ONE_CANCELLATION_FEE_RATE = 0.15
+
+export interface RefundOutcome {
+  refunded: boolean
+  /** Amount returned to the student (paid − 15%). */
+  amount?: number
+  /** Fee retained (15% of what was paid). */
+  fee?: number
+  currency?: string
+  error?: string
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+/** Split a paid amount into the 85% refund and the 15% fee. */
+export function computeOneOnOneRefund(paidAmount: number): { amount: number; fee: number } {
+  const fee = round2(paidAmount * ONE_ON_ONE_CANCELLATION_FEE_RATE)
+  return { amount: round2(paidAmount - fee), fee }
+}
+
+export async function refundPaidOneOnOne(
+  requestId: string,
+  reason?: string
+): Promise<RefundOutcome> {
+  const [pay] = await drizzleDb
+    .select()
+    .from(payment)
+    .where(
+      and(eq(payment.status, 'COMPLETED'), sql`${payment.metadata} ->> 'requestId' = ${requestId}`)
+    )
+    .limit(1)
+
+  if (!pay) return { refunded: false, error: 'No completed payment found for this booking.' }
+  if (!pay.gatewayPaymentId) {
+    return { refunded: false, error: 'Payment has no gateway reference to refund.' }
+  }
+  if (pay.gateway !== 'AIRWALLEX' && pay.gateway !== 'HITPAY') {
+    return { refunded: false, error: `Automated refunds aren't supported for ${pay.gateway}.` }
+  }
+
+  const { amount, fee } = computeOneOnOneRefund(pay.amount)
+
+  let result: { refundId: string; status: string; amountRefunded?: number; error?: string }
+  try {
+    result = await getPaymentGateway(pay.gateway as GatewayName).refundPayment(
+      pay.gatewayPaymentId,
+      amount
+    )
+  } catch (err) {
+    result = {
+      refundId: '',
+      status: 'FAILED',
+      error: err instanceof Error ? err.message : 'Gateway error',
+    }
+  }
+  const ok = !result.error
+
+  await drizzleDb.insert(refund).values({
+    refundId: nanoid(),
+    paymentId: pay.paymentId,
+    amount,
+    reason: reason ?? '1-on-1 cancellation (15% fee retained)',
+    status: ok ? 'COMPLETED' : 'FAILED',
+    gatewayRefundId: result.refundId || null,
+    processedAt: ok ? new Date() : null,
+  })
+
+  if (ok) {
+    await drizzleDb
+      .update(payment)
+      .set({ status: 'REFUNDED', refundedAt: new Date() })
+      .where(eq(payment.paymentId, pay.paymentId))
+    return { refunded: true, amount, fee, currency: pay.currency }
+  }
+  return { refunded: false, amount, fee, currency: pay.currency, error: result.error }
+}


### PR DESCRIPTION
Implements your refund policy: **cancel any time → refund minus a 15% fee**, automated across gateways, with students told before they pay.

## What it does
- **`refundPaidOneOnOne(requestId)`** — on cancelling a **PAID** booking: finds the completed `Payment` (by `metadata.requestId`), computes **85% refund / 15% fee** (`computeOneOnOneRefund`), calls the original gateway's `refundPayment()` (Hitpay / Airwallex), writes a `Refund` row, and flips the `Payment` to `REFUNDED`. On a gateway failure it **falls back** to the manual-refund flag so the owed amount is never lost.
- **Cancel route** wires this in and notifies **both parties** with the refunded amount + the 15% fee.
- **Disclosure:** the payment page shows *"Cancellations are refundable at any time, minus a 15% cancellation fee."* before the student pays.
- **Tests:** fee math (rounding, and amount+fee reconstructs the paid total).

## Verification
- `tsc` clean · `eslint` 0 errors · `prettier`/`format:check` clean · fee-math unit tests pass (4).

## ⚠️ Needs your sandbox check (money movement)
I can't run a real refund here (no gateway keys). Before relying on this in production, please verify one end-to-end refund in the **Hitpay** and **Airwallex** sandboxes — confirm the gateway `refundPayment()` calls succeed and the `Refund`/`Payment` rows update as expected. The code is gated to fall back to a manual flag if the gateway declines, so a failed call won't silently drop the refund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)