### PR TITLE
feat(group-sessions): redesign to match Analytics page layout

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -145,7 +145,7 @@ export default function TutorGroupSessionsPage() {
   return (
     <div className="flex h-full min-h-full flex-col bg-white px-3 pb-0 lg:px-4">
       {/* Hero — Analytics-style header */}
-      <section className="relative mb-4 flex-shrink-0 rounded-[20px] border border-white/10 bg-gradient-to-br from-[#0891B2] to-[#0E7490] p-5 shadow-[0_12px_40px_-4px_rgba(0,0,0,0.22)] ring-1 ring-white/20">
+      <section className="relative mb-4 flex-shrink-0 rounded-[20px] border border-white/10 bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] p-5 shadow-[0_12px_40px_-4px_rgba(0,0,0,0.22)] ring-1 ring-white/20">
         <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:items-center">
           <div className="flex flex-1 flex-col items-center justify-center text-center">
             <h1 className="text-xl font-bold text-white">Group Sessions</h1>
@@ -180,185 +180,214 @@ export default function TutorGroupSessionsPage() {
       </section>
 
       {/* Create form + Sessions list */}
-      <div className="flex min-h-0 flex-1 flex-col pb-0.5">
-        <div className="mb-8 rounded-[18px] border border-slate-200 bg-white p-5 shadow-sm">
-          <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-slate-900">
-            <Plus className="h-4 w-4" /> New group session
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="text-sm font-medium text-slate-700 sm:col-span-2">
-              Title
-              <input
-                className={field}
-                value={form.title}
-                maxLength={120}
-                placeholder="e.g. SAT Math crash session"
-                onChange={e => setForm({ ...form, title: e.target.value })}
-              />
-            </label>
-            <label className="text-sm font-medium text-slate-700 sm:col-span-2">
-              Description (optional)
-              <textarea
-                className={field}
-                value={form.description}
-                maxLength={1000}
-                rows={2}
-                onChange={e => setForm({ ...form, description: e.target.value })}
-              />
-            </label>
-            <label className="text-sm font-medium text-slate-700">
-              Date
-              <input
-                type="date"
-                className={field}
-                value={form.date}
-                onChange={e => setForm({ ...form, date: e.target.value })}
-              />
-            </label>
-            <div className="grid grid-cols-2 gap-3">
-              <label className="text-sm font-medium text-slate-700">
-                Start
+      <div className="flex min-h-0 flex-1 flex-col gap-4 pb-4">
+        {/* Panel 1 - Create New Group Session */}
+        <div className="flex flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+          <div className="panel-header panel-header-metallic w-full">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="panel-header-icon">
+                  <Plus className="h-5 w-5 text-slate-900" />
+                </div>
+                <div>
+                  <div className="panel-header-title">New Group Session</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="p-5">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="text-sm font-medium text-slate-700 sm:col-span-2">
+                Title
                 <input
-                  type="time"
                   className={field}
-                  value={form.startTime}
-                  onChange={e => setForm({ ...form, startTime: e.target.value })}
+                  value={form.title}
+                  maxLength={120}
+                  placeholder="e.g. SAT Math crash session"
+                  onChange={e => setForm({ ...form, title: e.target.value })}
+                />
+              </label>
+              <label className="text-sm font-medium text-slate-700 sm:col-span-2">
+                Description (optional)
+                <textarea
+                  className={field}
+                  value={form.description}
+                  maxLength={1000}
+                  rows={2}
+                  onChange={e => setForm({ ...form, description: e.target.value })}
                 />
               </label>
               <label className="text-sm font-medium text-slate-700">
-                End
+                Date
                 <input
-                  type="time"
+                  type="date"
                   className={field}
-                  value={form.endTime}
-                  onChange={e => setForm({ ...form, endTime: e.target.value })}
+                  value={form.date}
+                  onChange={e => setForm({ ...form, date: e.target.value })}
                 />
+              </label>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="text-sm font-medium text-slate-700">
+                  Start
+                  <input
+                    type="time"
+                    className={field}
+                    value={form.startTime}
+                    onChange={e => setForm({ ...form, startTime: e.target.value })}
+                  />
+                </label>
+                <label className="text-sm font-medium text-slate-700">
+                  End
+                  <input
+                    type="time"
+                    className={field}
+                    value={form.endTime}
+                    onChange={e => setForm({ ...form, endTime: e.target.value })}
+                  />
+                </label>
+              </div>
+              <label className="text-sm font-medium text-slate-700">
+                Seats
+                <input
+                  type="number"
+                  min={2}
+                  max={50}
+                  className={field}
+                  value={form.capacity}
+                  onChange={e => setForm({ ...form, capacity: e.target.value })}
+                />
+              </label>
+              <label className="text-sm font-medium text-slate-700">
+                Price per seat
+                <input
+                  type="number"
+                  min={0}
+                  disabled={form.free}
+                  className={`${field} disabled:bg-slate-100 disabled:text-slate-400`}
+                  value={form.free ? '0' : form.pricePerSeat}
+                  onChange={e => setForm({ ...form, pricePerSeat: e.target.value })}
+                />
+              </label>
+              <label className="flex items-center gap-2 self-end pb-2 text-sm font-medium text-slate-700 sm:col-span-2">
+                <input
+                  type="checkbox"
+                  checked={form.free}
+                  onChange={e => setForm({ ...form, free: e.target.checked })}
+                  className="h-4 w-4"
+                />
+                Free session — students book a seat with no payment (great for testing or free
+                workshops)
               </label>
             </div>
-            <label className="text-sm font-medium text-slate-700">
-              Seats
-              <input
-                type="number"
-                min={2}
-                max={50}
-                className={field}
-                value={form.capacity}
-                onChange={e => setForm({ ...form, capacity: e.target.value })}
-              />
-            </label>
-            <label className="text-sm font-medium text-slate-700">
-              Price per seat
-              <input
-                type="number"
-                min={0}
-                disabled={form.free}
-                className={`${field} disabled:bg-slate-100 disabled:text-slate-400`}
-                value={form.free ? '0' : form.pricePerSeat}
-                onChange={e => setForm({ ...form, pricePerSeat: e.target.value })}
-              />
-            </label>
-            <label className="flex items-center gap-2 self-end pb-2 text-sm font-medium text-slate-700 sm:col-span-2">
-              <input
-                type="checkbox"
-                checked={form.free}
-                onChange={e => setForm({ ...form, free: e.target.checked })}
-                className="h-4 w-4"
-              />
-              Free session — students book a seat with no payment (great for testing or free
-              workshops)
-            </label>
-          </div>
-          <div className="mt-4">
-            <Button variant="solocorn-book" onClick={create} disabled={creating}>
-              {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Create session
-            </Button>
+            <div className="mt-4">
+              <Button variant="solocorn-book" onClick={create} disabled={creating}>
+                {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                Create session
+              </Button>
+            </div>
           </div>
         </div>
 
-        {/* Existing sessions */}
-        <h2 className="mb-3 text-base font-semibold text-slate-900">Your sessions</h2>
-        {loading ? (
-          <div className="flex items-center gap-2 text-slate-500">
-            <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        {/* Panel 2 - Your Sessions */}
+        <div className="flex flex-col overflow-hidden rounded-[16px] bg-white shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
+          <div className="panel-header panel-header-metallic w-full">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="panel-header-icon">
+                  <CalendarDays className="h-5 w-5 text-slate-900" />
+                </div>
+                <div>
+                  <div className="panel-header-title">Your Sessions</div>
+                </div>
+              </div>
+            </div>
           </div>
-        ) : sessions.length === 0 ? (
-          <div className="py-16 text-center">
-            <CalendarDays className="mx-auto mb-4 h-12 w-12 text-gray-300" />
-            <h3 className="text-lg font-medium text-gray-700">No group sessions yet.</h3>
-            <p className="mt-1 text-sm text-gray-500">
-              Create your first session above to get started.
-            </p>
-          </div>
-        ) : (
-          <ul className="flex flex-col gap-3">
-            {sessions.map(gs => {
-              const cancelled = gs.status === 'CANCELLED'
-              return (
-                <li
-                  key={gs.groupSessionId}
-                  className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="truncate font-medium text-slate-900">{gs.title}</span>
-                      <span
-                        className={
-                          'rounded-full px-2 py-0.5 text-xs font-medium ' +
-                          (cancelled
-                            ? 'bg-slate-100 text-slate-500'
-                            : gs.status === 'FULL'
-                              ? 'bg-amber-100 text-amber-700'
-                              : 'bg-emerald-100 text-emerald-700')
-                        }
-                      >
-                        {gs.status}
-                      </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600">
-                      <span className="inline-flex items-center gap-1">
-                        <CalendarDays className="h-3.5 w-3.5" />
-                        {formatDate(gs.requestedDate)} · {gs.startTime}–{gs.endTime}
-                      </span>
-                      <span>
-                        {gs.pricePerSeat > 0 ? `${gs.pricePerSeat} ${gs.currency}/seat` : 'Free'}
-                      </span>
-                      <span>
-                        {gs.capacity - gs.seatsLeft}/{gs.capacity} booked
-                      </span>
-                    </div>
-                  </div>
-                  {!cancelled ? (
-                    <div className="flex shrink-0 items-center gap-2">
-                      {gs.liveSessionId ? (
-                        <Button
-                          variant="solocorn-book"
-                          onClick={() => router.push(`/call/${gs.liveSessionId}`)}
-                        >
-                          <Video className="mr-2 h-4 w-4" />
-                          Join room
-                        </Button>
+          <div className="min-h-0 flex-1 p-5">
+            {loading ? (
+              <div className="flex items-center gap-2 text-slate-500">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+              </div>
+            ) : sessions.length === 0 ? (
+              <div className="py-16 text-center">
+                <CalendarDays className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+                <h3 className="text-lg font-medium text-gray-700">No group sessions yet.</h3>
+                <p className="mt-1 text-sm text-gray-500">
+                  Create your first session above to get started.
+                </p>
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-3">
+                {sessions.map(gs => {
+                  const cancelled = gs.status === 'CANCELLED'
+                  return (
+                    <li
+                      key={gs.groupSessionId}
+                      className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate font-medium text-slate-900">{gs.title}</span>
+                          <span
+                            className={
+                              'rounded-full px-2 py-0.5 text-xs font-medium ' +
+                              (cancelled
+                                ? 'bg-slate-100 text-slate-500'
+                                : gs.status === 'FULL'
+                                  ? 'bg-amber-100 text-amber-700'
+                                  : 'bg-emerald-100 text-emerald-700')
+                            }
+                          >
+                            {gs.status}
+                          </span>
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600">
+                          <span className="inline-flex items-center gap-1">
+                            <CalendarDays className="h-3.5 w-3.5" />
+                            {formatDate(gs.requestedDate)} · {gs.startTime}–{gs.endTime}
+                          </span>
+                          <span>
+                            {gs.pricePerSeat > 0
+                              ? `${gs.pricePerSeat} ${gs.currency}/seat`
+                              : 'Free'}
+                          </span>
+                          <span>
+                            {gs.capacity - gs.seatsLeft}/{gs.capacity} booked
+                          </span>
+                        </div>
+                      </div>
+                      {!cancelled ? (
+                        <div className="flex shrink-0 items-center gap-2">
+                          {gs.liveSessionId ? (
+                            <Button
+                              variant="solocorn-book"
+                              onClick={() => router.push(`/call/${gs.liveSessionId}`)}
+                            >
+                              <Video className="mr-2 h-4 w-4" />
+                              Join room
+                            </Button>
+                          ) : null}
+                          <Button
+                            variant="outline"
+                            className="text-red-600 hover:bg-red-50"
+                            disabled={cancelId === gs.groupSessionId}
+                            onClick={() => cancel(gs.groupSessionId)}
+                          >
+                            {cancelId === gs.groupSessionId ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="mr-2 h-4 w-4" />
+                            )}
+                            Cancel &amp; refund
+                          </Button>
+                        </div>
                       ) : null}
-                      <Button
-                        variant="outline"
-                        className="text-red-600 hover:bg-red-50"
-                        disabled={cancelId === gs.groupSessionId}
-                        onClick={() => cancel(gs.groupSessionId)}
-                      >
-                        {cancelId === gs.groupSessionId ? (
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="mr-2 h-4 w-4" />
-                        )}
-                        Cancel &amp; refund
-                      </Button>
-                    </div>
-                  ) : null}
-                </li>
-              )
-            })}
-          </ul>
-        )}
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Redesigns the Group Sessions page to match the Analytics page layout with floating panels and dark metallic headers.

Changes:
- Hero gradient: cyan (#0891B2) → blue (#2563EB)
- Added Group Sessions to isFloatingPage in tutor layout (consistent spacing with Analytics)
- Split single card into two distinct floating panels
- Panel 1: New Group Session with dark metallic header + shadow-[0_14px_45px_rgba(0,0,0,0.14)]
- Panel 2: Your Sessions with dark metallic header + shadow-[0_14px_45px_rgba(0,0,0,0.14)]

Refs: Group Sessions design consistency with Analytics