### PR TITLE
refactor(ai): agent-kit runner — per-request guardrail domain (enables pci-master cutover)

### DIFF
--- a/tutorme-app/src/lib/ai/agent-kit/runner.test.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.test.ts
@@ -53,6 +53,54 @@ describe('agent-kit runner', () => {
     expect(typeof result.guardrail?.hasBlocking).toBe('boolean')
   })
 
+  it('applies a PER-REQUEST guardrail domain (from context) on an otherwise-unguarded agent', async () => {
+    const { fn, calls } = mockGenerate()
+    // No static guardrailDomain — the domain arrives per request (like pci-master,
+    // whose domain is context.type: task | assessment | none).
+    const def: AgentDefinition = { id: 'pci-master', description: '', systemPrompt: 'BASE' }
+
+    const result = await runAgent(
+      def,
+      { message: 'hi', context: { guardrailDomain: 'task' } },
+      { generate: fn }
+    )
+
+    // the request-supplied domain drives the guardrail prompt, temperature, and validator
+    expect(calls[0].system.startsWith(guardrailSystemPrompt('task'))).toBe(true)
+    expect(calls[0].system).toContain('BASE')
+    expect(calls[0].temperature).toBe(GUARDRAILED_TEMPERATURE)
+    expect(result.guardrail).toBeDefined()
+  })
+
+  it('runs UNGUARDED when neither the agent nor the request supplies a domain', async () => {
+    const { fn, calls } = mockGenerate()
+    const def: AgentDefinition = { id: 'pci-master', description: '', systemPrompt: 'BASE' }
+
+    const result = await runAgent(def, { message: 'hi', context: {} }, { generate: fn })
+
+    expect(calls[0].system).toBe('BASE') // no guardrail prompt prepended
+    expect(result.guardrail).toBeUndefined() // no post-validation
+  })
+
+  it('lets a per-request domain OVERRIDE the agent default', async () => {
+    const { fn, calls } = mockGenerate()
+    const def: AgentDefinition = {
+      id: 'x',
+      description: '',
+      systemPrompt: 'BASE',
+      guardrailDomain: 'task',
+    }
+
+    await runAgent(
+      def,
+      { message: 'hi', context: { guardrailDomain: 'assessment' } },
+      { generate: fn }
+    )
+
+    // the request's 'assessment' wins over the agent's static 'task'
+    expect(calls[0].system.startsWith(guardrailSystemPrompt('assessment'))).toBe(true)
+  })
+
   it('supports a function systemPrompt derived from the input', async () => {
     const { fn, calls } = mockGenerate()
     const def: AgentDefinition = {

--- a/tutorme-app/src/lib/ai/agent-kit/runner.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.ts
@@ -17,6 +17,8 @@ import {
   runAssessmentGuardrails,
   GUARDRAILED_TEMPERATURE,
   type GuardrailRunResult,
+  type GuardrailDomain,
+  type PciVariant,
 } from '@/lib/ai/guardrails'
 import type { AgentDefinition, AgentInput, AgentResult, GenerateFn, Tool } from './types'
 import { defaultGenerate } from './provider-adapter'
@@ -32,10 +34,30 @@ function resolveBasePrompt(def: AgentDefinition, input: AgentInput): string {
   return typeof def.systemPrompt === 'function' ? def.systemPrompt(input) : def.systemPrompt
 }
 
+/**
+ * Resolve the effective guardrail domain/variant for THIS call: a per-request
+ * override on `input.context` wins over the agent's static definition. This is
+ * what lets one agent (e.g. pci-master) serve requests whose domain varies.
+ */
+function resolveGuardrail(
+  def: AgentDefinition,
+  input: AgentInput
+): { domain?: GuardrailDomain; variant?: PciVariant } {
+  return {
+    domain: input.context?.guardrailDomain ?? def.guardrailDomain,
+    variant: input.context?.variant ?? def.variant,
+  }
+}
+
 /** Guardrail prompt (if guarded) + base prompt + active skill instructions. */
-function composeSystemPrompt(def: AgentDefinition, input: AgentInput): string {
+function composeSystemPrompt(
+  def: AgentDefinition,
+  input: AgentInput,
+  domain: GuardrailDomain | undefined,
+  variant: PciVariant | undefined
+): string {
   const parts: string[] = []
-  if (def.guardrailDomain) parts.push(guardrailSystemPrompt(def.guardrailDomain, def.variant))
+  if (domain) parts.push(guardrailSystemPrompt(domain, variant))
   parts.push(resolveBasePrompt(def, input))
   for (const skill of def.skills ?? []) parts.push(skill.instructions)
   return parts.join('\n\n')
@@ -124,9 +146,12 @@ async function runToolLoop(
 }
 
 /** Post-response guardrails, applied to the final answer regardless of tool use. */
-function runPostGuardrails(def: AgentDefinition, text: string): GuardrailRunResult | undefined {
-  if (def.guardrailDomain === 'task') return runTaskGuardrails(text)
-  if (def.guardrailDomain === 'assessment') {
+function runPostGuardrails(
+  domain: GuardrailDomain | undefined,
+  text: string
+): GuardrailRunResult | undefined {
+  if (domain === 'task') return runTaskGuardrails(text)
+  if (domain === 'assessment') {
     // Assessment/DMI output is structured — parse it and run the leak validator.
     const parsed = tryParseJson(text)
     if (!parsed) return undefined
@@ -146,8 +171,9 @@ export async function runAgent(
   input: AgentInput,
   deps: RunnerDeps = DEFAULT_DEPS
 ): Promise<AgentResult> {
-  const system = composeSystemPrompt(def, input)
-  const temperature = def.guardrailDomain ? GUARDRAILED_TEMPERATURE : (def.temperature ?? 0.7)
+  const { domain, variant } = resolveGuardrail(def, input)
+  const system = composeSystemPrompt(def, input, domain, variant)
+  const temperature = domain ? GUARDRAILED_TEMPERATURE : (def.temperature ?? 0.7)
 
   const text =
     collectTools(def).length > 0
@@ -161,5 +187,5 @@ export async function runAgent(
           })
         ).text
 
-  return { agentId: def.id, text, guardrail: runPostGuardrails(def, text) }
+  return { agentId: def.id, text, guardrail: runPostGuardrails(domain, text) }
 }

--- a/tutorme-app/src/lib/ai/agent-kit/types.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/types.ts
@@ -21,6 +21,16 @@ export interface AgentContext {
   sessionId?: string
   courseId?: string
   /**
+   * Per-request guardrail override. When set, the runner uses THIS domain (and
+   * `variant`) for the guardrail system prompt, the guardrailed temperature, and
+   * the post-response validators — overriding the agent's STATIC `guardrailDomain`.
+   * This lets one agent serve a route whose domain varies per request (e.g.
+   * pci-master: `task` | `assessment` | none). Falls back to the agent default
+   * when absent, so existing agents are unaffected.
+   */
+  guardrailDomain?: GuardrailDomain
+  variant?: PciVariant
+  /**
    * Agent-specific context rides along here (e.g. a ported agent's own
    * `TutorContext`/`GradingRequest`), so a `systemPrompt` function can delegate
    * to the existing prompt builder without a bespoke input type per agent.


### PR DESCRIPTION
Enabling infra for the first real route cutover (**pci-master**, next PR).

### Problem
The runner keyed guardrails off the agent's **static** `guardrailDomain`. But pci-master's domain is **per request** — `context.type` is `task` | `assessment` | none, with a per-request `variant` (composition/documentKind). One static agent can't serve all three.

### Change
Resolve the effective domain/variant **per call**: `input.context.guardrailDomain` (and `.variant`) win over the agent definition, falling back to the agent default when absent. Threaded through:
- the guardrail **system prompt** (`guardrailSystemPrompt(domain, variant)`),
- the guarded **temperature** (`GUARDRAILED_TEMPERATURE`),
- the **post-response validators** (`runTaskGuardrails` / `runAssessmentGuardrails`).

### Safety
**Fully backward-compatible** — agents that don't supply a per-request domain behave exactly as before (all prior runner tests pass unchanged). Additive: nothing in prod calls `runAgent` yet.

3 new tests (per-request domain drives guardrails; unguarded when neither supplies one; request overrides agent default). `typecheck` clean · **12/12** agent-kit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)