### PR TITLE
refactor(ai): pci-master agent config + shared system prompt (PR A, additive)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -20,6 +20,7 @@ import {
   GUARDRAILED_TEMPERATURE,
   type GuardrailViolation,
 } from '@/lib/ai/guardrails'
+import { PCI_MASTER_SYSTEM_PROMPT } from '@/lib/ai/agent-kit/agents/pci-master'
 import { z } from 'zod'
 
 /**
@@ -91,23 +92,6 @@ const PciMasterRequestSchema = z.object({
   // source document is attached.
   pdfPages: z.array(z.string().max(5_000_000)).max(5).optional(),
 })
-
-const SYSTEM_PROMPT = `You are a PCI (Programmatic Curriculum Instruction) Master - an expert educational AI that crafts and refines Socratic-style instructions.
-
-Your role:
-1. Help students discover answers through guided questioning (never give direct answers)
-2. Adapt your approach based on the content type (task, assessment, or concept)
-3. Use the conversation history to maintain context
-4. Provide clear, encouraging, and thought-provoking guidance
-
-Respond in JSON format with this structure:
-{
-  "response": "your Socratic response here",
-  "followUpQuestions": ["question 1", "question 2"],
-  "suggestedResources": ["resource 1", "resource 2"],
-  "difficulty": "easy|medium|hard",
-  "confidence": 0.8
-}`
 
 function truncate(value: string | undefined, max: number): string | undefined {
   if (!value) return value
@@ -184,7 +168,7 @@ export async function POST(request: NextRequest) {
     const guardrailDomain = context?.type
     const activeSystemPrompt = guardrailDomain
       ? guardrailSystemPrompt(guardrailDomain, context?.variant)
-      : SYSTEM_PROMPT
+      : PCI_MASTER_SYSTEM_PROMPT
     const activeTemperature = guardrailDomain ? GUARDRAILED_TEMPERATURE : 0.7
 
     // Observability: record which per-type variant actually fired, so the

--- a/tutorme-app/src/lib/ai/agent-kit/agents/pci-master.test.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/agents/pci-master.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { pciMasterAgent, PCI_MASTER_SYSTEM_PROMPT } from './pci-master'
+import { getAgent } from '../registry'
+import { runAgent } from '../runner'
+import { guardrailSystemPrompt } from '@/lib/ai/guardrails'
+import type { GenerateFn } from '../types'
+
+function mockGenerate() {
+  const calls: { system: string; user: string; temperature?: number }[] = []
+  const fn: GenerateFn = async ({ system, user, temperature }) => {
+    calls.push({ system, user, temperature })
+    return { text: 'ok' }
+  }
+  return { fn, calls }
+}
+
+function render(
+  input: Parameters<Extract<typeof pciMasterAgent.systemPrompt, (i: never) => string>>[0]
+) {
+  const fn = pciMasterAgent.systemPrompt
+  if (typeof fn !== 'function') throw new Error('expected a function systemPrompt')
+  return fn(input)
+}
+
+describe('pci-master agent', () => {
+  it('registers with the expected metadata and no STATIC guardrail domain', () => {
+    expect(getAgent('pci-master')).toBe(pciMasterAgent)
+    expect(pciMasterAgent.maxTokens).toBe(4096)
+    // domain is per-request (context.type), never fixed on the agent
+    expect(pciMasterAgent.guardrailDomain).toBeUndefined()
+  })
+
+  it('uses the generic Socratic prompt when UNGUARDED', () => {
+    expect(render({ message: 'hi', context: {} })).toBe(PCI_MASTER_SYSTEM_PROMPT)
+  })
+
+  it('emits an EMPTY base when guarded (guardrail prompt fully replaces it)', () => {
+    expect(render({ message: 'hi', context: { guardrailDomain: 'task' } })).toBe('')
+  })
+
+  it('through the runner: a task request yields exactly the guardrail prompt (no generic tail)', async () => {
+    const { fn, calls } = mockGenerate()
+    await runAgent(
+      pciMasterAgent,
+      { message: 'set marks', context: { guardrailDomain: 'task' } },
+      { generate: fn }
+    )
+    // exactly the guardrail prompt — not "guardrail\n\n" and not guardrail + generic
+    expect(calls[0].system).toBe(guardrailSystemPrompt('task'))
+    expect(calls[0].system).not.toContain('Respond in JSON format') // generic prompt is absent
+  })
+})

--- a/tutorme-app/src/lib/ai/agent-kit/agents/pci-master.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/agents/pci-master.ts
@@ -1,0 +1,46 @@
+/**
+ * PCI Master agent — the course-builder's Socratic instruction / marking-policy
+ * chat (POST /api/ai/pci-master).
+ *
+ * This is the FIRST agent whose guardrails the runner actually owns: its domain
+ * is per-request (`context.type` → `task` | `assessment` | none) with a
+ * per-request `variant`, so it relies on the runner's per-request guardrail
+ * resolution (see runner `resolveGuardrail`). When a domain is present the runner
+ * prepends the canonical guardrail prompt and runs the post-response validators;
+ * when absent it falls back to the generic Socratic prompt below.
+ *
+ * The base prompt is emitted ONLY in the unguarded case. When guarded, the
+ * generic prompt is intentionally empty: the guardrail prompt fully defines the
+ * behavior and output envelope ({reply,pci,spec}), and appending the generic
+ * {response,...} format would conflict with it.
+ */
+import { registerAgent } from '../registry'
+import type { AgentDefinition } from '../types'
+
+/**
+ * Single source of truth for the generic (unguarded) PCI Master system prompt.
+ * The route imports THIS constant instead of keeping its own copy.
+ */
+export const PCI_MASTER_SYSTEM_PROMPT = `You are a PCI (Programmatic Curriculum Instruction) Master - an expert educational AI that crafts and refines Socratic-style instructions.
+
+Your role:
+1. Help students discover answers through guided questioning (never give direct answers)
+2. Adapt your approach based on the content type (task, assessment, or concept)
+3. Use the conversation history to maintain context
+4. Provide clear, encouraging, and thought-provoking guidance
+
+Respond in JSON format with this structure:
+{
+  "response": "your Socratic response here",
+  "followUpQuestions": ["question 1", "question 2"],
+  "suggestedResources": ["resource 1", "resource 2"],
+  "difficulty": "easy|medium|hard",
+  "confidence": 0.8
+}`
+
+export const pciMasterAgent: AgentDefinition = registerAgent({
+  id: 'pci-master',
+  description: 'PCI Master — crafts and refines Socratic instructions and marking policies.',
+  systemPrompt: input => (input.context?.guardrailDomain ? '' : PCI_MASTER_SYSTEM_PROMPT),
+  maxTokens: 4096,
+})

