### PR TITLE
feat(data): getCategoryCountryCode helper for country-bound categories

### DIFF
--- a/tutorme-app/src/lib/data/category-country.test.ts
+++ b/tutorme-app/src/lib/data/category-country.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCategoryCountryCode,
+  isCountryBoundCategory,
+  getCountryNameByCode,
+  getRegionIdForCountry,
+} from './category-country'
+import { NATIONAL_EXAMS_DATA, AP_CATEGORIES } from './tutor-categories'
+
+describe('getCategoryCountryCode', () => {
+  it('maps a specific HKDSE national exam to HK', () => {
+    expect(getCategoryCountryCode('S5 HKDSE Chinese Language Preparation')).toBe('HK')
+  })
+
+  it('never returns a WRONG country for any national exam (full dataset sweep)', () => {
+    // Some generic exam names are shared across countries or overlap with global
+    // boards; the helper must return that exam's own country OR null — never a
+    // different country. This is the safety property that guards a prefill.
+    for (const [code, categories] of Object.entries(NATIONAL_EXAMS_DATA)) {
+      for (const category of categories) {
+        for (const exam of category.exams) {
+          const result = getCategoryCountryCode(exam)
+          expect(result === null || result === code).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('returns null for a global board category (AP) — board takes precedence', () => {
+    for (const cat of AP_CATEGORIES) {
+      for (const exam of cat.exams) {
+        expect(getCategoryCountryCode(exam)).toBeNull()
+      }
+    }
+  })
+
+  it('returns null for unknown/custom categories and empty input', () => {
+    expect(getCategoryCountryCode('Totally Custom Category')).toBeNull()
+    expect(getCategoryCountryCode('')).toBeNull()
+  })
+})
+
+describe('isCountryBoundCategory', () => {
+  it('is true for a national exam and false for global/custom', () => {
+    expect(isCountryBoundCategory('S5 HKDSE Chinese Language Preparation')).toBe(true)
+    expect(isCountryBoundCategory(AP_CATEGORIES[0].exams[0])).toBe(false)
+    expect(isCountryBoundCategory('Totally Custom Category')).toBe(false)
+  })
+})
+
+describe('getCountryNameByCode', () => {
+  it('resolves country codes to display names', () => {
+    expect(getCountryNameByCode('HK')).toBe('Hong Kong')
+    expect(getCountryNameByCode('SG')).toBe('Singapore')
+    expect(getCountryNameByCode('GL')).toBe('Global')
+  })
+
+  it('returns null for an unknown code or empty input', () => {
+    expect(getCountryNameByCode('ZZ')).toBeNull()
+    expect(getCountryNameByCode('')).toBeNull()
+  })
+})
+
+describe('getRegionIdForCountry', () => {
+  it('resolves a country code to its region id', () => {
+    expect(getRegionIdForCountry('HK')).toBe('asia')
+  })
+
+  it('returns null for Global or unknown', () => {
+    expect(getRegionIdForCountry('GL')).toBeNull()
+    expect(getRegionIdForCountry('ZZ')).toBeNull()
+  })
+})

--- a/tutorme-app/src/lib/data/category-country.ts
+++ b/tutorme-app/src/lib/data/category-country.ts
@@ -1,0 +1,73 @@
+/**
+ * The country a category belongs to, for course-country logic at publish time.
+ *
+ * National exams (HKDSE, Gaokao, SAT, …) are country-specific — their country is
+ * derivable from the category string via NATIONAL_EXAMS_DATA. This drives
+ * prefilling the publish country picker for a national-exam course.
+ *
+ * Global boards (AP / IB / IGCSE / A-Level / Global / Languages / Professional),
+ * university categories, and custom categories return null — they are treated as
+ * country-agnostic at publish. Universities are intentionally excluded (product
+ * decision: leave them as-is, not country-bound).
+ */
+
+import { NATIONAL_EXAMS_DATA, REGIONS } from './tutor-categories'
+import { getCategoryBoard } from './category-board'
+
+/**
+ * exam string -> set of owning country codes. Some generic exam names appear
+ * under more than one country in the dataset, so an exam can map to several
+ * codes — those are ambiguous and treated as country-agnostic (see below).
+ */
+const NATIONAL_EXAM_COUNTRY_MAP = new Map<string, Set<string>>()
+for (const [countryCode, categories] of Object.entries(NATIONAL_EXAMS_DATA)) {
+  for (const category of categories) {
+    for (const exam of category.exams) {
+      const set = NATIONAL_EXAM_COUNTRY_MAP.get(exam) ?? new Set<string>()
+      set.add(countryCode)
+      NATIONAL_EXAM_COUNTRY_MAP.set(exam, set)
+    }
+  }
+}
+
+/**
+ * The country code a category is bound to, or null if it is country-agnostic.
+ *
+ * Only an UNAMBIGUOUS national exam is country-bound:
+ * - A category that is also a global board (AP / IB / IGCSE / … / Universities)
+ *   is country-agnostic — the board takes precedence.
+ * - A generic exam name shared across multiple countries is ambiguous → null.
+ */
+export function getCategoryCountryCode(category: string): string | null {
+  if (!category) return null
+  // A global board (or university) category is never a country-bound national exam.
+  if (getCategoryBoard(category) !== null) return null
+  const codes = NATIONAL_EXAM_COUNTRY_MAP.get(category)
+  if (!codes || codes.size !== 1) return null // unknown, or ambiguous across countries
+  return [...codes][0]
+}
+
+/** Whether a category is tied to a single country (a national exam). */
+export function isCountryBoundCategory(category: string): boolean {
+  return getCategoryCountryCode(category) !== null
+}
+
+/** Display name for a country code (e.g. 'HK' -> 'Hong Kong'), or null. */
+export function getCountryNameByCode(code: string): string | null {
+  if (!code) return null
+  if (code === 'GL') return 'Global'
+  for (const region of REGIONS) {
+    const country = region.countries.find(c => c.code === code)
+    if (country) return country.name
+  }
+  return null
+}
+
+/** The region id that contains a country code (e.g. 'HK' -> 'asia'), or null. */
+export function getRegionIdForCountry(code: string): string | null {
+  if (!code || code === 'GL') return null
+  for (const region of REGIONS) {
+    if (region.countries.some(c => c.code === code)) return region.id
+  }
+  return null
+}


### PR DESCRIPTION
Phase 1 of the category/country coherence work. A pure, well-tested helper that other pieces build on.

## What
`src/lib/data/category-country.ts`:
- `getCategoryCountryCode(category) → code | null` — the country a **national exam** belongs to.
- `isCountryBoundCategory`, `getCountryNameByCode`, `getRegionIdForCountry` — for the upcoming publish-picker prefill.

## Why it's careful
The datasets have **real string collisions** the test surfaced:
- Some AP exam strings are *also* listed as US national entries.
- Some generic exam names appear under multiple countries (e.g. Indonesia + Oman).

A naive reverse-map would return a **wrong** country and mis-prefill the picker. So the helper:
- Defers to `getCategoryBoard` — anything that is a global board (or university) category returns `null` (country-agnostic).
- Treats a name shared across countries as **ambiguous → null**.

A full-dataset sweep test asserts the safety property: for every national exam the helper returns that exam's own country **or** null — never a different country.

Universities are intentionally excluded (per the agreed scope: left as-is, not country-bound).

## Verification
9 unit tests green; eslint/tsc/prettier clean.

Phase 2 (Course Details prefill + Choose-a-Category modal rescope) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)