### PR TITLE
fix(course-builder): let Schedule materialize an empty/unhydrated draft

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -725,30 +725,43 @@ function CourseBuilderInsightsRouteInner({
   const handlePublishDraft = async () => {
     if (!courseId || courseId === 'insights-draft') return
 
-    // 1. Read the current lesson tree FIRST. An empty tree is the signature of
-    //    an editor that hasn't finished hydrating — publishing it would trip the
-    //    server's floor guard on a course that already has lessons ("refusing to
-    //    delete all N lessons") or create an empty course. Bail before any save
-    //    so nothing is wiped: an already-persisted course is safe (its content
-    //    lives in the DB) so go straight to scheduling; an unmaterialized draft
-    //    just needs a moment to finish loading.
+    // 1. Read the editor's current tree. If it hasn't hydrated it can come back
+    //    empty — fall back to the draft's persisted builder content so we never
+    //    publish an empty tree over real draft lessons.
     const getLessonsCb = (model.courseBuilderRef.current as any)?.getLessons
-    const rawLessons = typeof getLessonsCb === 'function' ? getLessonsCb() : []
+    const editorLessons = typeof getLessonsCb === 'function' ? getLessonsCb() : []
+    let rawLessons = editorLessons
+    if ((!Array.isArray(rawLessons) || rawLessons.length === 0) && typeof window !== 'undefined') {
+      try {
+        const stored = window.localStorage.getItem(`insights-course-builder:${courseId}`)
+        const parsed = stored ? JSON.parse(stored) : null
+        if (Array.isArray(parsed?.lessons) && parsed.lessons.length > 0) {
+          rawLessons = parsed.lessons
+        }
+      } catch {
+        // ignore a malformed draft cache
+      }
+    }
     const { lessons, hasMissingDmis } = resolveLessonDmis(rawLessons)
 
-    if (lessons.length === 0) {
-      const isLocalDraft = (draftCourses ?? []).some((c: any) => c.id === courseId)
-      if (isLocalDraft) {
-        toast.error('The course is still loading. Please wait a moment, then click Schedule again.')
-      } else {
-        model.router.push(`/tutor/courses/${courseId}`)
-      }
+    const isLocalDraft = (draftCourses ?? []).some((c: any) => c.id === courseId)
+
+    // An empty tree on a course that already exists in the DB means the editor
+    // never loaded — its content is safe there, so just open scheduling instead
+    // of a destructive empty publish. A local draft with no lessons still
+    // materializes fine: saveCourse keeps the default lesson created on POST.
+    if (lessons.length === 0 && !isLocalDraft) {
+      model.router.push(`/tutor/courses/${courseId}`)
       return
     }
 
-    // 2. Persist the latest builder edits before publishing.
-    const saveCb = (model.courseBuilderRef.current as any)?.saveAll
-    if (typeof saveCb === 'function') await saveCb()
+    // 2. Persist the latest editor edits before publishing — but only if the
+    //    editor actually had content, so an unhydrated (empty) editor can't
+    //    clobber the draft's stored lessons.
+    if (editorLessons.length > 0) {
+      const saveCb = (model.courseBuilderRef.current as any)?.saveAll
+      if (typeof saveCb === 'function') await saveCb()
+    }
 
     if (hasMissingDmis) {
       if (

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
@@ -205,6 +205,16 @@ export async function saveCourse(options: SaveCourseOptions): Promise<SaveCourse
     return { success: false, error: 'No course ID available' }
   }
 
+  // A course we just created already carries the default lesson added by the
+  // POST above. Sending an empty lessons array to the content PUT would wipe it
+  // and trip the server's floor guard ("refusing to delete all N lessons"), so
+  // when publishing a brand-new course with no lessons, keep the default and
+  // return the new id instead of clearing it.
+  const createdNew = isDraftCourseId(courseId) || (mode === 'publish' && !isExistingDbCourse)
+  if (createdNew && (!Array.isArray(lessons) || lessons.length === 0)) {
+    return { success: true, courseId: targetCourseId }
+  }
+
   try {
     const saveRes = await fetchWithCsrf(`/api/tutor/courses/${targetCourseId}/course`, {
       method: 'PUT',


### PR DESCRIPTION
## Problem
Clicking **Schedule** dead-ended on *"The course is still loading. Please wait a moment…"* (the guard from #932) — and before that, errored with *"refusing to delete all 1 lesson(s)…"*.

## Root cause
`saveCourse` materializes a draft by **POST**ing `/api/tutor/courses` (which creates the course **with a default "Lesson 1"**) and then **PUT**ting the lessons. When the builder editor hasn't hydrated (or it's a genuinely empty new draft), `getLessons()` returns `[]`, so the PUT sends `lessons: []`, which wipes that default lesson and trips the server's floor guard.

## Fix
- **`save-course.ts`:** when publishing a **brand-new** course with no lessons, keep the default lesson the POST created and **skip the wiping content PUT** (return the new id). Only affects fresh creates with empty lessons; existing-course saves are unchanged.
- **`handlePublishDraft`:** 
  - Fall back to the draft's persisted `localStorage` lessons when the editor returns empty (recovers an unhydrated editor without losing content).
  - Only `saveAll()` when the editor actually had content, so an unhydrated (empty) editor can't clobber the stored draft.
  - Let an empty **local draft** materialize (removing the "still loading" dead-end); an empty tree on a course **already in the DB** still just opens the scheduling page (no destructive publish).

## Verification
0 eslint errors, tsc clean for both files, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)