### PR TITLE
chore(agents): prune dead exports from tutor/index.ts + task-generator.ts

### DIFF
--- a/tutorme-app/src/lib/agents/task-generator.ts
+++ b/tutorme-app/src/lib/agents/task-generator.ts
@@ -1,18 +1,15 @@
 /**
- * Task Generator Agent Service (canonical entrypoint)
+ * Task Generator Agent Service — uniform task generation.
  *
- * Moved from `lib/ai/task-generator` so app-facing AI services live under `lib/agents`.
- * The old module now re-exports this for backwards compatibility.
+ * Only `generateUniformTasks` is live (POST /api/tutor/questions/generate). The
+ * personalized / clustered / peer-group / distribute / save / getRecent
+ * functions were unused — `saveGeneratedTasks` was already a disabled stub
+ * ("Generated tasks have been removed from the platform") — and were removed
+ * along with their DB helpers and the now-unused Drizzle imports.
  */
 
-import crypto from 'crypto'
-import { desc, eq } from 'drizzle-orm'
-import { drizzleDb } from '@/lib/db/drizzle'
-import { studentPerformance, taskSubmission } from '@/lib/db/schema'
 import { generateWithFallback } from './orchestrator-llm'
 import { safeJsonParse } from '@/lib/ai/json'
-
-export type DistributionMode = 'uniform' | 'personalized' | 'clustered' | 'peer_group'
 
 export interface TaskConfiguration {
   difficulty: 'beginner' | 'intermediate' | 'advanced'
@@ -40,24 +37,11 @@ export interface GeneratedTask {
   }[]
 }
 
-export interface StudentProfile {
-  id: string
-  currentLevel: 'beginner' | 'intermediate' | 'advanced'
-  strengths: string[]
-  weaknesses: string[]
-  cluster?: 'advanced' | 'intermediate' | 'struggling'
-  recentPerformance?: number
-  learningStyle?: string | null
-}
-
 /**
- * Generate a prompt for task creation based on configuration
+ * Generate a prompt for task creation based on configuration.
  */
