### PR TITLE
feat(1-on-1): richer request cards (shared, tutor + student)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigat
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { OneOnOneRescheduleDialog } from '@/components/booking/one-on-one-reschedule-dialog'
+import { OneOnOneRequestCard } from '@/components/one-on-one/one-on-one-request-card'
 import { CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TabsContent } from '@/components/ui/tabs'
@@ -185,6 +186,11 @@ type OneOnOneRequest = {
   timezone: string
   costPerSession: number
   status: string
+  durationMinutes?: number | null
+  currency?: string | null
+  createdAt?: string | null
+  paymentDueAt?: string | null
+  paidAt?: string | null
   student?: {
     userId?: string | null
     handle?: string | null
@@ -1000,46 +1006,26 @@ function TutorDashboardContent() {
                     </div>
                   ) : (
                     oneOnOneRequests.map(request => (
-                      <div
+                      <OneOnOneRequestCard
                         key={request.requestId}
-                        className="border-border/20 bg-muted/30 hover:border-border/40 hover:bg-muted/50 flex flex-wrap items-center justify-between gap-3 rounded-lg border p-4 transition-all duration-200"
-                      >
-                        <div className="min-w-0 space-y-1">
-                          <p className="truncate font-semibold text-white">
-                            @{request.student?.handle || 'student'}
-                          </p>
-                          <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs">
-                            <span>
-                              {new Date(request.requestedDate).toLocaleDateString('en-US', {
-                                month: 'short',
-                                day: 'numeric',
-                                year: 'numeric',
-                              })}
-                            </span>
-                            <span>•</span>
-                            <span>
-                              {request.startTime} - {request.endTime}
-                            </span>
-                            <span>•</span>
-                            <span>{request.timezone}</span>
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {request.status === 'PENDING' ? (
+                        request={request}
+                        perspective="tutor"
+                        variant="dark"
+                        actions={
+                          request.status === 'PENDING' ? (
                             <>
                               <Button
                                 size="sm"
                                 variant="outline"
                                 disabled={respondingRequestId === request.requestId}
                                 onClick={() => handleOneOnOneResponse(request.requestId, 'accept')}
-                                className="transition-all duration-200"
                               >
                                 Accept
                               </Button>
                               <Button
                                 size="sm"
                                 variant="ghost"
-                                className="text-destructive hover:bg-destructive/10 transition-all duration-200"
+                                className="text-destructive hover:bg-destructive/10"
                                 disabled={respondingRequestId === request.requestId}
                                 onClick={() => handleOneOnOneResponse(request.requestId, 'reject')}
                               >
@@ -1051,13 +1037,12 @@ function TutorDashboardContent() {
                               size="sm"
                               variant="outline"
                               onClick={() => setRescheduleRequestId(request.requestId)}
-                              className="transition-all duration-200"
                             >
                               Reschedule
                             </Button>
-                          )}
-                        </div>
-                      </div>
+                          )
+                        }
+                      />
                     ))
                   )}
                 </div>

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from 'react'
 import { toast } from 'sonner'
-import { Loader2, MessageSquare, Bell } from 'lucide-react'
+import { Loader2, MessageSquare, Bell, CalendarClock } from 'lucide-react'
 import { TabsContent } from '@/components/ui/tabs'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { CollapsibleCard } from '@/components/collapsible-card'
 import { cn } from '@/lib/utils'
 import Messenger from './messenger'
 import NotificationsPanel from './notifications-panel'
+import StudentRequestsPanel from './student-requests-panel'
 import type { AppNotification, CommsRole } from './types'
 
 interface CommunicationsPageProps {
@@ -207,6 +208,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
           variant="charcoal"
           tabs={[
             { value: 'messaging', label: 'Messaging' },
+            ...(role === 'student' ? [{ value: 'requests', label: 'Requests' }] : []),
             { value: 'notifications', label: 'Notifications' },
           ]}
         >
@@ -222,6 +224,21 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               <Messenger />
             </CollapsibleCard>
           </TabsContent>
+
+          {role === 'student' && (
+            <TabsContent value="requests" className="flex h-full flex-col">
+              <CollapsibleCard
+                title="1-on-1 Requests"
+                icon={<CalendarClock className="h-5 w-5 text-slate-900" />}
+                defaultOpen
+                fillHeight
+                className="flex-1"
+                contentClassName="pt-3"
+              >
+                <StudentRequestsPanel />
+              </CollapsibleCard>
+            </TabsContent>
+          )}
 
           <TabsContent value="notifications" className="flex h-full flex-col">
             <CollapsibleCard

--- a/tutorme-app/src/components/communications/student-requests-panel.tsx
+++ b/tutorme-app/src/components/communications/student-requests-panel.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { toast } from 'sonner'
+import { Loader2, CalendarClock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import {
+  OneOnOneRequestCard,
+  type OneOnOneRequestSummary,
+} from '@/components/one-on-one/one-on-one-request-card'
+
+/**
+ * A student's own 1-on-1 booking requests (the `role=sent` view). Renders the
+ * shared OneOnOneRequestCard with student-facing actions: cancel a pending/accepted
+ * request, or pay for an accepted one.
+ */
+export default function StudentRequestsPanel() {
+  const params = useParams()
+  const locale = (params?.locale as string) || 'en'
+  const [requests, setRequests] = useState<OneOnOneRequestSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/one-on-one/request?role=sent', { credentials: 'include' })
+      const data = res.ok ? await res.json() : { requests: [] }
+      setRequests(Array.isArray(data.requests) ? data.requests : [])
+    } catch {
+      setRequests([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const cancel = useCallback(async (requestId: string) => {
+    setBusyId(requestId)
+    try {
+      const res = await fetchWithCsrf('/api/one-on-one/cancel', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ requestId }),
+      })
+      if (!res.ok) throw new Error('cancel failed')
+      setRequests(prev =>
+        prev.map(r => (r.requestId === requestId ? { ...r, status: 'CANCELLED' } : r))
+      )
+      toast.success('Request cancelled')
+    } catch {
+      toast.error('Could not cancel the request. Please try again.')
+    } finally {
+      setBusyId(null)
+    }
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+      </div>
+    )
+  }
+
+  if (requests.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-slate-200 py-10 text-center text-sm text-slate-500">
+        <CalendarClock className="mx-auto mb-2 h-8 w-8 text-slate-300" />
+        You haven&apos;t requested any 1-on-1 sessions yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {requests.map(r => {
+        const status = (r.status || '').toUpperCase()
+        const cancellable = status === 'PENDING' || status === 'ACCEPTED'
+        return (
+          <OneOnOneRequestCard
+            key={r.requestId}
+            request={r}
+            perspective="student"
+            variant="light"
+            actions={
+              status === 'ACCEPTED' || cancellable ? (
+                <>
+                  {status === 'ACCEPTED' ? (
+                    <Button asChild size="sm">
+                      <Link
+                        href={`/${locale}/payment?requestId=${encodeURIComponent(r.requestId)}`}
+                      >
+                        Pay now
+                      </Link>
+                    </Button>
+                  ) : null}
+                  {cancellable ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:bg-destructive/10"
+                      disabled={busyId === r.requestId}
+                      onClick={() => cancel(r.requestId)}
+                    >
+                      Cancel
+                    </Button>
+                  ) : null}
+                </>
+              ) : null
+            }
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
+++ b/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Calendar, Clock, CreditCard, Timer } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface OneOnOneParty {
+  userId?: string | null
+  handle?: string | null
+  email?: string | null
+  image?: string | null
+}
+
+export interface OneOnOneRequestSummary {
+  requestId: string
+  requestedDate: string
+  startTime: string
+  endTime: string
+  timezone: string
+  costPerSession: number
+  status: string
+  durationMinutes?: number | null
+  currency?: string | null
+  createdAt?: string | null
+  paymentDueAt?: string | null
+  paidAt?: string | null
+  student?: OneOnOneParty | null
+  tutor?: OneOnOneParty | null
+}
+
+interface Props {
+  request: OneOnOneRequestSummary
+  /** 'tutor' shows the requesting student; 'student' shows the tutor. */
+  perspective: 'tutor' | 'student'
+  /** Match the surrounding surface — dashboard is dark, comms page is light. */
+  variant?: 'dark' | 'light'
+  /** Role-specific buttons (Accept/Reject/Reschedule, or Pay/Cancel). */
+  actions?: ReactNode
+}
+
+const STATUS_META: Record<string, { label: string; className: string }> = {
+  PENDING: { label: 'Pending', className: 'bg-amber-500/15 text-amber-600 ring-amber-500/30' },
+  ACCEPTED: { label: 'Accepted', className: 'bg-blue-500/15 text-blue-600 ring-blue-500/30' },
+  PAID: { label: 'Confirmed', className: 'bg-emerald-500/15 text-emerald-600 ring-emerald-500/30' },
+  COMPLETED: { label: 'Completed', className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30' },
+  REJECTED: { label: 'Declined', className: 'bg-rose-500/15 text-rose-600 ring-rose-500/30' },
+  CANCELLED: { label: 'Cancelled', className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30' },
+}
+
+function partyName(p?: OneOnOneParty | null): string {
+  if (p?.handle) return p.handle
+  if (p?.email) return p.email.split('@')[0]
+  return 'User'
+}
+
+function initial(name: string): string {
+  return (name.trim()[0] || 'U').toUpperCase()
+}
+
+function money(cost: number, currency?: string | null): string {
+  if (!cost || cost <= 0) return 'Free'
+  const prefix = currency ? `${currency} ` : ''
+  return `${prefix}${cost % 1 === 0 ? cost.toFixed(0) : cost.toFixed(2)}`
+}
+
+/** minutes between two HH:mm strings, else the explicit duration. */
+function durationLabel(req: OneOnOneRequestSummary): string {
+  let mins = req.durationMinutes ?? 0
+  if (!mins && req.startTime && req.endTime) {
+    const [sh, sm] = req.startTime.split(':').map(Number)
+    const [eh, em] = req.endTime.split(':').map(Number)
+    if ([sh, sm, eh, em].every(n => Number.isFinite(n))) mins = eh * 60 + em - (sh * 60 + sm)
+  }
+  return mins > 0 ? `${mins} min` : ''
+}
+
+function relativeTime(iso?: string | null): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (!Number.isFinite(then)) return ''
+  const diff = Date.now() - then
+  const min = Math.round(diff / 60000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.round(hr / 24)
+  return `${day}d ago`
+}
+
+function untilLabel(iso?: string | null): string {
+  if (!iso) return ''
+  const diff = new Date(iso).getTime() - Date.now()
+  if (!Number.isFinite(diff) || diff <= 0) return 'now'
+  const hr = Math.round(diff / 3_600_000)
+  if (hr < 24) return `in ${hr}h`
+  return `in ${Math.round(hr / 24)}d`
+}
+
+export function OneOnOneRequestCard({ request, perspective, variant = 'light', actions }: Props) {
+  const dark = variant === 'dark'
+  const other = perspective === 'tutor' ? request.student : request.tutor
+  const name = partyName(other)
+  const status = (request.status || '').toUpperCase()
+  const meta = STATUS_META[status] ?? {
+    label: status || 'Request',
+    className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30',
+  }
+  const dur = durationLabel(request)
+  const dateLabel = new Date(request.requestedDate).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+  const cost = money(request.costPerSession, request.currency)
+
+  const detail = dark ? 'text-white/60' : 'text-slate-500'
+  const strong = dark ? 'text-white' : 'text-slate-900'
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-xl border p-4 transition-colors',
+        dark
+          ? 'border-white/10 bg-white/[0.04] hover:border-white/20'
+          : 'border-slate-200 bg-white hover:border-slate-300'
+      )}
+    >
+      {/* header: who + status */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <Avatar className="h-10 w-10 shrink-0">
+            {other?.image ? <AvatarImage src={other.image} alt={name} /> : null}
+            <AvatarFallback
+              className={cn(
+                'text-sm font-semibold',
+                dark ? 'bg-white/10 text-white' : 'bg-slate-100 text-slate-600'
+              )}
+            >
+              {initial(name)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <p className={cn('truncate text-sm font-semibold capitalize', strong)}>{name}</p>
+            {other?.handle ? (
+              <p className={cn('truncate text-xs', detail)}>@{other.handle}</p>
+            ) : null}
+          </div>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset',
+            meta.className
+          )}
+        >
+          {meta.label}
+        </span>
+      </div>
+
+      {/* session details */}
+      <div className={cn('flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs', detail)}>
+        <span className="inline-flex items-center gap-1.5">
+          <Calendar className="h-3.5 w-3.5" />
+          {dateLabel}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Clock className="h-3.5 w-3.5" />
+          {request.startTime}–{request.endTime}
+          {dur ? ` · ${dur}` : ''}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Timer className="h-3.5 w-3.5" />
+          {request.timezone}
+        </span>
+        <span className={cn('inline-flex items-center gap-1.5 font-medium', strong)}>
+          <CreditCard className="h-3.5 w-3.5" />
+          {cost}
+        </span>
+      </div>
+
+      {/* status-specific line: request age / payment */}
+      {(request.createdAt || (status === 'ACCEPTED' && request.paymentDueAt) || request.paidAt) && (
+        <div className={cn('flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]', detail)}>
+          {status === 'ACCEPTED' && request.paymentDueAt ? (
+            <span className="font-medium text-amber-600">
+              Payment due {untilLabel(request.paymentDueAt)}
+            </span>
+          ) : request.paidAt ? (
+            <span className="font-medium text-emerald-600">
+              Paid {relativeTime(request.paidAt)}
+            </span>
+          ) : request.createdAt ? (
+            <span>Requested {relativeTime(request.createdAt)}</span>
+          ) : null}
+        </div>
+      )}
+
+      {actions ? (
+        <div className="flex flex-wrap items-center justify-end gap-2">{actions}</div>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
The 1-on-1 request cards were scanty — just `@handle`, date, `start–end`, timezone — while the API returns much more. New **shared `OneOnOneRequestCard`** surfaces it, informative-but-restrained and variant-aware (dark dashboard / light comms page):

- other party **avatar + name + @handle**
- **colour-coded status badge** (Pending / Accepted / Confirmed / Declined / Cancelled / Completed)
- session **date · time · duration · timezone**
- **cost** (with currency + "Free" when applicable)
- a status line: **requested Xh ago**, or **"Payment due in Xh"** / **"Paid"** for accepted/paid

### Tutor side
The dashboard requests list now renders the shared card; **Accept / Reject / Reschedule** preserved.

### Student side
Students previously had **no dedicated requests view** (only the generic notifications panel). Added a **"Requests" tab** in Communications (`role=sent`) rendering the same card with **Cancel** + **"Pay now"** (→ `/payment?requestId=…`).

`typecheck` clean · **591** unit tests pass · lint clean.