### PR TITLE
refactor(ai): agent-kit foundation (Phase 1 of ADK replacement)

### DIFF
--- a/tutorme-app/src/lib/ai/agent-kit/README.md
+++ b/tutorme-app/src/lib/ai/agent-kit/README.md
@@ -1,0 +1,53 @@
+# agent-kit — lean, provider-agnostic agent foundation
+
+Replaces the Google **ADK** service (Gemini-centric, currently broken in prod, and
+duplicating prompts) with a thin, TypeScript-native structure: **agents are
+configs; tools & skills are typed units; guardrails are applied uniformly by the
+runner.** Built on the existing `generateWithFallback` provider (Kimi → OpenAI).
+
+## Why
+
+- ADK is optimized for Gemini; the app uses **Kimi + OpenAI** (Gemini was dropped).
+- Prompts are **triplicated** today: `lib/ai/*`, `lib/agents/*/prompts/`, and the ADK
+  repo's `agents/*/prompts.ts` — they drift.
+- **Guardrails live only in the app** (`lib/ai/guardrails/`); ADK agents run without
+  them. The runner makes guardrails un-bypassable.
+
+## Shape
+
+```
+agent-kit/
+  types.ts            # Tool / Skill / AgentDefinition / GenerateFn
+  runner.ts           # runAgent(): compose prompt (+guardrails) → generate → post-validate
+  provider-adapter.ts # defaultGenerate wraps generateWithFallback (system/user separation)
+  registry.ts         # register/get agents + tools
+  agents/             # each agent is a value of AgentDefinition (tutor.ts today)
+  # skills/           # (Phase 2) progressive-disclosure bundles: SKILL.md + scripts
+```
+
+### Principles
+1. **Agents are declarative configs**, not classes — trivial to test/version/diff.
+2. **Guardrails uniform & un-bypassable** — set `guardrailDomain` and the runner
+   prepends the canonical guardrail prompt *and* runs the post-response validator.
+3. **Tools/skills are typed** (Zod I/O); a tool may wrap a deterministic **script**.
+4. **Model layer injected** — runner reuses the existing provider; swappable per agent
+   (Bedrock/Anthropic later) without touching agents.
+5. **One home for prompts** — kills the app/ADK/route duplication.
+
+## Phased migration (each phase a reviewable PR; ADK stays until the end)
+
+- **Phase 1 (this PR) — foundation, ADDITIVE.** `types/runner/registry/adapter` + one
+  example agent + tests. Nothing in prod calls it yet; zero risk.
+- **Phase 2 — tool execution + skills.** A ReAct-style tool loop; skill loading
+  (SKILL.md + scripts); structured assessment/DMI post-validation via
+  `findEvaluationLeaks`.
+- **Phase 3 — port agents.** Move tutor/grader/content-generator/pci-master to configs;
+  point the existing routes at `runAgent` behind a flag; delete duplicate prompts.
+- **Phase 4 — background worker.** Live-monitor / transcription / recording-artifacts on
+  the same kit, in a small worker — **with the fallback + logging those paths lack today**
+  (they currently fail silently — see the ADK-in-prod findings).
+- **Phase 5 — retire ADK.** Remove `Solocorn-LLC/adk-service` once nothing calls it.
+
+## Status
+Phase 1 only. `runAgent` does a guardrailed single-shot generation; tool calls are
+declared but not yet executed (Phase 2).

--- a/tutorme-app/src/lib/ai/agent-kit/agents/tutor.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/agents/tutor.ts
@@ -1,0 +1,21 @@
+/**
+ * Example port: the Socratic tutor as a declarative config.
+ *
+ * Phase 1 keeps the prompt self-contained (additive, no coupling). In the
+ * porting phase its `systemPrompt` will delegate to the existing
+ * `lib/agents/tutor` prompt builder, and its `tools` will be populated
+ * (student progress, curriculum lookup, concept mastery).
+ */
+import { registerAgent } from '../registry'
+import type { AgentDefinition } from '../types'
+
+export const tutorAgent: AgentDefinition = registerAgent({
+  id: 'tutor',
+  description: 'Socratic AI tutor — guides students to answers, never gives them directly.',
+  systemPrompt:
+    'You are a Socratic tutor. Guide the student to discover the answer through ' +
+    'targeted questions and hints. Never state the final answer directly. Be encouraging ' +
+    'and concise.',
+  temperature: 0.7,
+  // tools: [getStudentProgress, getCurriculum, getConceptMastery]  // Phase 2/3
+})

