### PR TITLE
feat(pci): seed Board/Subject onto a DMI version at generation

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -3579,6 +3579,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
         const existingVersions = isTask ? taskDmiVersions : assessmentDmiVersions
         const nextVersionNumber = existingVersions.length + 1
+        // Seed the Board/Subject onto the new version from the course category so
+        // the DMI carries them as real data (not just a derived-on-the-fly badge).
+        // Board is assessment-only; honour a manual Board override; both are
+        // derived from the tutor's own category — never fabricated.
+        const seedExam = deriveExamContext(pciCategory || null, courseName)
         const newVersion: DMIVersion = {
           id: `dmi-version-${Date.now()}`,
           versionNumber: nextVersionNumber,
@@ -3586,6 +3591,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           createdAt: Date.now(),
           taskId: isTask ? loadedTaskId || undefined : undefined,
           assessmentId: !isTask ? loadedAssessmentId || undefined : undefined,
+          examBody: !isTask ? pciBoardOverride || seedExam.examBody || undefined : undefined,
+          subject: seedExam.subject || pciCategory || undefined,
           // ASMT-4: section grouping + total marks derived from the questions.
           sections: deriveSections(dmiItems),
           totalMarks: deriveTotalMarks(dmiItems),


### PR DESCRIPTION
Follow-up polish for UI/data consistency.

## Context
After #938, the Board/Subject **badges** already display correctly — they derive from the course category (`deriveExamContext(designatedFolder)`), which now resolves drafts too. But that value was computed on the fly and **never stored on the DMI** itself; the persisted `examBody`/`subject` on a freshly generated DMI version stayed empty until a manual edit or a marking-scheme parse.

## Change
Stamp `examBody`/`subject` onto the new `DMIVersion` at generation time (one-shot, at the version-construction site — no effect/loop, which matters in this React-#185-sensitive component). Now the DMI carries its Board/Subject as **real, self-describing data**, so any consumer that reads the stored value (not just the derive-fallback) gets it.

### Guardrails
- Derived from the tutor's own course category — **never fabricated**.
- **Board is assessment-only** — omitted for tasks (`!isTask`).
- Honours a manual Board override (`pciBoardOverride`).
- Metadata only; touches no questions/answers and no student-facing surface.

## Verification
0 eslint errors, tsc clean for the file, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)