### PR TITLE
fix(prod-schema): backfill 1-on-1 tables/columns the frozen migration journal skips

### DIFF
--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -204,6 +204,76 @@ CREATE INDEX IF NOT EXISTS "PushSubscription_userId_idx" ON "PushSubscription" (
 
 -- Account status (admins can suspend accounts to block sign-in).
 ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'active';
+
+-- ---------------------------------------------------------------------------
+-- 1-on-1 schema (drizzle/0069–0072). The drizzle journal is frozen at 0068, so
+-- the journal-based migrator ignores these files entirely — they only reach a
+-- prod DB through this idempotent boot-time block. Without it, the shipped
+-- buffer/reschedule/review/waitlist features silently degrade (queries hit
+-- missing columns/tables and fall back via try/catch).
+-- ---------------------------------------------------------------------------
+
+-- 0069: per-tutor buffer (minutes) enforced around 1-on-1 bookings.
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "bufferMinutes" integer;
+
+-- 0070: pending reschedule proposal fields (propose → accept/decline).
+ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedDate" timestamptz;
+ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedStart" text;
+ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedEnd" text;
+ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedBy" text;
+
+-- 0071: student reviews of completed 1-on-1 sessions (one per booking).
+CREATE TABLE IF NOT EXISTS "OneOnOneReview" (
+  "id" text PRIMARY KEY NOT NULL,
+  "requestId" text NOT NULL,
+  "tutorId" text NOT NULL,
+  "studentId" text NOT NULL,
+  "rating" integer NOT NULL,
+  "comment" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now(),
+  "updatedAt" timestamptz NOT NULL DEFAULT now()
+);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OneOnOneReview_requestId_fkey') THEN
+    ALTER TABLE "OneOnOneReview" ADD CONSTRAINT "OneOnOneReview_requestId_fkey"
+      FOREIGN KEY ("requestId") REFERENCES "OneOnOneBookingRequest"("id") ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OneOnOneReview_tutorId_fkey') THEN
+    ALTER TABLE "OneOnOneReview" ADD CONSTRAINT "OneOnOneReview_tutorId_fkey"
+      FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OneOnOneReview_studentId_fkey') THEN
+    ALTER TABLE "OneOnOneReview" ADD CONSTRAINT "OneOnOneReview_studentId_fkey"
+      FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneReview_requestId_key" ON "OneOnOneReview" ("requestId");
+CREATE INDEX IF NOT EXISTS "OneOnOneReview_tutorId_idx" ON "OneOnOneReview" ("tutorId");
+
+-- 0072: students waiting for a 1-on-1 opening with a tutor.
+CREATE TABLE IF NOT EXISTS "OneOnOneWaitlist" (
+  "id" text PRIMARY KEY NOT NULL,
+  "tutorId" text NOT NULL,
+  "studentId" text NOT NULL,
+  "note" text,
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OneOnOneWaitlist_tutorId_fkey') THEN
+    ALTER TABLE "OneOnOneWaitlist" ADD CONSTRAINT "OneOnOneWaitlist_tutorId_fkey"
+      FOREIGN KEY ("tutorId") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'OneOnOneWaitlist_studentId_fkey') THEN
+    ALTER TABLE "OneOnOneWaitlist" ADD CONSTRAINT "OneOnOneWaitlist_studentId_fkey"
+      FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutor_student_key"
+  ON "OneOnOneWaitlist" ("tutorId", "studentId");
+CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutorId_idx" ON "OneOnOneWaitlist" ("tutorId");
+CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_studentId_idx" ON "OneOnOneWaitlist" ("studentId");
 `)
 
 export async function applyStartupSchemaFixes(): Promise<void> {


### PR DESCRIPTION
## Problem

The drizzle migration journal (`drizzle/meta/_journal.json`) has been **frozen at idx 68** since `0068`. The deploy runs `node scripts/migrate.js` → drizzle's `migrate()`, which applies **only** migrations listed in the journal — so `drizzle/0069`–`0072` are **silently ignored** and never reach the production schema.

That means these already-merged features are missing their schema in prod and degrade via `try/catch`:

| Migration | Object | Feature |
|---|---|---|
| 0069 | `Profile.bufferMinutes` | session buffer around 1-on-1s |
| 0070 | `OneOnOneBookingRequest.rescheduleProposed{Date,Start,End,By}` | reschedule proposals |
| 0071 | `OneOnOneReview` table | 1-on-1 reviews/ratings |
| 0072 | `OneOnOneWaitlist` table | waitlist (#921 — **live in the UI but table absent in prod**) |

## Fix

Add all four to **`startup-schema-fix.ts`'s `ENSURE_TABLES_SQL`** — the idempotent block that runs on every boot (`applyStartupSchemaFixes()` from `server.ts`) and is the codebase's real post-0068 schema-delivery path (see the existing `PushSubscription` / `User.status` entries there).

- `ADD COLUMN IF NOT EXISTS` for the columns; `CREATE TABLE IF NOT EXISTS` + guarded `pg_constraint` FK adds + `CREATE … INDEX IF NOT EXISTS` for the tables.
- Journal intentionally **untouched** (registering a partial 0069+ range without the full snapshot chain would break drizzle's migrator).
- The numbered `.sql` files stay for local/dev parity.

## Verification

Ran the exact new block against an **ephemeral Postgres** (docker) with minimal `User`/`Profile`/`OneOnOneBookingRequest` prereqs:
- **Pass 1**: applies cleanly, no errors (`ON_ERROR_STOP=1`).
- **Pass 2**: every object → `NOTICE: … already exists, skipping`, no errors → **fully idempotent**.

Context: [[tutorme-migration-journal-frozen]]. Follow-up to #921/#924/#927; unblocks the shipped waitlist/reschedule/review/buffer features in prod. No app-code or money-movement changes — pure additive schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)