### PR TITLE
fix(1-on-1): student "not linked to a session" — carry sessionId + self-heal

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -233,6 +233,7 @@ export function DashboardCalendar({
           : evStatus === 'ended' || evStatus === 'completed'
             ? 'completed'
             : 'scheduled'
+      const isOneOnOne = (ev as any).type === 'one-on-one'
       return {
         id: ev.id,
         title: ev.title,
@@ -242,6 +243,12 @@ export function DashboardCalendar({
         status,
         subject: ev.subject,
         isOnline: true,
+        // Carry the join keys through: without sessionId the Join button
+        // always reported "not linked"; requestId lets a missing 1-on-1 session
+        // self-heal; maxStudents (2 for a 1-on-1) routes to the shared call room.
+        sessionId: (ev as any).sessionId ?? undefined,
+        requestId: (ev as any).requestId ?? undefined,
+        maxStudents: isOneOnOne ? 2 : ((ev as any).maxStudents ?? undefined),
         description:
           (ev as any).meetingUrl || (ev.tutorName ? `Tutor: ${ev.tutorName}` : undefined),
         color:

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -35,6 +35,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { CountryFlag } from '@/components/country-flag'
 
 // DnD Kit imports
@@ -85,6 +86,8 @@ interface CalendarEvent {
   type: 'class' | 'office_hours' | 'personal' | 'deadline'
   status: 'scheduled' | 'live' | 'completed' | 'cancelled'
   sessionId?: string
+  /** 1-on-1 booking request id — used to self-heal a missing session link. */
+  requestId?: string
   studentCount?: number
   maxStudents?: number
   subject?: string
@@ -411,6 +414,7 @@ export function InteractiveCalendar({
     [onViewChange]
   )
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
+  const [joiningSession, setJoiningSession] = useState(false)
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [subjectFilter, setSubjectFilter] = useState<string>('all')
   const [typeFilter] = useState<string>('all')
@@ -1460,25 +1464,58 @@ export function InteractiveCalendar({
                   </Button>
                   <Button
                     variant="modal-primary-dark"
-                    disabled={selectedEvent.status === 'cancelled'}
-                    onClick={() => {
-                      if (!selectedEvent.sessionId) {
-                        toast.error('This event is not linked to a TutorMekimi session.')
+                    disabled={selectedEvent.status === 'cancelled' || joiningSession}
+                    onClick={async () => {
+                      const isOneOnOne = (selectedEvent.maxStudents ?? 50) <= 2
+                      // 1-on-1 (capacity ≤ 2) → the shared two-way call room, which
+                      // works for both roles (course classrooms are role-specific and
+                      // can't host a course-less 1-on-1).
+                      const routeToSession = (sessionId: string) => {
+                        router.push(
+                          withLocalePath(
+                            isOneOnOne
+                              ? `/call/${sessionId}`
+                              : isStudent
+                                ? `/student/feedback?sessionId=${sessionId}`
+                                : `/tutor/classroom?sessionId=${sessionId}`
+                          )
+                        )
                         setSelectedEvent(null)
+                      }
+
+                      if (selectedEvent.sessionId) {
+                        routeToSession(selectedEvent.sessionId)
                         return
                       }
-                      // 1-on-1 (capacity ≤ 2) → the shared two-way call room, which
-                      // works for both roles (the course classrooms are role-specific
-                      // and can't host a course-less 1-on-1).
-                      const isOneOnOne = (selectedEvent.maxStudents ?? 50) <= 2
-                      router.push(
-                        withLocalePath(
-                          isOneOnOne
-                            ? `/call/${selectedEvent.sessionId}`
-                            : isStudent
-                              ? `/student/feedback?sessionId=${selectedEvent.sessionId}`
-                              : `/tutor/classroom?sessionId=${selectedEvent.sessionId}`
-                        )
+
+                      // No linked session. For a 1-on-1 booking we can self-heal:
+                      // ask the server to (re)link/create the session, then join.
+                      if (isOneOnOne && selectedEvent.requestId) {
+                        setJoiningSession(true)
+                        try {
+                          const res = await fetchWithCsrf('/api/one-on-one/ensure-session', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ requestId: selectedEvent.requestId }),
+                          })
+                          const data = await res.json().catch(() => ({}))
+                          if (res.ok && data?.sessionId) {
+                            routeToSession(data.sessionId)
+                            return
+                          }
+                          toast.error(
+                            data?.error || 'This session isn’t ready to join yet. Please try again.'
+                          )
+                        } catch {
+                          toast.error('Could not open the session. Please try again.')
+                        } finally {
+                          setJoiningSession(false)
+                        }
+                        return
+                      }
+
+                      toast.error(
+                        'This session isn’t ready to join yet — please refresh in a moment or contact your tutor.'
                       )
                       setSelectedEvent(null)
                     }}

--- a/tutorme-app/src/app/api/one-on-one/ensure-session/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/ensure-session/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Ensure a PAID 1-on-1 booking has a joinable live session.
+ *
+ * Normally the tutor's accept (`one-on-one/respond`) creates the LiveSession +
+ * linked CalendarEvent. This endpoint is a self-heal for the anomalous case
+ * where a PAID booking's event has no linked session (externalId null) — the
+ * student would otherwise see "not linked to a session" and be unable to join.
+ *
+ * It returns the existing session if one is linked, otherwise creates one
+ * (idempotently, mirroring respond) and re-points the booking at it.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { withCsrf, withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest, calendarEvent, liveSession } from '@/lib/db/schema'
+import { createSession } from '@/lib/sessions/create-session'
+
+const BodySchema = z.object({ requestId: z.string().min(1) })
+
+export const POST = withCsrf(
+  withAuth(async (req: NextRequest, session) => {
+    const parsed = BodySchema.safeParse(await req.json().catch(() => ({})))
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'requestId is required' }, { status: 400 })
+    }
+    const { requestId } = parsed.data
+    const userId = session.user.id
+
+    const [booking] = await drizzleDb
+      .select({
+        tutorId: oneOnOneBookingRequest.tutorId,
+        studentId: oneOnOneBookingRequest.studentId,
+        status: oneOnOneBookingRequest.status,
+        calendarEventId: oneOnOneBookingRequest.calendarEventId,
+        durationMinutes: oneOnOneBookingRequest.durationMinutes,
+        timezone: oneOnOneBookingRequest.timezone,
+      })
+      .from(oneOnOneBookingRequest)
+      .where(eq(oneOnOneBookingRequest.requestId, requestId))
+      .limit(1)
+
+    if (!booking) {
+      return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
+    }
+    // Only the two participants may resolve the session.
+    if (booking.studentId !== userId && booking.tutorId !== userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+    // A session is only joinable once the booking is confirmed/paid.
+    if (booking.status !== 'PAID') {
+      return NextResponse.json({ error: 'This session is not confirmed yet.' }, { status: 409 })
+    }
+
+    // Look up the currently-linked event (if any).
+    const [event] = booking.calendarEventId
+      ? await drizzleDb
+          .select({
+            externalId: calendarEvent.externalId,
+            startTime: calendarEvent.startTime,
+            endTime: calendarEvent.endTime,
+          })
+          .from(calendarEvent)
+          .where(eq(calendarEvent.eventId, booking.calendarEventId))
+          .limit(1)
+      : []
+
+    // Already linked to a real live session → nothing to heal.
+    if (event?.externalId) {
+      const [ls] = await drizzleDb
+        .select({ sessionId: liveSession.sessionId })
+        .from(liveSession)
+        .where(eq(liveSession.sessionId, event.externalId))
+        .limit(1)
+      if (ls) return NextResponse.json({ sessionId: ls.sessionId, healed: false })
+    }
+
+    // Derive the schedule from the existing event (authoritative), else now.
+    const scheduledAt = event?.startTime ?? new Date()
+    const durationMinutes =
+      booking.durationMinutes ||
+      (event?.startTime && event?.endTime
+        ? Math.max(15, Math.round((event.endTime.getTime() - event.startTime.getTime()) / 60000))
+        : 60)
+
+    const result = await drizzleDb.transaction(async tx => {
+      // Re-check under the transaction so concurrent joins don't double-create.
+      if (booking.calendarEventId) {
+        const [fresh] = await tx
+          .select({ externalId: calendarEvent.externalId })
+          .from(calendarEvent)
+          .where(eq(calendarEvent.eventId, booking.calendarEventId))
+          .limit(1)
+        if (fresh?.externalId) {
+          const [ls] = await tx
+            .select({ sessionId: liveSession.sessionId })
+            .from(liveSession)
+            .where(eq(liveSession.sessionId, fresh.externalId))
+            .limit(1)
+          if (ls) return { sessionId: ls.sessionId, healed: false }
+        }
+      }
+
+      const { liveSession: created, calendarEvent: newEvent } = await createSession(
+        {
+          tutorId: booking.tutorId,
+          title: '1-on-1 Session',
+          scheduledAt,
+          durationMinutes,
+          category: 'Consultation',
+          type: 'ONE_ON_ONE',
+          studentId: booking.studentId,
+          maxStudents: 2,
+          description: 'One-on-one tutoring session',
+          timezone: booking.timezone,
+        },
+        tx
+      )
+
+      // Point the booking at the freshly-linked event (mirrors respond).
+      await tx
+        .update(oneOnOneBookingRequest)
+        .set({ calendarEventId: newEvent.eventId, updatedAt: new Date() })
+        .where(eq(oneOnOneBookingRequest.requestId, requestId))
+
+      return { sessionId: created.sessionId, healed: true }
+    })
+
+    return NextResponse.json(result)
+  })
+)


### PR DESCRIPTION
Fixes the student side of the 1-on-1 join bug: clicking **Join** always showed *"This event is not linked to a TutorMekimi session."*

## Root cause (found it)
The student `DashboardCalendar` maps API events into the `InteractiveCalendar` shape, and that mapping **dropped `sessionId`, `maxStudents`, and `requestId`**. So every student event reached the Join button with `sessionId: undefined` → the "not linked" error **every time** (and `maxStudents: undefined` mis-routed 1-on-1s away from the shared call room). It's a pure **client mapping omission** — not data-specific, and not in the actively-churned server code.

**Fix:** carry `sessionId`, `requestId`, and `maxStudents` (2 for a 1-on-1) through the mapping.

## Defensive additions (safety net)
- **New `POST /api/one-on-one/ensure-session`:** for a PAID 1-on-1 whose calendar event has no linked live session (the rare genuine anomaly), it creates/links one **idempotently** (mirrors `respond`, re-checks under a transaction) and returns the `sessionId`. Only the booking's participants can call it; only when `PAID`.
- **`InteractiveCalendar` Join:** if a 1-on-1 has no `sessionId` but has a `requestId`, it calls `ensure-session` (with a loading state) then joins; otherwise it shows an actionable message instead of the confusing "not linked" text.

Together: normal bookings just work (mapping fix); a broken-link booking self-heals; and worst case the user gets a clear, retryable message.

## Verification
Prettier clean. Typecheck/Build via CI (worktree had no local deps). 

Pairs with #993 (tutor join-hang fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)