### PR TITLE
fix(tutor-public-page): restore missing OneOnOneReview schema + defensive rating

### DIFF
--- a/tutorme-app/drizzle/0071_one_on_one_review.sql
+++ b/tutorme-app/drizzle/0071_one_on_one_review.sql
@@ -1,0 +1,13 @@
+-- Student reviews of completed 1-on-1 sessions (one per booking).
+CREATE TABLE IF NOT EXISTS "OneOnOneReview" (
+  "id" text PRIMARY KEY NOT NULL,
+  "requestId" text NOT NULL REFERENCES "OneOnOneBookingRequest"("id") ON DELETE CASCADE,
+  "tutorId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "studentId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "rating" integer NOT NULL,
+  "comment" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now(),
+  "updatedAt" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneReview_requestId_key" ON "OneOnOneReview" ("requestId");
+CREATE INDEX IF NOT EXISTS "OneOnOneReview_tutorId_idx" ON "OneOnOneReview" ("tutorId");

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -263,3 +263,35 @@ export const oneOnOneBookingRequest = pgTable(
     ).on(table.tutorId, table.studentId, table.status),
   })
 )
+
+/**
+ * A student's review of a completed 1-on-1 session — one per booking. Drives the
+ * tutor's average rating shown on their public profile.
+ */
+export const oneOnOneReview = pgTable(
+  'OneOnOneReview',
+  {
+    reviewId: text('id').primaryKey().notNull(),
+    requestId: text('requestId')
+      .notNull()
+      .references(() => oneOnOneBookingRequest.requestId, { onDelete: 'cascade' }),
+    tutorId: text('tutorId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    rating: integer('rating').notNull(), // 1–5
+    comment: text('comment'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updatedAt', { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  table => ({
+    // One review per booking (a student can edit theirs, not create duplicates).
+    OneOnOneReview_requestId_key: uniqueIndex('OneOnOneReview_requestId_key').on(table.requestId),
+    OneOnOneReview_tutorId_idx: index('OneOnOneReview_tutorId_idx').on(table.tutorId),
+  })
+)

--- a/tutorme-app/src/lib/one-on-one/reviews.ts
+++ b/tutorme-app/src/lib/one-on-one/reviews.ts
@@ -1,0 +1,34 @@
+/**
+ * 1-on-1 review helpers — the tutor's aggregate rating shown on their profile.
+ */
+
+import { eq, sql } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneReview } from '@/lib/db/schema'
+
+export interface TutorRating {
+  /** Mean rating (1–5) rounded to 1 dp, or null when there are no reviews. */
+  average: number | null
+  count: number
+}
+
+export async function getTutorRating(tutorId: string): Promise<TutorRating> {
+  try {
+    const [row] = await drizzleDb
+      .select({
+        avg: sql<number>`avg(${oneOnOneReview.rating})`,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(oneOnOneReview)
+      .where(eq(oneOnOneReview.tutorId, tutorId))
+
+    const count = Number(row?.count ?? 0)
+    if (count === 0) return { average: null, count: 0 }
+    return { average: Math.round(Number(row.avg) * 10) / 10, count }
+  } catch (error) {
+    // Graceful degradation: if the OneOnOneReview table doesn't exist yet
+    // (migration not applied), return null rating instead of crashing.
+    console.warn('[getTutorRating] Table not ready, returning null rating:', error)
+    return { average: null, count: 0 }
+  }
+}


### PR DESCRIPTION
## Problem

The tutor's public profile page () stopped loading after PR #914 (reviews & ratings) was deployed.

**Root cause:** The  table schema definition and migration file were present on  but had been lost from the local working tree. When the public tutor API () called , it crashed because the table didn't exist in the database.

## Fixes

1. **Restore migration**  — creates the  table with indexes.

2. **Restore schema**  table definition in  — exported via .

3. **Defensive code**  wrapped in  — returns  if the table isn't ready, so the page loads even before the migration is applied.

## Files Changed

| File | Change |
|------|--------|
|  | **New** — migration to create OneOnOneReview table |
|  | **Added** — oneOnOneReview pgTable definition |
|  | **New** — getTutorRating() with graceful degradation |

## Verification

- TypeScript: clean ()
- Tests: 556/556 pass
- Prettier: clean