### PR TITLE
fix(migrations+booking): register 0069–0072 in journal; hide Book for non-students

### DIFF
--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -484,6 +484,34 @@
       "when": 1781900000068,
       "tag": "0068_tasksubmission_worked_solutions",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1781900000069,
+      "tag": "0069_profile_buffer_minutes",
+      "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1781900000070,
+      "tag": "0070_one_on_one_reschedule",
+      "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1781900000071,
+      "tag": "0071_one_on_one_review",
+      "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1781900000072,
+      "tag": "0072_one_on_one_waitlist",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -636,6 +636,19 @@ export default function PublicTutorPage() {
     }
   }
 
+  // Only students can request a 1-on-1 (the API rejects other roles). Logged-out
+  // visitors are sent to sign in; logged-in non-students don't see the button.
+  const canBookOneOnOne = !session?.user || session.user.role === 'STUDENT'
+
+  const handleBookClick = () => {
+    if (!session?.user) {
+      toast.info('Please log in as a student to book a session')
+      router.push(`/${locale}/login`)
+      return
+    }
+    setBookDialogOpen(true)
+  }
+
   const handleEnrollClick = (course: PublicTutorResponse['courses'][number]) => {
     if (!session?.user) {
       toast.info('Please log in to enroll')
@@ -1304,15 +1317,17 @@ export default function PublicTutorPage() {
                   />
                 )}
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                  <Button
-                    size="lg"
-                    variant="solocorn-book"
-                    className="w-full sm:w-auto"
-                    onClick={() => setBookDialogOpen(true)}
-                  >
-                    <CalendarDays className="mr-2 h-4 w-4" />
-                    Book 1-on-1
-                  </Button>
+                  {canBookOneOnOne && (
+                    <Button
+                      size="lg"
+                      variant="solocorn-book"
+                      className="w-full sm:w-auto"
+                      onClick={handleBookClick}
+                    >
+                      <CalendarDays className="mr-2 h-4 w-4" />
+                      Book 1-on-1
+                    </Button>
+                  )}
                   <Button
                     size="lg"
                     variant="solocorn-follow"


### PR DESCRIPTION
Fixes the "Book button not fetching" report — both the student flow (already patched by #928's `ENSURE_TABLES_SQL`) and, per follow-up, the **tutor** flow and the underlying migration pipeline.

## 1. Systemic: unfreeze the migration journal (`0069`–`0072`)

**Root cause (proven).** The drizzle journal was frozen at idx `68`, so the deploy's `migrate()` silently ignored `drizzle/0069`–`0072`. Their columns/tables never reached prod, and the booking routes 500 on them: `db.query.oneOnOneBookingRequest.findFirst/findMany` and `.insert().returning()` emit **every** schema column — including `0070`'s `rescheduleProposed*`. I reproduced this against Postgres with the real query builder:

| Query (real route code) | Correct schema | Prod pre-fix | After fix |
|---|---|---|---|
| Student status / existing-request check | ✅ | ❌ 500 | ✅ |
| Student create booking (`insert.returning`) | ✅ | ❌ 500 | ✅ |
| **Tutor** received-requests list | ✅ | ❌ 500 | ✅ |

So the tutor's dashboard (incoming requests) was broken by the same cause.

**Fix.** Register `0069`–`0072` in `drizzle/meta/_journal.json` so `migrate()` applies them.

**Verified the exact prod-upgrade path locally** (full schema pushed, `__drizzle_migrations` seeded at `0068`, the post-0068 objects dropped to mimic prod):
- `migrate()` applies **only** `0069`–`0072`, creates every object (4 reschedule cols, `Profile.bufferMinutes`, `OneOnOneReview`, `OneOnOneWaitlist`, all 5 FK constraints), and records them.
- Re-running `migrate()` is a clean **no-op** (idempotent — every `.sql` is `IF NOT EXISTS`).
- Composes safely with #928's `ENSURE_TABLES_SQL` (belt-and-suspenders; both idempotent, order-independent).

Also observed (pre-existing, **not** touched here): the chain fails when run *from scratch* against an empty DB (a legacy migration drops `TutorApplication` before it exists). Prod never runs from scratch — `__drizzle_migrations` sits at `0068` — so this is inert for the deploy. Flagging it as a known issue. Journal only; no snapshot files (runtime `migrate()` doesn't read them).

## 2. UX: hide "Book 1-on-1" for non-students

A tutor/parent/admin viewing a tutor page saw a Book button that could only 403 (`Only students can request…`). Now it's hidden for logged-in non-students, and logged-out visitors are routed to sign in (instead of the misleading "select a time slot" toast).

## Scope / safety
- No money-movement code.
- `tsc` clean, page lint-clean, prettier clean, journal JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)