### PR TITLE
fix(tutor): wire up the Create Class "Publish Class" button

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateSessionForm.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateSessionForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { format } from 'date-fns'
 import { DialogPanel } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -258,6 +259,37 @@ export function CreateSessionForm({
               </SelectContent>
             </Select>
           </div>
+        </div>
+
+        {/* Actions — the Publish button lives with the form that owns the
+            validation + submit, so it's actually wired (the parent dialog's
+            footer button was a disabled stub). */}
+        <div className="mt-5 flex items-center justify-end gap-2">
+          {onCancel && (
+            <Button
+              type="button"
+              variant="modal-secondary-dark"
+              onClick={onCancel}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="modal-primary-dark"
+            onClick={handleSubmit}
+            disabled={creating || !form.title.trim() || !form.date || !form.time}
+          >
+            {creating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Publishing…
+              </>
+            ) : (
+              'Publish Class'
+            )}
+          </Button>
         </div>
       </DialogPanel>
     </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1473,16 +1473,8 @@ function TutorDashboardContent() {
                     Create Class
                   </Button>
                 )}
-                {selectedCourseForCancel && sessionsView === 'create' && (
-                  <>
-                    <Button variant="modal-secondary-dark" onClick={() => setSessionsView('list')}>
-                      Cancel
-                    </Button>
-                    <Button variant="modal-primary-dark" onClick={() => {}} disabled>
-                      Publish Class
-                    </Button>
-                  </>
-                )}
+                {/* The create view's Cancel/Publish actions are rendered by
+                    CreateSessionForm itself (which owns the form state + submit). */}
                 {sessionsView === 'list' && (
                   <Button variant="modal-secondary-dark" onClick={() => setCancelModalOpen(false)}>
                     Close


### PR DESCRIPTION
## Bug
On the tutor dashboard, **Sessions → Create Class** → after filling in the details, the **"Publish Class" button stays inactive**.

## Root cause
Two halves that were never connected:
- The parent dialog's "Publish Class" button was a **hardcoded `disabled` stub** with an empty `onClick={() => {}}`.
- `CreateSessionForm` had all the real logic in `handleSubmit` (validate → `POST /api/class/rooms`) but **rendered no button and never called it**.

So there was no way to actually create the class.

## Fix
Moved the action buttons into `CreateSessionForm`, which owns the form state and submit:
- A real **"Publish Class"** button → `handleSubmit`, enabled once **title + date + time** are filled (spinner + disabled while submitting).
- A **Cancel** button → `onCancel`.
- Removed the parent dialog's stub footer buttons for the create view (no duplicate).

Title is prefilled from the course, so the button enables as soon as the tutor picks a date and time.

## Verification
`tsc` + lint + prettier clean. Confirmed `/api/class/rooms` POST (the create endpoint the form submits to) exists. UI-only wiring — no API/data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)