### PR TITLE
fix(courses): no Course Properties (name) prompt when scheduling

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1131,7 +1131,7 @@ function CourseBuilderInsightsRouteInner({
             <CourseBuilder
               ref={model.courseBuilderRef}
               courseId={courseId ?? ''}
-              courseName={courseName || model.course?.name}
+              courseName={courseName || model.course?.name || currentCourse?.name}
               courseDescription={model.course?.description ?? undefined}
               initialLessons={model.loadedLessons ?? undefined}
               hideDirectorySearch


### PR DESCRIPTION
## Report
Clicking **Schedule** in the builder pops a **"Course Properties"** modal asking for the course name again (name shouldn't be set here), instead of proceeding to the Course Details page.

## Cause
Schedule (draft) → `handlePublishDraft` → the builder's `saveAll`, which gates on `!courseName?.trim()` and opens the Course Properties modal when the name looks missing. The builder was passed `courseName={courseName || model.course?.name}` — **empty for a draft** (no `model.course`), so the gate fired even though the course already has a name (now always set at creation).

## Fix
Fall back to `currentCourse?.name`:
```
courseName={courseName || model.course?.name || currentCourse?.name}
```
The builder now always has the course's name → the save gate passes → **Schedule proceeds straight to Course Details**, no name prompt.

## Testing
- Typecheck + eslint clean (0 errors); one-line prop change.
- **Please verify after deploy:** create a course → click **Schedule** → it should open Course Details with no "Course Properties" modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)