### PR TITLE
fix(coursebuilder): allow PDF task loading via fileKey when url is empty

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6250,7 +6250,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         let pdfSplitSucceeded = false
                         let pdfSplitError: string | null = null
 
-                        if (isPdf && assetToLoad.url) {
+                        if (isPdf && (assetToLoad.url || assetToLoad.fileKey)) {
                           // Split + store every page in ONE server request (avoids the
                           // per-page upload burst that tripped the rate limiter).
                           try {
@@ -6307,7 +6307,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                           }
                         }
 
-                        if (isPdf && assetToLoad.url && !pdfSplitSucceeded) {
+                        if (isPdf && (assetToLoad.url || assetToLoad.fileKey) && !pdfSplitSucceeded) {
                           // Splitting the stored PDF into per-page files failed (e.g. the
                           // link is broken/expired or the object is unreadable). Don't
                           // abort — fall back to splitting the extracted text into
@@ -6328,10 +6328,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                 ...existingTask,
                                 description: pageContent,
                                 sourceDocument:
-                                  assetToLoad.url && assetToLoad.mimeType
+                                  (assetToLoad.url || assetToLoad.fileKey) && assetToLoad.mimeType
                                     ? {
                                         fileName: assetToLoad.name,
-                                        fileUrl: assetToLoad.url,
+                                        fileUrl:
+                                          assetToLoad.url ||
+                                          (assetToLoad.fileKey
+                                            ? `/api/proxy-file?key=${encodeURIComponent(assetToLoad.fileKey)}`
+                                            : ''),
                                         fileKey: assetToLoad.fileKey,
                                         mimeType: assetToLoad.mimeType,
                                         uploadedAt: new Date().toISOString(),
@@ -6344,10 +6348,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                               const newTask = DEFAULT_TASK(startIndex + idx)
                               newTask.title = `Task ${groupNumber}.${existingTask ? idx + 1 : idx + 1}`
                               newTask.description = pageContent
-                              if (assetToLoad.url && assetToLoad.mimeType) {
+                              if ((assetToLoad.url || assetToLoad.fileKey) && assetToLoad.mimeType) {
                                 newTask.sourceDocument = {
                                   fileName: assetToLoad.name,
-                                  fileUrl: assetToLoad.url,
+                                  fileUrl:
+                                    assetToLoad.url ||
+                                    (assetToLoad.fileKey
+                                      ? `/api/proxy-file?key=${encodeURIComponent(assetToLoad.fileKey)}`
+                                      : ''),
                                   fileKey: assetToLoad.fileKey,
                                   mimeType: assetToLoad.mimeType,
                                   uploadedAt: new Date().toISOString(),
@@ -6447,7 +6455,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
                         let pdfSplitSucceeded = false
 
-                        if (isPdf && assetToLoad.url) {
+                        if (isPdf && (assetToLoad.url || assetToLoad.fileKey)) {
                           // Split + store every page in ONE server request (avoids the
                           // per-page upload burst that tripped the rate limiter).
                           try {
@@ -6538,10 +6546,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                             uploadedAt: new Date().toISOString(),
                             extractedText: pages[0] || textToInsert,
                           }
-                        } else if (assetToLoad.url && assetToLoad.mimeType) {
+                        } else if ((assetToLoad.url || assetToLoad.fileKey) && assetToLoad.mimeType) {
                           newTask.sourceDocument = {
                             fileName: assetToLoad.name,
-                            fileUrl: assetToLoad.url,
+                            fileUrl:
+                              assetToLoad.url ||
+                              (assetToLoad.fileKey
+                                ? `/api/proxy-file?key=${encodeURIComponent(assetToLoad.fileKey)}`
+                                : ''),
                             fileKey: assetToLoad.fileKey,
                             mimeType: assetToLoad.mimeType,
                             uploadedAt: new Date().toISOString(),


### PR DESCRIPTION
- Blob URL sanitization strips fileUrl to empty string, but fileKey persists
- PDF split eligibility now checks (url || fileKey) instead of just url
- sourceDocument creation falls back to /api/proxy-file?key= when url is empty
- Fixes both new PDF task creation and loading of existing PDFs with expired GCS URLs