### PR TITLE
refactor(ai): make the tutor agent-kit config faithful (resolve prompt conflict, keep ASMT-15)

### DIFF
--- a/tutorme-app/src/lib/ai/agent-kit/README.md
+++ b/tutorme-app/src/lib/ai/agent-kit/README.md
@@ -58,6 +58,16 @@ agent-kit/
 ## Status
 **Phases 1–2 landed.** `runAgent` does guardrailed generation *and* executes tools via a
 provider-agnostic ReAct/JSON loop, with structured assessment/DMI post-validation.
-**Phase 3 in progress:** the **tutor** agent is ported (`agents/tutor.ts` delegates to the
-existing `buildSystemPrompt`); grader/content-generator/pci-master and the flag-gated route
-cutover follow, one PR each.
+**Phase 3 in progress:** the **tutor** agent is ported **faithfully** — `agents/tutor.ts` mirrors
+the LIVE `runTutorChat` prompt chain (`buildCompletePrompt` → `withTaskPci` (TASK-6) →
+`withAssessmentIntegrity` (ASMT-15)). The first port pointed at a *different, older* builder
+(`buildSystemPrompt`), which **conflicts** with the live prompt; per single-source-of-truth we keep
+the live chain and dropped the stale one from the kit, and a test now guards that the
+assessment-integrity constraint survives.
+
+**Cutover note:** `runTutorChat` is *already* a clean canonical entrypoint (sanitization, integrity,
+rich output extraction) and uses a **single baked prompt**, which doesn't map onto the runner's
+system/user split. So the tutor is a poor *first* cutover candidate — churn with regression risk.
+The better first real cutover is a **guardrailed PCI/assessment agent** (system/user separation +
+`guardrailDomain` — exactly what the runner is built for). grader/content-generator/pci-master and
+the flag-gated cutover follow, one PR each.

--- a/tutorme-app/src/lib/ai/agent-kit/agents/tutor.test.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/agents/tutor.test.ts
@@ -1,27 +1,47 @@
 import { describe, it, expect } from 'vitest'
-import { tutorAgent } from './tutor'
+import { tutorAgent, type TutorAgentContext } from './tutor'
 import { getAgent } from '../registry'
+import type { PromptConfig } from '@/lib/ai/teaching-prompts/prompt-builder'
 
