### PR TITLE
fix(course-builder): auto-select new course + keep Schedule always active

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -778,8 +778,6 @@ function CourseBuilderInsightsRouteInner({
 
   // Search both lists regardless of saveMode so the selected course is always found
   const currentCourse = [...(courses || []), ...(draftCourses || [])].find(c => c.id === courseId)
-  const isCoursePublished = currentCourse?.isPublished === true
-  const isCourseVariant = currentCourse?.isVariant === true
   const originalSchedule = currentCourse?.schedule || []
 
   // Reschedule handlers
@@ -1191,13 +1189,10 @@ function CourseBuilderInsightsRouteInner({
             onCreateCourse={onCreateCourse}
             onEditCourse={courseId ? openEditCourse : undefined}
             canDelete={!!(courseId && courseId !== 'insights-draft' && onDeleteCourse)}
-            canSchedule={
-              !!(
-                courseId &&
-                courseId !== 'insights-draft' &&
-                (saveMode === 'draft' || (saveMode === 'live' && isCourseVariant))
-              )
-            }
+            // Schedule stays available for any real selected course, published
+            // or not — a draft materializes + schedules, a live course opens
+            // the reschedule dialog. (Was gated to drafts / live variants only.)
+            canSchedule={!!(courseId && courseId !== 'insights-draft')}
             canGoLive={
               !!(
                 courseId &&

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -458,6 +458,9 @@ function TutorInsightsPageInner() {
         ])
         setCourseId(newCourse.id)
         setDetachedCourseName(newCourse.name)
+        // Point the URL at the new course so the courseId<-URL sync effect keeps
+        // it selected instead of snapping back to the previous ?courseId= value.
+        router.replace(`/tutor/insights?tab=builder&courseId=${newCourse.id}`)
         setNewCourseName('')
         setNewCourseCategories([])
         setIsCreateDialogOpen(false)
@@ -494,6 +497,9 @@ function TutorInsightsPageInner() {
         setCourses(prev => [...prev, withCategories])
         setCourseId(createdCourse.id)
         setDetachedCourseName(createdCourse.name)
+        // Point the URL at the new course so the courseId<-URL sync effect keeps
+        // it selected instead of snapping back to the previous ?courseId= value.
+        router.replace(`/tutor/insights?tab=builder&courseId=${createdCourse.id}`)
         setNewCourseName('')
         setNewCourseCategories([])
         setIsCreateDialogOpen(false)
@@ -504,7 +510,7 @@ function TutorInsightsPageInner() {
     } catch {
       toast.error('Failed to create course')
     }
-  }, [newCourseName, newCourseCategories, saveMode])
+  }, [newCourseName, newCourseCategories, saveMode, router, draftStorageKey])
 
   // Persist an edited course name/categories from the control-panel Edit button.
   const handleUpdateCourse = useCallback(


### PR DESCRIPTION
Two builder issues reported after creating a course.

## 1. Newly created course wasn't selected
After creating, the header stayed on "Select course" and the tutor had to pick the new course manually. `handleCreateNewCourse` set `courseId` but **never updated the URL**. The `courseId ← URL` sync effect (`insights/page.tsx`) re-runs whenever `courses` changes and force-sets `courseId` back to the current `?courseId=` value — so adding the new course to the list immediately snapped the selection back to the previous/absent id.

**Fix:** point the URL at the new course id in both create branches (draft + DB), exactly as `executeSave` already does after a save. Now `courseIdFromQuery` equals the new id and the effect keeps it selected.

## 2. Schedule button inactive for published/live courses
`canSchedule` was gated to drafts or live **variants** only, so a published (or live non-variant) course couldn't be rescheduled, and a freshly created live course showed an inactive Schedule button.

**Fix:** relax `canSchedule` to `courseId && courseId !== 'insights-draft'` — always active for any real selected course. Routing is unchanged: a draft materializes + schedules (`handlePublishDraft`), a live course opens the reschedule dialog (`openRescheduleDialog`, which safely guards on `currentCourse`). Removed the now-unused `isCourseVariant`/`isCoursePublished`.

## Verification
0 eslint errors, tsc clean for both files, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)