### PR TITLE
refactor(ai): agent-kit Phase 2 — tool execution + structured validation

### DIFF
--- a/tutorme-app/src/lib/ai/agent-kit/README.md
+++ b/tutorme-app/src/lib/ai/agent-kit/README.md
@@ -49,5 +49,7 @@ agent-kit/
 - **Phase 5 — retire ADK.** Remove `Solocorn-LLC/adk-service` once nothing calls it.
 
 ## Status
-Phase 1 only. `runAgent` does a guardrailed single-shot generation; tool calls are
-declared but not yet executed (Phase 2).
+**Phases 1–2 landed.** `runAgent` does guardrailed generation *and* executes tools via
+a provider-agnostic ReAct/JSON loop (`tools/mcq-score.ts` is a worked example), with
+structured assessment/DMI post-validation. Next: **Phase 3** — port the real agents to
+configs, point routes at `runAgent` behind a flag, and delete the duplicate prompts.

--- a/tutorme-app/src/lib/ai/agent-kit/registry.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/registry.ts
@@ -17,8 +17,8 @@ export function listAgents(): AgentDefinition[] {
   return Array.from(agents.values())
 }
 
-export function registerTool(tool: Tool): Tool {
-  tools.set(tool.name, tool)
+export function registerTool<I, O>(tool: Tool<I, O>): Tool<I, O> {
+  tools.set(tool.name, tool as Tool)
   return tool
 }
 

--- a/tutorme-app/src/lib/ai/agent-kit/runner.tools.test.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { runAgent } from './runner'
+import { mcqScoreTool } from './tools/mcq-score'
+import type { AgentDefinition, GenerateFn } from './types'
+
+/** A mock provider that returns queued responses turn by turn. */
+function queuedGenerate(responses: string[]) {
+  const calls: { system: string; user: string }[] = []
+  let i = 0
+  const fn: GenerateFn = async ({ system, user }) => {
+    calls.push({ system, user })
+    const text = responses[Math.min(i, responses.length - 1)]
+    i++
+    return { text }
+  }
+  return { fn, calls }
+}
+
+describe('agent-kit tool loop', () => {
+  it('executes a tool with validated input and feeds the result back', async () => {
+    const { fn, calls } = queuedGenerate([
+      JSON.stringify({ tool: 'mcq_score', input: { selected: 'b', correctKey: 'B' } }),
+      JSON.stringify({ final: 'Correct — you picked B.' }),
+    ])
+    const def: AgentDefinition = {
+      id: 'grader',
+      description: '',
+      systemPrompt: 'You grade MCQs.',
+      tools: [mcqScoreTool],
+    }
+
+    const result = await runAgent(def, { message: 'Is b right if key is B?' }, { generate: fn })
+
+    expect(result.text).toBe('Correct — you picked B.')
+    // the tool protocol + tool names were injected into the system prompt
+    expect(calls[0].system).toContain('mcq_score')
+    // the (case-insensitive) tool result was fed back into the next turn
+    expect(calls[1].user).toContain('"correct":true')
+  })
+
+  it('rejects invalid tool input and reports it back to the model', async () => {
+    const { fn, calls } = queuedGenerate([
+      JSON.stringify({ tool: 'mcq_score', input: { selected: 'b' } }), // missing correctKey
+      JSON.stringify({ final: 'ok' }),
+    ])
+    const def: AgentDefinition = {
+      id: 'grader',
+      description: '',
+      systemPrompt: 'x',
+      tools: [mcqScoreTool],
+    }
+
+    const result = await runAgent(def, { message: 'go' }, { generate: fn })
+
+    expect(result.text).toBe('ok')
+    expect(calls[1].user.toLowerCase()).toContain('invalid input')
+  })
+
+  it('parse-gates structured assessment validation (no crash on non-JSON)', async () => {
+    const def: AgentDefinition = {
+      id: 'dmi',
+      description: '',
+      systemPrompt: 'x',
+      guardrailDomain: 'assessment',
+    }
+
+    const jsonGen = queuedGenerate([JSON.stringify({ fields: [{ label: 'Q1', type: 'short' }] })])
+    const r1 = await runAgent(def, { message: 'go' }, { generate: jsonGen.fn })
+    expect(r1.text).toContain('Q1') // returns the model output unchanged
+
+    const textGen = queuedGenerate(['not json at all'])
+    const r2 = await runAgent(def, { message: 'go' }, { generate: textGen.fn })
+    expect(r2.guardrail).toBeUndefined() // non-JSON → no structured validation
+  })
+})

--- a/tutorme-app/src/lib/ai/agent-kit/runner.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.ts
@@ -1,19 +1,24 @@
 /**
- * The agent loop. Phase 1: compose the system prompt (guardrail prompt +
- * skills + base), call the model, and — for guarded agents — run the
- * post-response validator. Tool execution + hand-offs are Phase 2.
+ * The agent loop.
  *
- * The runner reuses the EXISTING guardrails and provider unchanged, so it can't
- * weaken answer-leak protection: every guarded agent gets the canonical guardrail
- * prompt prepended and the validator run, uniformly.
+ * Phase 1: compose the system prompt (guardrail prompt + skills + base), call the
+ * model, and — for guarded agents — run the post-response validator.
+ * Phase 2: a provider-agnostic ReAct/JSON tool loop (the model requests a tool as
+ * JSON; the runner validates the input with the tool's Zod schema, runs it, and
+ * feeds the result back), plus structured assessment/DMI post-validation.
+ *
+ * Reuses the EXISTING guardrails + provider unchanged, so answer-leak protection
+ * can't be weakened: every guarded agent gets the canonical guardrail prompt and
+ * the validator — uniformly, including on the final tool-loop answer.
  */
 import {
   guardrailSystemPrompt,
   runTaskGuardrails,
+  runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
   type GuardrailRunResult,
 } from '@/lib/ai/guardrails'
-import type { AgentDefinition, AgentInput, AgentResult, GenerateFn } from './types'
+import type { AgentDefinition, AgentInput, AgentResult, GenerateFn, Tool } from './types'
 import { defaultGenerate } from './provider-adapter'
 
 export interface RunnerDeps {
@@ -21,6 +26,7 @@ export interface RunnerDeps {
 }
 
 const DEFAULT_DEPS: RunnerDeps = { generate: defaultGenerate }
+const MAX_TOOL_ITERATIONS = 5
 
 function resolveBasePrompt(def: AgentDefinition, input: AgentInput): string {
   return typeof def.systemPrompt === 'function' ? def.systemPrompt(input) : def.systemPrompt
@@ -35,6 +41,106 @@ function composeSystemPrompt(def: AgentDefinition, input: AgentInput): string {
   return parts.join('\n\n')
 }
 
+function collectTools(def: AgentDefinition): Tool[] {
+  const tools: Tool[] = [...(def.tools ?? [])]
+  for (const skill of def.skills ?? []) tools.push(...(skill.tools ?? []))
+  return tools
+}
+
+function toolProtocol(tools: Tool[]): string {
+  const list = tools.map(t => `- ${t.name}: ${t.description}`).join('\n')
+  return [
+    'You have tools. To call one, reply with ONLY a JSON object:',
+    '  {"tool": "<name>", "input": { ... }}',
+    'When you have the final answer, reply with ONLY:',
+    '  {"final": "<answer>"}',
+    'Available tools:',
+    list,
+  ].join('\n')
+}
+
+function tryParseJson(text: string): Record<string, unknown> | null {
+  const trimmed = text
+    .trim()
+    .replace(/^```(?:json)?/i, '')
+    .replace(/```$/, '')
+    .trim()
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+/** ReAct/JSON tool loop — provider-agnostic (no native function-calling needed). */
+async function runToolLoop(
+  def: AgentDefinition,
+  input: AgentInput,
+  baseSystem: string,
+  temperature: number,
+  deps: RunnerDeps
+): Promise<string> {
+  const tools = collectTools(def)
+  const byName = new Map(tools.map(t => [t.name, t]))
+  const system = `${baseSystem}\n\n${toolProtocol(tools)}`
+  const ctx = input.context ?? {}
+  let transcript = input.message
+
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    const { text } = await deps.generate({
+      system,
+      user: transcript,
+      temperature,
+      maxTokens: def.maxTokens,
+    })
+    const parsed = tryParseJson(text)
+    if (!parsed) return text // the model answered in plain text
+    if (typeof parsed.final === 'string') return parsed.final
+    if (typeof parsed.tool !== 'string') return text
+
+    const tool = byName.get(parsed.tool)
+    if (!tool) {
+      transcript += `\n\n[system] Tool "${parsed.tool}" does not exist. Available: ${tools.map(t => t.name).join(', ')}.`
+      continue
+    }
+    const validation = tool.input.safeParse(parsed.input)
+    if (!validation.success) {
+      transcript += `\n\n[system] Invalid input for "${tool.name}": ${validation.error.message}`
+      continue
+    }
+    const result = await tool.run(validation.data, ctx)
+    transcript += `\n\n[system] Tool "${tool.name}" returned: ${JSON.stringify(result)}`
+  }
+
+  // Out of iterations — force a final answer with no further tool calls.
+  const { text } = await deps.generate({
+    system: baseSystem,
+    user: `${transcript}\n\n[system] Provide your final answer now.`,
+    temperature,
+    maxTokens: def.maxTokens,
+  })
+  return text
+}
+
+/** Post-response guardrails, applied to the final answer regardless of tool use. */
+function runPostGuardrails(def: AgentDefinition, text: string): GuardrailRunResult | undefined {
+  if (def.guardrailDomain === 'task') return runTaskGuardrails(text)
+  if (def.guardrailDomain === 'assessment') {
+    // Assessment/DMI output is structured — parse it and run the leak validator.
+    const parsed = tryParseJson(text)
+    if (!parsed) return undefined
+    try {
+      return runAssessmentGuardrails(
+        parsed as unknown as Parameters<typeof runAssessmentGuardrails>[0]
+      )
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
 export async function runAgent(
   def: AgentDefinition,
   input: AgentInput,
@@ -43,20 +149,17 @@ export async function runAgent(
   const system = composeSystemPrompt(def, input)
   const temperature = def.guardrailDomain ? GUARDRAILED_TEMPERATURE : (def.temperature ?? 0.7)
 
-  const { text } = await deps.generate({
-    system,
-    user: input.message,
-    temperature,
-    maxTokens: def.maxTokens,
-  })
+  const text =
+    collectTools(def).length > 0
+      ? await runToolLoop(def, input, system, temperature, deps)
+      : (
+          await deps.generate({
+            system,
+            user: input.message,
+            temperature,
+            maxTokens: def.maxTokens,
+          })
+        ).text
 
-  let guardrail: GuardrailRunResult | undefined
-  if (def.guardrailDomain === 'task') {
-    // Task PCI output is validated as free text. Assessment/DMI output is
-    // validated at the structured-payload boundary (findEvaluationLeaks /
-    // stripEvaluationLayer), not here — see README, Phase 2.
-    guardrail = runTaskGuardrails(text)
-  }
-
-  return { agentId: def.id, text, guardrail }
+  return { agentId: def.id, text, guardrail: runPostGuardrails(def, text) }
 }

--- a/tutorme-app/src/lib/ai/agent-kit/tools/mcq-score.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/tools/mcq-score.ts
@@ -1,0 +1,22 @@
+/**
+ * Example tool: a deterministic MCQ scorer. Demonstrates a tool that wraps a
+ * pure "script" (no LLM, no I/O) with Zod-validated input — the kind of
+ * function an agent should call for anything that must be exact.
+ */
+import { z } from 'zod'
+import { registerTool } from '../registry'
+import type { Tool } from '../types'
+
+const input = z.object({
+  selected: z.string().describe("the option the student picked, e.g. 'B'"),
+  correctKey: z.string().describe("the correct option, e.g. 'B'"),
+})
+
+export const mcqScoreTool: Tool<z.infer<typeof input>, { correct: boolean }> = registerTool({
+  name: 'mcq_score',
+  description: 'Score a multiple-choice answer against the answer key. Case-insensitive.',
+  input,
+  run: ({ selected, correctKey }) => ({
+    correct: selected.trim().toLowerCase() === correctKey.trim().toLowerCase(),
+  }),
+})


### PR DESCRIPTION
**Phase 2** of the ADK-replacement refactor. Still **additive** — nothing in prod calls the kit yet.

### What's added
- **Tool execution** — a provider-agnostic **ReAct/JSON loop**: the model emits `{"tool","input"}`, the runner **validates input against the tool's Zod schema**, runs it, feeds the result back, and loops (capped at 5). Works with the existing prompt→text provider (no native function-calling required).
- **Structured assessment validation** — for `guardrailDomain: 'assessment'`, the runner parses the JSON output and runs `runAssessmentGuardrails` (defensively — bad shapes can't crash the agent).
- **`tools/mcq-score.ts`** — a worked example of a tool that wraps a **deterministic script** (your "scripts and functions").
- **`registerTool` is now generic** so a tool's input/output types survive registration.

### Verification
- `npm run typecheck`: 0 errors · **6/6 tests pass** (Phase 1 + 2) · prettier clean.
- Guardrails still un-bypassable — they apply to the **final** answer whether or not tools ran.

### Next (Phase 3, separate PR)
Port the real agents (tutor/grader/content-gen/pci-master) to configs, point routes at `runAgent` behind a flag, and **delete the duplicate prompts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)