### PR TITLE
feat(1-on-1): student can cancel a booking; open chat thread on booking

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/app/[locale]/tutor/dashboard/components/InteractiveCalendar'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { Badge } from '@/components/ui/badge'
-import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2, Star } from 'lucide-react'
+import { CalendarDays, Clock, BookOpen, MapPin, Video, Users, Loader2, Star, X } from 'lucide-react'
+import { toast } from 'sonner'
 import { OneOnOneReviewDialog } from '@/components/booking/one-on-one-review-dialog'
 import { OneOnOneRescheduleDialog } from '@/components/booking/one-on-one-reschedule-dialog'
 import { cn } from '@/lib/utils'
@@ -106,6 +107,8 @@ export function DashboardCalendar({
   const [loading, setLoading] = useState(!initialEvents?.length)
   const [reviewRequestId, setReviewRequestId] = useState<string | null>(null)
   const [rescheduleRequestId, setRescheduleRequestId] = useState<string | null>(null)
+  const [cancellingId, setCancellingId] = useState<string | null>(null)
+  const [refreshTick, setRefreshTick] = useState(0)
   const monthStart = useMemo(() => new Date(month.getFullYear(), month.getMonth(), 1), [month])
   const monthEnd = useMemo(
     () => new Date(month.getFullYear(), month.getMonth() + 1, 0, 23, 59, 59),
@@ -137,7 +140,41 @@ export function DashboardCalendar({
     return () => {
       cancelled = true
     }
-  }, [monthStart, monthEnd, onRefresh])
+  }, [monthStart, monthEnd, onRefresh, refreshTick])
+
+  const handleCancelBooking = async (requestId: string) => {
+    if (
+      !window.confirm(
+        'Cancel this 1-on-1 booking? If you already paid, a refund (minus the 15% fee) is issued automatically.'
+      )
+    ) {
+      return
+    }
+    setCancellingId(requestId)
+    try {
+      const res = await fetch('/api/one-on-one/cancel', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok) {
+        toast.success(
+          data.refunded
+            ? `Booking cancelled — ${data.refundAmount} refunded (15% fee applied).`
+            : 'Booking cancelled.'
+        )
+        setRefreshTick(t => t + 1)
+      } else {
+        toast.error(data.error || 'Could not cancel the booking')
+      }
+    } catch {
+      toast.error('Could not cancel the booking')
+    } finally {
+      setCancellingId(null)
+    }
+  }
 
   // Derive classes list from calendar events for the Sessions tab.
   // Exclude completed/ended sessions and sort chronologically so the next session is on top.
@@ -294,14 +331,29 @@ export function DashboardCalendar({
                             {s.type === 'one-on-one' &&
                               s.requestId &&
                               new Date(s.end).getTime() >= Date.now() && (
-                                <button
-                                  type="button"
-                                  onClick={() => setRescheduleRequestId(s.requestId ?? null)}
-                                  className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50"
-                                >
-                                  <CalendarDays className="h-3.5 w-3.5" />
-                                  Reschedule
-                                </button>
+                                <>
+                                  <button
+                                    type="button"
+                                    onClick={() => setRescheduleRequestId(s.requestId ?? null)}
+                                    className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50"
+                                  >
+                                    <CalendarDays className="h-3.5 w-3.5" />
+                                    Reschedule
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleCancelBooking(s.requestId as string)}
+                                    disabled={cancellingId === s.requestId}
+                                    className="inline-flex items-center gap-1 rounded-lg border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-600 hover:bg-red-50 disabled:opacity-60"
+                                  >
+                                    {cancellingId === s.requestId ? (
+                                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    ) : (
+                                      <X className="h-3.5 w-3.5" />
+                                    )}
+                                    Cancel
+                                  </button>
+                                </>
                               )}
                             {s.type === 'one-on-one' &&
                             s.requestId &&

--- a/tutorme-app/src/app/api/one-on-one/cancel/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/cancel/route.ts
@@ -52,7 +52,9 @@ export async function PATCH(request: NextRequest) {
         { status: 400 }
       )
     }
-    const wasPaid = existingRequest.status === 'PAID'
+    // Only a genuinely paid booking (positive cost) triggers a refund. Free
+    // sessions are PAID with a 0 cost and have no payment to refund.
+    const wasPaid = existingRequest.status === 'PAID' && (existingRequest.costPerSession ?? 0) > 0
 
     // If there's a calendar event, mark it as cancelled and end the linked live session
     if (existingRequest.calendarEventId) {

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -15,6 +15,7 @@ import {
 import { parseJson } from '@/lib/api/parse'
 import { requestedDateFromString } from '@/lib/one-on-one/time'
 import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
+import { getOrCreateConversation } from '@/lib/messaging/conversation'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -149,6 +150,11 @@ export const POST = withCsrf(
         updatedAt: new Date(),
       })
       .returning(CORE_BOOKING_RETURNING)
+
+    // Open the student↔tutor direct-message thread on booking, so each appears
+    // in the other's chat contact list right away (idempotent — re-accept/pay
+    // just reuse this thread).
+    getOrCreateConversation(session.user.id, validated.tutorId).catch(() => {})
 
     // Send notification to tutor
     notify({

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -199,10 +199,13 @@ export async function PATCH(request: NextRequest) {
         return { updatedRequest, newEvent }
       })
 
+      // Open the student↔tutor direct-message thread as soon as the booking is
+      // accepted, so each shows up in the other's chat contact list right away
+      // (for a paid booking the payment webhook also ensures this).
+      getOrCreateConversation(existingRequest.studentId, existingRequest.tutorId).catch(() => {})
+
       if (isFree) {
-        // Free booking: confirmed immediately — mirror the paid webhook's side
-        // effects (open the student↔tutor chat) and skip the payment prompt.
-        getOrCreateConversation(existingRequest.studentId, existingRequest.tutorId).catch(() => {})
+        // Free booking: confirmed immediately — skip the payment prompt.
         notify({
           userId: existingRequest.studentId,
           type: 'class',

--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -120,6 +120,7 @@ export function CalendarBookingDialog({
   const [activeRequest, setActiveRequest] = useState<{ id: string; status: string } | null>(null)
   const [onWaitlist, setOnWaitlist] = useState(false)
   const [waitlistBusy, setWaitlistBusy] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
 
   // Recurring booking: how many weeks to repeat the selected slot
   const [recurringWeeks, setRecurringWeeks] = useState(1)
@@ -209,6 +210,43 @@ export function CalendarBookingDialog({
       toast.error('Could not update the waitlist')
     } finally {
       setWaitlistBusy(false)
+    }
+  }
+
+  const handleCancelRequest = async () => {
+    if (!activeRequest?.id) return
+    if (
+      !window.confirm(
+        'Cancel this 1-on-1 booking? If you already paid, a refund (minus the 15% fee) is issued automatically.'
+      )
+    ) {
+      return
+    }
+    setCancelling(true)
+    try {
+      const res = await fetch('/api/one-on-one/cancel', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId: activeRequest.id }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok) {
+        toast.success(
+          data.refunded
+            ? `Booking cancelled — ${data.refundAmount} refunded (15% fee applied).`
+            : 'Booking cancelled.'
+        )
+        setHasPendingRequest(false)
+        setActiveRequest(null)
+        onOpenChange(false)
+      } else {
+        toast.error(data.error || 'Could not cancel the booking')
+      }
+    } catch {
+      toast.error('Could not cancel the booking')
+    } finally {
+      setCancelling(false)
     }
   }
 
@@ -519,6 +557,15 @@ export function CalendarBookingDialog({
                 Complete Payment
               </Button>
             )}
+            <Button
+              variant="modal-secondary-dark"
+              onClick={handleCancelRequest}
+              disabled={cancelling}
+              className="h-10 border-red-300 text-red-600 hover:bg-red-50"
+            >
+              {cancelling ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Cancel booking
+            </Button>
             <Button
               variant="modal-secondary-dark"
               onClick={() => onOpenChange(false)}


### PR DESCRIPTION
Fixes two gaps in the 1-on-1 flow.

## 1. Students couldn't cancel a booking
There was a working cancel API (`PATCH /api/one-on-one/cancel`) but no UI reaching it. Added a **Cancel** action in the two places a student manages a booking:
- **Student dashboard → Bookings**: a Cancel button on each upcoming 1-on-1 (confirms, calls the API, refreshes the list).
- **Booking dialog's pending/accepted view**: a "Cancel booking" button, so a request can be withdrawn before it's even confirmed.

Also fixed the cancel route so a **free** booking (PAID with 0 cost, no payment row) doesn't trip the "refund failed — refund manually" notification — refunds only run when there's a positive cost.

## 2. Tutor/student didn't appear in each other's chat contacts after booking
The student↔tutor conversation was only opened on **payment completion**, so with no payment (or before paying) neither showed up in Communications. Now `getOrCreateConversation` fires when the **request is created** and again on **accept** (idempotent), so each appears in the other's contact list as soon as a booking exists — no payment needed.

**Verified against Postgres**: `getOrCreateConversation` is idempotent (same thread across repeat/reversed calls) and both the student and the tutor resolve to the same single conversation (the contact list is driven by `/api/conversations` on `participant1Id`/`participant2Id`).

## Scope
UI + wiring only; no gateway/money-movement code. Pairs naturally with the free-session option (#934) for full no-payment testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)