### PR TITLE
feat(1-on-1): waitlist when a tutor is full

### DIFF
--- a/tutorme-app/drizzle/0072_one_on_one_waitlist.sql
+++ b/tutorme-app/drizzle/0072_one_on_one_waitlist.sql
@@ -1,0 +1,11 @@
+-- Students waiting for a 1-on-1 opening with a tutor.
+CREATE TABLE IF NOT EXISTS "OneOnOneWaitlist" (
+  "id" text PRIMARY KEY NOT NULL,
+  "tutorId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "studentId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "note" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutor_student_key" ON "OneOnOneWaitlist" ("tutorId","studentId");
+CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutorId_idx" ON "OneOnOneWaitlist" ("tutorId");
+CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_studentId_idx" ON "OneOnOneWaitlist" ("studentId");

--- a/tutorme-app/src/app/api/one-on-one/cancel/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/cancel/route.ts
@@ -5,6 +5,7 @@ import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, calendarEvent, liveSession } from '@/lib/db/schema'
 import { notify } from '@/lib/notifications/notify'
 import { refundPaidOneOnOne, type RefundOutcome } from '@/lib/payments/refund-one-on-one'
+import { notifyWaitlistOfOpening } from '@/lib/one-on-one/waitlist'
 import { z } from 'zod'
 
 const cancelSchema = z.object({
@@ -148,6 +149,12 @@ export async function PATCH(request: NextRequest) {
           actionUrl: '/tutor/dashboard',
         }).catch(console.error)
       }
