### PR TITLE
fix(sessions): reachable video for 1-on-1 reminders + group-session rooms

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { Users, Loader2, Plus, CalendarDays, Trash2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Users, Loader2, Plus, CalendarDays, Trash2, Video } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 
@@ -18,6 +19,7 @@ interface GroupSessionItem {
   currency: string
   status: string
   seatsLeft: number
+  liveSessionId?: string | null
 }
 
 const emptyForm = {
@@ -41,6 +43,7 @@ function formatDate(iso: string): string {
 }
 
 export default function TutorGroupSessionsPage() {
+  const router = useRouter()
   const [sessions, setSessions] = useState<GroupSessionItem[]>([])
   const [loading, setLoading] = useState(true)
   const [form, setForm] = useState(emptyForm)
@@ -279,19 +282,30 @@ export default function TutorGroupSessionsPage() {
                   </div>
                 </div>
                 {!cancelled ? (
-                  <Button
-                    variant="outline"
-                    className="shrink-0 text-red-600 hover:bg-red-50"
-                    disabled={cancelId === gs.groupSessionId}
-                    onClick={() => cancel(gs.groupSessionId)}
-                  >
-                    {cancelId === gs.groupSessionId ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Trash2 className="mr-2 h-4 w-4" />
-                    )}
-                    Cancel &amp; refund
-                  </Button>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {gs.liveSessionId ? (
+                      <Button
+                        variant="solocorn-book"
+                        onClick={() => router.push(`/call/${gs.liveSessionId}`)}
+                      >
+                        <Video className="mr-2 h-4 w-4" />
+                        Join room
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant="outline"
+                      className="text-red-600 hover:bg-red-50"
+                      disabled={cancelId === gs.groupSessionId}
+                      onClick={() => cancel(gs.groupSessionId)}
+                    >
+                      {cancelId === gs.groupSessionId ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="mr-2 h-4 w-4" />
+                      )}
+                      Cancel &amp; refund
+                    </Button>
+                  </div>
                 ) : null}
               </li>
             )

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -16,8 +16,10 @@ import {
   course,
   sessionParticipant,
   oneOnOneBookingRequest,
+  groupSession,
+  groupSessionParticipant,
 } from '@/lib/db/schema'
-import { eq, and, gte, lte, inArray, isNull, sql } from 'drizzle-orm'
+import { eq, and, gte, lte, inArray, isNull, ne, sql } from 'drizzle-orm'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 export const GET = withAuth(
@@ -150,6 +152,34 @@ export const GET = withAuth(
       .where(and(...oneOnOneFilters))
       .orderBy(calendarEvent.startTime)
 
+    // --- Booked group sessions (student holds a paid seat) ---
+    // Surfaced so the student can find and join the shared room after booking.
+    const groupFilters = [
+      eq(groupSessionParticipant.studentId, studentId),
+      eq(groupSessionParticipant.status, 'PAID'),
+      ne(groupSession.status, 'CANCELLED'),
+    ]
+    if (startParam) groupFilters.push(gte(liveSession.scheduledAt, startDate))
+    if (endParam) groupFilters.push(lte(liveSession.scheduledAt, endDate))
+    const groupEvents = await drizzleDb
+      .select({
+        groupSessionId: groupSession.groupSessionId,
+        liveSessionId: groupSession.liveSessionId,
+        title: groupSession.title,
+        tutorId: groupSession.tutorId,
+        scheduledAt: liveSession.scheduledAt,
+        durationMinutes: liveSession.durationMinutes,
+        meetingUrl: liveSession.roomUrl,
+        sessionStatus: liveSession.status,
+      })
+      .from(groupSessionParticipant)
+      .innerJoin(
+        groupSession,
+        eq(groupSession.groupSessionId, groupSessionParticipant.groupSessionId)
+      )
+      .innerJoin(liveSession, eq(liveSession.sessionId, groupSession.liveSessionId))
+      .where(and(...groupFilters))
+
     // Build a set of externalIds already covered by CalendarEvent to avoid duplicates
     const coveredExternalIds = new Set(calEvents.map(e => e.externalId).filter(Boolean) as string[])
 
@@ -217,6 +247,28 @@ export const GET = withAuth(
         status: e.sessionStatus || e.status || 'scheduled',
         courseId: null as string | null,
       })),
+      ...groupEvents.map(e => {
+        const start = e.scheduledAt ?? new Date()
+        const dur = e.durationMinutes || 60
+        return {
+          id: e.groupSessionId,
+          sessionId: e.liveSessionId,
+          bookingId: e.groupSessionId,
+          requestId: null as string | null,
+          title: e.title || 'Group session',
+          subject: 'Group session',
+          start: start.toISOString(),
+          end: new Date(start.getTime() + dur * 60000).toISOString(),
+          duration: dur,
+          type: 'one-on-one' as const,
+          tutorId: e.tutorId,
+          meetingUrl: e.meetingUrl,
+          location: 'Online',
+          isVirtual: true,
+          status: e.sessionStatus || 'scheduled',
+          courseId: null as string | null,
+        }
+      }),
     ]
 
     // Sort by start time

--- a/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
+++ b/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
@@ -112,7 +112,12 @@ export async function runSessionReminderScan(): Promise<void> {
         type: 'reminder',
         title: 'Upcoming session',
         message,
-        actionUrl: `/tutor/insights?sessionId=${encodeURIComponent(s.sessionId)}&view=classroom`,
+        // Course sessions open the course classroom; a course-less session
+        // (1-on-1 or group) opens the shared two-way call room, since the course
+        // classroom can't host it.
+        actionUrl: s.courseId
+          ? `/tutor/insights?sessionId=${encodeURIComponent(s.sessionId)}&view=classroom`
+          : `/call/${encodeURIComponent(s.sessionId)}`,
         data,
       })
     } catch (err) {
@@ -168,7 +173,8 @@ export async function runSessionReminderScan(): Promise<void> {
             type: 'reminder',
             title: 'Upcoming session',
             message,
-            actionUrl: `/student/live/${encodeURIComponent(s.sessionId)}`,
+            // Two-way call room (not the course classroom).
+            actionUrl: `/call/${encodeURIComponent(s.sessionId)}`,
             data,
           })
         }


### PR DESCRIPTION
Follow-up to #944 — fills the **join-entry gaps** I found auditing the 1-on-1 / group video flows. `/call/[sessionId]` already handles both (two-way for 1-on-1, class-style for groups); these are the routing + visibility fixes so people can actually reach it.

## 1-on-1 reminder notifications
They pointed a 1-on-1 at the **course classroom** (student) and a **course-only insights page** (tutor) — neither can host a course-less session. Now any **course-less** session (1-on-1 or group) links both roles to **`/call/[sessionId]`**; course sessions are unchanged.

## Group-session rooms were unreachable
- **Tutor:** added a **"Join room"** button on `/tutor/group-sessions` → `/call/[liveSessionId]`.
- **Student:** booked (PAID) group sessions now **surface in the student's calendar/bookings** with a **Join** → `/call/[liveSessionId]`, so a student can find and enter their session after booking (a released/cancelled seat drops off). Previously a booked group session was invisible with no way in.

## Verification
- `tsc` + lint + prettier clean.
- **DB-verified** (Postgres): a paid group seat surfaces in the student query with `sessionId = the group's liveSessionId`; a cancelled seat does **not** surface.
- Live media still needs the two-person test from #944 (unchanged).

**Cosmetic follow-up:** group bookings currently appear under the student's "1-on-1 Sessions" list (the group title disambiguates); a dedicated "Group sessions" section would be nicer but is non-functional polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)