### PR TITLE
fix(course-builder): X close button and panel height fixes v2

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
@@ -460,7 +460,7 @@ export function CourseCategoryPicker({
 
         <div
           className={cn(
-            'scrollbar-no-arrows overscroll-contain border-t border-white/10 pb-4 pt-2',
+            'scrollbar-no-arrows flex flex-col overscroll-contain border-t border-white/10 pb-4 pt-2',
             categoryTab === 'global' ? 'overflow-hidden' : 'overflow-y-auto'
           )}
           style={{ height: globalContentHeight, maxHeight: globalContentHeight }}

--- a/tutorme-app/src/components/ui/dialog.tsx
+++ b/tutorme-app/src/components/ui/dialog.tsx
@@ -174,7 +174,7 @@ const DialogContent = React.forwardRef<
           {showCloseButton && (
             <DialogPrimitive.Close
               className={cn(
-                'absolute right-4 top-4',
+                'absolute right-4 top-4 z-50',
                 'flex items-center justify-center',
                 'h-8 w-8 rounded-lg',
                 'transition-all duration-150',


### PR DESCRIPTION
Fixes two issues that persisted after PR #1008:

**X Close Button**
- Added z-50 to DialogPrimitive.Close to ensure it renders above the inner content wrapper (which has z-10)
- The close button was being visually covered by the relative z-10 flex container inside DialogContent

**Panel Height (National/Universities tabs)**
- Added flex flex-col to the TabsContent container div
- Without display: flex, h-full on TabsContent children doesn't fill the fixed height properly
- Now National and Universities tabs correctly fill the same height as Global/AP tabs

Files changed:
- CourseCategoryPicker.tsx — flex container for tab content
- dialog.tsx — z-50 on close button