### PR TITLE
fix(course-builder): correct the DMI format-chooser modal header

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -13536,7 +13536,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           <DialogContent className="max-w-md border border-slate-200 shadow-2xl">
             <DialogHeader className="text-center">
               <DialogTitle className="mx-auto text-center text-white">
-                How should this assessment be marked?
+                How are the questions answered?
               </DialogTitle>
               <DialogDescription className="text-white/80">
                 Choose the response format. Multiple-choice papers are configured directly — no need


### PR DESCRIPTION
The response-format chooser shown when you click **Generate DMI** picks between **Multiple choice** and **Free response** — i.e. how the paper is answered, which determines the DMI generation path. Its header read *"How should this assessment be marked?"*, implying marking policy — misleading.

Changed the header to **"How are the questions answered?"**, which matches the two options and the existing "Choose the response format" description. One-line copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)