--- a/tutorme-app/src/lib/ai/agent-kit/runner.ts
+++ b/tutorme-app/src/lib/ai/agent-kit/runner.ts
@@ -60,7 +60,10 @@ function composeSystemPrompt(
   if (domain) parts.push(guardrailSystemPrompt(domain, variant))
   parts.push(resolveBasePrompt(def, input))
   for (const skill of def.skills ?? []) parts.push(skill.instructions)
-  return parts.join('\n\n')
+  // Drop empty parts so an agent that returns an empty base when guarded (e.g.
+  // pci-master, whose guardrail prompt fully replaces its generic prompt) yields
+  // exactly the guardrail prompt, not "guardrail\n\n".
+  return parts.filter(Boolean).join('\n\n')
 }
 
 function collectTools(def: AgentDefinition): Tool[] {


### PR DESCRIPTION
**PR A** of the pci-master cutover — additive, **no behavior change**. (PR B wires the flag-gated route cutover.)

- **New `agents/pci-master.ts`** — the PCI Master agent. Base prompt only when **unguarded**; **empty when guarded**, so the runner's canonical guardrail prompt *fully replaces* it (the guardrail `{reply,pci,spec}` envelope would otherwise conflict with the generic `{response,...}` format). No static `guardrailDomain` — the domain is per-request (`context.type`), riding on the runner's per-request resolution from #957.
- **`PCI_MASTER_SYSTEM_PROMPT` is now the single source of truth** — the route imports it instead of keeping an inline copy. Kills the duplication (per the prompt-conflict rule).
- **runner**: `composeSystemPrompt` drops empty parts, so an empty guarded base yields *exactly* the guardrail prompt.

Route change is import-only: `activeSystemPrompt`'s unguarded branch now references the imported constant — same text, same behavior.

`typecheck` clean · **16/16** agent-kit tests (4 new: unguarded→generic, guarded→empty, runner→exactly-guardrail-prompt, metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)