### PR TITLE
chore(deploy): stop injecting ADK env vars (make the ADK-disable permanent)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -140,9 +140,10 @@ jobs:
           docker push "$IMAGE"
           echo "IMAGE=${IMAGE}" >> $GITHUB_ENV
 
-      # ADK is now built & deployed from its own repository (Solocorn-LLC/adk-service).
-      # This pipeline no longer manages the adk-service Cloud Run service; the app
-      # reaches it via the ADK_BASE_URL secret (its stable Cloud Run URL) below.
+      # ADK is currently DISABLED: the app no longer receives ADK_BASE_URL/ADK_AUTH_TOKEN,
+      # so it runs the direct Kimi path (ADK is broken and being retired by the agent-kit
+      # refactor). adk-service lives in its own repo (Solocorn-LLC/adk-service); to re-enable
+      # ADK, re-add those two vars to the app env_vars below and fix/redeploy adk-service.
 
       - name: Run migrations (inline docker)
         run: |
@@ -181,7 +182,7 @@ jobs:
           # VAPID_PUBLIC_KEY is public (served to browsers) so it's a literal here;
           # VAPID_SUBJECT is optional (web-push.ts falls back to a default mailto).
           # VAPID_PRIVATE_KEY is mounted from Secret Manager via `secrets:` below.
-          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},KIMI_API_KEY=${{ secrets.KIMI_API_KEY }},KIMI_BASE_URL=https://api.moonshot.ai/v1,KIMI_MODEL=moonshot-v1-32k,KIMI_VISION_MODEL=moonshot-v1-32k-vision-preview,DAILY_API_KEY=${{ secrets.DAILY_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,ADK_BASE_URL=${{ secrets.ADK_BASE_URL }},ADK_AUTH_TOKEN=${{ secrets.ADK_AUTH_TOKEN }},VAPID_PUBLIC_KEY=BLU03HUyohyMlSRHnva794Ea1Y7BKl76i8xZNLiwHgR0D5NI4AhQUURdgI_m6aZo931gW4LsoP7RwguNwkwklK0,VAPID_SUBJECT=${{ secrets.VAPID_SUBJECT }}
+          env_vars: NODE_ENV=production,APP_VERSION=${{ github.sha }},DATABASE_URL=${{ secrets.DATABASE_URL }},DIRECT_URL=${{ secrets.DIRECT_URL }},NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }},NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }},NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }},REDIS_URL=${{ secrets.REDIS_URL }},KIMI_API_KEY=${{ secrets.KIMI_API_KEY }},KIMI_BASE_URL=https://api.moonshot.ai/v1,KIMI_MODEL=moonshot-v1-32k,KIMI_VISION_MODEL=moonshot-v1-32k-vision-preview,DAILY_API_KEY=${{ secrets.DAILY_API_KEY }},GCS_BUCKET=${{ secrets.GCS_BUCKET }},GCS_VIDEO_BUCKET=${{ secrets.GCS_VIDEO_BUCKET }},GCS_VIDEO_BUCKET_URL=${{ secrets.GCS_VIDEO_BUCKET_URL }},SKIP_MIGRATIONS=true,MIGRATIONS_REQUIRED=false,VAPID_PUBLIC_KEY=BLU03HUyohyMlSRHnva794Ea1Y7BKl76i8xZNLiwHgR0D5NI4AhQUURdgI_m6aZo931gW4LsoP7RwguNwkwklK0,VAPID_SUBJECT=${{ secrets.VAPID_SUBJECT }}
           # Web-push private key, mounted from Secret Manager as an env var.
           secrets: |-
             VAPID_PRIVATE_KEY=VAPID_PRIVATE_KEY:latest


### PR DESCRIPTION
You deleted `ADK_BASE_URL` on Cloud Run, but the pipeline **re-injects it every deploy** (`ADK_BASE_URL=${{ secrets.ADK_BASE_URL }}`), so it came right back. This removes `ADK_BASE_URL` + `ADK_AUTH_TOKEN` from the app's `env_vars` so the disable **sticks**.

- No runtime break: the app guards missing ADK (`if (!adkBaseUrl) return` / fallback) → chat/PCI run on the direct Kimi path.
- On merge, the canary deploy ships the app **without ADK** — the failing 401 calls + latency stop.
- The `ADK_*` GitHub secrets can stay (harmless) or be deleted later; the adk-client code cleanup lands with the refactor (Phase 4/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)