-function createTaskGenerationPrompt(
-  config: TaskConfiguration,
-  studentProfile?: StudentProfile
-): string {
-  const basePrompt = `作为一位专业的教育AI助手，请为${config.subject}科目生成${config.count}道练习题。
+function createTaskGenerationPrompt(config: TaskConfiguration): string {
+  return `作为一位专业的教育AI助手，请为${config.subject}科目生成${config.count}道练习题。
 
 主题：${config.topics.join('、')}
 难度级别：${config.difficulty}
@@ -91,24 +75,10 @@ function createTaskGenerationPrompt(
     }
   ]
 }`
-
-  if (studentProfile) {
-    return `${basePrompt}
-
-针对该学生的个性化要求：
-- 当前水平：${studentProfile.currentLevel}
-- 优势领域：${studentProfile.strengths.join('、') || '暂无'}
-- 薄弱领域：${studentProfile.weaknesses.join('、') || '暂无'}
-- 学习风格：${studentProfile.learningStyle || '综合'}
-
-请根据学生的水平调整题目难度，针对薄弱领域加强练习，在优势领域提供挑战性题目。`
-  }
-
-  return basePrompt
 }
 
 /**
- * Parse AI response into structured tasks
+ * Parse AI response into structured tasks.
  */
 function parseTaskResponse(response: string): GeneratedTask[] {
   const parsed = safeJsonParse<{ tasks?: GeneratedTask[] }>(response, { extract: true })
@@ -129,224 +99,10 @@ function parseTaskResponse(response: string): GeneratedTask[] {
 }
 
 /**
- * Generate uniform tasks (same for all students)
+ * Generate uniform tasks (same for all students).
  */
 export async function generateUniformTasks(config: TaskConfiguration): Promise<GeneratedTask[]> {
   const prompt = createTaskGenerationPrompt(config)
   const result = await generateWithFallback(prompt, { temperature: 0.7 })
   return parseTaskResponse(result.content)
-}
-
-/**
- * Generate personalized tasks for a specific student
- */
-export async function generatePersonalizedTasks(
-  config: TaskConfiguration,
-  studentProfile: StudentProfile
-): Promise<GeneratedTask[]> {
-  const prompt = createTaskGenerationPrompt(config, studentProfile)
-  const result = await generateWithFallback(prompt, { temperature: 0.7 })
-  return parseTaskResponse(result.content)
-}
-
-/**
- * Get student profiles for a course
- */
-async function getStudentProfiles(
-  studentIds: string[],
-  _courseId?: string
-): Promise<StudentProfile[]> {
-  const profiles = await Promise.all(
-    studentIds.map(async id => {
-      const rows = await drizzleDb
-        .select()
-        .from(studentPerformance)
-        .where(eq(studentPerformance.studentId, id))
-        .limit(1)
-      const performance = rows[0]
-
-      if (!performance) {
-        return {
-          id,
-          currentLevel: 'intermediate' as const,
-          strengths: [],
-          weaknesses: [],
-          cluster: 'intermediate' as const,
-        }
-      }
-
-      return {
-        id,
-        currentLevel: mapLevelToDifficulty(performance.cluster),
-        strengths: (performance.strengths as string[]) || [],
-        weaknesses: (performance.weaknesses as string[]) || [],
-        cluster: performance.cluster as any,
-        learningStyle: performance.learningStyle,
-      }
-    })
-  )
-
-  return profiles
-}
-
-function mapLevelToDifficulty(level: string): 'beginner' | 'intermediate' | 'advanced' {
-  switch (level) {
-    case 'advanced':
-      return 'advanced'
-    case 'struggling':
-      return 'beginner'
-    default:
-      return 'intermediate'
-  }
-}
-
-/**
- * Generate clustered tasks (grouped by skill level)
- */
-export async function generateClusteredTasks(
-  config: TaskConfiguration,
-  studentIds: string[],
-  courseId?: string
-): Promise<Map<string, GeneratedTask[]>> {
-  const profiles = await getStudentProfiles(studentIds, courseId)
-  const tasksByCluster = new Map<string, GeneratedTask[]>()
-
-  // Group students by cluster
-  const clusters: Record<string, StudentProfile[]> = {
-    advanced: [],
-    intermediate: [],
-    struggling: [],
-  }
-
-  profiles.forEach(profile => {
-    const cluster = profile.cluster || 'intermediate'
-    clusters[cluster].push(profile)
-  })
-
-  // Generate tasks for each cluster
-  for (const [clusterName, clusterStudents] of Object.entries(clusters)) {
-    if (clusterStudents.length === 0) continue
-
-    // Adjust difficulty based on cluster
-    const clusterConfig: TaskConfiguration = {
-      ...config,
-      difficulty:
-        clusterName === 'advanced'
-          ? 'advanced'
-          : clusterName === 'struggling'
-            ? 'beginner'
-            : 'intermediate',
-    }
-
-    const prompt = createTaskGenerationPrompt(clusterConfig)
-    const result = await generateWithFallback(prompt, { temperature: 0.7 })
-    const tasks = parseTaskResponse(result.content)
-
-    // Assign to all students in cluster
-    for (const student of clusterStudents) {
-      tasksByCluster.set(student.id, tasks)
-    }
-  }
-
-  return tasksByCluster
-}
-
-/**
- * Generate peer group tasks (mixed abilities, same tasks)
- */
-export async function generatePeerGroupTasks(
-  config: TaskConfiguration,
-  studentIds: string[],
-  courseId?: string
-): Promise<Map<string, GeneratedTask[]>> {
-  await getStudentProfiles(studentIds, courseId)
-  const tasks = await generateUniformTasks(config)
-  const out = new Map<string, GeneratedTask[]>()
-  for (const id of studentIds) out.set(id, tasks)
-  return out
-}
-
-/**
- * Generate tasks based on distribution mode
- */
-export async function generateAndDistributeTasks(
-  mode: DistributionMode,
-  config: TaskConfiguration,
-  params: { studentIds?: string[]; targetStudentId?: string; courseId?: string } = {}
-): Promise<{ success: boolean; tasks?: Map<string, GeneratedTask[]>; error?: string }> {
-  try {
-    const studentIds = params.studentIds || (params.targetStudentId ? [params.targetStudentId] : [])
-
-    if (mode === 'uniform') {
-      const tasks = await generateUniformTasks(config)
-      const map = new Map<string, GeneratedTask[]>()
-      for (const id of studentIds) map.set(id, tasks)
-      return { success: true, tasks: map }
-    }
-
-    if (mode === 'personalized') {
-      if (!params.targetStudentId)
-        return { success: false, error: 'targetStudentId is required for personalized mode' }
-      const profiles = await getStudentProfiles([params.targetStudentId], params.courseId)
-      const tasks = await generatePersonalizedTasks(config, profiles[0]!)
-      return { success: true, tasks: new Map([[params.targetStudentId, tasks]]) }
-    }
-
-    if (mode === 'clustered') {
-      if (studentIds.length === 0)
-        return { success: false, error: 'studentIds required for clustered mode' }
-      const tasks = await generateClusteredTasks(config, studentIds, params.courseId)
-      return { success: true, tasks }
-    }
-
-    if (mode === 'peer_group') {
-      if (studentIds.length === 0)
-        return { success: false, error: 'studentIds required for peer_group mode' }
-      const tasks = await generatePeerGroupTasks(config, studentIds, params.courseId)
-      return { success: true, tasks }
-    }
-
-    return { success: false, error: 'Unknown distribution mode' }
-  } catch (e: any) {
-    return { success: false, error: e?.message || 'Task generation failed' }
-  }
-}
-
-/**
- * Save generated tasks to database and link them to students.
- */
-export async function saveGeneratedTasks(
-  tasksByStudent: Map<string, GeneratedTask[]>,
-  meta: {
-    roomId: string
-    tutorId: string
-    distributionMode: DistributionMode
-    title: string
-    description?: string
-    type?: string
-  }
-): Promise<{ success: boolean; taskIds?: string[]; error?: string }> {
-  try {
-    if (tasksByStudent.size === 0) {
-      return { success: false, error: 'No tasks to save' }
-    }
-    return {
-      success: false,
-      error: 'Generated tasks have been removed from the platform.',
-    }
-  } catch (e: any) {
-    return { success: false, error: e?.message || 'Failed to save generated tasks' }
-  }
-}
-
-/**
- * Fetch recent submissions for a student (for adaptive generation).
- */
-export async function getRecentTaskSubmissions(studentId: string, limit = 20) {
-  return drizzleDb
-    .select()
-    .from(taskSubmission)
-    .where(eq(taskSubmission.studentId, studentId))
-    .orderBy(desc(taskSubmission.submittedAt))
-    .limit(limit)
 }

--- a/tutorme-app/src/lib/agents/tutor/index.ts
+++ b/tutorme-app/src/lib/agents/tutor/index.ts
@@ -1,31 +1,14 @@
 /**
- * ============================================================================
- * TUTOR AGENT - Main Implementation
- * ============================================================================
+ * Tutor agent — response-classification helpers.
  *
- * UI LOCATIONS:
- * - /student/ai-tutor (ai-tutor-chat.tsx) - Main chat interface
- * - /student/learn/[contentId] - "Ask AI" button in lessons
- * - /student/quizzes/[id] - "Hint" button during quizzes
+ * The interactive tutoring flow now lives in `lib/agents/tutor-chat-service.ts`
+ * (`runTutorChat`), which is what the API routes call. Only the two pure string
+ * helpers below remain in use — imported by that service to classify a reply and
+ * extract next-step suggestions.
  *
- * This agent handles all student tutoring interactions using Socratic method.
+ * The former `tutorChat` / `generateHint` / `explainConcept` / `analyzeIntent`
+ * functions were superseded by `runTutorChat` and removed (they had no callers).
  */
-
-import { generateWithFallback, chatWithFallback } from '../orchestrator-llm'
-import {
-  Student,
-  Conversation,
-  Message,
-  Course,
-  ProgressData,
-  getStudent,
-  getConversation,
-  getCourse,
-  getProgress,
-  saveMessage,
-} from '../shared-data'
-import { buildSystemPrompt, buildHintPrompt, buildExplanationPrompt } from './prompts/system-prompt'
-import { findRelevantConcepts } from '@/lib/ai/subjects'
 
 export interface TutorRequest {
   studentId: string
@@ -42,158 +25,6 @@ export interface TutorResponse {
   hintType?: 'socratic' | 'direct' | 'encouragement' | 'clarification'
   relevantConcepts?: string[]
   suggestedNextSteps?: string[]
-}
-
-/**
- * Main tutoring function - handles student messages
- *
- * UI FLOW:
- * 1. Student types in /student/ai-tutor chat
- * 2. Frontend calls POST /api/ai/chat
- * 3. API route calls this function
- * 4. Response streamed back to UI
- */
-export async function tutorChat(request: TutorRequest): Promise<TutorResponse> {
-  const startTime = Date.now()
-
-  // FETCH DATA (READ access only)
-  const [student, conversation, course, progress] = await Promise.all([
-    getStudent(request.studentId),
-    getConversation(request.studentId, request.subject, request.conversationId),
-    getCourse(request.subject, 'default'),
-    getProgress(request.studentId, 'current'),
-  ])
-
-  if (!student) {
-    throw new Error('Student not found')
-  }
-
-  // Build context for the prompt
-  const context = {
-    student,
-    subject: request.subject,
-    course: course || undefined,
-    progress: progress || undefined,
-    conversationHistory:
-      conversation?.messages
-        .slice(-5)
-        .map(m => `${m.role}: ${m.content}`)
-        .join('\n') || 'No previous conversation',
-  }
-
-  // Build messages array with system prompt
-  const messages = [
-    { role: 'system' as const, content: buildSystemPrompt(context) },
-    ...(conversation?.messages.map(m => ({
-      role: m.role as 'user' | 'assistant',
-      content: m.content,
-    })) || []),
-    { role: 'user' as const, content: request.message },
-  ]
-
-  if (conversation) {
-    await saveMessage(conversation.id, {
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: request.message,
-      timestamp: new Date(),
-      metadata: {
-        intent: analyzeIntent(request.message),
-      },
-    })
-  }
-
-  // Call AI (uses Kimi as primary)
-  const result = await chatWithFallback(messages, {
-    temperature: 0.7,
-    maxTokens: 2048,
-  })
-
-  const hintType = classifyHintType(result.content)
-  const relevantConcepts = findRelevantConcepts(request.subject, request.message)
-  const suggestedNextSteps = extractNextSteps(result.content)
-
-  // SAVE TO DATABASE (WRITE access)
-  if (conversation) {
-    await saveMessage(conversation.id, {
-      id: crypto.randomUUID(),
-      role: 'assistant',
-      content: result.content,
-      timestamp: new Date(),
-      metadata: {
-        intent: 'tutoring',
-        sentiment: 'positive',
-      },
-    })
-  }
-
-  return {
-    content: result.content,
-    provider: result.provider,
-    latencyMs: Date.now() - startTime,
-    hintType,
-    relevantConcepts,
-    suggestedNextSteps,
-  }
-}
-
-/**
- * Generate a hint for a question
- *
- * UI: "Hint" button in quiz interface (/student/quizzes/[id])
- * TRIGGER: Student clicks hint during quiz
- */
-export async function generateHint(question: string, studentAttempt?: string): Promise<string> {
-  const prompt = buildHintPrompt(question, studentAttempt)
-
-  const result = await generateWithFallback(prompt, {
-    temperature: 0.5, // Lower for more focused hints
-    maxTokens: 150,
-  })
-
-  return result.content
-}
-
-/**
- * Explain a concept
- *
- * UI: "Explain" button in lesson content (/student/learn/[contentId])
- * TRIGGER: Student clicks explain on a difficult concept
- */
-export async function explainConcept(concept: string, studentId: string): Promise<string> {
-  const student = await getStudent(studentId)
-  if (!student) throw new Error('Student not found')
-
-  const prompt = buildExplanationPrompt(concept, student.currentLevel || 'beginner')
-
-  const result = await generateWithFallback(prompt, {
-    temperature: 0.6,
-    maxTokens: 500,
-  })
-
-  return result.content
-}
-
-/**
- * Analyze student message intent
- * Used to categorize messages for analytics
- */
-export function analyzeIntent(message: string): string {
-  const lower = message.toLowerCase()
-
-  if (lower.includes('hint') || lower.includes('help') || lower.includes('stuck')) {
-    return 'asking_for_help'
-  }
-  if (lower.includes('why') || lower.includes('how come')) {
-    return 'seeking_explanation'
-  }
-  if (lower.includes('answer') || lower.includes('solution')) {
-    return 'asking_for_answer'
-  }
-  if (lower.includes('correct') || lower.includes('right') || lower.includes('wrong')) {
-    return 'checking_understanding'
-  }
-  return 'general_chat'
 }
 
 export function classifyHintType(message: string): TutorResponse['hintType'] {


### PR DESCRIPTION
Second cleanup from the AI agent inventory — prunes the two partially-dead modules down to their one live surface each. **431 lines removed.**

### `tutor/index.ts`
**Kept:** `classifyHintType`, `extractNextSteps` (imported by `tutor-chat-service`) + the two interfaces.
**Removed:** `tutorChat`, `generateHint`, `explainConcept`, `analyzeIntent` — superseded by `runTutorChat`, zero callers — and all their now-unused imports.

### `task-generator.ts`
**Kept:** `generateUniformTasks` (POST `/api/tutor/questions/generate`) + its `createTaskGenerationPrompt`/`parseTaskResponse` helpers + `TaskConfiguration`/`GeneratedTask`.
**Removed:** `generatePersonalizedTasks`, `generateClusteredTasks`, `generatePeerGroupTasks`, `generateAndDistributeTasks`, `saveGeneratedTasks` (a disabled stub), `getRecentTaskSubmissions`, the `getStudentProfiles`/`mapLevelToDifficulty` DB helpers, the `StudentProfile` interface + `DistributionMode` type, and the now-unused Drizzle/crypto imports.

### Safety
Verified no external importer of any removed symbol — the live caller imports only `generateUniformTasks` + `TaskConfiguration`; the 4 other files that mention `StudentProfile` import a *different* one from `types/context`. `typecheck` clean · agent tests pass.

**Not in this PR:** the `content-generator` / quiz-generation island — that's a built-but-unrendered UI feature, so it's a product decision (flagged separately), not obvious-dead pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)