### PR TITLE
fix(chat): expose id on conversation + message responses (real 'Failed to send' cause)

### DIFF
--- a/tutorme-app/src/app/api/conversations/[id]/messages/route.ts
+++ b/tutorme-app/src/app/api/conversations/[id]/messages/route.ts
@@ -124,6 +124,7 @@ export const GET = withAuth(async (req: NextRequest, session, context) => {
 
   const messagesWithSender = messages.map(m => ({
     ...m,
+    id: m.directMessageId, // client reads `message.id` (row exposes `directMessageId`)
     sender: userById[m.senderId]
       ? {
           id: userById[m.senderId].userId,
@@ -243,6 +244,7 @@ export const POST = withAuth(async (req: NextRequest, session, context) => {
     const messageResponse = message
       ? {
           ...message,
+          id: message.directMessageId, // client reads `message.id`
           sender: sender
             ? {
                 id: sender.userId,

--- a/tutorme-app/src/app/api/conversations/route.ts
+++ b/tutorme-app/src/app/api/conversations/route.ts
@@ -79,6 +79,10 @@ export const GET = withAuth(async (req: NextRequest, session) => {
       const lastMsg = lastMessageByConvId[conv.conversationId]
       return {
         ...conv,
+        // The DB row exposes `conversationId` (column `id`); the client reads
+        // `conversation.id` (used to build /api/conversations/:id/messages URLs).
+        // Without this, that id was `undefined` → 404 on load and send.
+        id: conv.conversationId,
         participant1: p1
           ? {
               id: p1?.userId,


### PR DESCRIPTION
### The actual bug
Cloud Run logs showed the send POSTs hitting **`/api/conversations/undefined/messages` → 404**. The conversations list API spread the raw DB row (which exposes `conversationId`, column `id`) but never set a top-level **`id`**, so the client's `selectedConversation.id` was `undefined` — breaking both message loading and sending.

### Fix
- **conversations list** — add `id: conv.conversationId`.
- **messages GET + POST** — add `id: <row>.directMessageId` (same `id`-field mismatch; the client uses `message.id` for React keys and the optimistic update).

### Note
The earlier CSRF fix (#990) is still correct — it just wasn't the cause of *this* symptom (the 404 fired before CSRF was ever checked). Diagnosed from prod logs after #990 didn't resolve it. `typecheck` clean.