+    }
+
+    // Cancelling a confirmed booking frees a slot — let this tutor's waitlist
+    // know they may have new availability.
+    if (existingRequest.status === 'ACCEPTED' || existingRequest.status === 'PAID') {
+      void notifyWaitlistOfOpening(existingRequest.tutorId)
     }
 
     return NextResponse.json({

--- a/tutorme-app/src/app/api/one-on-one/waitlist/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/waitlist/route.ts
@@ -1,0 +1,107 @@
+/**
+ * 1-on-1 waitlist.
+ *
+ * GET  ?tutorId=…  → { onWaitlist } for a student.
+ *      (no tutorId, as a tutor) → { entries: [...] } — who's waiting on you.
+ * POST { tutorId, note? } → student joins a tutor's waitlist.
+ * DELETE ?tutorId=…       → student leaves.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { and, eq, desc } from 'drizzle-orm'
+import { z } from 'zod'
+import { nanoid } from 'nanoid'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneWaitlist, user, profile } from '@/lib/db/schema'
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions, req)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const tutorId = new URL(req.url).searchParams.get('tutorId')
+
+  // Tutor viewing their own waitlist.
+  if (!tutorId && session.user.role === 'TUTOR') {
+    const entries = await drizzleDb
+      .select({
+        studentId: oneOnOneWaitlist.studentId,
+        note: oneOnOneWaitlist.note,
+        createdAt: oneOnOneWaitlist.createdAt,
+        studentName: profile.name,
+      })
+      .from(oneOnOneWaitlist)
+      .leftJoin(profile, eq(profile.userId, oneOnOneWaitlist.studentId))
+      .where(eq(oneOnOneWaitlist.tutorId, session.user.id))
+      .orderBy(desc(oneOnOneWaitlist.createdAt))
+    return NextResponse.json({ entries })
+  }
+
+  if (!tutorId) return NextResponse.json({ error: 'tutorId required' }, { status: 400 })
+  const [row] = await drizzleDb
+    .select({ id: oneOnOneWaitlist.waitlistId })
+    .from(oneOnOneWaitlist)
+    .where(
+      and(eq(oneOnOneWaitlist.tutorId, tutorId), eq(oneOnOneWaitlist.studentId, session.user.id))
+    )
+    .limit(1)
+  return NextResponse.json({ onWaitlist: !!row })
+}
+
+const postSchema = z.object({ tutorId: z.string().min(1), note: z.string().max(500).optional() })
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions, req)
+    if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (session.user.role !== 'STUDENT') {
+      return NextResponse.json({ error: 'Only students can join a waitlist' }, { status: 403 })
+    }
+
+    const { tutorId, note } = postSchema.parse(await req.json())
+    if (tutorId === session.user.id) {
+      return NextResponse.json({ error: 'Invalid tutor' }, { status: 400 })
+    }
+
+    const [tutor] = await drizzleDb
+      .select({ enabled: profile.oneOnOneEnabled })
+      .from(user)
+      .leftJoin(profile, eq(profile.userId, user.userId))
+      .where(eq(user.userId, tutorId))
+      .limit(1)
+    if (!tutor) return NextResponse.json({ error: 'Tutor not found' }, { status: 404 })
+    if (tutor.enabled === false) {
+      return NextResponse.json(
+        { error: 'This tutor is not offering 1-on-1 sessions' },
+        { status: 400 }
+      )
+    }
+
+    await drizzleDb
+      .insert(oneOnOneWaitlist)
+      .values({ waitlistId: nanoid(), tutorId, studentId: session.user.id, note: note ?? null })
+      .onConflictDoNothing()
+
+    return NextResponse.json({ success: true, onWaitlist: true })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+    console.error('waitlist join failed:', err)
+    return NextResponse.json({ error: 'Failed to join waitlist' }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await getServerSession(authOptions, req)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const tutorId = new URL(req.url).searchParams.get('tutorId')
+  if (!tutorId) return NextResponse.json({ error: 'tutorId required' }, { status: 400 })
+
+  await drizzleDb
+    .delete(oneOnOneWaitlist)
+    .where(
+      and(eq(oneOnOneWaitlist.tutorId, tutorId), eq(oneOnOneWaitlist.studentId, session.user.id))
+    )
+  return NextResponse.json({ success: true, onWaitlist: false })
+}

--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -117,6 +117,8 @@ export function CalendarBookingDialog({
   const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null)
   const [hasPendingRequest, setHasPendingRequest] = useState(false)
   const [activeRequest, setActiveRequest] = useState<{ id: string; status: string } | null>(null)
+  const [onWaitlist, setOnWaitlist] = useState(false)
+  const [waitlistBusy, setWaitlistBusy] = useState(false)
 
   // Recurring booking: how many weeks to repeat the selected slot
   const [recurringWeeks, setRecurringWeeks] = useState(1)
@@ -167,6 +169,47 @@ export function CalendarBookingDialog({
       checkExistingRequest()
     }
   }, [open, tutor.id, weekOffset])
+
+  // Waitlist status (so the button reads Join vs Leave).
+  useEffect(() => {
+    if (!open || !tutor.id) return
+    fetch(`/api/one-on-one/waitlist?tutorId=${encodeURIComponent(tutor.id)}`, {
+      credentials: 'include',
+    })
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => setOnWaitlist(!!d?.onWaitlist))
+      .catch(() => {})
+  }, [open, tutor.id])
+
+  const toggleWaitlist = async () => {
+    setWaitlistBusy(true)
+    try {
+      const res = onWaitlist
+        ? await fetch(`/api/one-on-one/waitlist?tutorId=${encodeURIComponent(tutor.id)}`, {
+            method: 'DELETE',
+            credentials: 'include',
+          })
+        : await fetch('/api/one-on-one/waitlist', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ tutorId: tutor.id }),
+          })
+      const d = await res.json().catch(() => ({}))
+      if (res.ok) {
+        setOnWaitlist(!!d.onWaitlist)
+        toast.success(
+          d.onWaitlist ? "You're on the waitlist — we'll notify you." : 'Left the waitlist.'
+        )
+      } else {
+        toast.error(d.error || 'Could not update the waitlist')
+      }
+    } catch {
+      toast.error('Could not update the waitlist')
+    } finally {
+      setWaitlistBusy(false)
+    }
+  }
 
   // Reset selected slot when week changes
   useEffect(() => {
@@ -857,6 +900,21 @@ export function CalendarBookingDialog({
         </Tabs>
 
         <DialogFooter className="shrink-0 gap-3 px-6 pb-6">
+          <Button
+            variant="modal-secondary-dark"
+            onClick={toggleWaitlist}
+            disabled={waitlistBusy}
+            className="h-10"
+            title="Get notified when this tutor has a new opening"
+          >
+            {waitlistBusy ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : onWaitlist ? (
+              'Leave waitlist'
+            ) : (
+              'Join waitlist'
+            )}
+          </Button>
           <Button
             variant="modal-secondary-dark"
             onClick={() => onOpenChange(false)}

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -295,3 +295,31 @@ export const oneOnOneReview = pgTable(
     OneOnOneReview_tutorId_idx: index('OneOnOneReview_tutorId_idx').on(table.tutorId),
   })
 )
+
+/**
+ * A student waiting for a 1-on-1 opening with a tutor who has no bookable slots.
+ * When a confirmed booking is cancelled, everyone on that tutor's waitlist is
+ * notified that a slot may have opened.
+ */
+export const oneOnOneWaitlist = pgTable(
+  'OneOnOneWaitlist',
+  {
+    waitlistId: text('id').primaryKey().notNull(),
+    tutorId: text('tutorId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    studentId: text('studentId')
+      .notNull()
+      .references(() => user.userId, { onDelete: 'cascade' }),
+    note: text('note'),
+    createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => ({
+    OneOnOneWaitlist_tutor_student_key: uniqueIndex('OneOnOneWaitlist_tutor_student_key').on(
+      table.tutorId,
+      table.studentId
+    ),
+    OneOnOneWaitlist_tutorId_idx: index('OneOnOneWaitlist_tutorId_idx').on(table.tutorId),
+    OneOnOneWaitlist_studentId_idx: index('OneOnOneWaitlist_studentId_idx').on(table.studentId),
+  })
+)

--- a/tutorme-app/src/lib/one-on-one/waitlist.ts
+++ b/tutorme-app/src/lib/one-on-one/waitlist.ts
@@ -1,0 +1,45 @@
+/**
+ * 1-on-1 waitlist helper — notify students waiting on a tutor when a slot may
+ * have opened (e.g. a confirmed booking was cancelled).
+ */
+
+import { eq } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneWaitlist, profile } from '@/lib/db/schema'
+import { notify } from '@/lib/notifications/notify'
+
+/** Notify everyone on a tutor's waitlist that a slot may have opened. Returns
+ *  how many students were notified. Best-effort; never throws. */
+export async function notifyWaitlistOfOpening(tutorId: string): Promise<number> {
+  try {
+    const rows = await drizzleDb
+      .select({ studentId: oneOnOneWaitlist.studentId })
+      .from(oneOnOneWaitlist)
+      .where(eq(oneOnOneWaitlist.tutorId, tutorId))
+    if (rows.length === 0) return 0
+
+    const [tutorProfile] = await drizzleDb
+      .select({ name: profile.name, username: profile.username })
+      .from(profile)
+      .where(eq(profile.userId, tutorId))
+      .limit(1)
+    const tutorName = tutorProfile?.name || 'A tutor'
+    const actionUrl = tutorProfile?.username ? `/u/${tutorProfile.username}` : '/student/dashboard'
+
+    await Promise.all(
+      rows.map(r =>
+        notify({
+          userId: r.studentId,
+          type: 'class',
+          title: 'A 1-on-1 slot may have opened',
+          message: `${tutorName} may have new availability — book a 1-on-1 while it lasts.`,
+          data: { tutorId, type: 'one-on-one-waitlist-opening' },
+          actionUrl,
+        }).catch(() => {})
+      )
+    )
+    return rows.length
+  } catch {
+    return 0
+  }
+}


### PR DESCRIPTION
## What

Students can join a tutor's 1-on-1 **waitlist** when they can't book (tutor full / no slots). When a confirmed booking is later cancelled — freeing a slot — everyone on that tutor's waitlist is notified they may have new availability.

## Changes

- **Schema**: `OneOnOneWaitlist` table (`tutorId`, `studentId`, `note`, unique per tutor+student) + migration `0072_one_on_one_waitlist.sql`.
- **API** `/api/one-on-one/waitlist`:
  - `GET ?tutorId=` → `{ onWaitlist }` for a student; `GET` (as tutor, no id) → `{ entries }` of who's waiting.
  - `POST { tutorId, note? }` → student joins (validates tutor exists + `oneOnOneEnabled`, idempotent via `onConflictDoNothing`).
  - `DELETE ?tutorId=` → student leaves.
- **Helper** `notifyWaitlistOfOpening(tutorId)` — best-effort notification fan-out; wired into the cancel route when an `ACCEPTED`/`PAID` booking is cancelled.
- **UI**: Join/Leave waitlist button in the calendar booking dialog with live status.

## Notes

- Notifications are best-effort (never throw) so they can't block a cancellation/refund.
- Migration runs automatically on deploy via `scripts/migrate.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)