### PR TITLE
feat(1-on-1): reschedule UI (propose / accept / decline)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -14,6 +14,7 @@ import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { Badge } from '@/components/ui/badge'
 import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2, Star } from 'lucide-react'
 import { OneOnOneReviewDialog } from '@/components/booking/one-on-one-review-dialog'
+import { OneOnOneRescheduleDialog } from '@/components/booking/one-on-one-reschedule-dialog'
 import { cn } from '@/lib/utils'
 
 export interface CalendarEvent {
@@ -104,6 +105,7 @@ export function DashboardCalendar({
   const [events, setEvents] = useState<CalendarEvent[]>(initialEvents ?? [])
   const [loading, setLoading] = useState(!initialEvents?.length)
   const [reviewRequestId, setReviewRequestId] = useState<string | null>(null)
+  const [rescheduleRequestId, setRescheduleRequestId] = useState<string | null>(null)
   const monthStart = useMemo(() => new Date(month.getFullYear(), month.getMonth(), 1), [month])
   const monthEnd = useMemo(
     () => new Date(month.getFullYear(), month.getMonth() + 1, 0, 23, 59, 59),
@@ -288,35 +290,49 @@ export function DashboardCalendar({
                               {formatDate(s.start)} · {formatEventTime(s.start)}
                             </p>
                           </div>
-                          {s.type === 'one-on-one' &&
-                          s.requestId &&
-                          new Date(s.end).getTime() < Date.now() ? (
-                            <button
-                              type="button"
-                              onClick={() => setReviewRequestId(s.requestId ?? null)}
-                              className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600"
-                            >
-                              <Star className="h-3.5 w-3.5" />
-                              Rate
-                            </button>
-                          ) : s.meetingUrl ? (
-                            <a
-                              href={s.meetingUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className={cn(
-                                'inline-flex shrink-0 items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
-                                isLive
-                                  ? 'bg-emerald-600 hover:bg-emerald-700'
-                                  : 'bg-blue-600 hover:bg-blue-700'
+                          <div className="flex shrink-0 items-center gap-2">
+                            {s.type === 'one-on-one' &&
+                              s.requestId &&
+                              new Date(s.end).getTime() >= Date.now() && (
+                                <button
+                                  type="button"
+                                  onClick={() => setRescheduleRequestId(s.requestId ?? null)}
+                                  className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50"
+                                >
+                                  <CalendarDays className="h-3.5 w-3.5" />
+                                  Reschedule
+                                </button>
                               )}
-                            >
-                              <Video className="h-3.5 w-3.5" />
-                              {isLive ? 'Join now' : 'Join'}
-                            </a>
-                          ) : (
-                            <span className="shrink-0 text-xs text-gray-400">Scheduled</span>
-                          )}
+                            {s.type === 'one-on-one' &&
+                            s.requestId &&
+                            new Date(s.end).getTime() < Date.now() ? (
+                              <button
+                                type="button"
+                                onClick={() => setReviewRequestId(s.requestId ?? null)}
+                                className="inline-flex items-center gap-1 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600"
+                              >
+                                <Star className="h-3.5 w-3.5" />
+                                Rate
+                              </button>
+                            ) : s.meetingUrl ? (
+                              <a
+                                href={s.meetingUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={cn(
+                                  'inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
+                                  isLive
+                                    ? 'bg-emerald-600 hover:bg-emerald-700'
+                                    : 'bg-blue-600 hover:bg-blue-700'
+                                )}
+                              >
+                                <Video className="h-3.5 w-3.5" />
+                                {isLive ? 'Join now' : 'Join'}
+                              </a>
+                            ) : (
+                              <span className="text-xs text-gray-400">Scheduled</span>
+                            )}
+                          </div>
                         </li>
                       )
                     })}
@@ -451,6 +467,14 @@ export function DashboardCalendar({
           requestId={reviewRequestId}
           open
           onOpenChange={o => !o && setReviewRequestId(null)}
+        />
+      )}
+      {rescheduleRequestId && (
+        <OneOnOneRescheduleDialog
+          requestId={rescheduleRequestId}
+          open
+          onOpenChange={o => !o && setRescheduleRequestId(null)}
+          onChanged={onRefresh}
         />
       )}
     </>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { OneOnOneRescheduleDialog } from '@/components/booking/one-on-one-reschedule-dialog'
 import { CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TabsContent } from '@/components/ui/tabs'
@@ -236,6 +237,7 @@ function TutorDashboardContent() {
   const [launchingCourseId, setLaunchingCourseId] = useState<string | null>(null)
   const [oneAccountTipDismissed, setOneAccountTipDismissed] = useState(true)
   const [oneOnOneRequests, setOneOnOneRequests] = useState<OneOnOneRequest[]>([])
+  const [rescheduleRequestId, setRescheduleRequestId] = useState<string | null>(null)
   const [respondingRequestId, setRespondingRequestId] = useState<string | null>(null)
 
   const [classroomDialogOpen, setClassroomDialogOpen] = useState(false)
@@ -334,10 +336,12 @@ function TutorDashboardContent() {
 
       if (oneOnOneRes.status === 'fulfilled' && oneOnOneRes.value.ok) {
         const d = await oneOnOneRes.value.json()
-        const pending = (d.requests ?? []).filter(
-          (req: OneOnOneRequest) => req.status === 'PENDING'
+        // Show pending requests (accept/reject) plus confirmed bookings
+        // (accept/paid) so the tutor can reschedule them.
+        const relevant = (d.requests ?? []).filter((req: OneOnOneRequest) =>
+          ['PENDING', 'ACCEPTED', 'PAID'].includes(req.status)
         )
-        setOneOnOneRequests(pending)
+        setOneOnOneRequests(relevant)
       }
 
       if (failures.length >= 2) {
@@ -1021,24 +1025,37 @@ function TutorDashboardContent() {
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={respondingRequestId === request.requestId}
-                            onClick={() => handleOneOnOneResponse(request.requestId, 'accept')}
-                            className="transition-all duration-200"
-                          >
-                            Accept
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="text-destructive hover:bg-destructive/10 transition-all duration-200"
-                            disabled={respondingRequestId === request.requestId}
-                            onClick={() => handleOneOnOneResponse(request.requestId, 'reject')}
-                          >
-                            Reject
-                          </Button>
+                          {request.status === 'PENDING' ? (
+                            <>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={respondingRequestId === request.requestId}
+                                onClick={() => handleOneOnOneResponse(request.requestId, 'accept')}
+                                className="transition-all duration-200"
+                              >
+                                Accept
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-destructive hover:bg-destructive/10 transition-all duration-200"
+                                disabled={respondingRequestId === request.requestId}
+                                onClick={() => handleOneOnOneResponse(request.requestId, 'reject')}
+                              >
+                                Reject
+                              </Button>
+                            </>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setRescheduleRequestId(request.requestId)}
+                              className="transition-all duration-200"
+                            >
+                              Reschedule
+                            </Button>
+                          )}
                         </div>
                       </div>
                     ))
@@ -1447,6 +1464,14 @@ function TutorDashboardContent() {
         canCreate
         onClose={() => setScheduleCourse(null)}
       />
+      {rescheduleRequestId && (
+        <OneOnOneRescheduleDialog
+          requestId={rescheduleRequestId}
+          open
+          onOpenChange={o => !o && setRescheduleRequestId(null)}
+          onChanged={fetchData}
+        />
+      )}
     </div>
   )
 }

--- a/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
@@ -43,6 +43,39 @@ async function loadOwnedBooking(requestId: string, userId: string): Promise<Book
   return row
 }
 
+// Current reschedule state for the dialog: the session's current time, any
+// pending proposal (and whether the caller made it), and whether it can still
+// be rescheduled.
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions, req)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const requestId = new URL(req.url).searchParams.get('requestId')
+  if (!requestId) return NextResponse.json({ error: 'requestId required' }, { status: 400 })
+
+  const booking = await loadOwnedBooking(requestId, session.user.id)
+  if (!booking) return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
+
+  const proposal = booking.rescheduleProposedBy
+    ? {
+        date: booking.rescheduleProposedDate?.toISOString().split('T')[0] ?? null,
+        startTime: booking.rescheduleProposedStart,
+        endTime: booking.rescheduleProposedEnd,
+        proposedByMe: booking.rescheduleProposedBy === session.user.id,
+      }
+    : null
+
+  return NextResponse.json({
+    current: {
+      date: booking.requestedDate.toISOString().split('T')[0],
+      startTime: booking.startTime,
+      endTime: booking.endTime,
+    },
+    proposal,
+    canReschedule: booking.status === 'ACCEPTED' || booking.status === 'PAID',
+  })
+}
+
 /** Availability + conflict + buffer checks for moving `booking` to a new slot.
  *  Returns an error message, or null when the slot is bookable. */
 async function validateSlot(

--- a/tutorme-app/src/components/booking/one-on-one-reschedule-dialog.tsx
+++ b/tutorme-app/src/components/booking/one-on-one-reschedule-dialog.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+/**
+ * Reschedule a 1-on-1 booking. Self-fetches the booking's reschedule state and
+ * shows one of three modes:
+ *  - a pending proposal from the OTHER party → Accept / Decline
+ *  - a pending proposal I made → "waiting for their response"
+ *  - no proposal → a form to propose a new date/time
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface Proposal {
+  date: string | null
+  startTime: string | null
+  endTime: string | null
+  proposedByMe: boolean
+}
+interface RescheduleState {
+  current: { date: string; startTime: string; endTime: string }
+  proposal: Proposal | null
+  canReschedule: boolean
+}
+
+interface Props {
+  requestId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChanged?: () => void
+}
+
+export function OneOnOneRescheduleDialog({ requestId, open, onOpenChange, onChanged }: Props) {
+  const [state, setState] = useState<RescheduleState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [date, setDate] = useState('')
+  const [startTime, setStartTime] = useState('')
+  const [endTime, setEndTime] = useState('')
+
+  const load = useCallback(() => {
+    setLoading(true)
+    fetch(`/api/one-on-one/reschedule?requestId=${encodeURIComponent(requestId)}`, {
+      credentials: 'include',
+    })
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: RescheduleState | null) => {
+        setState(data)
+        if (data?.current) {
+          setDate(data.current.date)
+          setStartTime(data.current.startTime)
+          setEndTime(data.current.endTime)
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [requestId])
+
+  useEffect(() => {
+    if (open) load()
+  }, [open, load])
+
+  const propose = async () => {
+    if (!date || !startTime || !endTime) {
+      toast.error('Pick a date, start and end time')
+      return
+    }
+    setBusy(true)
+    try {
+      const res = await fetch('/api/one-on-one/reschedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId, date, startTime, endTime }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok) {
+        toast.success('New time proposed — waiting for the other person to accept.')
+        onChanged?.()
+        onOpenChange(false)
+      } else {
+        toast.error(data.error || 'Could not propose a new time')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const respond = async (action: 'accept' | 'decline') => {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/one-on-one/reschedule', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId, action }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok) {
+        toast.success(
+          action === 'accept' ? 'Session moved to the new time.' : 'Reschedule declined.'
+        )
+        onChanged?.()
+        onOpenChange(false)
+      } else {
+        toast.error(data.error || 'Could not respond')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const proposal = state?.proposal
+  const incoming = proposal && !proposal.proposedByMe
+  const mine = proposal && proposal.proposedByMe
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reschedule session</DialogTitle>
+          <DialogDescription>
+            {state?.current
+              ? `Currently ${state.current.date}, ${state.current.startTime}–${state.current.endTime}.`
+              : 'Propose a new time for this 1-on-1.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex justify-center py-6">
+            <Loader2 className="h-5 w-5 animate-spin text-gray-400" />
+          </div>
+        ) : incoming ? (
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-gray-700">
+              The other person proposed a new time:{' '}
+              <span className="font-semibold">
+                {proposal!.date}, {proposal!.startTime}–{proposal!.endTime}
+              </span>
+              .
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" disabled={busy} onClick={() => respond('decline')}>
+                Decline
+              </Button>
+              <Button disabled={busy} onClick={() => respond('accept')}>
+                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Accept new time
+              </Button>
+            </div>
+          </div>
+        ) : mine ? (
+          <p className="py-4 text-sm text-gray-600">
+            You proposed {proposal!.date}, {proposal!.startTime}–{proposal!.endTime}. Waiting for
+            the other person to accept or decline.
+          </p>
+        ) : (
+          <div className="space-y-3 py-2">
+            <div className="space-y-1">
+              <Label htmlFor="rs-date">Date</Label>
+              <Input
+                id="rs-date"
+                type="date"
+                value={date}
+                onChange={e => setDate(e.target.value)}
+              />
+            </div>
+            <div className="flex gap-3">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="rs-start">Start</Label>
+                <Input
+                  id="rs-start"
+                  type="time"
+                  value={startTime}
+                  onChange={e => setStartTime(e.target.value)}
+                />
+              </div>
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="rs-end">End</Label>
+                <Input
+                  id="rs-end"
+                  type="time"
+                  value={endTime}
+                  onChange={e => setEndTime(e.target.value)}
+                />
+              </div>
+            </div>
+            <DialogFooter className="gap-2 pt-2">
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={propose} disabled={busy}>
+                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Propose new time
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
Wires the reschedule backend (#911) into the UI — the propose→accept loop is now usable by **both** parties.

- **`GET /api/one-on-one/reschedule`** — returns the current time, any pending proposal (+ `proposedByMe`), and `canReschedule`.
- **`OneOnOneRescheduleDialog`** (reusable) — self-fetches state and renders one of: a **propose** form (date + start/end), **Accept/Decline** of an incoming proposal, or a "waiting for their response" note for your own proposal.
- **Student:** a **Reschedule** button on upcoming 1-on-1s in the dashboard **Bookings** tab.
- **Tutor:** the dashboard 1-on-1 list now includes confirmed (accepted/paid) bookings with a **Reschedule** button (pending requests keep Accept/Reject).

## Verification
- `tsc` clean · `eslint` 0 errors · `prettier`/`format:check` clean.
- Completes the reschedule feature (backend shipped in #911).

🤖 Generated with [Claude Code](https://claude.com/claude-code)