### PR TITLE
fix(test-task-chat): remove nested border causing double outline

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -191,14 +191,13 @@ export function TestTaskChat({
   const accentColor = isClassroom ? 'text-[#F17623]' : 'text-violet-600'
   const accentBg = isClassroom ? 'bg-orange-50/60' : 'bg-violet-50/60'
   const accentBorder = isClassroom ? 'border-orange-100' : 'border-violet-100'
-  const accentBorderStrong = isClassroom ? 'border-[rgba(241,118,35,0.4)]' : 'border-violet-300'
   const sendButtonBg = isClassroom ? 'bg-[#F17623]' : 'bg-violet-600'
   const taskCompleteBg = isClassroom ? 'bg-[#F17623]' : 'bg-violet-600'
   const taskCompleteHover = isClassroom ? 'hover:bg-[#d9631a]' : 'hover:bg-violet-700'
 
   return (
     <div
-      className={`relative flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl border ${accentBorderStrong} bg-white`}
+      className={`relative flex h-full min-h-[320px] flex-col overflow-hidden rounded-2xl bg-white`}
     >
       {/* Header bar */}
       <div className={`flex items-center gap-2 border-b ${accentBorder} ${accentBg} px-4 py-2`}>


### PR DESCRIPTION
The TestTaskChat component had its own rounded-2xl border that nested inside the CourseBuilder container's rounded-2xl border, creating a double outline effect. Removed the redundant border from TestTaskChat since the parent already provides the container border.