### PR TITLE
fix(student): bridge template/published variant split across student reads

### DIFF
--- a/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/submit/route.ts
@@ -11,7 +11,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { randomUUID } from 'crypto'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
@@ -102,12 +103,18 @@ export async function POST(
       return NextResponse.json({ error: 'Task not available' }, { status: 404 })
     }
 
-    // Student must be enrolled in the task's course
+    // Student must be enrolled in the task's course. The task can be scoped to
+    // the template id while the student enrolled in a published variant, so match
+    // the whole variant family.
+    const taskCourseFamily = await expandToCourseFamily(task.courseId ? [task.courseId] : [])
     const [enrollment] = await drizzleDb
       .select({ enrollmentId: courseEnrollment.enrollmentId })
       .from(courseEnrollment)
       .where(
-        and(eq(courseEnrollment.studentId, studentId), eq(courseEnrollment.courseId, task.courseId))
+        and(
+          eq(courseEnrollment.studentId, studentId),
+          inArray(courseEnrollment.courseId, taskCourseFamily)
+        )
       )
       .limit(1)
 

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
@@ -14,7 +14,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { randomUUID } from 'crypto'
 import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
@@ -79,11 +80,15 @@ export async function POST(
 
     // Ownership: the student must be enrolled in the task's course, OR already
     // have a submission for it (so follow-ups keep working).
+    const taskCourseFamily = await expandToCourseFamily(task.courseId ? [task.courseId] : [])
     const [enrolled] = await drizzleDb
       .select({ id: courseEnrollment.enrollmentId })
       .from(courseEnrollment)
       .where(
-        and(eq(courseEnrollment.studentId, studentId), eq(courseEnrollment.courseId, task.courseId))
+        and(
+          eq(courseEnrollment.studentId, studentId),
+          inArray(courseEnrollment.courseId, taskCourseFamily)
+        )
       )
       .limit(1)
     const [existing] = await drizzleDb

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -18,9 +18,9 @@ import {
   oneOnOneBookingRequest,
   groupSession,
   groupSessionParticipant,
-  courseVariant,
 } from '@/lib/db/schema'
-import { eq, and, or, gte, lte, inArray, isNull, ne, sql } from 'drizzle-orm'
+import { eq, and, gte, lte, inArray, isNull, ne, sql } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 export const GET = withAuth(
@@ -46,32 +46,9 @@ export const GET = withAuth(
     const enrolledIds = enrollments.map(e => e.courseId).filter(Boolean) as string[]
 
     // A student enrolls in the PUBLISHED variant, but the tutor's sessions and
-    // schedules may be stored under the TEMPLATE course id (or a sibling published
-    // variant). Expand each enrolled id to its whole variant family so we match
-    // sessions regardless of which id in the family they carry — otherwise
-    // `calendarEvent.courseId IN (publishedIds)` never matches a template-scoped
-    // session and the student sees nothing.
-    let courseIds = enrolledIds
-    if (enrolledIds.length > 0) {
-      const variants = await drizzleDb
-        .select({
-          templateCourseId: courseVariant.templateCourseId,
-          publishedCourseId: courseVariant.publishedCourseId,
-        })
-        .from(courseVariant)
-        .where(
-          or(
-            inArray(courseVariant.publishedCourseId, enrolledIds),
-            inArray(courseVariant.templateCourseId, enrolledIds)
-          )
-        )
-      courseIds = Array.from(
-        new Set([
-          ...enrolledIds,
-          ...variants.flatMap(v => [v.templateCourseId, v.publishedCourseId]),
-        ])
-      )
-    }
+    // schedules may be stored under the TEMPLATE course id — expand to the whole
+    // variant family so a template-scoped session still matches.
+    const courseIds = await expandToCourseFamily(enrolledIds)
 
     // --- Primary source: CalendarEvent (course sessions) ---
     // Only queried when the student is enrolled in courses; 1-on-1 sessions

--- a/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { eq, and, asc } from 'drizzle-orm'
+import { eq, and, asc, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
@@ -52,10 +53,13 @@ export const GET = withAuth(
       // they have one (a switch then cascades to which sessions they see).
       // One-time/ad-hoc sessions (scheduleId null) are shown to everyone.
       // Lesson titles so each session can show which lesson it covers.
+      // The student enrolls in the published variant, but lessons/sessions may be
+      // stored under the template id — match the whole variant family.
+      const familyIds = await expandToCourseFamily([courseId])
       const lessonRows = await drizzleDb
         .select({ id: courseLesson.lessonId, title: courseLesson.title, order: courseLesson.order })
         .from(courseLesson)
-        .where(and(eq(courseLesson.courseId, courseId), isNull(courseLesson.deletedAt)))
+        .where(and(inArray(courseLesson.courseId, familyIds), isNull(courseLesson.deletedAt)))
         .orderBy(asc(courseLesson.order))
       const lessonTitleById = new Map(lessonRows.map(l => [l.id, l.title]))
       const lessonNumberById = new Map(lessonRows.map((l, i) => [l.id, i + 1]))
@@ -64,13 +68,13 @@ export const GET = withAuth(
       const realSessions = await drizzleDb.query.liveSession.findMany({
         where: enrolledScheduleId
           ? and(
-              eq(liveSessionTable.courseId, courseId),
+              inArray(liveSessionTable.courseId, familyIds),
               or(
                 eq(liveSessionTable.scheduleId, enrolledScheduleId),
                 isNull(liveSessionTable.scheduleId)
               )
             )
-          : eq(liveSessionTable.courseId, courseId),
+          : inArray(liveSessionTable.courseId, familyIds),
         orderBy: [asc(liveSessionTable.scheduledAt)],
       })
 

--- a/tutorme-app/src/app/api/student/dashboard-stats/route.ts
+++ b/tutorme-app/src/app/api/student/dashboard-stats/route.ts
@@ -25,6 +25,7 @@ import {
   type LiveSessionStatus,
 } from '@/lib/db/schema'
 import { eq, and, inArray, isNull, gte } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 // A booking that was rejected by the tutor or expired never became a booking, so
@@ -64,7 +65,11 @@ export const GET = withAuth(
         .where(eq(courseEnrollment.studentId, studentId))
 
       const activeEnrollments = enrollmentRows.filter(e => !e.courseDeletedAt)
-      const courseIds = [...new Set(activeEnrollments.map(e => e.courseId).filter(Boolean))]
+      // Expand enrolled (published) ids to the variant family so template-scoped
+      // sessions are counted too (see @/lib/courses/variant-family).
+      const courseIds = await expandToCourseFamily([
+        ...new Set(activeEnrollments.map(e => e.courseId).filter(Boolean)),
+      ] as string[])
 
       // --- 2. Counts that don't depend on sessions ---
       const coursesEnrolled = activeEnrollments.length

--- a/tutorme-app/src/lib/courses/variant-family.ts
+++ b/tutorme-app/src/lib/courses/variant-family.ts
@@ -1,0 +1,46 @@
+/**
+ * Course-variant family expansion.
+ *
+ * A course is split into a TEMPLATE course (`isPublished = false`) and one or
+ * more PUBLISHED variant courses (per category × nationality), linked via
+ * `courseVariant` (templateCourseId ↔ publishedCourseId). Students enroll in the
+ * PUBLISHED variant, but a tutor's sessions / schedules / lessons / tasks /
+ * deployed materials can be stored under the TEMPLATE id (or a published id)
+ * depending on which course view created them.
+ *
+ * Any read that scopes content by a student's enrolled course id therefore has
+ * to match the whole family, or the student silently sees nothing (or is wrongly
+ * blocked). Use `expandToCourseFamily` on the enrolled ids (or on a single
+ * course id) before filtering `... .courseId IN (ids)`.
+ */
+
+import { or, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseVariant } from '@/lib/db/schema'
+
+/**
+ * Expand the given course ids to include, for each one, the OTHER id in its
+ * template↔published pair (whichever direction it was given). A published id maps
+ * to its template; a template id maps to its published variant(s). Ids that
+ * aren't part of any variant are returned unchanged. Order/uniqueness preserved
+ * via a Set. Single round-trip; a no-op for an empty list.
+ */
+export async function expandToCourseFamily(ids: readonly string[]): Promise<string[]> {
+  const input = ids.filter(Boolean)
+  if (input.length === 0) return [...input]
+  const rows = await drizzleDb
+    .select({
+      templateCourseId: courseVariant.templateCourseId,
+      publishedCourseId: courseVariant.publishedCourseId,
+    })
+    .from(courseVariant)
+    .where(
+      or(
+        inArray(courseVariant.publishedCourseId, input),
+        inArray(courseVariant.templateCourseId, input)
+      )
+    )
+  return Array.from(
+    new Set([...input, ...rows.flatMap(r => [r.templateCourseId, r.publishedCourseId])])
+  )
+}

--- a/tutorme-app/src/lib/progress/get-student-progress.ts
+++ b/tutorme-app/src/lib/progress/get-student-progress.ts
@@ -1,4 +1,5 @@
 import { eq, inArray, desc, isNull, and } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { drizzleDb } from '@/lib/db/drizzle'
 import {
   contentProgress,
@@ -57,7 +58,7 @@ export async function fetchLessonProgress(studentId: string): Promise<ProgressIt
     .from(courseEnrollment)
     .where(eq(courseEnrollment.studentId, studentId))
 
-  const courseIds = enrollments.map(e => e.courseId)
+  const courseIds = await expandToCourseFamily(enrollments.map(e => e.courseId))
   if (courseIds.length === 0) return []
 
   const lessons = await drizzleDb
@@ -120,7 +121,7 @@ export async function fetchCourseProgress(studentId: string): Promise<ProgressIt
     .from(courseEnrollment)
     .where(eq(courseEnrollment.studentId, studentId))
 
-  const courseIds = enrollments.map(e => e.courseId)
+  const courseIds = await expandToCourseFamily(enrollments.map(e => e.courseId))
   if (courseIds.length === 0) return []
 
   const coursesData =


### PR DESCRIPTION
## Answer to "anything else to fix?"
**Yes — the same bug I fixed in #992 (student Sessions tab) exists in several other student endpoints.** Courses split into a template course and published variants (different ids); students enroll in the **published** id, but tutor content (sessions, lessons, tasks) can live under the **template** id, so `courseId IN (enrolledIds)` filters and enrollment checks silently fail.

## New shared helper
`expandToCourseFamily(ids)` — expands enrolled ids to their template↔published family. **Verified against Postgres**: published → `{itself, its template}` (not sibling variants); template → `{itself, all its published variants}`; no-op for stand-alone ids. `calendar/events` refactored onto it.

## Fixed — student was BLOCKED / saw nothing
- **`/api/student/courses/[id]/sessions`** — a course's sessions + lesson titles matched the raw courseId → empty list. Now matches the whole family.
- **`/api/student/assignments/[taskId]/submit`** — the enrollment check compared the task's courseId (template) to the enrolled (published) id → **403 "Not enrolled"**, blocking submission. Now checks the family. *(DB-verified: template-scoped task → enrolled student passes.)*
- **`/api/student/assignments/[taskId]/task-chat`** — same 403 block, same fix.

## Fixed — wrong counts (simple, correct expansion)
- **`/api/student/dashboard-stats`** — upcoming-session count.
- **`src/lib/progress/get-student-progress`** — per-lesson progress (both functions).

## Deferred (flagged, needs a follow-up)
Three endpoints aggregate **per-course keyed by the enrolled id**, so a correct fix needs a family→enrolled reverse map (not just query expansion) or counts land under the wrong course node: `/api/student/enrollments` (per-course counts), `/api/student/directory` (materials tree), `/api/student/learning-path` (lesson grouping). Left untouched here to avoid a buggy half-fix.

## Verification
`tsc` + lint + prettier clean. Helper + the enrollment-in-family check DB-verified (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)