### PR TITLE
fix(course-builder): stop draft "Schedule" from dropping the category

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -748,6 +748,14 @@ function CourseBuilderInsightsRouteInner({
 
     const isExistingDbCourse = courses?.some((c: any) => c.id === courseId)
 
+    // Carry the category chosen at creation. Drafts hold it locally, so when
+    // this first persists the draft to the DB we must pass it through — else
+    // the new course row gets categories:[] and the Course Details page shows
+    // no variant and no scheduler. (executeSave threads it the same way.)
+    const draftCategories = [...(courses || []), ...(draftCourses || [])].find(
+      (c: any) => c.id === courseId
+    )?.categories
+
     // 4. Publish via shared save function
     const result = await saveCourse({
       courseId,
@@ -755,6 +763,7 @@ function CourseBuilderInsightsRouteInner({
       mode: 'publish',
       courseName,
       detachedCourseName,
+      categories: draftCategories,
       developmentMode: 'single',
       previewDifficulty: 'all',
       isExistingDbCourse,


### PR DESCRIPTION
## Problem
On the Course Details page: *"This course has no category yet. Set one from the course builder (Edit Course)…"* and the scheduler is unavailable — even though the tutor selected a category at creation.

## Root cause
For **draft-created** courses, clicking **Schedule** runs `handlePublishDraft`, which materializes the draft into a real DB course via `saveCourse({ mode: 'publish', … })`. That call **omitted `categories`**, so `saveCourse` POSTed `categories: []` when creating the row. The category the tutor picked at creation lives only on the local draft object, and `executeSave` is the only place that threads it through (`insights/page.tsx:355`) — this direct call didn't. Result: the new course row has no category → Course Details prefills nothing → `desiredKeys` is empty → no variant → no scheduler.

The direct-DB create path (`handleCreateNewCourse`) already POSTs `categories`, so it only reproduces for courses that were created as drafts.

## Fix
Thread the draft's categories (same `[...courses, ...draftCourses].find(...)` lookup `executeSave` uses) into the `saveCourse` call in `handlePublishDraft`. `saveCourse` uses `categories` **only in its create branch**, so re-publishing an already-persisted course is unaffected.

## Existing broken courses
Courses already materialized without a category can be repaired by the tutor via the builder's **Edit Course** button (PATCHes `categories`) — which is exactly what the empty-state message points to. This fix prevents new occurrences.

## Verification
0 eslint errors, tsc clean for the file, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)