--- a/tutorme-app/src/lib/ai/agent-kit/provider-adapter.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/provider-adapter.ts
@@ -1,0 +1,17 @@
+/**
+ * Default model adapter — wraps the existing `generateWithFallback` provider
+ * (Kimi primary -> OpenAI fallback) so the runner depends only on `GenerateFn`.
+ *
+ * It also introduces proper system/user separation: `generateWithFallback` takes
+ * a single prompt string, so we fence the user input in <user_input> tags after
+ * the system prompt. This is a small hardening the review called out (structured
+ * roles resist prompt injection better than a raw concatenated blob).
+ */
+import { generateWithFallback } from '@/lib/agents'
+import type { GenerateFn } from './types'
+
+export const defaultGenerate: GenerateFn = async ({ system, user, temperature, maxTokens }) => {
+  const prompt = system ? `${system}\n\n<user_input>\n${user}\n</user_input>` : user
+  const result = await generateWithFallback(prompt, { temperature, maxTokens })
+  return { text: result.content }
+}

--- a/tutorme-app/src/lib/ai/agent-kit/registry.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/registry.ts
@@ -1,0 +1,31 @@
+/** In-process registry of agents and tools (single source of truth). */
+import type { AgentDefinition, Tool } from './types'
+
+const agents = new Map<string, AgentDefinition>()
+const tools = new Map<string, Tool>()
+
+export function registerAgent(def: AgentDefinition): AgentDefinition {
+  agents.set(def.id, def)
+  return def
+}
+
+export function getAgent(id: string): AgentDefinition | undefined {
+  return agents.get(id)
+}
+
+export function listAgents(): AgentDefinition[] {
+  return Array.from(agents.values())
+}
+
+export function registerTool(tool: Tool): Tool {
+  tools.set(tool.name, tool)
+  return tool
+}
+
+export function getTool(name: string): Tool | undefined {
+  return tools.get(name)
+}
+
+export function listTools(): Tool[] {
+  return Array.from(tools.values())
+}

--- a/tutorme-app/src/lib/ai/agent-kit/runner.test.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { runAgent } from './runner'
+import { guardrailSystemPrompt, GUARDRAILED_TEMPERATURE } from '@/lib/ai/guardrails'
+import type { AgentDefinition, GenerateFn } from './types'
+
+function mockGenerate() {
+  const calls: { system: string; user: string; temperature?: number }[] = []
+  const fn: GenerateFn = async ({ system, user, temperature }) => {
+    calls.push({ system, user, temperature })
+    return { text: 'ok' }
+  }
+  return { fn, calls }
+}
+
+describe('agent-kit runner', () => {
+  it('runs a plain (unguarded) agent with its base prompt and no post-validation', async () => {
+    const { fn, calls } = mockGenerate()
+    const def: AgentDefinition = {
+      id: 't',
+      description: '',
+      systemPrompt: 'BASE',
+      temperature: 0.5,
+    }
+
+    const result = await runAgent(def, { message: 'hi' }, { generate: fn })
+
+    expect(result.text).toBe('ok')
+    expect(result.guardrail).toBeUndefined()
+    expect(calls[0].system).toBe('BASE')
+    expect(calls[0].user).toBe('hi')
+    expect(calls[0].temperature).toBe(0.5)
+  })
+
+  it('prepends the guardrail prompt, forces the guarded temperature, and post-validates', async () => {
+    const { fn, calls } = mockGenerate()
+    const def: AgentDefinition = {
+      id: 'pci',
+      description: '',
+      systemPrompt: 'BASE',
+      guardrailDomain: 'task',
+    }
+
+    const result = await runAgent(def, { message: 'hi' }, { generate: fn })
+
+    // canonical guardrail prompt is prepended to the base prompt — no agent can skip it
+    expect(calls[0].system.startsWith(guardrailSystemPrompt('task'))).toBe(true)
+    expect(calls[0].system).toContain('BASE')
+    // guarded generation runs at the low, consistent temperature
+    expect(calls[0].temperature).toBe(GUARDRAILED_TEMPERATURE)
+    // post-response validator ran and returned a structured result
+    expect(result.guardrail).toBeDefined()
+    expect(Array.isArray(result.guardrail?.violations)).toBe(true)
+    expect(typeof result.guardrail?.hasBlocking).toBe('boolean')
+  })
+
+  it('supports a function systemPrompt derived from the input', async () => {
+    const { fn, calls } = mockGenerate()
+    const def: AgentDefinition = {
+      id: 'dyn',
+      description: '',
+      systemPrompt: input => `Hello ${input.context?.role ?? 'user'}`,
+    }
+
+    await runAgent(def, { message: 'x', context: { role: 'tutor' } }, { generate: fn })
+
+    expect(calls[0].system).toBe('Hello tutor')
+  })
+})

