### PR TITLE
feat(1-on-1): free session option — test the whole flow without a payment gateway

### DIFF
--- a/tutorme-app/drizzle/0074_profile_one_on_one_free.sql
+++ b/tutorme-app/drizzle/0074_profile_one_on_one_free.sql
@@ -1,0 +1,3 @@
+-- Tutors can offer 1-on-1 sessions for free: booking skips payment and an
+-- accepted request is confirmed immediately.
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "oneOnOneFree" boolean NOT NULL DEFAULT false;

--- a/tutorme-app/drizzle/meta/_journal.json
+++ b/tutorme-app/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1781900000072,
       "tag": "0072_one_on_one_waitlist",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1781900000074,
+      "tag": "0074_profile_one_on_one_free",
+      "breakpoints": true
     }
   ]
 }

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -97,6 +97,7 @@ interface BillingRecord {
 function OneOnOneSettingsCard() {
   const [settings, setSettings] = useState({
     oneOnOneEnabled: true,
+    oneOnOneFree: false,
     hourlyRate: 50,
     sessionDuration: 60,
     bufferMinutes: 0,
@@ -117,6 +118,7 @@ function OneOnOneSettingsCard() {
         const data = await res.json()
         setSettings({
           oneOnOneEnabled: data.oneOnOneEnabled ?? true,
+          oneOnOneFree: data.oneOnOneFree ?? false,
           hourlyRate: data.hourlyRate ?? 50,
           sessionDuration: data.sessionDuration ?? 60,
           bufferMinutes: data.bufferMinutes ?? 0,
@@ -138,6 +140,7 @@ function OneOnOneSettingsCard() {
         credentials: 'include',
         body: JSON.stringify({
           oneOnOneEnabled: settings.oneOnOneEnabled,
+          oneOnOneFree: settings.oneOnOneFree,
           hourlyRate: settings.hourlyRate,
           bufferMinutes: settings.bufferMinutes,
         }),
@@ -197,37 +200,57 @@ function OneOnOneSettingsCard() {
           <>
             <Separator />
 
-            {/* Hourly Rate */}
-            <div className="space-y-2">
-              <Label htmlFor="hourlyRate">Hourly Rate (USD)</Label>
-              <div className="flex items-center justify-start gap-2">
-                <span className="text-lg text-gray-500">$</span>
-                <Input
-                  id="hourlyRate"
-                  type="number"
-                  min={1}
-                  max={1000}
-                  value={settings.hourlyRate}
-                  onChange={e =>
-                    setSettings(prev => ({
-                      ...prev,
-                      hourlyRate: parseInt(e.target.value) || 0,
-                    }))
-                  }
-                  className="w-32"
-                />
-                <span className="whitespace-nowrap text-sm text-gray-500">per hour</span>
+            {/* Free sessions toggle */}
+            <div className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm">
+              <div>
+                <p className="font-medium">Offer sessions for free</p>
+                <p className="text-sm text-gray-500">
+                  Skip payment entirely — an accepted request is confirmed instantly. Handy for free
+                  intro sessions or testing the booking flow end-to-end.
+                </p>
               </div>
-              <p className="text-xs text-gray-500">
-                Students will see this rate when booking a session
-              </p>
-              {(!settings.hourlyRate || settings.hourlyRate <= 0) && (
-                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-                  <span className="font-medium">⚠️ Rate Required:</span> You must set an hourly rate
-                  above $0 for students to be able to book one-on-one sessions with you.
-                </div>
-              )}
+              <Switch
+                checked={settings.oneOnOneFree}
+                onCheckedChange={checked =>
+                  setSettings(prev => ({ ...prev, oneOnOneFree: checked }))
+                }
+              />
             </div>
+
+            {/* Hourly Rate — only relevant for paid sessions */}
+            {!settings.oneOnOneFree && (
+              <div className="space-y-2">
+                <Label htmlFor="hourlyRate">Hourly Rate (USD)</Label>
+                <div className="flex items-center justify-start gap-2">
+                  <span className="text-lg text-gray-500">$</span>
+                  <Input
+                    id="hourlyRate"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={settings.hourlyRate}
+                    onChange={e =>
+                      setSettings(prev => ({
+                        ...prev,
+                        hourlyRate: parseInt(e.target.value) || 0,
+                      }))
+                    }
+                    className="w-32"
+                  />
+                  <span className="whitespace-nowrap text-sm text-gray-500">per hour</span>
+                </div>
+                <p className="text-xs text-gray-500">
+                  Students will see this rate when booking a session
+                </p>
+                {(!settings.hourlyRate || settings.hourlyRate <= 0) && (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                    <span className="font-medium">⚠️ Rate Required:</span> You must set an hourly
+                    rate above $0 (or turn on “Offer sessions for free”) for students to be able to
+                    book one-on-one sessions with you.
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Session Duration */}
             <div className="space-y-2">

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -50,6 +50,7 @@ export const POST = withCsrf(
       columns: {
         hourlyRate: true,
         oneOnOneEnabled: true,
+        oneOnOneFree: true,
         currency: true,
         timezone: true,
       },
@@ -61,7 +62,8 @@ export const POST = withCsrf(
       throw new ValidationError('Tutor does not offer one-on-one sessions')
     }
 
-    if (!tutorProfile.hourlyRate || tutorProfile.hourlyRate <= 0) {
+    // Free tutors need no rate; paid tutors must have one set.
+    if (!tutorProfile.oneOnOneFree && (!tutorProfile.hourlyRate || tutorProfile.hourlyRate <= 0)) {
       throw new ValidationError('Tutor has not set an hourly rate yet. Please check back later.')
     }
 
@@ -117,7 +119,9 @@ export const POST = withCsrf(
     // Store remaining slots in tutorNotes as JSON
     const [primarySlot, ...additionalSlots] = validated.proposedSlots
     const durationHours = validated.duration / 60
-    const costPerSession = Math.round(tutorProfile.hourlyRate * durationHours * 100) / 100
+    const costPerSession = tutorProfile.oneOnOneFree
+      ? 0
+      : Math.round((tutorProfile.hourlyRate ?? 0) * durationHours * 100) / 100
 
     // Store the calendar date as midnight-UTC so it round-trips regardless of
     // the server's own timezone (wall-clock times live in `timezone` below).

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/student-availability'
 import { slotInstants } from '@/lib/one-on-one/time'
 import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
+import { getOrCreateConversation } from '@/lib/messaging/conversation'
 
 const respondSchema = z.object({
   requestId: z.string().min(1),
@@ -116,10 +117,13 @@ export async function PATCH(request: NextRequest) {
       // CHECK FOR CONFLICTS using unified conflict detector, expanded by the
       // tutor's configured buffer so bookings can't be scheduled too close.
       const [tutorProfileRow] = await drizzleDb
-        .select({ bufferMinutes: profile.bufferMinutes })
+        .select({ bufferMinutes: profile.bufferMinutes, oneOnOneFree: profile.oneOnOneFree })
         .from(profile)
         .where(eq(profile.userId, session.user.id))
         .limit(1)
+      // Free sessions (or a zero-cost request) skip payment: accepting confirms
+      // the booking immediately instead of opening a payment window.
+      const isFree = !!tutorProfileRow?.oneOnOneFree || (existingRequest.costPerSession ?? 0) <= 0
       const conflicts = await findConflicts(session.user.id, eventStart, eventEnd, {
         excludeOneOnOneId: validated.requestId,
         bufferMinutes: tutorProfileRow?.bufferMinutes ?? 0,
@@ -179,11 +183,13 @@ export async function PATCH(request: NextRequest) {
         const [updatedRequest] = await tx
           .update(oneOnOneBookingRequest)
           .set({
-            status: 'ACCEPTED',
+            // Free bookings are confirmed on accept (no payment step); paid ones
+            // wait in ACCEPTED until the student pays within the 48h window.
+            status: isFree ? 'PAID' : 'ACCEPTED',
+            paidAt: isFree ? new Date() : undefined,
             tutorNotes: validated.tutorNotes || existingRequest.tutorNotes,
             tutorResponseAt: new Date(),
-            // Payment window: the student has 48h to pay before the hold lapses.
-            paymentDueAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+            paymentDueAt: isFree ? null : new Date(Date.now() + 48 * 60 * 60 * 1000),
             calendarEventId: newEvent.eventId,
             updatedAt: new Date(),
           })
@@ -193,15 +199,29 @@ export async function PATCH(request: NextRequest) {
         return { updatedRequest, newEvent }
       })
 
-      // Send notification to student that request was accepted
-      notify({
-        userId: existingRequest.studentId,
-        type: 'class',
-        title: '1-on-1 Request Accepted!',
-        message: `Your tutor has accepted your 1-on-1 session request. Please complete payment to confirm your booking.`,
-        data: { requestId: txResult.updatedRequest.requestId, type: 'one-on-one-accepted' },
-        actionUrl: `/payment?requestId=${txResult.updatedRequest.requestId}`,
-      }).catch(console.error)
+      if (isFree) {
+        // Free booking: confirmed immediately — mirror the paid webhook's side
+        // effects (open the student↔tutor chat) and skip the payment prompt.
+        getOrCreateConversation(existingRequest.studentId, existingRequest.tutorId).catch(() => {})
+        notify({
+          userId: existingRequest.studentId,
+          type: 'class',
+          title: '1-on-1 Confirmed!',
+          message: `Your tutor accepted your free 1-on-1 session — you're all set. It's on your schedule.`,
+          data: { requestId: txResult.updatedRequest.requestId, type: 'one-on-one-confirmed' },
+          actionUrl: '/student/dashboard',
+        }).catch(console.error)
+      } else {
+        // Paid booking: prompt the student to complete payment.
+        notify({
+          userId: existingRequest.studentId,
+          type: 'class',
+          title: '1-on-1 Request Accepted!',
+          message: `Your tutor has accepted your 1-on-1 session request. Please complete payment to confirm your booking.`,
+          data: { requestId: txResult.updatedRequest.requestId, type: 'one-on-one-accepted' },
+          actionUrl: `/payment?requestId=${txResult.updatedRequest.requestId}`,
+        }).catch(console.error)
+      }
 
       return NextResponse.json({
         success: true,

--- a/tutorme-app/src/app/api/one-on-one/settings/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/settings/route.ts
@@ -31,6 +31,7 @@ export async function GET(req: NextRequest) {
         profileId: profile.profileId,
         hourlyRate: profile.hourlyRate,
         oneOnOneEnabled: profile.oneOnOneEnabled,
+        oneOnOneFree: profile.oneOnOneFree,
         bufferMinutes: profile.bufferMinutes,
       })
       .from(profile)
@@ -44,6 +45,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({
       hourlyRate: tutorProfile[0].hourlyRate || 50, // Default $50/hour
       oneOnOneEnabled: tutorProfile[0].oneOnOneEnabled ?? true,
+      oneOnOneFree: tutorProfile[0].oneOnOneFree ?? false,
       sessionDuration: 60, // Default 1 hour
       bufferMinutes: tutorProfile[0].bufferMinutes ?? 0, // gap around bookings
     })
@@ -62,7 +64,7 @@ export async function PATCH(req: NextRequest) {
     }
 
     const body = await req.json()
-    const { hourlyRate, oneOnOneEnabled, bufferMinutes } = body
+    const { hourlyRate, oneOnOneEnabled, oneOnOneFree, bufferMinutes } = body
     const tutorId = session.user.id
 
     // Clamp the buffer to a sane 0–120 minute range when provided.
@@ -77,6 +79,7 @@ export async function PATCH(req: NextRequest) {
       .set({
         hourlyRate: hourlyRate !== undefined ? hourlyRate : undefined,
         oneOnOneEnabled: oneOnOneEnabled !== undefined ? oneOnOneEnabled : undefined,
+        oneOnOneFree: oneOnOneFree !== undefined ? !!oneOnOneFree : undefined,
         bufferMinutes: buffer,
         updatedAt: new Date(),
       })

--- a/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
@@ -264,12 +264,15 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
       currentDate = new Date(currentDate.getTime() + 24 * 60 * 60 * 1000)
     }
 
+    const isFree = !!tutorProfile.oneOnOneFree
     const hasHourlyRate = typeof tutorProfile.hourlyRate === 'number' && tutorProfile.hourlyRate > 0
 
     return NextResponse.json({
       available: true,
-      hourlyRate: hasHourlyRate ? tutorProfile.hourlyRate : 0,
-      pricingIncomplete: !hasHourlyRate,
+      free: isFree,
+      // Free sessions cost 0 and are never "pricing incomplete".
+      hourlyRate: isFree ? 0 : hasHourlyRate ? tutorProfile.hourlyRate : 0,
+      pricingIncomplete: !isFree && !hasHourlyRate,
       currency: tutorProfile.currency || 'USD',
       timezone: tutorProfile.timezone || 'UTC',
       slots,

--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -81,6 +81,7 @@ interface TimeSlot {
 interface AvailabilityData {
   available: boolean
   hourlyRate: number
+  free?: boolean
   pricingIncomplete?: boolean
   reason?: string
   currency: string
@@ -566,7 +567,9 @@ export function CalendarBookingDialog({
                 <DialogPanel className="flex items-center gap-2">
                   <DollarSign className="h-5 w-5 text-blue-600" />
                   <span className="font-medium text-gray-900">
-                    {availability?.currency} {availability?.hourlyRate} per session (1 hour)
+                    {availability?.free
+                      ? 'Free session — no payment needed'
+                      : `${availability?.currency} ${availability?.hourlyRate} per session (1 hour)`}
                   </span>
                 </DialogPanel>
               </div>
@@ -875,8 +878,9 @@ export function CalendarBookingDialog({
                           Price
                         </span>
                         <span className="text-sm font-semibold">
-                          {availability?.currency}{' '}
-                          {(availability?.hourlyRate ?? 0) * summaryData.sessionCount}
+                          {availability?.free
+                            ? 'Free'
+                            : `${availability?.currency} ${(availability?.hourlyRate ?? 0) * summaryData.sessionCount}`}
                         </span>
                       </div>
                     </div>

--- a/tutorme-app/src/lib/db/schema/tables/auth.ts
+++ b/tutorme-app/src/lib/db/schema/tables/auth.ts
@@ -90,6 +90,9 @@ export const profile = pgTable(
     isOnboarded: boolean('isOnboarded').notNull().default(false),
     hourlyRate: doublePrecision('hourlyRate'),
     oneOnOneEnabled: boolean('oneOnOneEnabled'),
+    // When true, 1-on-1 sessions are offered free: booking skips payment and a
+    // tutor-accepted request is confirmed immediately (no gateway needed).
+    oneOnOneFree: boolean('oneOnOneFree').notNull().default(false),
     // Minutes of gap the tutor wants around 1-on-1 bookings, enforced in
     // conflict detection so back-to-back sessions can't be double-booked.
     bufferMinutes: integer('bufferMinutes'),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -274,6 +274,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutor_student_key"
   ON "OneOnOneWaitlist" ("tutorId", "studentId");
 CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_tutorId_idx" ON "OneOnOneWaitlist" ("tutorId");
 CREATE INDEX IF NOT EXISTS "OneOnOneWaitlist_studentId_idx" ON "OneOnOneWaitlist" ("studentId");
+
+-- 0074: tutors can offer 1-on-1 sessions for free (booking skips payment).
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "oneOnOneFree" boolean NOT NULL DEFAULT false;
 `)
 
 export async function applyStartupSchemaFixes(): Promise<void> {


### PR DESCRIPTION
Adds a **"Offer sessions for free"** toggle to the tutor's 1-on-1 settings. When on, the booking flow skips payment entirely: a tutor-accepted request is **confirmed immediately** — so the full request → accept → confirmed → join → reschedule → review → cancel flow can be exercised end-to-end with no Airwallex/HitPay bank setup.

## Changes
- **Schema**: `Profile.oneOnOneFree` boolean (default false). Migration `0074` + registered in the drizzle journal (now that #930 unfroze it) + mirrored into `ENSURE_TABLES_SQL`. Verified valid + idempotent against Postgres.
- **Settings** (`/api/one-on-one/settings` + tutor settings UI): new toggle; when free, the hourly-rate field and the "rate required" warning are hidden.
- **Availability API**: returns `free: true`, `hourlyRate: 0`, and `pricingIncomplete: false` when free — so the booking dialog isn't blocked on "pricing not set".
- **Request API**: a free tutor needs no rate; `costPerSession` is `0`.
- **Respond API (accept)**: when free, the request goes straight to **PAID** (`paidAt` set, no `paymentDueAt`) and the side-effects that normally fire on payment run here instead — the student↔tutor chat opens and the student is notified "Confirmed!" rather than "please pay".
- **Booking dialog**: shows "Free session — no payment needed" / "Free" instead of a price.

## How to test
1. Tutor settings → 1-on-1 Booking → turn on **Offer sessions for free** → Save.
2. As a student, book that tutor — the dialog shows **Free**, no payment step.
3. Tutor accepts → booking is immediately confirmed (status PAID), chat opens, it's on both schedules.
4. Exercise join / reschedule / review / cancel as normal.

## Notes
- Rebased onto #933 — the hardened `respond` queries (`columns`/`.returning()` scoping) and this free logic coexist; `paidAt`/`costPerSession` are in the core column set.
- Paid flow is untouched: a tutor without the toggle behaves exactly as before.
- No gateway code touched — this is purely a payment-skip path, so it's safe to merge without the bank account (and is what lets you verify everything else, including #927 group sessions later, conceptually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)