### PR TITLE
fix(tutor-public-page): defensive getTutorRating with try/catch

### DIFF
--- a/tutorme-app/src/lib/one-on-one/reviews.ts
+++ b/tutorme-app/src/lib/one-on-one/reviews.ts
@@ -13,15 +13,22 @@ export interface TutorRating {
 }
 
 export async function getTutorRating(tutorId: string): Promise<TutorRating> {
-  const [row] = await drizzleDb
-    .select({
-      avg: sql<number>`avg(${oneOnOneReview.rating})`,
-      count: sql<number>`count(*)::int`,
-    })
-    .from(oneOnOneReview)
-    .where(eq(oneOnOneReview.tutorId, tutorId))
+  try {
+    const [row] = await drizzleDb
+      .select({
+        avg: sql<number>`avg(${oneOnOneReview.rating})`,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(oneOnOneReview)
+      .where(eq(oneOnOneReview.tutorId, tutorId))
 
-  const count = Number(row?.count ?? 0)
-  if (count === 0) return { average: null, count: 0 }
-  return { average: Math.round(Number(row.avg) * 10) / 10, count }
+    const count = Number(row?.count ?? 0)
+    if (count === 0) return { average: null, count: 0 }
+    return { average: Math.round(Number(row.avg) * 10) / 10, count }
+  } catch (error) {
+    // Graceful degradation: if the OneOnOneReview table doesn't exist yet
+    // (migration not applied), return null rating instead of crashing.
+    console.warn('[getTutorRating] Table not ready, returning null rating:', error)
+    return { average: null, count: 0 }
+  }
 }


### PR DESCRIPTION
## Problem

The tutor public profile page may crash if the OneOnOneReview table is queried before the migration is fully applied.

## Fix

Wrap  in  for graceful degradation — returns  if the table isn't ready instead of crashing the page.

## Files Changed

| File | Change |
|------|--------|
|  | Added try/catch around rating query |

## Verification

- TypeScript: clean
- Tests: 556/556 pass
- Prettier: clean