### PR TITLE
fix(chat): attach CSRF token when sending a message

### DIFF
--- a/tutorme-app/src/app/[locale]/student/messages/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/messages/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { MentionInput } from '@/components/mentions/MentionInput'
 import { renderMentions } from '@/lib/mentions/render-mentions'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -111,7 +112,7 @@ export default function StudentMessagesPage() {
     setInputMessage('')
 
     try {
-      const res = await fetch(`/api/conversations/${selectedConversation.id}/messages`, {
+      const res = await fetchWithCsrf(`/api/conversations/${selectedConversation.id}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/tutorme-app/src/app/[locale]/tutor/messages/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/messages/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { MentionInput } from '@/components/mentions/MentionInput'
 import { renderMentions } from '@/lib/mentions/render-mentions'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -118,7 +119,7 @@ export default function CommunicationCenterPage() {
     setInputMessage('')
 
     try {
-      const res = await fetch(`/api/conversations/${selectedConversation.id}/messages`, {
+      const res = await fetchWithCsrf(`/api/conversations/${selectedConversation.id}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/tutorme-app/src/components/communications/messenger.tsx
+++ b/tutorme-app/src/components/communications/messenger.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { MentionInput } from '@/components/mentions/MentionInput'
 import { renderMentions } from '@/lib/mentions/render-mentions'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -114,7 +115,7 @@ export default function Messenger() {
     const content = inputMessage
     setInputMessage('')
     try {
-      const res = await fetch(`/api/conversations/${selectedConversation.id}/messages`, {
+      const res = await fetchWithCsrf(`/api/conversations/${selectedConversation.id}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
### Bug
Sending a direct message showed **"Failed to send message"** for both tutors and students.

### Root cause
The compose POST to `/api/conversations/[id]/messages` runs through `withAuth`, which **auto-enforces CSRF** on state-changing methods (`CSRF_METHODS = POST/PUT/PATCH/DELETE`), and this route isn't in `CSRF_SKIP_PATHS`. But all three chat send handlers used a **plain `fetch()` with no `X-CSRF-Token` header**, so every send was rejected. (The earlier crash fix #987 was what let users reach the send button at all — exposing this.)

### Fix
Swap the send `fetch()` for the shared **`fetchWithCsrf()`** helper (obtains `/api/csrf` and attaches the token; it no-ops for GET) in:
- `components/communications/messenger.tsx` (the 1-on-1 chat)
- `app/[locale]/student/messages/page.tsx`
- `app/[locale]/tutor/messages/page.tsx`

GET loads stay on plain `fetch`. `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)