### PR TITLE
fix(course-builder): stop Schedule from tripping the empty-save guard

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -725,16 +725,30 @@ function CourseBuilderInsightsRouteInner({
   const handlePublishDraft = async () => {
     if (!courseId || courseId === 'insights-draft') return
 
-    // 1. Trigger save to ensure latest data is persisted
-    const saveCb = (model.courseBuilderRef.current as any)?.saveAll
-    if (typeof saveCb === 'function') await saveCb()
-
-    // 2. Get current lessons from the builder ref
+    // 1. Read the current lesson tree FIRST. An empty tree is the signature of
+    //    an editor that hasn't finished hydrating — publishing it would trip the
+    //    server's floor guard on a course that already has lessons ("refusing to
+    //    delete all N lessons") or create an empty course. Bail before any save
+    //    so nothing is wiped: an already-persisted course is safe (its content
+    //    lives in the DB) so go straight to scheduling; an unmaterialized draft
+    //    just needs a moment to finish loading.
     const getLessonsCb = (model.courseBuilderRef.current as any)?.getLessons
     const rawLessons = typeof getLessonsCb === 'function' ? getLessonsCb() : []
-
-    // 3. Resolve active DMI versions
     const { lessons, hasMissingDmis } = resolveLessonDmis(rawLessons)
+
+    if (lessons.length === 0) {
+      const isLocalDraft = (draftCourses ?? []).some((c: any) => c.id === courseId)
+      if (isLocalDraft) {
+        toast.error('The course is still loading. Please wait a moment, then click Schedule again.')
+      } else {
+        model.router.push(`/tutor/courses/${courseId}`)
+      }
+      return
+    }
+
+    // 2. Persist the latest builder edits before publishing.
+    const saveCb = (model.courseBuilderRef.current as any)?.saveAll
+    if (typeof saveCb === 'function') await saveCb()
 
     if (hasMissingDmis) {
       if (


### PR DESCRIPTION
## Problem
Clicking **Schedule** produced: *"refusing to delete all 1 lesson(s) on an empty save — the editor may not have finished loading. Reload the course and try again."*

## Root cause
For `saveMode === 'draft'`, Schedule runs `handlePublishDraft`, which calls the builder's `saveAll()` then `getLessons()`. If the builder editor hasn't finished hydrating, `getLessons()` returns an **empty** tree, so the publish-save is sent with `lessons: []`. The server's floor guard (`course-builder.service.ts`) then refuses it, because wiping all lessons on an empty payload is the signature of a failed content-load. #931 (Schedule always active) made this path reachable in more states.

## Fix
Read the lesson tree **first** and bail on empty **before** any save:
- **Already-persisted course** → content is safe in the DB, so navigate straight to the scheduling page (`/tutor/courses/[id]`).
- **Unmaterialized local draft** → toast asking the tutor to wait for the editor to finish loading.

This never attempts the destructive empty publish, and `saveAll()` no longer runs against an unhydrated editor. The happy path (lessons present) is unchanged — it saves then publishes as before.

## Verification
0 eslint errors, tsc clean for the file, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)