### PR TITLE
fix(variants/pci): propagate on autosave, prefill countries, honour board override

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/page.tsx
@@ -133,6 +133,47 @@ export default function TutorCoursePage() {
     return code
   }, [])
 
+  // Prefill the country picker from the course's already-published variants so a
+  // re-published course reflects its real countries instead of defaulting to
+  // Global (which would otherwise add a spurious Global variant next to them).
+  useEffect(() => {
+    if (!id) return
+    let active = true
+    fetch(`/api/tutor/courses/${id}/publish`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { variants: [] }))
+      .then((data: { variants?: Array<{ nationality?: string }> }) => {
+        if (!active) return
+        const nationalities = [
+          ...new Set((data.variants ?? []).map(v => v.nationality).filter(Boolean)),
+        ] as string[]
+        if (nationalities.length === 0) return // no variants yet → keep Global default
+        const codes: string[] = []
+        let regionId = ''
+        for (const nat of nationalities) {
+          if (nat === 'Global') {
+            codes.push('GL')
+            continue
+          }
+          for (const region of REGIONS) {
+            const match = region.countries.find(c => c.name === nat)
+            if (match) {
+              codes.push(match.code)
+              if (region.id !== 'global') regionId = region.id
+              break
+            }
+          }
+        }
+        if (codes.length > 0) {
+          setSelectedCountryCodes(codes)
+          if (regionId) setSelectedRegion(regionId)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [id])
+
   const loadCourse = useCallback(async () => {
     if (!id) return
     setLoading(true)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -3432,7 +3432,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             documentKindOverride,
             // Board/subject context from the course category so generation
             // follows the right exam conventions (a hint, not a source override).
-            examBody: deriveExamContext(pciCategory || null, courseName).examBody || undefined,
+            // Honour the tutor's manual Board override if they set one.
+            examBody:
+              pciBoardOverride ||
+              deriveExamContext(pciCategory || null, courseName).examBody ||
+              undefined,
             subject:
               deriveExamContext(pciCategory || null, courseName).subject ||
               pciCategory ||

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -408,9 +408,12 @@ function TutorInsightsPageInner() {
 
   const handleSave = useCallback(
     async (lessons: any[], options?: any) => {
-      // For published variants on manual save, auto-propagate to sibling variants
-      // (variants published with this course, NOT all tutor courses)
-      if (isPublishedVariant && !options?.isAutoSave) {
+      // For published variants, auto-propagate edits to sibling variants (those
+      // published with this course, NOT all tutor courses). This runs on autosave
+      // too — autosave is debounced (~2s after edits settle), so siblings stay in
+      // sync without the tutor needing a manual Save. Independent variants are
+      // still excluded server-side.
+      if (isPublishedVariant) {
         await executeSave(lessons, options, true, false)
         return
       }


### PR DESCRIPTION
Three gap fixes from the recent multi-country / PCI work.

## 1. Variant propagation now runs on autosave (not just manual Save)
`handleSave` only propagated edits to sibling variants on a **manual** Save (`!options?.isAutoSave`). So autosaved edits left siblings stale until the next manual save. Dropped the gate — propagation now runs on autosave too. Safe because the insights course-edit autosave is debounced (~2s after edits settle) and independent variants are still excluded server-side.

## 2. Country picker prefills from existing variants
The publish country picker always defaulted to **Global** on load, so a course that already had published non-Global variants would get a spurious Global variant added next to the real ones. It now fetches the course's variants and maps each nationality back to its region/country to prefill `selectedCountryCodes` (falls back to Global when there are no variants yet).

## 3. generate-dmi honours a manual Board override
The generate-dmi payload sent only the category-derived board. If a tutor manually overrode the Board in the modal (`pciBoardOverride`), that wasn't used. Now it sends the override when set, falling back to the derived board.

## Verification
0 eslint errors, tsc clean for all touched files, prettier clean.

Tests for these (and the earlier session fixes) follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)