### PR TITLE
fix(student): attribute variant-family content to the enrolled course (counts/tree/path)

### DIFF
--- a/tutorme-app/src/app/api/student/directory/route.ts
+++ b/tutorme-app/src/app/api/student/directory/route.ts
@@ -9,6 +9,7 @@ import {
   studentTaskReport,
 } from '@/lib/db/schema'
 import { eq, inArray, and } from 'drizzle-orm'
+import { expandFamilyWithMap } from '@/lib/courses/variant-family'
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
 
 export const dynamic = 'force-dynamic'
@@ -107,7 +108,12 @@ export const GET = withAuth(
       return NextResponse.json({ directory: {}, errors })
     }
 
-    const courseIds = enrollments.map(e => e.courseId).filter((id): id is string => id != null)
+    // Expand enrolled (published) ids to the variant family (so template-scoped
+    // materials/reports are fetched) with a map back to the enrolled id for
+    // attributing each item to the right course node in the tree.
+    const { ids: courseIds, toEnrolled } = await expandFamilyWithMap(
+      enrollments.map(e => e.courseId).filter((id): id is string => id != null)
+    )
 
     // --- 2. Fetch deployed materials ---
     let deployedMaterials: any[] = []
@@ -162,7 +168,8 @@ export const GET = withAuth(
     // Populate individual reports
     studentReports.forEach(report => {
       if (!report.courseId) return
-      const en = enrollments.find(e => e.courseId === report.courseId)
+      const ownerId = toEnrolled.get(report.courseId) ?? report.courseId
+      const en = enrollments.find(e => e.courseId === ownerId)
       if (!en) return
 
       const tutorKey = en.tutorName ? `Tutor@${en.tutorName.replace(/\s+/g, '')}` : 'Tutor@Unknown'
@@ -199,7 +206,8 @@ export const GET = withAuth(
     })
 
     for (const material of sortedMaterials) {
-      const en = enrollments.find(e => e.courseId === material.courseId)
+      const ownerId = toEnrolled.get(material.courseId) ?? material.courseId
+      const en = enrollments.find(e => e.courseId === ownerId)
       if (!en) continue
 
       const tutorKey = en.tutorName ? `Tutor@${en.tutorName.replace(/\s+/g, '')}` : 'Tutor@Unknown'

--- a/tutorme-app/src/app/api/student/enrollments/route.ts
+++ b/tutorme-app/src/app/api/student/enrollments/route.ts
@@ -21,6 +21,7 @@ import {
   profile,
 } from '@/lib/db/schema'
 import { and, eq, inArray, desc } from 'drizzle-orm'
+import { expandFamilyWithMap } from '@/lib/courses/variant-family'
 import { sql } from 'drizzle-orm'
 import { enrollStudentInCourse, enrollmentPaymentRequiredResponse } from '@/lib/api/enrollments'
 
@@ -86,8 +87,12 @@ export const GET = withAuth(
       .where(eq(courseEnrollment.studentId, session.user.id))
       .orderBy(desc(courseEnrollment.enrolledAt))
 
-    // Batch query lesson counts to avoid N+1
-    const courseIds = enrollmentsRows.map(row => row.courseId)
+    // Batch query lesson/session counts. Expand enrolled (published) ids to the
+    // variant family (so template-scoped content is counted) and keep a map back
+    // to the enrolled id so counts roll up to the right enrollment card.
+    const { ids: courseIds, toEnrolled } = await expandFamilyWithMap(
+      enrollmentsRows.map(row => row.courseId)
+    )
     const lessonCounts =
       courseIds.length > 0
         ? await drizzleDb
@@ -99,7 +104,11 @@ export const GET = withAuth(
             .where(inArray(courseLesson.courseId, courseIds))
             .groupBy(courseLesson.courseId)
         : []
-    const lessonCountByCourse = new Map(lessonCounts.map(m => [m.courseId, m.count ?? 0]))
+    const lessonCountByCourse = new Map<string, number>()
+    for (const m of lessonCounts) {
+      const owner = toEnrolled.get(m.courseId) ?? m.courseId
+      lessonCountByCourse.set(owner, (lessonCountByCourse.get(owner) ?? 0) + (m.count ?? 0))
+    }
 
     // Real per-course progress for this student. Completion mirrors dashboard-stats:
     // courseProgress.isCompleted OR enrollment.completedAt is set.
@@ -121,7 +130,9 @@ export const GET = withAuth(
               )
             )
         : []
-    const progressByCourse = new Map(progressRows.map(p => [p.courseId, p]))
+    const progressByCourse = new Map(
+      progressRows.map(p => [toEnrolled.get(p.courseId) ?? p.courseId, p])
+    )
 
     // Real session counts: a "session" is a materialized liveSession (one per
     // scheduled time slot, expanded over the schedule's weeks) — NOT a content
@@ -141,9 +152,13 @@ export const GET = withAuth(
     const sessionCountBySchedule = new Map<string, number>() // `courseId:scheduleId`
     const sessionCountByCourse = new Map<string, number>() // course-wide total
     for (const r of sessionRows) {
-      const cid = r.courseId ?? ''
+      // Roll a template-scoped session up under the enrolled (published) id.
+      const cid = toEnrolled.get(r.courseId ?? '') ?? r.courseId ?? ''
       sessionCountByCourse.set(cid, (sessionCountByCourse.get(cid) ?? 0) + (r.count ?? 0))
-      if (r.scheduleId) sessionCountBySchedule.set(`${cid}:${r.scheduleId}`, r.count ?? 0)
+      if (r.scheduleId) {
+        const key = `${cid}:${r.scheduleId}`
+        sessionCountBySchedule.set(key, (sessionCountBySchedule.get(key) ?? 0) + (r.count ?? 0))
+      }
     }
 
     // The chosen schedule per enrollment (name/index for display + slots/weeks

--- a/tutorme-app/src/app/api/student/learning-path/route.ts
+++ b/tutorme-app/src/app/api/student/learning-path/route.ts
@@ -20,6 +20,7 @@ import {
   studentPerformance,
 } from '@/lib/db/schema'
 import { eq, inArray, and, asc } from 'drizzle-orm'
+import { expandFamilyWithMap } from '@/lib/courses/variant-family'
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions, req)
@@ -57,19 +58,23 @@ export async function GET(req: NextRequest) {
 
     const courseMap = new Map(curricula.map(c => [c.courseId, c]))
 
-    // Lessons now directly reference courses (no modules)
+    // Lessons may be authored under the template id while the student enrolled in
+    // a published variant — fetch across the variant family and roll each lesson
+    // up under the ENROLLED id so `lessonsByCourse.get(enrollment.courseId)` finds
+    // them.
+    const { ids: lessonCourseIds, toEnrolled } = await expandFamilyWithMap(courseIds)
     const lessons =
-      courseIds.length > 0
+      lessonCourseIds.length > 0
         ? await drizzleDb
             .select()
             .from(courseLesson)
-            .where(inArray(courseLesson.courseId, courseIds))
+            .where(inArray(courseLesson.courseId, lessonCourseIds))
             .orderBy(asc(courseLesson.order))
         : []
 
     const lessonsByCourse = new Map<string, typeof lessons>()
     for (const l of lessons) {
-      const courseId = l.courseId ?? 'default'
+      const courseId = toEnrolled.get(l.courseId ?? '') ?? l.courseId ?? 'default'
       const list = lessonsByCourse.get(courseId) ?? []
       list.push(l)
       lessonsByCourse.set(courseId, list)

--- a/tutorme-app/src/lib/courses/variant-family.ts
+++ b/tutorme-app/src/lib/courses/variant-family.ts
@@ -44,3 +44,46 @@ export async function expandToCourseFamily(ids: readonly string[]): Promise<stri
     new Set([...input, ...rows.flatMap(r => [r.templateCourseId, r.publishedCourseId])])
   )
 }
+
+/**
+ * Like `expandToCourseFamily`, but also returns a map from every id in the
+ * expanded set back to the ENROLLED id it belongs to. Use this when a read
+ * aggregates content per-course keyed by the enrolled id (e.g. per-enrollment
+ * lesson/session counts, a materials tree, lesson grouping): fetch content with
+ * `ids`, then attribute each row via `toEnrolled.get(row.courseId) ?? row.courseId`
+ * so template-scoped rows roll up under the enrolled (published) id.
+ *
+ * If a student is enrolled in two published variants of the same template, the
+ * shared template maps to whichever enrolled id is seen first (rare; the common
+ * one-enrollment-per-family case is exact).
+ */
+export async function expandFamilyWithMap(
+  enrolledIds: readonly string[]
+): Promise<{ ids: string[]; toEnrolled: Map<string, string> }> {
+  const input = enrolledIds.filter(Boolean)
+  const toEnrolled = new Map<string, string>()
+  input.forEach(id => toEnrolled.set(id, id))
+  if (input.length === 0) return { ids: [...input], toEnrolled }
+  const rows = await drizzleDb
+    .select({
+      templateCourseId: courseVariant.templateCourseId,
+      publishedCourseId: courseVariant.publishedCourseId,
+    })
+    .from(courseVariant)
+    .where(
+      or(
+        inArray(courseVariant.publishedCourseId, input),
+        inArray(courseVariant.templateCourseId, input)
+      )
+    )
+  const ids = new Set<string>(input)
+  for (const r of rows) {
+    const owner = toEnrolled.get(r.publishedCourseId) ?? toEnrolled.get(r.templateCourseId)
+    if (!owner) continue
+    for (const id of [r.templateCourseId, r.publishedCourseId]) {
+      ids.add(id)
+      if (!toEnrolled.has(id)) toEnrolled.set(id, owner)
+    }
+  }
+  return { ids: [...ids], toEnrolled }
+}


### PR DESCRIPTION
Completes the template/published variant-split fixes (#992, #997) — the three student endpoints I deferred because they **aggregate per-course keyed by the enrolled id**, so plain query expansion isn't enough (a template-scoped row would land under the template id and never roll up to the enrolled course).

## New helper
`expandFamilyWithMap(enrolledIds)` → the expanded family ids **plus** `toEnrolled`, a map from every family id back to the enrolled id it belongs to.

## Fixed
- **`/api/student/enrollments`** — per-course lesson / session / progress counts now sum across the family under the enrolled id (were showing **0** for template-scoped content).
- **`/api/student/directory`** — deployed materials + reports attribute to the correct course node (were **dropped** when their courseId was the template id).
- **`/api/student/learning-path`** — lessons roll up under the enrolled course, so `lessonsByCourse.get(enrollment.courseId)` finds **template-authored** lessons (were missing → empty path).

## Verification
`tsc` + lint + prettier clean. **DB-verified**: with lessons authored under the template id and the student enrolled in the published variant, the lesson count rolls up under the enrolled id (**3, was 0**) and lesson grouping finds them (4/4).

With this, all the variant-split student reads I found are covered — no known remaining gaps in that area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)