### PR TITLE
fix: Classroom tab aggregates student messages in Test mode

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -218,7 +218,7 @@ import { parsePciTranscript, type PciMessage } from '@/lib/assessment/pci'
 import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
 import { PciSpecSoFar } from './PciSpecSoFar'
-import { TestTaskChat, type TestTaskChatState } from './TestTaskChat'
+import { TestTaskChat, type TestTaskChatState, type TestTaskChatMsg } from './TestTaskChat'
 import { splitDocIntoSections } from '@/lib/documents/split-sections'
 import { assessmentDmiReadiness } from '@/lib/assessment/dmi-readiness'
 import { Separator } from '@/components/ui/separator'
@@ -1298,6 +1298,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // tab) across the remounts that happen when switching Test students, so the
     // conversation isn't lost. A ref: writing it must not trigger a re-render.
     const testTaskChatStore = useRef<Record<string, TestTaskChatState>>({})
+    // Shared state for the Classroom tab — aggregates messages from all student tabs
+    // plus tutor messages sent from the classroom view. Keyed by extension id.
+    // Must be useState (not ref) so changes trigger re-renders of the Classroom tab.
+    const [classroomMessages, setClassroomMessages] = useState<Record<string, TestTaskChatMsg[]>>(
+      {}
+    )
     // Test-tab-only DEBUG control: grade against all available bases (default) or
     // isolate one (PCI / rubric / model answer) to see its effect alone. Never
     // affects student/production grading — only the tutor's test-grade requests.
@@ -10144,6 +10150,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                 )
                                               : null
                                             const previewKey = `${previewExt ? previewExt.id : 'base'}:${tab.id}`
