### PR TITLE
feat(ai): specialise the tutor-assist prompt per tool (teaching / builder / analytics)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/AIAssistAgent.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/AIAssistAgent.tsx
@@ -96,6 +96,7 @@ Format your response clearly and concisely.`
         body: JSON.stringify({
           message: prompt,
           assistant: 'tutor_assist',
+          assistKind: 'builder',
         }),
       })
 

--- a/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/reports/page.tsx
@@ -581,6 +581,7 @@ function ItemAIChat({
         body: JSON.stringify({
           message: text,
           assistant: 'tutor_assist',
+          assistKind: 'analytics',
           subject: course?.categories?.[0] ?? session?.subject ?? 'general',
           context: {
             ...contextPayload,

--- a/tutorme-app/src/app/api/ai/chat/route.test.ts
+++ b/tutorme-app/src/app/api/ai/chat/route.test.ts
@@ -65,11 +65,19 @@ describe('/api/ai/chat — assistant routing + gate', () => {
     expect(mocks.runTutorAssistChat).not.toHaveBeenCalled()
   })
 
-  it('routes a TUTOR + tutor_assist to the DIRECT assistant', async () => {
+  it('routes a TUTOR + tutor_assist to the DIRECT assistant with the tool-specific kind', async () => {
     mocks.getServerSession.mockResolvedValue({ user: { id: 't1', role: 'TUTOR' } })
-    const res = await post({ message: 'draft 3 poll questions as JSON', assistant: 'tutor_assist' })
+    const res = await post({
+      message: 'draft 3 poll questions as JSON',
+      assistant: 'tutor_assist',
+      assistKind: 'teaching',
+    })
     const data = await res.json()
     expect(mocks.runTutorAssistChat).toHaveBeenCalledTimes(1)
+    // the tool's kind is threaded through so the right specialised prompt is used
+    expect(mocks.runTutorAssistChat).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'teaching' })
+    )
     expect(mocks.runTutorChat).not.toHaveBeenCalled()
     expect(data.response).toBe('direct')
   })

--- a/tutorme-app/src/app/api/ai/chat/route.ts
+++ b/tutorme-app/src/app/api/ai/chat/route.ts
@@ -23,6 +23,8 @@ const AIChatRequestSchema = z.object({
   // 'tutor' (default) = the student Socratic tutor. 'tutor_assist' = a DIRECT
   // assistant for the tutor's own tools; only honoured for TUTOR/ADMIN sessions.
   assistant: z.enum(['tutor', 'tutor_assist']).default('tutor'),
+  // Which tutor tool is asking, so the assistant uses the right specialised prompt.
+  assistKind: z.enum(['general', 'teaching', 'builder', 'analytics']).default('general'),
 })
 
 export async function POST(request: NextRequest) {
@@ -39,7 +41,14 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
-    const { message, subject, context: _context, conversationId, assistant } = parsed.data
+    const {
+      message,
+      subject,
+      context: _context,
+      conversationId,
+      assistant,
+      assistKind,
+    } = parsed.data
 
     const safeMessage = AISecurityManager.sanitizeAiInput(message)
     if (!safeMessage) {
@@ -66,7 +75,11 @@ export async function POST(request: NextRequest) {
     // can never bypass the pedagogy or the ASMT-15 assessment guardrail.
     const isTutor = session.user.role === 'TUTOR' || session.user.role === 'ADMIN'
     if (assistant === 'tutor_assist' && isTutor) {
-      const assist = await runTutorAssistChat({ message: safeMessage, previousMessages })
+      const assist = await runTutorAssistChat({
+        message: safeMessage,
+        kind: assistKind,
+        previousMessages,
+      })
       return NextResponse.json({
         response: assist.response,
         conversationId: convoKey,

--- a/tutorme-app/src/components/tutor/AITeachingAssistant.tsx
+++ b/tutorme-app/src/components/tutor/AITeachingAssistant.tsx
@@ -110,7 +110,11 @@ Each object must match this interface:
       const res = await fetch('/api/ai/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: promptText, assistant: 'tutor_assist' }),
+        body: JSON.stringify({
+          message: promptText,
+          assistant: 'tutor_assist',
+          assistKind: 'teaching',
+        }),
       })
 
       if (res.ok) {

--- a/tutorme-app/src/lib/agents/tutor-assist-service.test.ts
+++ b/tutorme-app/src/lib/agents/tutor-assist-service.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { tutorAssistPrompt, type TutorAssistKind } from './tutor-assist-service'
+
+describe('tutorAssistPrompt', () => {
+  const kinds: TutorAssistKind[] = ['general', 'teaching', 'builder', 'analytics']
+
+  it('returns a distinct, specialised prompt for each tool', () => {
+    const prompts = kinds.map(k => tutorAssistPrompt(k))
+    expect(new Set(prompts).size).toBe(kinds.length) // all four differ
+  })
+
+  it('every prompt keeps the direct-answer framing (not the student Socratic one)', () => {
+    for (const k of kinds) {
+      const p = tutorAssistPrompt(k)
+      expect(p).toContain('TEACHER, not a student')
+      expect(p).toContain('answer directly')
+    }
+  })
+
+  it('specialisations mention their focus', () => {
+    expect(tutorAssistPrompt('teaching')).toMatch(/poll|discussion|class/i)
+    expect(tutorAssistPrompt('builder')).toMatch(/rubric|marking policy|PCI/i)
+    expect(tutorAssistPrompt('analytics')).toMatch(/at-risk|trends|analytics/i)
+  })
+
+  it('falls back to general for an unknown kind', () => {
+    expect(tutorAssistPrompt(undefined)).toBe(tutorAssistPrompt('general'))
+  })
+})

--- a/tutorme-app/src/lib/agents/tutor-assist-service.ts
+++ b/tutorme-app/src/lib/agents/tutor-assist-service.ts
@@ -3,9 +3,12 @@
  *
  * Distinct from `runTutorChat` (the STUDENT Socratic tutor): the person here is a
  * professional educator, so the assistant answers DIRECTLY — no Socratic
- * deflection, no answer-withholding. Backs the tutor's own tools: the in-class
- * teaching-suggestion generator, the course-builder "AI Assist", and the reports
- * analytics chat.
+ * deflection, no answer-withholding. Backs the tutor's own tools, each with its
+ * own specialised prompt (`kind`):
+ *   - `teaching`  — in-class questions / polls (AITeachingAssistant)
+ *   - `builder`   — task/assessment content + marking policy (AIAssistAgent)
+ *   - `analytics` — interpret class/student performance data (Reports chat)
+ *   - `general`   — fallback
  *
  * SECURITY: this direct-answer path must only ever run for TUTOR/ADMIN sessions.
  * The route gates it; a student calling with this mode falls back to the Socratic
@@ -14,17 +17,37 @@
 import { generateWithFallback } from './orchestrator-llm'
 import { AISecurityManager } from '@/lib/security/ai-sanitization'
 
-export const TUTOR_ASSIST_SYSTEM_PROMPT = `You are an AI assistant for a professional tutor using the Solocorn teaching platform. The person you are helping is a TEACHER, not a student — answer their requests directly, accurately, and concisely. Never use Socratic deflection or withhold answers.
+export type TutorAssistKind = 'general' | 'teaching' | 'builder' | 'analytics'
 
