### PR TITLE
fix(one-on-one): scope booking hot-path reads to core columns (drift defense-in-depth)

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/api/middleware'
 import { parseJson } from '@/lib/api/parse'
 import { requestedDateFromString } from '@/lib/one-on-one/time'
+import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -74,6 +75,7 @@ export const POST = withCsrf(
           eq(oneOnOneBookingRequest.status, 'ACCEPTED')
         )
       ),
+      columns: CORE_BOOKING_COLUMNS,
     })
 
     if (existingRequest) {
@@ -142,7 +144,7 @@ export const POST = withCsrf(
         createdAt: new Date(),
         updatedAt: new Date(),
       })
-      .returning()
+      .returning(CORE_BOOKING_RETURNING)
 
     // Send notification to tutor
     notify({
@@ -173,6 +175,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
   if (requestId) {
     const requestRow = await drizzleDb.query.oneOnOneBookingRequest.findFirst({
       where: eq(oneOnOneBookingRequest.requestId, requestId),
+      columns: CORE_BOOKING_COLUMNS,
     })
 
     if (!requestRow) throw new NotFoundError('Request not found')
@@ -208,6 +211,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     requests = await drizzleDb.query.oneOnOneBookingRequest.findMany({
       where: eq(oneOnOneBookingRequest.studentId, session.user.id),
       orderBy: (oneOnOneBookingRequest, { desc }) => [desc(oneOnOneBookingRequest.createdAt)],
+      columns: CORE_BOOKING_COLUMNS,
       with: {
         tutor: {
           columns: {
@@ -224,6 +228,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     requests = await drizzleDb.query.oneOnOneBookingRequest.findMany({
       where: eq(oneOnOneBookingRequest.tutorId, session.user.id),
       orderBy: (oneOnOneBookingRequest, { desc }) => [desc(oneOnOneBookingRequest.createdAt)],
+      columns: CORE_BOOKING_COLUMNS,
       with: {
         student: {
           columns: {

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -14,6 +14,7 @@ import {
   studentHasAvailabilityConfigured,
 } from '@/lib/student-availability'
 import { slotInstants } from '@/lib/one-on-one/time'
+import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
 
 const respondSchema = z.object({
   requestId: z.string().min(1),
@@ -49,6 +50,7 @@ export async function PATCH(request: NextRequest) {
         eq(oneOnOneBookingRequest.requestId, validated.requestId),
         eq(oneOnOneBookingRequest.tutorId, session.user.id)
       ),
+      columns: CORE_BOOKING_COLUMNS,
     })
 
     if (!existingRequest) {
@@ -186,7 +188,7 @@ export async function PATCH(request: NextRequest) {
             updatedAt: new Date(),
           })
           .where(eq(oneOnOneBookingRequest.requestId, validated.requestId))
-          .returning()
+          .returning(CORE_BOOKING_RETURNING)
 
         return { updatedRequest, newEvent }
       })
@@ -217,7 +219,7 @@ export async function PATCH(request: NextRequest) {
           updatedAt: new Date(),
         })
         .where(eq(oneOnOneBookingRequest.requestId, validated.requestId))
-        .returning()
+        .returning(CORE_BOOKING_RETURNING)
 
       // Send notification to student that request was rejected
       notify({

--- a/tutorme-app/src/app/api/one-on-one/status/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/status/route.ts
@@ -3,6 +3,7 @@ import { getServerSession, authOptions } from '@/lib/auth'
 import { eq, and, or } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, profile } from '@/lib/db/schema'
+import { CORE_BOOKING_COLUMNS } from '@/lib/one-on-one/columns'
 
 // Check if there's an active request between student and tutor
 export async function GET(request: NextRequest) {
@@ -37,6 +38,7 @@ export async function GET(request: NextRequest) {
           eq(oneOnOneBookingRequest.status, 'PAID')
         )
       ),
+      columns: CORE_BOOKING_COLUMNS,
       with: {
         tutor: {
           columns: {

--- a/tutorme-app/src/lib/one-on-one/columns.ts
+++ b/tutorme-app/src/lib/one-on-one/columns.ts
@@ -1,0 +1,70 @@
+/**
+ * Defense-in-depth column projections for the 1-on-1 booking hot paths.
+ *
+ * The booking routes read a request via `db.query...findFirst`/`.returning()`,
+ * which otherwise select EVERY mapped column. If any column is absent from the
+ * database (schema drift — e.g. a migration that never reached prod), Postgres
+ * throws "column does not exist" and the whole endpoint 500s. That is exactly
+ * how the booking flow broke when the `rescheduleProposed*` columns (0070) were
+ * missing in prod.
+ *
+ * Scoping the hot-path reads to only the STABLE columns they actually use makes
+ * them immune to drift in unrelated (e.g. newly-added) columns. `tsc` guarantees
+ * we never drop a column a route depends on: referencing an unselected field is
+ * a compile error. The reschedule route is intentionally NOT scoped — it needs
+ * the reschedule columns.
+ */
+
+import { oneOnOneBookingRequest } from '@/lib/db/schema'
+
+/** For relational queries: `db.query.oneOnOneBookingRequest.findFirst({ columns: CORE_BOOKING_COLUMNS })`. */
+export const CORE_BOOKING_COLUMNS = {
+  requestId: true,
+  tutorId: true,
+  studentId: true,
+  requestedDate: true,
+  startTime: true,
+  endTime: true,
+  timezone: true,
+  durationMinutes: true,
+  costPerSession: true,
+  status: true,
+  tutorResponseAt: true,
+  tutorNotes: true,
+  paymentDueAt: true,
+  paidAt: true,
+  calendarEventId: true,
+  createdAt: true,
+  updatedAt: true,
+} as const
+
+/**
+ * For UPDATE/INSERT: `.returning(CORE_BOOKING_RETURNING)`.
+ *
+ * Note the asymmetry: an UPDATE only names the columns in its `.set()`, so
+ * `.returning(CORE_BOOKING_RETURNING)` makes the whole statement drift-safe. An
+ * INSERT, however, always lists EVERY table column (Drizzle fills unset ones with
+ * `default`), so a missing column still breaks the insert regardless of the
+ * returning projection — the create path relies on the schema actually being
+ * present (guaranteed by the journal fix + ENSURE_TABLES_SQL). We still scope the
+ * returning so the API response shape matches the reads.
+ */
+export const CORE_BOOKING_RETURNING = {
+  requestId: oneOnOneBookingRequest.requestId,
+  tutorId: oneOnOneBookingRequest.tutorId,
+  studentId: oneOnOneBookingRequest.studentId,
+  requestedDate: oneOnOneBookingRequest.requestedDate,
+  startTime: oneOnOneBookingRequest.startTime,
+  endTime: oneOnOneBookingRequest.endTime,
+  timezone: oneOnOneBookingRequest.timezone,
+  durationMinutes: oneOnOneBookingRequest.durationMinutes,
+  costPerSession: oneOnOneBookingRequest.costPerSession,
+  status: oneOnOneBookingRequest.status,
+  tutorResponseAt: oneOnOneBookingRequest.tutorResponseAt,
+  tutorNotes: oneOnOneBookingRequest.tutorNotes,
+  paymentDueAt: oneOnOneBookingRequest.paymentDueAt,
+  paidAt: oneOnOneBookingRequest.paidAt,
+  calendarEventId: oneOnOneBookingRequest.calendarEventId,
+  createdAt: oneOnOneBookingRequest.createdAt,
+  updatedAt: oneOnOneBookingRequest.updatedAt,
+} as const


### PR DESCRIPTION
Defense-in-depth so schema drift can't silently 500 the booking flow again (the "Book not fetching" class of bug).

## Why
The booking routes read via `db.query.oneOnOneBookingRequest.findFirst/findMany`, which select **every** mapped column. If one column is missing from the DB (a migration that never reached prod — exactly `0070`'s `rescheduleProposed*`), Postgres throws `column does not exist` and the endpoint 500s.

## What
Scope the booking-critical **reads** to `CORE_BOOKING_COLUMNS` — the stable columns, excluding the drift-prone reschedule fields (only the reschedule route needs those). `tsc` guarantees I never drop a column a route uses (referencing an unselected field is a compile error).

Scoped: `status` (findFirst), `request` (existing-check findFirst, single findFirst, both list findMany), `respond` (findFirst + both UPDATE `.returning()`).

## Proof
Ran the hardened queries against Postgres **with the reschedule columns dropped**:
- `findFirst` (status/existing-check) → ✅ OK (previously 500)
- `findMany` (tutor received list) → ✅ OK (previously 500)

The dialog-open read path — where "not fetching" surfaced — is now drift-resilient.

## Honest limitation (documented in `columns.ts`)
An **INSERT** always lists every table column (Drizzle fills unset ones with `default`), so `.returning()` scoping can't make the create path drift-proof — it still relies on the schema being present, which #930 (journal) + #928 (`ENSURE_TABLES_SQL`) now guarantee. An **UPDATE** `.returning()` *is* drift-safe (it only names its `.set()` columns), so those are fully hardened. No client reads the reschedule fields off these endpoints, so response shapes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)