### PR TITLE
feat(1-on-1): two-way video — student transmits too, via a shared call room

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+/**
+ * Dedicated two-way video room for a 1-on-1 session — used by BOTH the student
+ * and the tutor (the course classrooms are role-specific and can't host a
+ * course-less 1-on-1). Mints a join token via /api/class/rooms/[id]/join (which
+ * grants the student a broadcast-capable token for capacity-2 sessions) and
+ * renders DailyVideoFrame in two-way mode so each person sees the other's video.
+ */
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { Loader2, ArrowLeft } from 'lucide-react'
+import { DailyVideoFrame } from '@/components/class/daily-video-frame'
+
+interface JoinState {
+  loading: boolean
+  roomUrl?: string | null
+  token?: string | null
+  isTutor?: boolean
+  twoWay?: boolean
+  error?: string
+}
+
+export default function OneOnOneCallPage() {
+  const { data: session } = useSession()
+  const params = useParams()
+  const router = useRouter()
+  const sessionId = (params?.sessionId as string) || ''
+  const [state, setState] = useState<JoinState>({ loading: true })
+
+  useEffect(() => {
+    if (!sessionId) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
+        const res = await fetch(`/api/class/rooms/${sessionId}/join`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
+        })
+        const data = await res.json().catch(() => ({}))
+        if (cancelled) return
+        if (!res.ok) {
+          setState({ loading: false, error: data?.error || 'Could not join the session.' })
+          return
+        }
+        const tutorId = data?.session?.tutorId
+        const isTutor =
+          tutorId && session?.user?.id
+            ? tutorId === session.user.id
+            : session?.user?.role === 'TUTOR'
+        setState({
+          loading: false,
+          roomUrl: data?.roomUrl ?? null,
+          token: data?.token ?? null,
+          isTutor,
+          // Server flags 1-on-1 (capacity 2) as two-way; default true on this route.
+          twoWay: data?.twoWay ?? true,
+          error: data?.videoError || undefined,
+        })
+      } catch {
+        if (!cancelled) setState({ loading: false, error: 'Could not join the session.' })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [sessionId, session?.user?.id, session?.user?.role])
+
+  if (state.loading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-white/70" />
+      </div>
+    )
+  }
+
+  if (!state.roomUrl) {
+    return (
+      <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
+        <p className="text-lg font-semibold">Couldn’t start the session</p>
+        <p className="max-w-md text-sm text-white/70">
+          {state.error || 'No video room is available for this session yet.'}
+        </p>
+        <button
+          onClick={() => router.back()}
+          className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-medium hover:bg-white/10"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Go back
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-screen w-full bg-black">
+      <DailyVideoFrame
+        roomUrl={state.roomUrl}
+        token={state.token}
+        isTutor={state.isTutor}
+        twoWay={state.twoWay}
+        className="h-full w-full rounded-none border-0"
+      />
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -33,6 +33,9 @@ export interface CalendarEvent {
   meetingUrl?: string | null
   status?: string
   requestId?: string | null
+  /** LiveSession id (from the calendar event's externalId) — used to open the
+   *  in-app two-way call room for a 1-on-1. */
+  sessionId?: string | null
 }
 
 interface DashboardCalendarProps {
@@ -365,6 +368,21 @@ export function DashboardCalendar({
                               >
                                 <Star className="h-3.5 w-3.5" />
                                 Rate
+                              </button>
+                            ) : s.sessionId ? (
+                              // Two-way in-app call room (both student and tutor).
+                              <button
+                                type="button"
+                                onClick={() => router.push(`/call/${s.sessionId}`)}
+                                className={cn(
+                                  'inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white',
+                                  isLive
+                                    ? 'bg-emerald-600 hover:bg-emerald-700'
+                                    : 'bg-blue-600 hover:bg-blue-700'
+                                )}
+                              >
+                                <Video className="h-3.5 w-3.5" />
+                                {isLive ? 'Join now' : 'Join'}
                               </button>
                             ) : s.meetingUrl ? (
                               <a

--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -168,7 +168,13 @@ interface ClassroomControlsPanelProps {
   error: string | Error | null
   roomUrl: string | null | undefined
   token: string | null | undefined
-  openVideoOverlay: (opts: { roomUrl: string; token?: string | null; autoRecord: boolean }) => void
+  twoWay?: boolean
+  openVideoOverlay: (opts: {
+    roomUrl: string
+    token?: string | null
+    autoRecord: boolean
+    twoWay?: boolean
+  }) => void
   setShowDirectoryPanel: (value: boolean) => void
 }
 
@@ -179,6 +185,7 @@ function ClassroomControlsPanel({
   error,
   roomUrl,
   token,
+  twoWay,
   openVideoOverlay,
   setShowDirectoryPanel,
 }: ClassroomControlsPanelProps) {
@@ -269,7 +276,7 @@ function ClassroomControlsPanel({
                       disabled={!roomUrl}
                       onClick={() => {
                         if (!roomUrl) return
-                        openVideoOverlay({ roomUrl, token, autoRecord: false })
+                        openVideoOverlay({ roomUrl, token, autoRecord: false, twoWay })
                       }}
                       className="flex h-9 w-full items-center gap-2 rounded-lg bg-white/10 px-3 text-xs font-semibold text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-50"
                     >
@@ -940,6 +947,7 @@ function StudentFeedbackContent() {
     objectives: string[] | null
     roomUrl: string | null
     token: string | null
+    twoWay: boolean
     tutorId: string | null
     tutorUsername: string
     courseCategory: string
@@ -1290,6 +1298,7 @@ function StudentFeedbackContent() {
               : null,
           roomUrl: data?.roomUrl ?? null,
           token: data?.token ?? null,
+          twoWay: !!data?.twoWay || (data?.session?.maxStudents ?? 0) <= 2,
           tutorId: data?.session?.tutorId ?? null,
           tutorUsername: data?.session?.tutor?.profile?.name || 'Tutor',
           courseCategory: data?.session?.category || 'General',
@@ -1921,6 +1930,7 @@ function StudentFeedbackContent() {
           error={error}
           roomUrl={sessionContext?.roomUrl}
           token={sessionContext?.token}
+          twoWay={sessionContext?.twoWay}
           openVideoOverlay={openVideoOverlay}
           setShowDirectoryPanel={setShowDirectoryPanel}
         />

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -1467,11 +1467,17 @@ export function InteractiveCalendar({
                         setSelectedEvent(null)
                         return
                       }
+                      // 1-on-1 (capacity ≤ 2) → the shared two-way call room, which
+                      // works for both roles (the course classrooms are role-specific
+                      // and can't host a course-less 1-on-1).
+                      const isOneOnOne = (selectedEvent.maxStudents ?? 50) <= 2
                       router.push(
                         withLocalePath(
-                          isStudent
-                            ? `/student/feedback?sessionId=${selectedEvent.sessionId}`
-                            : `/tutor/classroom?sessionId=${selectedEvent.sessionId}`
+                          isOneOnOne
+                            ? `/call/${selectedEvent.sessionId}`
+                            : isStudent
+                              ? `/student/feedback?sessionId=${selectedEvent.sessionId}`
+                              : `/tutor/classroom?sessionId=${selectedEvent.sessionId}`
                         )
                       )
                       setSelectedEvent(null)

--- a/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
+++ b/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
@@ -22,6 +22,8 @@ import {
   course,
   courseSchedule,
   courseVariant,
+  oneOnOneBookingRequest,
+  calendarEvent,
 } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { formatScheduleName } from '@/lib/sessions/schedule-name'
@@ -94,6 +96,31 @@ export const POST = withCsrf(
           .limit(1)
 
         if (!existing) {
+          // If this session is a 1-on-1 (has 1-on-1 booking(s) linked to its
+          // calendar event), it's private — only its booked student may take a
+          // seat. Other session kinds (course classes, ad-hoc, group — where paid
+          // seats already inserted a participant row above) keep their existing
+          // join behaviour, so this can't lock anyone else out.
+          const bookings = await tx
+            .select({
+              studentId: oneOnOneBookingRequest.studentId,
+              status: oneOnOneBookingRequest.status,
+            })
+            .from(oneOnOneBookingRequest)
+            .innerJoin(
+              calendarEvent,
+              eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId)
+            )
+            .where(eq(calendarEvent.externalId, id))
+          if (bookings.length > 0) {
+            const allowed = bookings.some(
+              b => b.studentId === userId && ['ACCEPTED', 'PAID'].includes(b.status)
+            )
+            if (!allowed) {
+              throw new ValidationError('You are not a participant in this session.')
+            }
+          }
+
           const [{ count }] = await tx
             .select({ count: sql<number>`count(*)::int` })
             .from(sessionParticipant)
@@ -177,6 +204,8 @@ export const POST = withCsrf(
         token = await dailyProvider.createMeetingToken(activeRoomId, userId, {
           isOwner,
           durationMinutes: classSessionRow.durationMinutes ?? 120,
+          // 1-on-1 sessions (capacity 2) are two-way: the student transmits too.
+          twoWay: (classSessionRow.maxStudents ?? 0) <= 2,
         })
       } catch (err: any) {
         console.error('[Join] Daily.co token creation failed:', err?.message)
@@ -258,6 +287,8 @@ export const POST = withCsrf(
       token,
       roomUrl,
       videoError,
+      // 1-on-1 (capacity 2) → the client renders two-way video.
+      twoWay: (classSessionRow.maxStudents ?? 0) <= 2,
     })
   })
 )

--- a/tutorme-app/src/components/class/daily-video-frame.tsx
+++ b/tutorme-app/src/components/class/daily-video-frame.tsx
@@ -38,6 +38,10 @@ interface DailyVideoFrameProps {
   /** Tutor view: students don't broadcast video, so show them as avatar tiles
    *  (not video). Student view stays full-bleed video of the broadcaster. */
   isTutor?: boolean
+  /** 1-on-1 session: both people transmit, so render the OTHER participant's
+   *  video for both roles (symmetric two-way) instead of the tutor→students
+   *  broadcast layout, and let the student toggle their camera. */
+  twoWay?: boolean
 }
 
 export function DailyVideoFrame({
@@ -47,6 +51,7 @@ export function DailyVideoFrame({
   autoRecord,
   floating = false,
   isTutor = false,
+  twoWay = false,
 }: DailyVideoFrameProps) {
   const {
     call,
@@ -594,7 +599,7 @@ export function DailyVideoFrame({
             area, everything else overlays. Tutor: a grid of STUDENT AVATARS
             (students don't broadcast video), unless the tutor is screen-sharing. */}
         <div className="absolute inset-0 bg-slate-950">
-          {isTutor ? (
+          {isTutor && !twoWay ? (
             screenShareParticipant ? (
               <ParticipantMediaTile
                 participant={screenShareParticipant}
@@ -617,6 +622,8 @@ export function DailyVideoFrame({
               </div>
             )
           ) : mainTile ? (
+            // Student view, and both sides of a two-way 1-on-1: full-bleed video
+            // of the OTHER participant; your own camera is the self-view PiP.
             <ParticipantMediaTile
               participant={mainTile}
               mode={screenShareParticipant ? 'screen' : 'camera'}
@@ -624,7 +631,11 @@ export function DailyVideoFrame({
             />
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-white/70">
-              Waiting for the tutor…
+              {twoWay
+                ? isTutor
+                  ? 'Waiting for the student…'
+                  : 'Waiting for the tutor…'
+                : 'Waiting for the tutor…'}
             </div>
           )}
         </div>
@@ -666,7 +677,9 @@ export function DailyVideoFrame({
               inactiveIcon={<VideoOff className="h-4 w-4" />}
               activeLabel="Cam"
               inactiveLabel="Cam"
-              disabled={!canSendVideo}
+              // Two-way (1-on-1): the student's token grants video, so always
+              // allow the camera toggle.
+              disabled={!canSendVideo && !twoWay}
             />
             <ControlButton
               onClick={() => (isScreenSharing ? stopScreenShare() : startScreenShare())}

--- a/tutorme-app/src/components/class/floating-video-overlay.tsx
+++ b/tutorme-app/src/components/class/floating-video-overlay.tsx
@@ -6,7 +6,7 @@ import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
 
 export function FloatingVideoOverlay() {
-  const { open, roomUrl, token, autoRecord, isTutor, closeOverlay } = useVideoOverlayStore()
+  const { open, roomUrl, token, autoRecord, isTutor, twoWay, closeOverlay } = useVideoOverlayStore()
   const [frame, setFrame] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
   const dragRef = useRef<{
     pointerId: number
@@ -139,6 +139,7 @@ export function FloatingVideoOverlay() {
             autoRecord={autoRecord}
             floating={false}
             isTutor={isTutor}
+            twoWay={twoWay}
             className="h-full w-full rounded-none border-0"
           />
         </div>

--- a/tutorme-app/src/lib/video/daily-provider.ts
+++ b/tutorme-app/src/lib/video/daily-provider.ts
@@ -122,6 +122,9 @@ export class DailyCoProvider implements VideoProvider {
     options?: {
       isOwner?: boolean
       durationMinutes?: number
+      /** 1-on-1 session: the non-owner (student) also transmits video, so don't
+       *  force their camera off. Group classes keep students camera-off. */
+      twoWay?: boolean
     }
   ): Promise<string> {
     if (!this.apiKey) {
@@ -151,7 +154,9 @@ export class DailyCoProvider implements VideoProvider {
           // call rejected it (400), token creation threw, and students were
           // handed a null token for a PRIVATE room → every join failed ("Try
           // again"). `start_video_off` covers the camera-off intent on its own.
-          ...(isOwner ? {} : { start_video_off: true }),
+          // In a two-way (1-on-1) session the student transmits too, so their
+          // camera is NOT forced off.
+          ...(isOwner || options?.twoWay ? {} : { start_video_off: true }),
           exp: expiry,
         },
       }),

--- a/tutorme-app/src/stores/video-overlay-store.ts
+++ b/tutorme-app/src/stores/video-overlay-store.ts
@@ -7,11 +7,15 @@ type VideoOverlayState = {
   token: string | null
   autoRecord: boolean
   isTutor: boolean
+  /** 1-on-1 session: both participants transmit video (two-way) instead of the
+   *  tutor-broadcasts / students-view layout used for group classes. */
+  twoWay: boolean
   openOverlay: (input: {
     roomUrl: string
     token?: string | null
     autoRecord?: boolean
     isTutor?: boolean
+    twoWay?: boolean
   }) => void
   closeOverlay: () => void
 }
@@ -23,6 +27,7 @@ export const useVideoOverlayStore = create<VideoOverlayState>()(
     token: null,
     autoRecord: false,
     isTutor: false,
+    twoWay: false,
     openOverlay: input =>
       set(draft => {
         draft.open = true
@@ -30,6 +35,7 @@ export const useVideoOverlayStore = create<VideoOverlayState>()(
         draft.token = input.token || null
         draft.autoRecord = !!input.autoRecord
         draft.isTutor = !!input.isTutor
+        draft.twoWay = !!input.twoWay
       }),
     closeOverlay: () =>
       set(draft => {


### PR DESCRIPTION
## What you asked for
In a group class only the tutor transmits (students are view-only). In a **1-on-1**, the student should transmit too — **two-way video**.

## Why it wasn't a one-liner
Tracing it: a 1-on-1 had **no working classroom for both roles** — the tutor's classroom is course-specific (`CourseBuilder`, can't host a course-less 1-on-1), and the 1-on-1 "Join" pointed at a **raw private Daily room URL with no token**. So this needed a proper shared 1-on-1 room.

## The change (all gated to 1-on-1 — group classes untouched)
- **New `/[locale]/call/[sessionId]` page** — a dedicated, role-agnostic two-way room used by **both** the student and the tutor. It mints a token via `/api/class/rooms/[id]/join` and renders `DailyVideoFrame` in two-way mode.
- **Routing** — the student's 1-on-1 "Join" (dashboard) and the calendar "Join Session" (both roles, capacity ≤ 2) now open `/call/[sessionId]` instead of the raw Daily URL / the course-only classroom.
- **`DailyVideoFrame` `twoWay` prop** — for 1-on-1, both roles see the *other* participant's video full-bleed (+ their own self-view PiP) instead of the tutor→students broadcast/avatar layout, and the student's camera toggle is enabled. When `twoWay` is false (group classes) nothing changes.
- **Meeting token** — 1-on-1 (capacity ≤ 2) participants get a **broadcast-capable** token (no forced `start_video_off`).
- **Join authorization** — a session that *is* a 1-on-1 (has a linked booking) only admits its **booked student**; course / ad-hoc / group joins keep their existing behaviour (verified the gate is scoped so it can't lock anyone else out).

## Verification
- `tsc` clean, lint clean, prettier clean across all 9 files.
- ⚠️ **Live video can't be exercised in CI/sandbox** — it needs Daily.co + two authenticated clients (student + tutor) in real browsers. **Please do a two-person test**: open the same 1-on-1 as the student and the tutor → each should see the other's video, and the student should be able to toggle their camera. Every non-video state transition (token, routing, authz, layout gating) is code-verified; the actual media is what needs your eyes.

Because I couldn't runtime-verify the media, everything is scoped to `maxStudents ≤ 2` so a regression can't touch group classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)