### PR TITLE
fix(live): stop 1-on-1 join from hanging forever on a stuck video provider

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -33,14 +33,23 @@ export default function OneOnOneCallPage() {
   useEffect(() => {
     if (!sessionId) return
     let cancelled = false
+    // Bound the whole join so a stuck request (e.g. an unresponsive video
+    // provider) can't spin forever — abort after 30s and surface a retryable
+    // error instead of an endless loader.
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 30000)
     ;(async () => {
       try {
-        const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+        const csrfRes = await fetch('/api/csrf', {
+          credentials: 'include',
+          signal: controller.signal,
+        })
         const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
         const res = await fetch(`/api/class/rooms/${sessionId}/join`, {
           method: 'POST',
           credentials: 'include',
           headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
+          signal: controller.signal,
         })
         const data = await res.json().catch(() => ({}))
         if (cancelled) return
@@ -62,12 +71,23 @@ export default function OneOnOneCallPage() {
           twoWay: data?.twoWay ?? true,
           error: data?.videoError || undefined,
         })
-      } catch {
-        if (!cancelled) setState({ loading: false, error: 'Could not join the session.' })
+      } catch (err) {
+        if (cancelled) return
+        const timedOut = err instanceof DOMException && err.name === 'AbortError'
+        setState({
+          loading: false,
+          error: timedOut
+            ? 'Joining is taking too long. Please check your connection and try again.'
+            : 'Could not join the session.',
+        })
+      } finally {
+        clearTimeout(timeoutId)
       }
     })()
     return () => {
       cancelled = true
+      clearTimeout(timeoutId)
+      controller.abort()
     }
   }, [sessionId, session?.user?.id, session?.user?.role])
 

--- a/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
+++ b/tutorme-app/src/app/api/class/rooms/[id]/join/route.ts
@@ -31,6 +31,19 @@ import { formatCourseVariantName } from '@/lib/courses/variant-name'
 
 const EARLY_ENTRY_MS = 20 * 60 * 1000 // students may enter 20 min before scheduledAt
 
+// Bound a video-provider call so an unresponsive Daily.co API can't hang the
+// whole join request (which left /call spinning forever). On timeout this
+// rejects, and the existing try/catch around each call recovers gracefully
+// (recreate the room, or surface videoError while chat/whiteboard still work).
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    ),
+  ])
+}
+
 export const POST = withCsrf(
   withAuth(async (req: NextRequest, session, context) => {
     const id = await getParamAsync(context?.params, 'id')
@@ -159,12 +172,20 @@ export const POST = withCsrf(
       // recreating it more than once.
       let activeRoomId = classSessionRow.roomId
       try {
-        const roomLive = await dailyProvider.isRoomActive(classSessionRow.roomId)
+        const roomLive = await withTimeout(
+          dailyProvider.isRoomActive(classSessionRow.roomId),
+          10000,
+          'isRoomActive'
+        )
         if (!roomLive) {
-          const fresh = await dailyProvider.createRoom(classSessionRow.tutorId, {
-            maxParticipants: Math.min((classSessionRow.maxStudents ?? 9) + 1, 50),
-            durationMinutes: classSessionRow.durationMinutes ?? 120,
-          })
+          const fresh = await withTimeout(
+            dailyProvider.createRoom(classSessionRow.tutorId, {
+              maxParticipants: Math.min((classSessionRow.maxStudents ?? 9) + 1, 50),
+              durationMinutes: classSessionRow.durationMinutes ?? 120,
+            }),
+            15000,
+            'createRoom'
+          )
           const updated = await drizzleDb
             .update(liveSession)
             .set({ roomId: fresh.id, roomUrl: fresh.url })
@@ -201,12 +222,16 @@ export const POST = withCsrf(
       }
 
       try {
-        token = await dailyProvider.createMeetingToken(activeRoomId, userId, {
-          isOwner,
-          durationMinutes: classSessionRow.durationMinutes ?? 120,
-          // 1-on-1 sessions (capacity 2) are two-way: the student transmits too.
-          twoWay: (classSessionRow.maxStudents ?? 0) <= 2,
-        })
+        token = await withTimeout(
+          dailyProvider.createMeetingToken(activeRoomId, userId, {
+            isOwner,
+            durationMinutes: classSessionRow.durationMinutes ?? 120,
+            // 1-on-1 sessions (capacity 2) are two-way: the student transmits too.
+            twoWay: (classSessionRow.maxStudents ?? 0) <= 2,
+          }),
+          10000,
+          'createMeetingToken'
+        )
       } catch (err: any) {
         console.error('[Join] Daily.co token creation failed:', err?.message)
         Sentry.captureException(err instanceof Error ? err : new Error(String(err?.message)), {


### PR DESCRIPTION
Addresses the reported **tutor "keeps loading unending"** when joining a 1-on-1.

## Cause
The `/call/[sessionId]` page's join fetch has **no timeout**, and the join API (`/api/class/rooms/[id]/join`) awaits Daily.co calls (`isRoomActive` / `createRoom` / `createMeetingToken`) inside try/catch but **without a timeout** — so an unresponsive provider *hangs* the request (it never throws), leaving the page's loader spinning forever.

## Fix (defensive, additive)
- **Server:** wrap each Daily.co call in `withTimeout(...)`. On timeout it rejects, which falls into the **existing** graceful recovery — recreate the room, or surface `videoError` while chat/whiteboard still work — so the endpoint always returns instead of hanging. (Benefits every live-session join, not just 1-on-1.)
- **Client:** abort the whole join after 30s (`AbortController`) and show a retryable error instead of an endless spinner.

## Out of scope (separate issue)
The **student's "This event is not linked to a session"** is a different problem — the student's calendar event has a null `externalId` (no live session attached). In static analysis the tutor-accept → `createSession` link path looks correct, so this is likely data-specific or a recent regression in the actively-changing 1-on-1 area. I need the specific session/booking to root-cause it precisely; happy to fix once identified.

## Verification
Prettier clean. Typecheck/Build verified by CI (worktree had no local deps). Simple, type-safe additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)