+                                            const extKey = previewExt ? previewExt.id : 'base'
+                                            const isClassroomTab = tab.id === 'classroom'
+                                            const studentTabName =
+                                              tab.id === 'student1'
+                                                ? 'Test Student 1'
+                                                : tab.id === 'student2'
+                                                  ? 'Test Student 2'
+                                                  : 'Student'
+
                                             return (
                                               <div className="h-full min-h-0 w-full">
                                                 <TestTaskChat
@@ -10162,15 +10177,62 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                       : currentTaskDocument
                                                   }
                                                   initialState={
-                                                    testTaskChatStore.current[previewKey]
+                                                    isClassroomTab
+                                                      ? undefined
+                                                      : testTaskChatStore.current[previewKey]
+                                                  }
+                                                  incomingMessages={
+                                                    isClassroomTab
+                                                      ? classroomMessages[extKey]
+                                                      : undefined
                                                   }
                                                   onPersist={s => {
-                                                    testTaskChatStore.current[previewKey] = s
+                                                    if (!isClassroomTab) {
+                                                      testTaskChatStore.current[previewKey] = s
+                                                    }
+                                                  }}
+                                                  onBroadcast={msg => {
+                                                    if (isClassroomTab) {
+                                                      // Tutor message from classroom → broadcast to all student tabs
+                                                      const tutorMsg = { ...msg, name: 'Tutor' }
+                                                      ;['student1', 'student2'].forEach(st => {
+                                                        const sk = `${extKey}:${st}`
+                                                        const existing =
+                                                          testTaskChatStore.current[sk]
+                                                        testTaskChatStore.current[sk] = {
+                                                          messages: [
+                                                            ...(existing?.messages ?? []),
+                                                            tutorMsg,
+                                                          ],
+                                                          draft: existing?.draft ?? '',
+                                                          completed: existing?.completed ?? false,
+                                                        }
+                                                      })
+                                                      // Also append to classroom state so it appears in the classroom view
+                                                      setClassroomMessages(prev => ({
+                                                        ...prev,
+                                                        [extKey]: [
+                                                          ...(prev[extKey] ?? []),
+                                                          tutorMsg,
+                                                        ],
+                                                      }))
+                                                    } else {
+                                                      // Student message → add to classroom view with student name
+                                                      const studentMsg = {
+                                                        ...msg,
+                                                        name: studentTabName,
+                                                      }
+                                                      setClassroomMessages(prev => ({
+                                                        ...prev,
+                                                        [extKey]: [
+                                                          ...(prev[extKey] ?? []),
+                                                          studentMsg,
+                                                        ],
+                                                      }))
+                                                    }
                                                   }}
                                                   mode={
-                                                    tab.id === 'classroom'
-                                                      ? 'classroom'
-                                                      : 'test-student'
+                                                    isClassroomTab ? 'classroom' : 'test-student'
                                                   }
                                                 />
                                               </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -28,6 +28,8 @@ export interface TestTaskChatMsg {
   content: string
   re?: string
   timestamp?: number
+  /** Display name for this message sender (e.g. "Test Student 1" in classroom view). */
+  name?: string
 }
 
 export interface TestTaskChatState {
@@ -52,6 +54,8 @@ export function TestTaskChat({
   sourceDocument,
   initialState,
   onPersist,
+  onBroadcast,
+  incomingMessages,
   mode = 'test-student',
 }: {
   pci?: string
@@ -61,6 +65,10 @@ export function TestTaskChat({
   sourceDocument?: TaskDocumentSource | null
   initialState?: TestTaskChatState
   onPersist?: (state: TestTaskChatState) => void
+  /** Called when a new message is sent from this tab so the parent can relay it to other tabs. */
+  onBroadcast?: (msg: TestTaskChatMsg) => void
+  /** Messages injected from outside (e.g. from other tabs via the parent). Appended to the chat. */
+  incomingMessages?: TestTaskChatMsg[]
   /** Which preview mode this is rendering in. */
   mode?: 'classroom' | 'test-student'
 }) {
@@ -70,11 +78,22 @@ export function TestTaskChat({
   const [busy, setBusy] = useState(false)
   const [pdfPopupOpen, setPdfPopupOpen] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const lastIncomingLen = useRef(incomingMessages?.length ?? 0)
 
   useEffect(() => {
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [messages, busy])
+
+  // Append any new incoming messages from the parent (cross-tab relay).
+  useEffect(() => {
+    const len = incomingMessages?.length ?? 0
+    if (len > lastIncomingLen.current) {
+      const newMsgs = incomingMessages!.slice(lastIncomingLen.current)
+      setMessages(prev => [...prev, ...newMsgs])
+      lastIncomingLen.current = len
+    }
+  }, [incomingMessages])
 
   // Mirror state to the parent's store so a remount (switching Test students)
   // can rehydrate it. Cheap; runs only when the persisted fields change.
@@ -107,8 +126,14 @@ export function TestTaskChat({
   const addAnswer = () => {
     const a = draft.trim()
     if (!a || busy) return
-    setMessages(prev => [...prev, { role: 'student', content: a, timestamp: Date.now() }])
+    const msg: ChatMsg = {
+      role: isClassroom ? 'tutor' : 'student',
+      content: a,
+      timestamp: Date.now(),
+    }
+    setMessages(prev => [...prev, msg])
     setDraft('')
+    onBroadcast?.(msg)
   }
 
   const complete = async () => {
@@ -120,8 +145,14 @@ export function TestTaskChat({
       return
     }
     if (pending) {
-      setMessages(prev => [...prev, { role: 'student', content: pending, timestamp: Date.now() }])
+      const pendingMsg: ChatMsg = {
+        role: isClassroom ? 'tutor' : 'student',
+        content: pending,
+        timestamp: Date.now(),
+      }
+      setMessages(prev => [...prev, pendingMsg])
       setDraft('')
+      onBroadcast?.(pendingMsg)
     }
     setBusy(true)
     try {
@@ -131,15 +162,14 @@ export function TestTaskChat({
       const responses: Array<{ answer: string; response: string }> = Array.isArray(data.responses)
         ? data.responses
         : []
-      setMessages(prev => [
-        ...prev,
-        ...responses.map(r => ({
-          role: 'ai' as const,
-          content: r.response,
-          re: r.answer,
-          timestamp: Date.now(),
-        })),
-      ])
+      const aiMsgs: ChatMsg[] = responses.map(r => ({
+        role: 'ai' as const,
+        content: r.response,
+        re: r.answer,
+        timestamp: Date.now(),
+      }))
+      setMessages(prev => [...prev, ...aiMsgs])
+      aiMsgs.forEach(m => onBroadcast?.(m))
       setCompleted(true)
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to grade')
@@ -151,8 +181,14 @@ export function TestTaskChat({
   const ask = async () => {
     const q = draft.trim()
     if (!q || busy) return
-    setMessages(prev => [...prev, { role: 'student', content: q, timestamp: Date.now() }])
+    const questionMsg: ChatMsg = {
+      role: isClassroom ? 'tutor' : 'student',
+      content: q,
+      timestamp: Date.now(),
+    }
+    setMessages(prev => [...prev, questionMsg])
     setDraft('')
+    onBroadcast?.(questionMsg)
     setBusy(true)
     try {
       const history = messages
@@ -161,10 +197,13 @@ export function TestTaskChat({
       const res = await post({ question: q, history, answers: studentAnswers })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) throw new Error(data?.error || 'Failed to answer')
-      setMessages(prev => [
-        ...prev,
-        { role: 'ai', content: data.answer || '…', timestamp: Date.now() },
-      ])
+      const aiMsg: ChatMsg = {
+        role: 'ai',
+        content: data.answer || '…',
+        timestamp: Date.now(),
+      }
+      setMessages(prev => [...prev, aiMsg])
+      onBroadcast?.(aiMsg)
     } catch {
       setMessages(prev => [
         ...prev,
@@ -292,7 +331,9 @@ export function TestTaskChat({
           <ChatMessageBubble
             key={i}
             sender={m.role}
-            name={m.role === 'student' ? 'Student' : m.role === 'ai' ? 'Tutor' : 'Tutor'}
+            name={
+              m.name || (m.role === 'student' ? 'Student' : m.role === 'ai' ? 'Tutor' : 'Tutor')
+            }
             content={m.content}
             re={m.re}
             timestamp={m.timestamp ? new Date(m.timestamp) : undefined}


### PR DESCRIPTION
## Problem
The Test mode Classroom tab was functioning as a third student view (orange styling only difference). Student inputs from Test Student 1 & 2 tabs did not appear in the tutor's Classroom display.

## Root Cause
- `TestTaskChat` hardcoded `role: 'student'` for all user inputs regardless of `mode` prop
- `mode` prop only affected colors, not behavior
- No cross-tab message sharing existed between the three Test tabs

## Solution
Client-side mock implementation using shared React state (no socket, no DB writes):

### TestTaskChat.tsx
- Added `onBroadcast?: (msg: TestTaskChatMsg) => void` callback — called whenever a new message is sent so the parent can relay it to other tabs
- `addAnswer()`, `complete()`, `ask()` now use `role: 'tutor'` when `isClassroom`, `role: 'student'` otherwise
- Added optional `name?: string` field to `TestTaskChatMsg` for labeled sender names (e.g. "Test Student 1") in the classroom view
- Added `incomingMessages?: TestTaskChatMsg[]` prop with `useEffect` that appends new external messages to the local `messages` state — enables cross-tab injection
- AI responses are also broadcast so they appear in the classroom monitor view

### CourseBuilder.tsx
- Added `classroomMessages` useState (keyed by extension id) for the Classroom tab's aggregated message state — must be useState (not ref) so changes trigger re-renders
- Wired `onBroadcast`:
  - **Student tab sends message** → appended to classroom state with `name: "Test Student 1"` or `"Test Student 2"`
  - **Classroom tab sends message** → appended to all student tab stores as `role: 'tutor'` with `name: 'Tutor'`
- Classroom tab receives `incomingMessages={classroomMessages[extKey]}` so new student messages appear in real-time

## Verification
- TypeScript: `tsc --noEmit` passes cleanly
- Tests: all 556 unit tests pass (95 test files)