--- a/tutorme-app/src/lib/ai/agent-kit/runner.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.ts
@@ -1,0 +1,62 @@
+/**
+ * The agent loop. Phase 1: compose the system prompt (guardrail prompt +
+ * skills + base), call the model, and — for guarded agents — run the
+ * post-response validator. Tool execution + hand-offs are Phase 2.
+ *
+ * The runner reuses the EXISTING guardrails and provider unchanged, so it can't
+ * weaken answer-leak protection: every guarded agent gets the canonical guardrail
+ * prompt prepended and the validator run, uniformly.
+ */
+import {
+  guardrailSystemPrompt,
+  runTaskGuardrails,
+  GUARDRAILED_TEMPERATURE,
+  type GuardrailRunResult,
+} from '@/lib/ai/guardrails'
+import type { AgentDefinition, AgentInput, AgentResult, GenerateFn } from './types'
+import { defaultGenerate } from './provider-adapter'
+
+export interface RunnerDeps {
+  generate: GenerateFn
+}
+
+const DEFAULT_DEPS: RunnerDeps = { generate: defaultGenerate }
+
+function resolveBasePrompt(def: AgentDefinition, input: AgentInput): string {
+  return typeof def.systemPrompt === 'function' ? def.systemPrompt(input) : def.systemPrompt
+}
+
+/** Guardrail prompt (if guarded) + base prompt + active skill instructions. */
+function composeSystemPrompt(def: AgentDefinition, input: AgentInput): string {
+  const parts: string[] = []
+  if (def.guardrailDomain) parts.push(guardrailSystemPrompt(def.guardrailDomain, def.variant))
+  parts.push(resolveBasePrompt(def, input))
+  for (const skill of def.skills ?? []) parts.push(skill.instructions)
+  return parts.join('\n\n')
+}
+
+export async function runAgent(
+  def: AgentDefinition,
+  input: AgentInput,
+  deps: RunnerDeps = DEFAULT_DEPS
+): Promise<AgentResult> {
+  const system = composeSystemPrompt(def, input)
+  const temperature = def.guardrailDomain ? GUARDRAILED_TEMPERATURE : (def.temperature ?? 0.7)
+
+  const { text } = await deps.generate({
+    system,
+    user: input.message,
+    temperature,
+    maxTokens: def.maxTokens,
+  })
+
+  let guardrail: GuardrailRunResult | undefined
+  if (def.guardrailDomain === 'task') {
+    // Task PCI output is validated as free text. Assessment/DMI output is
+    // validated at the structured-payload boundary (findEvaluationLeaks /
+    // stripEvaluationLayer), not here — see README, Phase 2.
+    guardrail = runTaskGuardrails(text)
+  }
+
+  return { agentId: def.id, text, guardrail }
+}

