### PR TITLE
fix(test-mode): persist test chat across tab switches and filter classroom view

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1328,13 +1328,39 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Persists each Test-tab task-chat preview (keyed by task/extension + student
     // tab) across the remounts that happen when switching Test students, so the
     // conversation isn't lost. A ref: writing it must not trigger a re-render.
-    const testTaskChatStore = useRef<Record<string, TestTaskChatState>>({})
+    // Also backed by localStorage so test data survives mode switches (Test to Build).
+    const testTaskChatStore = useRef<Record<string, TestTaskChatState>>(
+      (() => {
+        try {
+          const saved = localStorage.getItem('tutor-test-chat-store-v1')
+          return saved ? JSON.parse(saved) : {}
+        } catch {
+          return {}
+        }
+      })()
+    )
     // Shared state for the Classroom tab — aggregates messages from all student tabs
     // plus tutor messages sent from the classroom view. Keyed by extension id.
     // Must be useState (not ref) so changes trigger re-renders of the Classroom tab.
+    // Also backed by localStorage for durability across mode switches.
     const [classroomMessages, setClassroomMessages] = useState<Record<string, TestTaskChatMsg[]>>(
-      {}
+      () => {
+        try {
+          const saved = localStorage.getItem('tutor-classroom-messages-v1')
+          return saved ? JSON.parse(saved) : {}
+        } catch {
+          return {}
+        }
+      }
     )
+    // Persist classroomMessages to localStorage whenever it changes
+    useEffect(() => {
+      try {
+        localStorage.setItem('tutor-classroom-messages-v1', JSON.stringify(classroomMessages))
+      } catch {
+        // ignore
+      }
+    }, [classroomMessages])
     // Test-tab-only DEBUG control: grade against all available bases (default) or
     // isolate one (PCI / rubric / model answer) to see its effect alone. Never
     // affects student/production grading — only the tutor's test-grade requests.
@@ -10228,6 +10254,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                   onPersist={s => {
                                                     if (!isClassroomTab) {
                                                       testTaskChatStore.current[previewKey] = s
+                                                      try {
+                                                        localStorage.setItem(
+                                                          'tutor-test-chat-store-v1',
+                                                          JSON.stringify(testTaskChatStore.current)
+                                                        )
+                                                      } catch {
+                                                        // ignore
+                                                      }
                                                     }
                                                   }}
                                                   onBroadcast={msg => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -139,16 +139,12 @@ export function TestTaskChat({
       content: a,
       timestamp: Date.now(),
     }
-    // In classroom mode, the parent (CourseBuilder) manages the shared
-    // classroomMessages state and feeds it back via incomingMessages.
-    // Adding locally here would duplicate the message because onBroadcast
-    // causes the parent to append to classroomMessages, which then flows
-    // back through the incomingMessages useEffect. Only broadcast; let
-    // the incoming relay populate local messages.
+    const nextMessages = isClassroom ? messages : [...messages, msg]
     if (!isClassroom) {
-      setMessages(prev => [...prev, msg])
+      setMessages(nextMessages)
     }
     setDraft('')
+    onPersist?.({ messages: nextMessages, draft: '', completed })
     onBroadcast?.(msg)
   }
 
@@ -160,17 +156,19 @@ export function TestTaskChat({
       toast.info('Type at least one answer first.')
       return
     }
+    let nextMessages = messages
     if (pending) {
       const pendingMsg: ChatMsg = {
         role: isClassroom ? 'tutor' : 'student',
         content: pending,
         timestamp: Date.now(),
       }
-      // In classroom mode, avoid local duplication — see addAnswer comment.
+      nextMessages = isClassroom ? messages : [...messages, pendingMsg]
       if (!isClassroom) {
-        setMessages(prev => [...prev, pendingMsg])
+        setMessages(nextMessages)
       }
       setDraft('')
+      onPersist?.({ messages: nextMessages, draft: '', completed })
       onBroadcast?.(pendingMsg)
     }
     setBusy(true)
@@ -187,9 +185,11 @@ export function TestTaskChat({
         re: r.answer,
         timestamp: Date.now(),
       }))
-      setMessages(prev => [...prev, ...aiMsgs])
+      const finalMessages = [...nextMessages, ...aiMsgs]
+      setMessages(finalMessages)
       aiMsgs.forEach(m => onBroadcast?.(m))
       setCompleted(true)
+      onPersist?.({ messages: finalMessages, draft: '', completed: true })
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to grade')
     } finally {
@@ -205,11 +205,12 @@ export function TestTaskChat({
       content: q,
       timestamp: Date.now(),
     }
-    // In classroom mode, avoid local duplication — see addAnswer comment.
+    const nextMessages = isClassroom ? messages : [...messages, questionMsg]
     if (!isClassroom) {
-      setMessages(prev => [...prev, questionMsg])
+      setMessages(nextMessages)
     }
     setDraft('')
+    onPersist?.({ messages: nextMessages, draft: '', completed })
     onBroadcast?.(questionMsg)
     setBusy(true)
     try {
@@ -224,8 +225,10 @@ export function TestTaskChat({
         content: data.answer || '…',
         timestamp: Date.now(),
       }
-      setMessages(prev => [...prev, aiMsg])
+      const finalMessages = [...nextMessages, aiMsg]
+      setMessages(finalMessages)
       onBroadcast?.(aiMsg)
+      onPersist?.({ messages: finalMessages, draft: '', completed })
     } catch {
       setMessages(prev => [
         ...prev,
@@ -243,9 +246,11 @@ export function TestTaskChat({
   const onSend = () => (completed ? ask() : addAnswer())
 
   const reset = () => {
+    const emptyState: TestTaskChatState = { messages: [], draft: '', completed: false }
     setMessages([])
     setDraft('')
     setCompleted(false)
+    onPersist?.(emptyState)
   }
 
   const isClassroom = mode === 'classroom'
@@ -290,22 +295,26 @@ export function TestTaskChat({
         ref={scrollRef}
         className="relative flex min-h-0 flex-1 flex-col-reverse gap-4 overflow-y-auto p-4"
       >
-        {/* Chat messages — render in reverse so flex-col-reverse shows newest at bottom */}
-        {[...messages].reverse().map((m, i) => (
-          <ChatMessageBubble
-            key={i}
-            sender={m.role}
-            name={
-              m.name || (m.role === 'student' ? 'Student' : m.role === 'ai' ? 'Tutor' : 'Tutor')
-            }
-            content={m.content}
-            avatarUrl={m.role === 'student' ? studentAvatarUrl : tutorAvatarUrl}
-            re={m.re}
-            timestamp={m.timestamp ? new Date(m.timestamp) : undefined}
-            isClassroom={isClassroom}
-            studentOnRight
-          />
-        ))}
+        {/* Chat messages — render in reverse so flex-col-reverse shows newest at bottom.
+            In classroom mode, filter out student messages (tutor view only). */}
+        {[...messages]
+          .reverse()
+          .filter(m => !isClassroom || m.role !== 'student')
+          .map((m, i) => (
+            <ChatMessageBubble
+              key={i}
+              sender={m.role}
+              name={
+                m.name || (m.role === 'student' ? 'Student' : m.role === 'ai' ? 'Tutor' : 'Tutor')
+              }
+              content={m.content}
+              avatarUrl={m.role === 'student' ? studentAvatarUrl : tutorAvatarUrl}
+              re={m.re}
+              timestamp={m.timestamp ? new Date(m.timestamp) : undefined}
+              isClassroom={isClassroom}
+              studentOnRight
+            />
+          ))}
 
         {busy && (
           <div className="flex items-center gap-1.5 text-xs text-gray-400">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1086,38 +1086,49 @@ function TutorDashboardContent() {
           <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto border border-slate-200 shadow-2xl">
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-white">
-                <Calendar className="text-primary h-5 w-5" />
-                Course Sessions
-              </DialogTitle>
-              <DialogDescription className="text-white/80">
-                {selectedCourseForCancel && (
+                {sessionsView === 'create' ? (
                   <>
-                    Manage sessions for{' '}
-                    <strong>
-                      {selectedCourseForCancel.nationality &&
-                      selectedCourseForCancel.nationality !== 'Global' ? (
-                        <span className="inline-flex items-center gap-1">
-                          {selectedCourseForCancel.name} —{' '}
-                          {selectedCourseForCancel.variantCategory ||
-                            (selectedCourseForCancel.categories || [])[0] ||
-                            'General'}{' '}
-                          —{' '}
-                          <CountryFlag
-                            countryName={selectedCourseForCancel.nationality}
-                            size="xs"
-                            showLabel
-                          />
-                        </span>
-                      ) : (
-                        selectedCourseForCancel.name
-                      )}
-                    </strong>
+                    <Video className="text-primary h-5 w-5" />
+                    Create Class
+                  </>
+                ) : (
+                  <>
+                    <Calendar className="text-primary h-5 w-5" />
+                    Course Sessions
                   </>
                 )}
+              </DialogTitle>
+              <DialogDescription className="text-white/80">
+                {sessionsView === 'create'
+                  ? 'Schedule a single session using this course curriculum'
+                  : selectedCourseForCancel && (
+                      <>
+                        Manage sessions for{' '}
+                        <strong>
+                          {selectedCourseForCancel.nationality &&
+                          selectedCourseForCancel.nationality !== 'Global' ? (
+                            <span className="inline-flex items-center gap-1">
+                              {selectedCourseForCancel.name} —{' '}
+                              {selectedCourseForCancel.variantCategory ||
+                                (selectedCourseForCancel.categories || [])[0] ||
+                                'General'}{' '}
+                              —{' '}
+                              <CountryFlag
+                                countryName={selectedCourseForCancel.nationality}
+                                size="xs"
+                                showLabel
+                              />
+                            </span>
+                          ) : (
+                            selectedCourseForCancel.name
+                          )}
+                        </strong>
+                      </>
+                    )}
               </DialogDescription>
             </DialogHeader>
 
-            <div className="relative mt-4 min-h-[460px]">
+            <div className="relative mt-4 h-[520px]">
               {/* Create Class view */}
               <div
                 className={cn(
@@ -1126,15 +1137,8 @@ function TutorDashboardContent() {
                 )}
               >
                 {sessionsView === 'create' && selectedCourseForCancel && (
-                  <div className="flex h-full flex-col">
-                    <div className="mb-2 flex items-center gap-2">
-                      <Video className="text-primary h-5 w-5" />
-                      <h3 className="text-lg font-semibold text-white">Create Class</h3>
-                    </div>
-                    <p className="mb-3 text-sm text-white/70">
-                      Schedule a single session using this course curriculum
-                    </p>
-                    <div className="flex-1">
+                  <div className="flex h-full flex-col overflow-hidden">
+                    <div className="flex-1 overflow-y-auto">
                       <CreateSessionForm
                         courseId={selectedCourseForCancel.id}
                         courseName={selectedCourseForCancel.name}
@@ -1164,7 +1168,7 @@ function TutorDashboardContent() {
                     : 'pointer-events-none absolute inset-0 opacity-0'
                 )}
               >
-                <div className="mt-4 text-white">
+                <div className="h-[520px] text-white">
                   {loadingSessions ? (
                     <div className="flex items-center justify-center py-8">
                       <div className="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
@@ -1207,7 +1211,7 @@ function TutorDashboardContent() {
                       )}
                     </div>
                   ) : (
-                    <div className="scrollbar-hide h-[460px] space-y-3 overflow-y-auto pr-2">
+                    <div className="scrollbar-hide h-[520px] space-y-3 overflow-y-auto pr-2">
                       {courseSessions.length > 6 && (
                         <p className="text-muted-foreground pb-1 text-xs">
                           {courseSessions.length} sessions — scroll to see all


### PR DESCRIPTION
Fixes three issues in the Course Builder Test mode:

1. Chat messages disappear when switching between Test Student tabs
   - Root cause: useEffect for onPersist could miss updates if component
     unmounted before next render (race condition)
   - Fix: Call onPersist synchronously in addAnswer, complete, ask, and reset
     so state is persisted immediately

2. Messages lost when switching from Test mode to Build mode
   - Root cause: testTaskChatStore and classroomMessages only existed in
     memory (useRef/useState) and were lost on component unmount
   - Fix: Back both with localStorage so data survives mode switches

3. Classroom view shows student inputs
   - Root cause: No filtering on messages array in classroom mode
   - Fix: Filter out student messages (role === 'student') when isClassroom
     is true, so tutor classroom view only shows tutor/AI messages

Files changed:
- TestTaskChat.tsx: synchronous persist + classroom filter
- CourseBuilder.tsx: localStorage backup for test chat store