-describe('tutor agent (ported)', () => {
+const promptConfig = {
+  language: 'en',
+  teachingMode: 'socratic',
+  personality: 'friendly_mentor',
+  subject: 'Mathematics',
+  topic: null,
+  tier: 'FREE',
+  chatHistory: [],
+  userMessage: 'How do I factor x^2 - 9?',
+} as unknown as PromptConfig
+
+function render(ctx: Partial<TutorAgentContext>): string {
+  const fn = tutorAgent.systemPrompt
+  if (typeof fn !== 'function') throw new Error('expected a function systemPrompt')
+  return fn({ message: 'help', context: { promptConfig, ...ctx } })
+}
+
+describe('tutor agent (faithful port)', () => {
   it('registers itself with the expected metadata', () => {
     expect(getAgent('tutor')).toBe(tutorAgent)
     expect(tutorAgent.temperature).toBe(0.7)
+    expect(tutorAgent.maxTokens).toBe(2048)
     expect(tutorAgent.guardrailDomain).toBeUndefined() // tutor chat is not a PCI domain
     expect(typeof tutorAgent.systemPrompt).toBe('function')
   })
 
-  it('delegates its system prompt to the existing builder (single source of truth)', () => {
-    // A representative TutorContext; the assertion is about *delegation*, so we
-    // only require that the ported agent returns the builder's output verbatim.
-    const context = {
-      student: { id: 's1', name: 'A', grade: '10' },
-      subject: 'Mathematics',
-      conversationHistory: '',
-    }
-    const fn = tutorAgent.systemPrompt
-    if (typeof fn !== 'function') throw new Error('expected a function systemPrompt')
-    const prompt = fn({ message: 'help', context })
+  it('builds a prompt from the live builder (buildCompletePrompt), not the stale one', () => {
+    const prompt = render({ assessmentActive: false })
     expect(typeof prompt).toBe('string')
     expect(prompt.length).toBeGreaterThan(0)
+  })
+
+  it('preserves the ASMT-15 assessment-integrity constraint when an assessment is active', () => {
+    // The integrity layer is added ONLY when assessmentActive === true, so an
+    // active-assessment prompt must differ from (and be longer than) an inactive
+    // one. This guards against a cutover silently dropping the safety directive.
+    const active = render({ assessmentActive: true })
+    const inactive = render({ assessmentActive: false })
+    expect(active).not.toEqual(inactive)
+    expect(active.length).toBeGreaterThan(inactive.length)
   })
 })

--- a/tutorme-app/src/lib/ai/agent-kit/agents/tutor.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/agents/tutor.ts
@@ -1,19 +1,48 @@
 /**
- * Tutor agent — Phase 3 port.
+ * Tutor agent — faithful to the LIVE tutor-chat path.
  *
- * Delegates its system prompt to the EXISTING builder so there's a single source
- * of truth for the Socratic tutor prompt (no duplicate copy in the kit). The
- * calling route passes a `TutorContext`-shaped `context`; `buildHintPrompt` /
- * `buildExplanationPrompt` become tools in a later PR.
+ * The canonical tutor entrypoint is `runTutorChat` (lib/agents/tutor-chat-service),
+ * which builds its prompt with `buildCompletePrompt` and then layers TASK-6
+ * (`withTaskPci`) and ASMT-15 (`withAssessmentIntegrity`) — in that order, so the
+ * integrity directive stays highest.
+ *
+ * The initial Phase-3a port delegated to a DIFFERENT, older builder
+ * (`buildSystemPrompt`, lib/agents/tutor/prompts) — the two prompts CONFLICT.
+ * Per the single-source-of-truth rule we keep the live `buildCompletePrompt`
+ * chain and drop the stale one here, and we preserve the assessment-integrity
+ * constraint: dropping it would let the tutor help a student during a live
+ * assessment (an academic-integrity regression).
+ *
+ * NOTE: `runTutorChat` remains the canonical runtime for now. This config exists
+ * so the kit's tutor is a FAITHFUL mirror (not a landmine) ahead of any route
+ * cutover; the cutover itself is a separate, flag-gated, reviewed PR.
  */
-import { buildSystemPrompt } from '@/lib/agents/tutor/prompts/system-prompt'
+import { buildCompletePrompt, type PromptConfig } from '@/lib/ai/teaching-prompts/prompt-builder'
+import { withTaskPci } from '@/lib/assessment/task-pci-context'
+import { withAssessmentIntegrity } from '@/lib/assessment/active-assessment'
+import type { PciSpec } from '@/lib/assessment/pci-spec'
 import { registerAgent } from '../registry'
 import type { AgentDefinition } from '../types'
+
+/** Prompt inputs the tutor agent expects (mirrors `runTutorChat`'s inputs). */
+export interface TutorAgentContext {
+  promptConfig: PromptConfig
+  taskPci?: string | null
+  taskPciSpec?: PciSpec | null
+  assessmentActive?: boolean
+}
 
 export const tutorAgent: AgentDefinition = registerAgent({
   id: 'tutor',
   description: 'Socratic AI tutor — guides students to answers, never gives them directly.',
-  systemPrompt: input =>
-    buildSystemPrompt(input.context as unknown as Parameters<typeof buildSystemPrompt>[0]),
+  systemPrompt: input => {
+    const c = (input.context ?? {}) as unknown as TutorAgentContext
+    // Same three layers, same order, as runTutorChat: base prompt → task PCI →
+    // assessment-integrity on top.
+    const base = buildCompletePrompt(c.promptConfig)
+    const taskAware = withTaskPci(base, c.taskPci ?? null, c.taskPciSpec ?? null)
+    return withAssessmentIntegrity(taskAware, c.assessmentActive === true)
+  },
   temperature: 0.7,
+  maxTokens: 2048,
 })


### PR DESCRIPTION
Follow-up to Phase 3a. While preparing the tutor **route cutover** I found the ported config was pointing at the **wrong prompt**.

### The conflict
- **Live path** (`runTutorChat`): `buildCompletePrompt` → `withTaskPci` (TASK-6) → `withAssessmentIntegrity` (**ASMT-15** — no tutoring help during a live assessment).
- **Phase-3a config**: delegated to `buildSystemPrompt` (a *different, older* builder).

These two prompts **conflict**. Per single-source-of-truth I keep the **live** `buildCompletePrompt` chain and **drop the stale builder from the kit**.

### Why it matters (safety)
The old delegation didn't carry `withAssessmentIntegrity`, so a naive cutover would have **silently dropped the academic-integrity guardrail**. This config now layers it exactly as the live path does, and a **test guards it** (active-assessment prompt must differ from / be longer than the inactive one).

### Scope
- **Additive** — `runTutorChat` stays the canonical runtime; nothing calls `runAgent` yet.
- `buildSystemPrompt` is **not** globally deleted — it has other live callers (`tutor-service`, `teaching-prompts`, `subjects`); reconciling those is a separate pass.
- README updated with a **cutover note**: the tutor's single-baked-prompt shape doesn't fit the runner's system/user split, so it's a poor *first* cutover — a guardrailed PCI agent is the better first target.

`typecheck` clean · **9/9** agent-kit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)