--- a/tutorme-app/src/lib/ai/agent-kit/types.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/types.ts
@@ -1,0 +1,88 @@
+/**
+ * agent-kit — a thin, provider-agnostic foundation for the app's AI agents.
+ *
+ * Design goals (see ./README.md for the full plan):
+ *  - Agents are declarative CONFIGS, not framework classes.
+ *  - Guardrails are applied uniformly by the runner — no agent can bypass them.
+ *  - Tools & skills are typed, registerable units (functions and scripts).
+ *  - The model layer is injected, so the runner is pure and testable and reuses
+ *    the existing `generateWithFallback` provider (Kimi -> OpenAI) unchanged.
+ *
+ * Phase 1 (this file + runner/registry/adapter) is ADDITIVE — nothing in prod
+ * calls it yet. Tool EXECUTION and agent hand-offs land in later phases.
+ */
+import type { ZodType } from 'zod'
+import type { GuardrailDomain, PciVariant, GuardrailRunResult } from '@/lib/ai/guardrails'
+
+/** Everything a tool/skill may need at call time (extend as the kit grows). */
+export interface AgentContext {
+  userId?: string
+  role?: string
+  sessionId?: string
+  courseId?: string
+}
+
+/**
+ * A tool is a typed function the agent can call. It may be a pure function or
+ * wrap a deterministic script (e.g. a rubric scorer, a marking-scheme parser).
+ */
+export interface Tool<TInput = unknown, TOutput = unknown> {
+  name: string
+  description: string
+  /** Zod schema validating the tool input at the boundary. */
+  input: ZodType<TInput>
+  run: (input: TInput, ctx: AgentContext) => Promise<TOutput> | TOutput
+}
+
+/**
+ * A skill is a progressive-disclosure bundle: instructions loaded only when
+ * relevant, optionally shipping its own tools. (Full loading semantics: Phase 2.)
+ */
+export interface Skill {
+  name: string
+  description: string
+  /** Markdown instructions injected into the system prompt when the skill is active. */
+  instructions: string
+  tools?: Tool[]
+}
+
+/** How the model is called. Injected so the runner never imports a provider directly. */
+export interface GenerateInput {
+  system: string
+  user: string
+  temperature?: number
+  maxTokens?: number
+}
+export type GenerateFn = (input: GenerateInput) => Promise<{ text: string }>
+
+/** A declarative agent definition. Ported agents are just values of this shape. */
+export interface AgentDefinition {
+  id: string
+  description: string
+  /** Base system prompt — static, or derived from the input/context. */
+  systemPrompt: string | ((input: AgentInput) => string)
+  /**
+   * When set, the runner PREPENDS the canonical guardrail prompt for this domain
+   * and runs the post-response guardrail validators. This is how every guarded
+   * agent gets answer-leak protection uniformly.
+   */
+  guardrailDomain?: GuardrailDomain
+  variant?: PciVariant
+  /** Sampling temperature. Ignored (forced to GUARDRAILED_TEMPERATURE) when guarded. */
+  temperature?: number
+  maxTokens?: number
+  tools?: Tool[]
+  skills?: Skill[]
+}
+
+export interface AgentInput {
+  message: string
+  context?: AgentContext
+}
+
+export interface AgentResult {
+  agentId: string
+  text: string
+  /** Present only for guarded agents — the post-response validator outcome. */
+  guardrail?: GuardrailRunResult
+}


### PR DESCRIPTION
**Phase 1 of the agent-architecture refactor** — a lean, TypeScript-native, provider-agnostic foundation to replace the Gemini-centric **ADK** service (which is currently broken in prod and duplicates prompts across the app + ADK repo).

### This PR is fully **additive** — zero prod risk
Nothing calls `agent-kit` yet. It reuses the *existing* `generateWithFallback` provider and `lib/ai/guardrails` **unchanged**, via dependency injection, so it can't weaken answer-leak protection.

### What's here
| File | Purpose |
|---|---|
| `types.ts` | declarative `AgentDefinition`, typed `Tool`/`Skill` (Zod I/O), injected `GenerateFn` |
| `runner.ts` | `runAgent()` — compose prompt (+ **canonical guardrails**) → generate → post-validate |
| `provider-adapter.ts` | wraps `generateWithFallback` (Kimi→OpenAI); adds system/user separation (a review-flagged hardening) |
| `registry.ts` | single source of truth for agents + tools |
| `agents/tutor.ts` | an agent as a **config** |
| `runner.test.ts` | proves the guardrail prompt is prepended, the guarded temperature is forced, and post-validation runs — **un-bypassable** |
| `README.md` | target structure + the 5-phase migration plan |

### Verification
- `npm run typecheck`: 0 errors · **3/3 tests pass** · prettier clean.

### Why phased (not one big-bang)
This touches the **answer-leak guardrails** on a live AI system. A single mega-commit would be unreviewable and risky. Each phase (foundation → tool execution → port agents → background worker → retire ADK) is a separate reviewable PR; ADK stays until nothing calls the new kit's replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)