### PR TITLE
refactor(ai): flag-gated pci-master cutover to the agent-kit runner (PR B — review before flipping)

### DIFF
--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -64,6 +64,8 @@ describe('/api/ai/pci-master', () => {
 
   afterEach(() => {
     global.fetch = originalFetch
+    delete process.env.AGENT_KIT_PCI_MASTER
+    delete process.env.KIMI_API_KEY
   })
 
   it('uses tutor realm session when available', async () => {
@@ -179,6 +181,38 @@ describe('/api/ai/pci-master', () => {
     const data = await res.json()
 
     expect(data.response).toBe('Just plain prose, no JSON at all.')
+    expect(data.pciDraft).toBe('')
+  })
+
+  it('flag ON: routes local generation through the agent-kit runner, preserving skipCache/timeout/retries + guardrails', async () => {
+    // Force the LOCAL path (no ADK) with a local provider available, flag ON.
+    process.env.AGENT_KIT_PCI_MASTER = 'true'
+    delete process.env.ADK_BASE_URL
+    process.env.KIMI_API_KEY = 'test-key'
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
+    mocks.generateWithFallback.mockResolvedValue({
+      content: '{"reply":"What makes an answer correct?","pci":""}',
+      provider: 'kimi',
+      latencyMs: 5,
+    })
+
+    const res = await postBody({ message: 'set marks', context: { type: 'task' } })
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    // generation went through the kit's injected generate → generateWithFallback
+    expect(mocks.generateWithFallback).toHaveBeenCalledTimes(1)
+    const [prompt, opts] = mocks.generateWithFallback.mock.calls[0]
+    // the retry/cache budget is preserved (the default adapter would drop these)
+    expect(opts).toMatchObject({
+      skipCache: true,
+      timeoutMs: expect.any(Number),
+      retries: expect.any(Number),
+    })
+    // user input is injection-fenced, and the task guardrail prompt is applied
+    expect(prompt).toContain('<user_input>')
+    // downstream envelope extraction still runs on the kit's output
+    expect(data.response).toBe('What makes an answer correct?')
     expect(data.pciDraft).toBe('')
   })
 

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -20,8 +20,20 @@ import {
   GUARDRAILED_TEMPERATURE,
   type GuardrailViolation,
 } from '@/lib/ai/guardrails'
-import { PCI_MASTER_SYSTEM_PROMPT } from '@/lib/ai/agent-kit/agents/pci-master'
+import { PCI_MASTER_SYSTEM_PROMPT, pciMasterAgent } from '@/lib/ai/agent-kit/agents/pci-master'
+import { runAgent } from '@/lib/ai/agent-kit/runner'
 import { z } from 'zod'
+
+/**
+ * Flag-gated cutover: route the LOCAL text generation through the agent-kit
+ * runner so guardrail selection + post-validation are owned by the kit uniformly.
+ * Default OFF — prod behavior is unchanged until this is flipped after review.
+ * The vision and ADK paths are unaffected. Read per-request (not at module load)
+ * so it can be toggled by a revision's env without a code change, and is testable.
+ */
+function agentKitPciMasterEnabled(): boolean {
+  return process.env.AGENT_KIT_PCI_MASTER === 'true'
+}
 
 /**
  * Normalize a raw LLM response into clean assistant text + parsed structure.
@@ -280,6 +292,45 @@ export async function POST(request: NextRequest) {
       retries: GEN_RETRIES,
     }
 
+    // Local (text) generation — used by both the else branch and the ADK-failure
+    // fallback. When the flag is ON it runs through the agent-kit runner, which
+    // owns guardrail-prompt selection (per-request domain) + temperature; the
+    // injected `generate` preserves skipCache/timeout/retries that the default
+    // adapter doesn't carry. When OFF it's the original direct call, byte-for-byte.
+    const generateLocal = async (): Promise<{
+      response: string
+      parsed?: { response?: string } | null
+    }> => {
+      if (agentKitPciMasterEnabled()) {
+        const agentResult = await runAgent(
+          pciMasterAgent,
+          {
+            message: userPrompt,
+            context: { userId: session.user.id, guardrailDomain, variant: context?.variant },
+          },
+          {
+            generate: async ({ system, user, temperature, maxTokens }) => {
+              const prompt = system ? `${system}\n\n<user_input>\n${user}\n</user_input>` : user
+              const r = await generateWithFallback(prompt, {
+                temperature,
+                maxTokens,
+                skipCache: true,
+                timeoutMs: GEN_TIMEOUT_MS,
+                retries: GEN_RETRIES,
+              })
+              return { text: r.content }
+            },
+          }
+        )
+        return toCleanResponse(agentResult.text)
+      }
+      const fallback = await generateWithFallback(
+        `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
+        fallbackOptions
+      )
+      return toCleanResponse(fallback.content)
+    }
+
     try {
       if (pdfPages && pdfPages.length > 0) {
         // Vision path: let the model actually SEE the attached document pages so it can
@@ -325,18 +376,10 @@ export async function POST(request: NextRequest) {
             )
           }
           console.warn('ADK PCI master failed, falling back to local providers:', error)
-          const fallback = await generateWithFallback(
-            `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
-            fallbackOptions
-          )
-          response = toCleanResponse(fallback.content)
+          response = await generateLocal()
         }
       } else {
-        const fallback = await generateWithFallback(
-          `System:\n${activeSystemPrompt}\n\n${userPrompt}`,
-          fallbackOptions
-        )
-        response = toCleanResponse(fallback.content)
+        response = await generateLocal()
       }
     } catch (providerError) {
       // The upstream model failed (timeout / 429 / 5xx) after retries. Surface a


### PR DESCRIPTION
**PR B** — the first real route cutover. **Default OFF; flag OFF is byte-for-byte the original.** Opening for your review before we ever flip it.

### What flips (behind `AGENT_KIT_PCI_MASTER=true`)
The **local text generation** runs through `runAgent(pciMasterAgent, …)`, so the **runner owns** guardrail-prompt selection (per-request `context.type`), the guarded temperature, and post-response validation — uniformly.

### Faithfulness (verified 1:1)
- temperature: unguarded 0.7 / guarded `GUARDRAILED_TEMPERATURE` ✓
- `maxTokens` 4096 ✓ · **`skipCache`/`timeoutMs`/`retries` preserved** via an injected `generate` (the default adapter drops them) ✓
- guarded → system is **exactly** the guardrail prompt; unguarded → `PCI_MASTER_SYSTEM_PROMPT` ✓
- both local call sites funnel through one `generateLocal()` ✓
- **vision + ADK paths untouched**; route keeps its own richer `guardrailWarnings` (runner's is a subset) ✓

### Intentional deltas when ON (please eval before flipping)
- drops the `"System:\n"` prefix
- adds `<user_input>` fencing around the user block (prompt-injection hardening)

Downstream envelope parsing (`pciSpec`/`pciSpecSoFar`/`pciUnconfirmed`/warnings) is unchanged.

### Tests
New route test asserts the **ON** path calls `generateWithFallback` once with `skipCache`/`timeoutMs`/`retries`, fences the user input, and still parses the `{reply,pci}` envelope. `typecheck` clean · **24/24** pci-master + agent-kit tests.

### To flip (after review)
Set `AGENT_KIT_PCI_MASTER=true` on the app's Cloud Run env (canary first). Roll back = delete the var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)