### PR TITLE
feat(1-on-1): timezone hardening — absolute-UTC + cross-TZ conflict math

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -13,6 +13,7 @@ import {
   NotFoundError,
 } from '@/lib/api/middleware'
 import { parseJson } from '@/lib/api/parse'
+import { requestedDateFromString } from '@/lib/one-on-one/time'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -116,8 +117,9 @@ export const POST = withCsrf(
     const durationHours = validated.duration / 60
     const costPerSession = Math.round(tutorProfile.hourlyRate * durationHours * 100) / 100
 
-    // Parse the date and time
-    const requestedDate = new Date(`${primarySlot.date}T00:00:00`)
+    // Store the calendar date as midnight-UTC so it round-trips regardless of
+    // the server's own timezone (wall-clock times live in `timezone` below).
+    const requestedDate = requestedDateFromString(primarySlot.date)
 
     // Create the request
     const newRequest = await drizzleDb

--- a/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
@@ -20,6 +20,7 @@ import {
   studentHasAvailabilityConfigured,
 } from '@/lib/student-availability'
 import { notify } from '@/lib/notifications/notify'
+import { slotInstants, requestedDateFromString } from '@/lib/one-on-one/time'
 
 const proposeSchema = z.object({
   requestId: z.string().min(1),
@@ -90,9 +91,14 @@ async function validateSlot(
   if (!(await isSlotWithinStudentAvailability(booking.studentId, date, startTime, endTime))) {
     return "That time is outside the student's available hours."
   }
-  const eventStart = new Date(`${date}T${startTime}:00`)
-  const eventEnd = new Date(`${date}T${endTime}:00`)
-  if (!(eventEnd > eventStart)) return 'The end time must be after the start time.'
+  if (endTime <= startTime) return 'The end time must be after the start time.'
+  // Resolve the proposed wall-clock slot in the booking's own timezone.
+  const { start: eventStart, end: eventEnd } = slotInstants(
+    date,
+    startTime,
+    endTime,
+    booking.timezone
+  )
 
   const [tutorProfile] = await drizzleDb
     .select({ bufferMinutes: profile.bufferMinutes })
@@ -138,7 +144,7 @@ export async function POST(req: NextRequest) {
     await drizzleDb
       .update(oneOnOneBookingRequest)
       .set({
-        rescheduleProposedDate: new Date(`${date}T00:00:00.000Z`),
+        rescheduleProposedDate: requestedDateFromString(date),
         rescheduleProposedStart: startTime,
         rescheduleProposedEnd: endTime,
         rescheduleProposedBy: session.user.id,
@@ -226,8 +232,12 @@ export async function PATCH(req: NextRequest) {
       )
     }
 
-    const eventStart = new Date(`${date}T${startTime}:00`)
-    const eventEnd = new Date(`${date}T${endTime}:00`)
+    const { start: eventStart, end: eventEnd } = slotInstants(
+      date,
+      startTime,
+      endTime,
+      booking.timezone
+    )
 
     await drizzleDb.transaction(async tx => {
       if (booking.calendarEventId) {
@@ -249,7 +259,7 @@ export async function PATCH(req: NextRequest) {
       await tx
         .update(oneOnOneBookingRequest)
         .set({
-          requestedDate: new Date(`${date}T00:00:00.000Z`),
+          requestedDate: requestedDateFromString(date),
           startTime,
           endTime,
           ...clearProposal,

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -13,6 +13,7 @@ import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
 } from '@/lib/student-availability'
+import { slotInstants } from '@/lib/one-on-one/time'
 
 const respondSchema = z.object({
   requestId: z.string().min(1),
@@ -100,9 +101,14 @@ export async function PATCH(request: NextRequest) {
         )
       }
 
-      // Create event timestamps
-      const eventStart = new Date(`${slotDate}T${slotStartTime}:00`)
-      const eventEnd = new Date(`${slotDate}T${slotEndTime}:00`)
+      // Resolve the picked wall-clock slot to true UTC instants in the
+      // booking's own timezone (not the server's).
+      const { start: eventStart, end: eventEnd } = slotInstants(
+        slotDate,
+        slotStartTime,
+        slotEndTime,
+        existingRequest.timezone
+      )
       const durationMinutes = existingRequest.durationMinutes || 60
 
       // CHECK FOR CONFLICTS using unified conflict detector, expanded by the

--- a/tutorme-app/src/app/api/one-on-one/review/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/review/route.ts
@@ -14,6 +14,7 @@ import { z } from 'zod'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, oneOnOneReview } from '@/lib/db/schema'
 import { nanoid } from 'nanoid'
+import { bookingInstants } from '@/lib/one-on-one/time'
 
 const postSchema = z.object({
   requestId: z.string().min(1),
@@ -22,10 +23,15 @@ const postSchema = z.object({
 })
 
 /** A booking is reviewable once it's paid and its scheduled end has passed. */
-function isReviewable(booking: { status: string; requestedDate: Date; endTime: string }): boolean {
+function isReviewable(booking: {
+  status: string
+  requestedDate: Date
+  startTime: string
+  endTime: string
+  timezone: string | null
+}): boolean {
   if (booking.status !== 'PAID') return false
-  const date = booking.requestedDate.toISOString().split('T')[0]
-  const end = new Date(`${date}T${booking.endTime}:00`)
+  const { end } = bookingInstants(booking)
   return Number.isFinite(end.getTime()) && end.getTime() < Date.now()
 }
 

--- a/tutorme-app/src/lib/one-on-one/time.test.ts
+++ b/tutorme-app/src/lib/one-on-one/time.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { slotInstants, bookingInstants, requestedDateFromString } from './time'
+
+describe('slotInstants', () => {
+  it('interprets wall-clock in the given zone (not the server)', () => {
+    // 14:00 in Shanghai (UTC+8) is 06:00 UTC.
+    const { start, end } = slotInstants('2026-06-20', '14:00', '15:00', 'Asia/Shanghai')
+    expect(start.toISOString()).toBe('2026-06-20T06:00:00.000Z')
+    expect(end.toISOString()).toBe('2026-06-20T07:00:00.000Z')
+  })
+
+  it('resolves the same wall-clock to different instants across zones', () => {
+    const sh = slotInstants('2026-06-20', '14:00', '15:00', 'Asia/Shanghai').start
+    const ny = slotInstants('2026-06-20', '14:00', '15:00', 'America/New_York').start
+    // 14:00 SH = 06:00Z; 14:00 NY (EDT, -4) = 18:00Z → 12h apart, NOT equal.
+    expect(sh.toISOString()).toBe('2026-06-20T06:00:00.000Z')
+    expect(ny.toISOString()).toBe('2026-06-20T18:00:00.000Z')
+    expect(sh.getTime()).not.toBe(ny.getTime())
+  })
+
+  it('is DST-aware (New York summer offset is -4)', () => {
+    const { start } = slotInstants('2026-07-01', '09:00', '10:00', 'America/New_York')
+    expect(start.toISOString()).toBe('2026-07-01T13:00:00.000Z')
+  })
+
+  it('defaults to UTC when no zone is given', () => {
+    const { start } = slotInstants('2026-06-20', '09:00', '10:00', null)
+    expect(start.toISOString()).toBe('2026-06-20T09:00:00.000Z')
+  })
+})
+
+describe('bookingInstants', () => {
+  it('rebuilds a stored booking in its own timezone', () => {
+    const booking = {
+      requestedDate: requestedDateFromString('2026-06-20'),
+      startTime: '14:00',
+      endTime: '15:00',
+      timezone: 'Asia/Shanghai',
+    }
+    const { start, end } = bookingInstants(booking)
+    expect(start.toISOString()).toBe('2026-06-20T06:00:00.000Z')
+    expect(end.toISOString()).toBe('2026-06-20T07:00:00.000Z')
+  })
+
+  it('two same-wall-clock bookings in different zones do NOT overlap', () => {
+    const a = bookingInstants({
+      requestedDate: requestedDateFromString('2026-06-20'),
+      startTime: '14:00',
+      endTime: '15:00',
+      timezone: 'Asia/Shanghai',
+    })
+    const b = bookingInstants({
+      requestedDate: requestedDateFromString('2026-06-20'),
+      startTime: '14:00',
+      endTime: '15:00',
+      timezone: 'America/New_York',
+    })
+    const overlaps = a.start < b.end && a.end > b.start
+    expect(overlaps).toBe(false)
+  })
+})
+
+describe('requestedDateFromString', () => {
+  it('stores midnight UTC of the calendar date', () => {
+    expect(requestedDateFromString('2026-06-20').toISOString()).toBe('2026-06-20T00:00:00.000Z')
+  })
+})

--- a/tutorme-app/src/lib/one-on-one/time.ts
+++ b/tutorme-app/src/lib/one-on-one/time.ts
@@ -1,0 +1,68 @@
+/**
+ * Absolute-UTC reconstruction for 1-on-1 bookings.
+ *
+ * A booking stores three pieces: `requestedDate` (a timestamp written as
+ * midnight-UTC of the picked calendar date), `startTime`/`endTime` (wall-clock
+ * "HH:MM" strings) and `timezone` (the zone those wall-clock times belong to).
+ * Historically the scheduler rebuilt instants with `new Date(`${date}T${time}`)`,
+ * which silently interprets the time in the *server's* zone and ignores the
+ * stored `timezone` entirely — so a Shanghai 14:00 booking and a New York 14:00
+ * booking collapsed to the same instant. These helpers pin every booking to its
+ * own zone so conflict math is done on true UTC instants.
+ */
+
+import { zonedWallClockToUtc } from '@/lib/time/tz'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function hhmm(time: string): [number, number] {
+  const [h, m] = time.split(':').map(Number)
+  return [Number.isFinite(h) ? h : 0, Number.isFinite(m) ? m : 0]
+}
+
+/**
+ * The true UTC start/end instants for a wall-clock slot (`YYYY-MM-DD` +
+ * `HH:MM` strings) interpreted in `timezone`. DST-aware via the tz helpers.
+ * If the end wall-clock is at//before the start (a slot crossing midnight),
+ * the end rolls forward a day so the interval stays positive.
+ */
+export function slotInstants(
+  date: string,
+  startTime: string,
+  endTime: string,
+  timezone: string | null | undefined
+): { start: Date; end: Date } {
+  const tz = timezone || 'UTC'
+  const [y, mo, d] = date.split('-').map(Number)
+  const [sh, sm] = hhmm(startTime)
+  const [eh, em] = hhmm(endTime)
+  const start = zonedWallClockToUtc(y, mo, d, sh, sm, tz)
+  let end = zonedWallClockToUtc(y, mo, d, eh, em, tz)
+  if (end.getTime() <= start.getTime()) end = new Date(end.getTime() + DAY_MS)
+  return { start, end }
+}
+
+/**
+ * The true UTC start/end instants of a stored booking. The calendar date is
+ * taken from `requestedDate`'s UTC parts (that's how it is written — midnight
+ * UTC of the picked date), and the wall-clock times are interpreted in the
+ * booking's stored `timezone`.
+ */
+export function bookingInstants(booking: {
+  requestedDate: Date
+  startTime: string
+  endTime: string
+  timezone: string | null | undefined
+}): { start: Date; end: Date } {
+  const rd = booking.requestedDate
+  const date = `${rd.getUTCFullYear()}-${String(rd.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    rd.getUTCDate()
+  ).padStart(2, '0')}`
+  return slotInstants(date, booking.startTime, booking.endTime, booking.timezone)
+}
+
+/** The storable `requestedDate` for a picked `YYYY-MM-DD` — midnight UTC, so
+ *  the calendar date round-trips regardless of the server's own timezone. */
+export function requestedDateFromString(date: string): Date {
+  return new Date(`${date}T00:00:00.000Z`)
+}

--- a/tutorme-app/src/lib/schedule/conflicts.ts
+++ b/tutorme-app/src/lib/schedule/conflicts.ts
@@ -12,6 +12,7 @@ import {
   calendarException,
 } from '@/lib/db/schema'
 import { eq, and, or, gte, lte, lt, gt, isNull, inArray, ne } from 'drizzle-orm'
+import { bookingInstants } from '@/lib/one-on-one/time'
 
 export interface ConflictResult {
   type: 'live_session' | 'calendar_event' | 'one_on_one'
@@ -120,13 +121,19 @@ export async function findConflicts(
     })
   }
 
-  // 3. Overlapping one-on-one bookings
+  // 3. Overlapping one-on-one bookings.
+  // requestedDate is midnight-UTC of the booking's calendar date, but the real
+  // instant depends on the booking's own timezone — so a booking whose UTC date
+  // sits just outside [start, end] can still overlap once its wall-clock time is
+  // resolved in a far-off zone. Pre-filter by UTC date widened ±1 day, then do
+  // exact instant overlap in JS via bookingInstants().
+  const rangeStartDay = new Date(new Date(start.toISOString().split('T')[0]).getTime() - 86_400_000)
+  const rangeEndDay = new Date(new Date(end.toISOString().split('T')[0]).getTime() + 86_400_000)
   const oneOnOneConditions = [
     eq(oneOnOneBookingRequest.tutorId, tutorId),
     inArray(oneOnOneBookingRequest.status, ['ACCEPTED', 'PAID']),
-    // requestedDate is a date; we approximate by checking if the booking date is within the range
-    gte(oneOnOneBookingRequest.requestedDate, new Date(start.toISOString().split('T')[0])),
-    lte(oneOnOneBookingRequest.requestedDate, new Date(end.toISOString().split('T')[0])),
+    gte(oneOnOneBookingRequest.requestedDate, rangeStartDay),
+    lte(oneOnOneBookingRequest.requestedDate, rangeEndDay),
   ]
   if (options.excludeOneOnOneId) {
     oneOnOneConditions.push(ne(oneOnOneBookingRequest.requestId, options.excludeOneOnOneId))
@@ -138,14 +145,13 @@ export async function findConflicts(
       requestedDate: oneOnOneBookingRequest.requestedDate,
       startTime: oneOnOneBookingRequest.startTime,
       endTime: oneOnOneBookingRequest.endTime,
+      timezone: oneOnOneBookingRequest.timezone,
     })
     .from(oneOnOneBookingRequest)
     .where(and(...oneOnOneConditions))
 
   for (const oo of oneOnOnes) {
-    const dateStr = oo.requestedDate.toISOString().split('T')[0]
-    const ooStart = new Date(`${dateStr}T${oo.startTime}:00`)
-    const ooEnd = new Date(`${dateStr}T${oo.endTime}:00`)
+    const { start: ooStart, end: ooEnd } = bookingInstants(oo)
     if (ooStart < end && ooEnd > start) {
       conflicts.push({
         type: 'one_on_one',

--- a/tutorme-app/src/lib/student-availability.ts
+++ b/tutorme-app/src/lib/student-availability.ts
@@ -61,7 +61,9 @@ export async function isSlotWithinStudentAvailability(
   const free = await getStudentFreeHourSet(studentId)
   if (free === null) return true // no availability configured → don't block
 
-  const day = new Date(`${date}T00:00:00`).getDay()
+  // Day-of-week of the calendar date itself — parse as UTC so it doesn't shift
+  // with the server's timezone (a plain YYYY-MM-DD has a fixed weekday).
+  const day = new Date(`${date}T00:00:00.000Z`).getUTCDay()
   const [sh, sm] = startTime.split(':').map(Number)
   const [eh, em] = endTime.split(':').map(Number)
   const startMin = sh * 60 + (sm || 0)


### PR DESCRIPTION
## Problem

1-on-1 scheduling rebuilt time instants with `new Date(\`\${date}T\${time}\`)`, which interprets wall-clock times in the **server's** timezone and ignores each booking's stored `timezone` field. Consequences:

- A **Shanghai 14:00** booking and a **New York 14:00** booking collapsed to the *same* instant.
- Real cross-timezone overlaps were **missed** (double-bookings slipped through).
- Non-overlaps were **falsely flagged** as conflicts.
- Review eligibility ("has the session ended?") and student availability day-of-week were computed in the wrong frame.

## Fix

All 1-on-1 times are now pinned to their own zone using the existing DST-aware helpers in `src/lib/time/tz.ts`.

- **New `src/lib/one-on-one/time.ts`**
  - `slotInstants(date, start, end, tz)` → true UTC instants for a wall-clock slot in `tz`.
  - `bookingInstants(booking)` → same, from a stored booking (calendar date from `requestedDate`'s UTC parts + wall-clock times in the booking's `timezone`).
  - `requestedDateFromString(date)` → midnight-UTC of the picked date, so it round-trips regardless of server TZ.
- **`conflicts.ts`** — one-on-one overlap now resolved via `bookingInstants`; DB pre-filter widened ±1 day so bookings whose *UTC* date sits just outside the window (but overlap once resolved in a far-off zone) aren't missed.
- **respond / request / reschedule / review** routes — event instants + stored dates go through the shared helpers.
- **student-availability** — day-of-week parsed as UTC (a plain `YYYY-MM-DD` has a fixed weekday) instead of server-local.

## Storage

No schema/migration change. Columns are unchanged (`requestedDate` timestamptz, `startTime`/`endTime` text, `timezone` text) — this hardens **interpretation**, and standardizes new writes to midnight-UTC calendar dates.

## Tests

`src/lib/one-on-one/time.test.ts` locks in cross-TZ behavior — including "two same-wall-clock bookings in different zones do NOT overlap". Passes under a non-UTC server TZ (`TZ=America/Chicago`), which is the real regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)