### PR TITLE
fix(student): show course sessions across the template/published variant split

### DIFF
--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -18,8 +18,9 @@ import {
   oneOnOneBookingRequest,
   groupSession,
   groupSessionParticipant,
+  courseVariant,
 } from '@/lib/db/schema'
-import { eq, and, gte, lte, inArray, isNull, ne, sql } from 'drizzle-orm'
+import { eq, and, or, gte, lte, inArray, isNull, ne, sql } from 'drizzle-orm'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 export const GET = withAuth(
@@ -42,7 +43,35 @@ export const GET = withAuth(
       .from(courseEnrollment)
       .where(eq(courseEnrollment.studentId, studentId))
 
-    const courseIds = enrollments.map(e => e.courseId).filter(Boolean)
+    const enrolledIds = enrollments.map(e => e.courseId).filter(Boolean) as string[]
+
+    // A student enrolls in the PUBLISHED variant, but the tutor's sessions and
+    // schedules may be stored under the TEMPLATE course id (or a sibling published
+    // variant). Expand each enrolled id to its whole variant family so we match
+    // sessions regardless of which id in the family they carry — otherwise
+    // `calendarEvent.courseId IN (publishedIds)` never matches a template-scoped
+    // session and the student sees nothing.
+    let courseIds = enrolledIds
+    if (enrolledIds.length > 0) {
+      const variants = await drizzleDb
+        .select({
+          templateCourseId: courseVariant.templateCourseId,
+          publishedCourseId: courseVariant.publishedCourseId,
+        })
+        .from(courseVariant)
+        .where(
+          or(
+            inArray(courseVariant.publishedCourseId, enrolledIds),
+            inArray(courseVariant.templateCourseId, enrolledIds)
+          )
+        )
+      courseIds = Array.from(
+        new Set([
+          ...enrolledIds,
+          ...variants.flatMap(v => [v.templateCourseId, v.publishedCourseId]),
+        ])
+      )
+    }
 
     // --- Primary source: CalendarEvent (course sessions) ---
     // Only queried when the student is enrolled in courses; 1-on-1 sessions


### PR DESCRIPTION
## Bug (as reported)
A tutor creates a course (no schedule), publishes it; a student enrolls; the tutor creates a session students can join and later adds a schedule — but the student's **Sessions tab shows nothing**.

## Root cause — template vs published course-id mismatch
Courses split into a **template** course and a **published variant** (different ids, linked via `CourseVariant`).
- A student **enrolls in the published variant** → `courseEnrollment.courseId = publishedId`.
- The tutor's **sessions/schedules are stored under the template id** (the tutor operates on the course they created).
- The student calendar/events API filtered `calendarEvent.courseId IN (enrolledPublishedIds)` / `liveSession.courseId IN (...)` with **no variant bridging** → a template-scoped session never matches → **0 sessions shown** (even though it exists and is joinable via its session id, which is why "students can join" but "can't see it in the list").

So yes — the wiring was broken by the id split; the calendar query never bridged it.

## Fix
Before filtering, **expand the enrolled ids to the whole variant family** (template ↔ all published variants, via `CourseVariant`), so sessions match regardless of which id in the family they carry. Bridges both directions and is a no-op for course-less sessions.

## Verification (Postgres)
Reproduced the exact scenario — session created under the **template** id, student enrolled under the **published** id:
- **Before:** query returns **0** sessions (matches the report).
- **After:** the **calendar event** and the **live session** are both visible.

Data-layer only; no change to how sessions are stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)