### PR TITLE
feat(publish): global price/language defaults with "Apply to all variants"

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -543,6 +543,90 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
 
           {generatedVariantsOpen ? (
             <CardContent spacing="default" className="bg-white text-slate-900">
+              {/* Global defaults: set price/currency/language once, then apply to every variant */}
+              <div className="mb-6 rounded-xl border border-slate-200 bg-slate-50/50 p-5">
+                <div className="mb-4 flex flex-wrap items-center gap-2">
+                  <SlidersHorizontal className="h-4 w-4 text-slate-500" />
+                  <h3 className="text-sm font-semibold text-slate-700">
+                    Default price &amp; language
+                  </h3>
+                  <span className="text-xs text-slate-400">
+                    Set once, then apply to every variant below
+                  </span>
+                </div>
+                <div className="grid gap-6 sm:grid-cols-4">
+                  <div className="form-group space-y-2">
+                    <Label className="form-label font-semibold text-slate-700">Free</Label>
+                    <div className="border-input flex h-10 items-center justify-between rounded-xl border bg-white px-4">
+                      <span className="text-sm font-medium text-slate-600">
+                        {globalIsFree ? 'Yes' : 'No'}
+                      </span>
+                      <Switch
+                        checked={globalIsFree}
+                        onCheckedChange={checked => {
+                          setGlobalIsFree(checked)
+                          if (checked) setGlobalPrice('0')
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="form-group space-y-2">
+                    <Label className="form-label font-semibold text-slate-700">Price</Label>
+                    <div className="flex items-center gap-2">
+                      <DollarSign className="h-4 w-4 text-slate-400" />
+                      <Input
+                        type="number"
+                        min={0}
+                        value={globalPrice}
+                        onChange={e => setGlobalPrice(e.target.value)}
+                        placeholder="0.00"
+                        disabled={globalIsFree}
+                        className="bg-white"
+                      />
+                    </div>
+                  </div>
+                  <div className="form-group space-y-2">
+                    <Label className="form-label font-semibold text-slate-700">Currency</Label>
+                    <Select value={globalCurrency} onValueChange={setGlobalCurrency}>
+                      <SelectTrigger className="bg-white">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {['USD', 'SGD', 'EUR', 'GBP', 'KRW', 'JPY', 'HKD', 'CNY', 'INR'].map(c => (
+                          <SelectItem key={c} value={c}>
+                            {c}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="form-group space-y-2">
+                    <Label className="form-label font-semibold text-slate-700">Language</Label>
+                    <div className="flex items-center gap-2">
+                      <Languages className="h-4 w-4 text-slate-400" />
+                      <Input
+                        value={globalLanguage}
+                        onChange={e => setGlobalLanguage(e.target.value)}
+                        placeholder="e.g. English"
+                        className="bg-white"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-4 flex justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={applyGlobalsToAll}
+                    disabled={variants.length === 0}
+                  >
+                    <SlidersHorizontal className="mr-2 h-4 w-4" />
+                    Apply to all variants
+                  </Button>
+                </div>
+              </div>
+
               {variants.length === 0 && (
                 <div className="rounded-xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
                   This course has no category yet. Set one from the course builder (Edit Course) to


### PR DESCRIPTION
## Why
With category set at creation, publishing a course can fan out into several category×country **variants**, each with its own Free / Price / Currency / Language controls. Setting those one variant at a time is tedious. `VariantManager` already held the global state (`globalPrice`/`globalCurrency`/`globalLanguage`/`globalIsFree`) and an `applyGlobalsToAll()` helper — but no UI was wired to them, so both were orphaned dead code.

## What
Adds a **"Default price & language"** panel at the top of the Price and Schedule section:
- Free toggle, Price, Currency (same 9-currency list as the per-variant rows), and Language inputs, wired to the global state.
- An **"Apply to all variants"** button that copies those defaults onto every variant. Disabled when there are no variants.

Reuses the existing per-variant control styling and currency options for consistency. No schema/API changes — it only sets the in-memory variant config that the existing Save/Publish flow already persists.

## Verification
- eslint: `SlidersHorizontal` and `applyGlobalsToAll` are no longer "unused" (the two warnings this feature was meant to resolve are gone). Remaining warnings are pre-existing and unrelated.
- tsc: no errors for the file. prettier: clean.

## Note
This is the "build the full defaults panel" option chosen over simply deleting the orphaned helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)