### PR TITLE
fix(ai): tutor tools get a direct assistant prompt, not the student Socratic one

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AIAssistAgent.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AIAssistAgent.tsx
@@ -94,8 +94,8 @@ Format your response clearly and concisely.`
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          messages: [{ role: 'user', content: prompt }],
-          temperature: 0.7,
+          message: prompt,
+          assistant: 'tutor_assist',
         }),
       })
 
@@ -106,7 +106,7 @@ Format your response clearly and concisely.`
         ...prev,
         {
           role: 'assistant',
-          content: data.content || 'I apologize, but I was unable to process your request.',
+          content: data.response || 'I apologize, but I was unable to process your request.',
         },
       ])
     } catch (error) {

--- a/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
@@ -580,6 +580,7 @@ function ItemAIChat({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           message: text,
+          assistant: 'tutor_assist',
           subject: course?.categories?.[0] ?? session?.subject ?? 'general',
           context: {
             ...contextPayload,

--- a/tutorme-app/src/app/api/ai/chat/route.test.ts
+++ b/tutorme-app/src/app/api/ai/chat/route.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  withRateLimitPreset: vi.fn(),
+  handleApiError: vi.fn(),
+  getServerSession: vi.fn(),
+  runTutorChat: vi.fn(),
+  runTutorAssistChat: vi.fn(),
+  hasActiveAssessment: vi.fn(),
+  sanitizeAiInput: vi.fn(),
+  validateAiResponse: vi.fn(),
+}))
+
+vi.mock('@/lib/api/middleware', () => ({
+  withRateLimitPreset: mocks.withRateLimitPreset,
+  handleApiError: mocks.handleApiError,
+}))
+vi.mock('@/lib/auth', () => ({ getServerSession: mocks.getServerSession, authOptions: {} }))
+vi.mock('@/lib/agents/tutor-chat-service', () => ({ runTutorChat: mocks.runTutorChat }))
+vi.mock('@/lib/agents/tutor-assist-service', () => ({
+  runTutorAssistChat: mocks.runTutorAssistChat,
+}))
+vi.mock('@/lib/assessment/active-assessment', () => ({
+  hasActiveAssessment: mocks.hasActiveAssessment,
+}))
+vi.mock('@/lib/security/ai-sanitization', () => ({
+  AISecurityManager: {
+    sanitizeAiInput: mocks.sanitizeAiInput,
+    validateAiResponse: mocks.validateAiResponse,
+  },
+}))
+
+import { POST } from './route'
+
+describe('/api/ai/chat — assistant routing + gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.withRateLimitPreset.mockResolvedValue({ response: null })
+    mocks.sanitizeAiInput.mockImplementation((m: string) => m)
+    mocks.validateAiResponse.mockResolvedValue({ isValid: true, severity: 'LOW' })
+    mocks.hasActiveAssessment.mockResolvedValue(false)
+    mocks.runTutorChat.mockResolvedValue({ response: 'socratic', provider: 'kimi', latencyMs: 1 })
+    mocks.runTutorAssistChat.mockResolvedValue({
+      response: 'direct',
+      provider: 'kimi',
+      latencyMs: 1,
+    })
+  })
+
+  const post = (body: Record<string, unknown>) => {
+    const req = new Request('http://localhost/api/ai/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return POST(req as unknown as NextRequest)
+  }
+
+  it('defaults to the student Socratic tutor (no assistant param)', async () => {
+    mocks.getServerSession.mockResolvedValue({ user: { id: 's1', role: 'STUDENT' } })
+    const res = await post({ message: 'help me learn' })
+    expect(res.status).toBe(200)
+    expect(mocks.runTutorChat).toHaveBeenCalledTimes(1)
+    expect(mocks.runTutorAssistChat).not.toHaveBeenCalled()
+  })
+
+  it('routes a TUTOR + tutor_assist to the DIRECT assistant', async () => {
+    mocks.getServerSession.mockResolvedValue({ user: { id: 't1', role: 'TUTOR' } })
+    const res = await post({ message: 'draft 3 poll questions as JSON', assistant: 'tutor_assist' })
+    const data = await res.json()
+    expect(mocks.runTutorAssistChat).toHaveBeenCalledTimes(1)
+    expect(mocks.runTutorChat).not.toHaveBeenCalled()
+    expect(data.response).toBe('direct')
+  })
+
+  it('GATE: a STUDENT requesting tutor_assist falls back to the Socratic tutor', async () => {
+    // A student must never reach the direct-answer path — it would bypass the
+    // Socratic pedagogy and the ASMT-15 assessment-integrity guardrail.
+    mocks.getServerSession.mockResolvedValue({ user: { id: 's1', role: 'STUDENT' } })
+    await post({ message: 'just give me the answer', assistant: 'tutor_assist' })
+    expect(mocks.runTutorAssistChat).not.toHaveBeenCalled()
+    expect(mocks.runTutorChat).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tutorme-app/src/app/api/ai/chat/route.ts
+++ b/tutorme-app/src/app/api/ai/chat/route.ts
@@ -12,6 +12,7 @@ import { withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { z } from 'zod'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 import { runTutorChat } from '@/lib/agents/tutor-chat-service'
+import { runTutorAssistChat } from '@/lib/agents/tutor-assist-service'
 import { hasActiveAssessment } from '@/lib/assessment/active-assessment'
 
 const AIChatRequestSchema = z.object({
@@ -19,6 +20,9 @@ const AIChatRequestSchema = z.object({
   subject: z.string().max(80).default('general'),
   context: z.record(z.string(), z.unknown()).default({}),
   conversationId: z.string().max(128).optional(),
+  // 'tutor' (default) = the student Socratic tutor. 'tutor_assist' = a DIRECT
+  // assistant for the tutor's own tools; only honoured for TUTOR/ADMIN sessions.
+  assistant: z.enum(['tutor', 'tutor_assist']).default('tutor'),
 })
 
 export async function POST(request: NextRequest) {
@@ -35,7 +39,7 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
-    const { message, subject, context: _context, conversationId } = parsed.data
+    const { message, subject, context: _context, conversationId, assistant } = parsed.data
 
     const safeMessage = AISecurityManager.sanitizeAiInput(message)
     if (!safeMessage) {
@@ -54,6 +58,22 @@ export async function POST(request: NextRequest) {
       Array.isArray((_context as any).previousMessages)
         ? (_context as any).previousMessages
         : []
+
+    // Tutor-facing assistant path: the tutor's own tools (teaching-suggestion
+    // generator, course-builder assist, reports analytics) want DIRECT help, not
+    // the student Socratic prompt. GATED to TUTOR/ADMIN — a student requesting
+    // this mode falls through to the Socratic tutor below, so the direct path
+    // can never bypass the pedagogy or the ASMT-15 assessment guardrail.
+    const isTutor = session.user.role === 'TUTOR' || session.user.role === 'ADMIN'
+    if (assistant === 'tutor_assist' && isTutor) {
+      const assist = await runTutorAssistChat({ message: safeMessage, previousMessages })
+      return NextResponse.json({
+        response: assist.response,
+        conversationId: convoKey,
+        provider: assist.provider,
+        latencyMs: assist.latencyMs,
+      })
+    }
 
     // ASMT-15: refuse to solve assessment questions while one is in progress.
     const assessmentActive = await hasActiveAssessment(session.user.id)

--- a/tutorme-app/src/components/tutor/AITeachingAssistant.tsx
+++ b/tutorme-app/src/components/tutor/AITeachingAssistant.tsx
@@ -110,7 +110,7 @@ Each object must match this interface:
       const res = await fetch('/api/ai/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: promptText }),
+        body: JSON.stringify({ message: promptText, assistant: 'tutor_assist' }),
       })
 
       if (res.ok) {

--- a/tutorme-app/src/lib/agents/tutor-assist-service.ts
+++ b/tutorme-app/src/lib/agents/tutor-assist-service.ts
@@ -1,0 +1,64 @@
+/**
+ * Tutor-facing assistant.
+ *
+ * Distinct from `runTutorChat` (the STUDENT Socratic tutor): the person here is a
+ * professional educator, so the assistant answers DIRECTLY — no Socratic
+ * deflection, no answer-withholding. Backs the tutor's own tools: the in-class
+ * teaching-suggestion generator, the course-builder "AI Assist", and the reports
+ * analytics chat.
+ *
+ * SECURITY: this direct-answer path must only ever run for TUTOR/ADMIN sessions.
+ * The route gates it; a student calling with this mode falls back to the Socratic
+ * tutor (which also enforces the ASMT-15 assessment-integrity guardrail).
+ */
+import { generateWithFallback } from './orchestrator-llm'
+import { AISecurityManager } from '@/lib/security/ai-sanitization'
+
+export const TUTOR_ASSIST_SYSTEM_PROMPT = `You are an AI assistant for a professional tutor using the Solocorn teaching platform. The person you are helping is a TEACHER, not a student — answer their requests directly, accurately, and concisely. Never use Socratic deflection or withhold answers.
+
+You help tutors:
+- draft teaching questions, polls, and discussion prompts for their class
+- build assessments and marking policies, and write lesson content
+- interpret class and student analytics with concrete, actionable insights
+
+When the tutor asks for output in a specific format (e.g. a JSON array), return exactly that format with no extra prose or code fences. When given data (student performance, session details), analyse it and give specific, practical recommendations.`
+
+export interface TutorAssistInput {
+  message: string
+  previousMessages?: Array<{ role?: string; content?: string }>
+}
+
+export interface TutorAssistOutput {
+  response: string
+  provider: string
+  latencyMs: number
+}
+
+export async function runTutorAssistChat(input: TutorAssistInput): Promise<TutorAssistOutput> {
+  const safeMessage = AISecurityManager.sanitizeAiInput(String(input.message))
+  if (!safeMessage) {
+    throw new Error('Message is required or invalid after sanitization')
+  }
+
+  const history = (input.previousMessages ?? [])
+    .slice(-6)
+    .map(m => `${m?.role === 'assistant' ? 'Assistant' : 'Tutor'}: ${String(m?.content ?? '')}`)
+    .join('\n')
+
+  const prompt = [
+    TUTOR_ASSIST_SYSTEM_PROMPT,
+    history && `Conversation so far:\n${history}`,
+    `Tutor: ${safeMessage}`,
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+
+  const result = await generateWithFallback(prompt, { temperature: 0.7, maxTokens: 2048 })
+
+  const validation = await AISecurityManager.validateAiResponse(result.content)
+  if (!validation.isValid && validation.severity === 'CRITICAL') {
+    throw new Error('AI response failed security validation')
+  }
+
+  return { response: result.content, provider: result.provider, latencyMs: result.latencyMs }
+}


### PR DESCRIPTION
Closes the `/api/ai/chat` reuse mismatch from the AI audit — and fixes two tutor tools that the mismatch had **silently broken**.

### The problem
Three tutor tools POST to `/api/ai/chat`, which always runs `runTutorChat` — the **student Socratic prompt** ("guide the student, don't give the answer"). For tutors that's wrong, and it broke two of them:
- **AITeachingAssistant** — `JSON.parse`d the Socratic prose, failed, and always fell back to hardcoded suggestions (AI path dead).
- **AIAssistAgent** — sent the old `{ messages, temperature }` shape and read `data.content`; the route wants `message` and returns `data.response` → **400s every time**, always shows its error.
- **Reports** — worked, but analytics answered in a Socratic "don't tell you" tone.

### The fix
- **`runTutorAssistChat`** (`TUTOR_ASSIST_SYSTEM_PROMPT`) — answers the tutor **directly**; handles teaching-content generation, builder help, and analytics.
- **`/api/ai/chat`** gains `assistant: 'tutor' | 'tutor_assist'` (default `'tutor'`). 

### Security gate (tested)
`tutor_assist` is honoured **only for TUTOR/ADMIN**. A student sending `assistant: 'tutor_assist'` **falls through to the Socratic tutor** — so the direct-answer path can never be used to bypass the pedagogy or the **ASMT-15** assessment-integrity guardrail. Route test covers: default→tutor, tutor+assist→direct, **student+assist→blocked**.

### Callers
Repointed the 3 tools to `assistant: 'tutor_assist'`; fixed AIAssistAgent's payload (`{ message }`) and response field (`data.response`).

**Student behaviour is unchanged** (default path untouched). `typecheck` clean; tests pass.

The `TUTOR_ASSIST_SYSTEM_PROMPT` wording is easy to tweak — say the word if you want it more/less formal or specialised per tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)