### PR TITLE
fix(course-details): restore scheduler lost to variant-load race

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -300,7 +300,13 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
           `${a.category} - ${a.nationality}`.localeCompare(`${b.category} - ${b.nationality}`)
         )
       })
-    }, [desiredKeys, globalPrice, globalCurrency, globalLanguage, defaultSchedule])
+      // `loading` is a dependency so this re-runs once the async publish fetch
+      // above settles. Without it, a fresh/unpublished course hits a race: the
+      // fetch resolves with `{ variants: [] }` and overwrites the desired
+      // variant this effect already added, and since `desiredKeys` never
+      // changes again the scheduler would stay empty. Re-running here re-adds
+      // the desired variant on top of whatever the fetch loaded.
+    }, [desiredKeys, globalPrice, globalCurrency, globalLanguage, defaultSchedule, loading])
 
     const applyGlobalsToAll = useCallback(() => {
       const price = globalPrice ? parseFloat(globalPrice) : null
@@ -539,7 +545,8 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
             <CardContent spacing="default" className="bg-white text-slate-900">
               {variants.length === 0 && (
                 <div className="rounded-xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
-                  Select categories and countries above to generate variant courses.
+                  This course has no category yet. Set one from the course builder
+                  (Edit Course) to generate a schedulable variant.
                 </div>
               )}
 

--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -545,8 +545,8 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
             <CardContent spacing="default" className="bg-white text-slate-900">
               {variants.length === 0 && (
                 <div className="rounded-xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
-                  This course has no category yet. Set one from the course builder
-                  (Edit Course) to generate a schedulable variant.
+                  This course has no category yet. Set one from the course builder (Edit Course) to
+                  generate a schedulable variant.
                 </div>
               )}
 


### PR DESCRIPTION
## Problem
"The scheduler is missing from the course details page." After #908 removed the on-page Category picker, the scheduler (the per-variant `VariantScheduleEditor` inside `VariantManager`) intermittently fails to appear.

## Root cause — a latent race, newly exposed
The scheduler only renders for a **variant**, and variants are generated from `selectedCategories` (now prefilled once from the stored course category). Two async things fight:

1. Parent prefills `selectedCategories` → `desiredKeys` changes → the sync effect **adds** the desired variant → scheduler appears.
2. `VariantManager`'s own publish fetch resolves with `{ variants: [] }` for a fresh/unpublished course → `setVariants([])` **overwrites** the just-added variant.
3. `desiredKeys` never changes again, so the sync effect (deps `[desiredKeys, …]`) **never re-runs** → the variant stays gone → empty "Price and Schedule" section.

Before #908 the on-page picker made the tutor change `selectedCategories` *after* load, which re-triggered the sync and masked the race. With the picker gone the category is set once, so whichever fetch wins decides whether the scheduler shows — intermittent, exactly matching the report.

## Fix
- Add `loading` to the sync effect's dependency array so it re-runs once the publish fetch settles, re-adding the desired variant on top of whatever loaded. The merge is idempotent (keyed by `category|nationality`) and the existing `hasPersistedSameCategory` guard prevents duplicates for published courses.
- Correct the empty-state copy, which still told tutors to "select categories and countries above" — pickers that #908 removed. It now points to the builder's Edit Course action.

## Testing
- `eslint` on the file: 0 errors (pre-existing warnings only).
- Manual reasoning: for a category-bearing course the scheduler now appears regardless of which fetch resolves first; for a genuinely category-less course the empty state gives an accurate next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)