### PR TITLE
fix(course-builder): resolve PDF rendering crash and proxy URL issues

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -11246,7 +11246,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                 <div className="absolute inset-0 flex items-center justify-center bg-white p-4">
                                                   {/* eslint-disable-next-line @next/next/no-img-element */}
                                                   <img
-                                                    src={currentTaskDocument.fileUrl}
+                                                    src={
+                                                      currentTaskDocument.fileKey
+                                                        ? `/api/proxy-file?key=${encodeURIComponent(currentTaskDocument.fileKey)}`
+                                                        : currentTaskDocument.fileUrl
+                                                    }
                                                     alt={currentTaskDocument.fileName}
                                                     className="max-h-full max-w-full object-contain"
                                                   />
@@ -11254,13 +11258,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               ) : currentTaskDocument &&
                                                 currentTaskDocument.mimeType !==
                                                   'application/pdf' &&
-                                                !currentTaskDocument.mimeType.startsWith(
+                                                !currentTaskDocument.mimeType?.startsWith(
                                                   'image/'
                                                 ) ? (
                                                 <div className="absolute inset-0 flex flex-col items-center justify-center bg-white p-6">
                                                   <FileText className="mb-4 h-16 w-16 text-blue-500" />
                                                   <a
-                                                    href={currentTaskDocument.fileUrl}
+                                                    href={
+                                                      currentTaskDocument.fileKey
+                                                        ? `/api/proxy-file?key=${encodeURIComponent(currentTaskDocument.fileKey)}`
+                                                        : currentTaskDocument.fileUrl
+                                                    }
                                                     target="_blank"
                                                     rel="noreferrer"
                                                     className="text-center text-sm font-medium text-blue-600 hover:underline"
@@ -11657,7 +11665,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                 <div className="absolute inset-0 flex items-center justify-center bg-white p-4">
                                                   <div className="relative h-full w-full">
                                                     <NextImage
-                                                      src={currentAssessmentDocument.fileUrl}
+                                                      src={
+                                                        currentAssessmentDocument.fileKey
+                                                          ? `/api/proxy-file?key=${encodeURIComponent(currentAssessmentDocument.fileKey)}`
+                                                          : currentAssessmentDocument.fileUrl
+                                                      }
                                                       alt={currentAssessmentDocument.fileName}
                                                       fill
                                                       className="object-contain"
@@ -11670,7 +11682,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                 <div className="absolute inset-0 flex flex-col items-center justify-center bg-white p-6">
                                                   <FileText className="mb-4 h-16 w-16 text-blue-500" />
                                                   <a
-                                                    href={currentAssessmentDocument.fileUrl}
+                                                    href={
+                                                      currentAssessmentDocument.fileKey
+                                                        ? `/api/proxy-file?key=${encodeURIComponent(currentAssessmentDocument.fileKey)}`
+                                                        : currentAssessmentDocument.fileUrl
+                                                    }
                                                     target="_blank"
                                                     rel="noreferrer"
                                                     className="text-center text-sm font-medium text-blue-600 hover:underline"

--- a/tutorme-app/src/components/task/TaskDocumentCard.tsx
+++ b/tutorme-app/src/components/task/TaskDocumentCard.tsx
@@ -81,7 +81,11 @@ export function TaskDocumentCard({
       </p>
     </div>
   ) : isPdf ? (
-    <PDFViewer fileUrl={url} className="h-full w-full" />
+    <PDFViewer
+      fileUrl={url}
+      fileKey={sourceDocument?.fileKey ?? undefined}
+      className="h-full w-full"
+    />
   ) : isImage ? (
     <div className="flex h-full items-center justify-center bg-slate-50 p-2">
       {/* eslint-disable-next-line @next/next/no-img-element */}


### PR DESCRIPTION
Fixes PDFs not rendering in the Course Builder selected lesson view.

Root Cause: The previous fix only added optional chaining to the image branch but missed the Open in new tab branch which still used mimeType.startsWith without optional chaining. When mimeType is undefined, this throws a TypeError that crashes the entire React render, preventing the PDF branch from being reached.

Changes:
- Add optional chaining in task document Open in new tab branch
- Use proxy-file URL for task/assessment images and links when fileKey exists
- Pass fileKey prop to PDFViewer in TaskDocumentCard for fallback proxy support