-You help tutors:
-- draft teaching questions, polls, and discussion prompts for their class
-- build assessments and marking policies, and write lesson content
-- interpret class and student analytics with concrete, actionable insights
+/** Shared framing every specialised prompt builds on. */
+const SHARED_PREAMBLE = `You are an AI assistant for a professional tutor using the Solocorn teaching platform. The person you are helping is a TEACHER, not a student — answer directly, accurately, and concisely. Never use Socratic deflection or withhold answers. When asked for a specific output format (e.g. a JSON array), return exactly that with no extra prose or code fences.`
 
-When the tutor asks for output in a specific format (e.g. a JSON array), return exactly that format with no extra prose or code fences. When given data (student performance, session details), analyse it and give specific, practical recommendations.`
+const KIND_PROMPTS: Record<TutorAssistKind, string> = {
+  general: `${SHARED_PREAMBLE}
+
+You help tutors draft teaching material, build assessments and marking policies, and interpret class analytics.`,
+
+  teaching: `${SHARED_PREAMBLE}
+
+Your job: generate ready-to-use in-class material — discussion questions, polls, and prompts — pitched to the lesson content and the students' level. Make each one specific and classroom-ready (not generic), with useful follow-ups where asked. If a JSON shape is specified, match it exactly.`,
+
+  builder: `${SHARED_PREAMBLE}
+
+Your job: help the tutor build course content in the assessment/task builder — draft and refine questions, tighten rubrics, and turn a rough intention into clear, gradeable instructions and marking policies (PCI). Be concrete and edit-ready; when the tutor pastes existing content, improve it in place rather than restating it.`,
+
+  analytics: `${SHARED_PREAMBLE}
+
+Your job: interpret class and student analytics. Given performance data, session details, or a roster, surface concrete insights — trends, at-risk students, and specific next actions — and cite the numbers you were given. No vague generalities; if the data is thin, say what's missing.`,
+}
+
+/** The specialised system prompt for a tool. Unknown kinds fall back to general. */
+export function tutorAssistPrompt(kind: TutorAssistKind = 'general'): string {
+  return KIND_PROMPTS[kind] ?? KIND_PROMPTS.general
+}
 
 export interface TutorAssistInput {
   message: string
+  kind?: TutorAssistKind
   previousMessages?: Array<{ role?: string; content?: string }>
 }
 
@@ -46,7 +69,7 @@ export async function runTutorAssistChat(input: TutorAssistInput): Promise<Tutor
     .join('\n')
 
   const prompt = [
-    TUTOR_ASSIST_SYSTEM_PROMPT,
+    tutorAssistPrompt(input.kind),
     history && `Conversation so far:\n${history}`,
     `Tutor: ${safeMessage}`,
   ]


### PR DESCRIPTION
Follow-up to #970 — replaces the single generic tutor-assist prompt with a **`kind`-keyed set**, so each tutor tool gets a prompt tuned to its job.

| kind | tool | prompt focus |
|------|------|--------------|
| `teaching` | AITeachingAssistant | classroom questions/polls, classroom-ready, honours the JSON shape it asks for |
| `builder` | AIAssistAgent | task/assessment content + rubrics/PCI, edits in place |
| `analytics` | Reports chat | interpret performance data, **cite the numbers**, name at-risk students |
| `general` | — | fallback |

- `runTutorAssistChat` now takes a `kind`; `/api/ai/chat` threads an `assistKind` param (default `general`) through the **gated** `tutor_assist` path.
- Each tool declares its kind (`teaching` / `builder` / `analytics`).
- **Gate unchanged** — still TUTOR/ADMIN only; students still fall back to the Socratic tutor.

**Tests:** the route test asserts the kind is passed through; a new service test verifies the 4 prompts are distinct, all keep the direct (non-Socratic) framing, and each mentions its focus. `typecheck` clean · 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)