### PR TITLE
fix(1-on-1): readable tutor cards + Join button on confirmed bookings

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
   OneOnOneRequestCard,
   groupIntoSeries,
 } from '@/components/one-on-one/one-on-one-request-card'
+import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
 import { CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TabsContent } from '@/components/ui/tabs'
@@ -252,6 +253,7 @@ function TutorDashboardContent() {
   const [oneOnOneRequests, setOneOnOneRequests] = useState<OneOnOneRequest[]>([])
   const [rescheduleRequestId, setRescheduleRequestId] = useState<string | null>(null)
   const [respondingRequestId, setRespondingRequestId] = useState<string | null>(null)
+  const [joiningRequestId, setJoiningRequestId] = useState<string | null>(null)
 
   const [classroomDialogOpen, setClassroomDialogOpen] = useState(false)
   const [classroomCourse, setClassroomCourse] = useState<EnrolledCourse | null>(null)
@@ -485,7 +487,13 @@ function TutorDashboardContent() {
           body: JSON.stringify({ requestId, action }),
         })
         if (res.ok) {
-          setOneOnOneRequests(prev => prev.filter(r => r.requestId !== requestId))
+          // Accepting/rejecting a series resolves ALL its rows — drop every
+          // sibling that shares the seriesId, not just the head that was clicked.
+          setOneOnOneRequests(prev => {
+            const responded = prev.find(r => r.requestId === requestId)
+            const sid = responded?.seriesId
+            return prev.filter(r => (sid ? r.seriesId !== sid : r.requestId !== requestId))
+          })
           toast.success(`Request ${action === 'accept' ? 'accepted' : 'rejected'}`)
         } else {
           const data = await res.json().catch(() => ({}))
@@ -498,6 +506,16 @@ function TutorDashboardContent() {
       }
     },
     []
+  )
+
+  const handleJoinOneOnOne = useCallback(
+    async (requestId: string) => {
+      setJoiningRequestId(requestId)
+      const sessionId = await resolveOneOnOneSession(requestId)
+      if (sessionId) router.push(`/call/${sessionId}`)
+      setJoiningRequestId(null)
+    },
+    [router]
   )
 
   const handleOpenSessionsModal = useCallback(async (course: EnrolledCourse) => {
@@ -1021,7 +1039,7 @@ function TutorDashboardContent() {
                           key={request.seriesId ?? request.requestId}
                           request={request}
                           perspective="tutor"
-                          variant="dark"
+                          variant="light"
                           series={group.series}
                           actions={
                             request.status === 'PENDING' ? (
@@ -1049,13 +1067,31 @@ function TutorDashboardContent() {
                                 </Button>
                               </>
                             ) : (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => setRescheduleRequestId(request.requestId)}
-                              >
-                                Reschedule
-                              </Button>
+                              <>
+                                {(() => {
+                                  const joinId =
+                                    request.status === 'PAID'
+                                      ? joinableRequestId(group.members)
+                                      : null
+                                  return joinId ? (
+                                    <Button
+                                      size="sm"
+                                      disabled={joiningRequestId === joinId}
+                                      onClick={() => handleJoinOneOnOne(joinId)}
+                                    >
+                                      <Video className="mr-1.5 h-3.5 w-3.5" />
+                                      {joiningRequestId === joinId ? 'Opening…' : 'Join session'}
+                                    </Button>
+                                  ) : null
+                                })()}
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setRescheduleRequestId(request.requestId)}
+                                >
+                                  Reschedule
+                                </Button>
+                              </>
                             )
                           }
                         />

--- a/tutorme-app/src/components/communications/student-requests-panel.tsx
+++ b/tutorme-app/src/components/communications/student-requests-panel.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { Loader2, CalendarClock } from 'lucide-react'
+import { Loader2, CalendarClock, Video } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
 import {
   OneOnOneRequestCard,
   groupIntoSeries,
@@ -20,10 +21,22 @@ import {
  */
 export default function StudentRequestsPanel() {
   const params = useParams()
+  const router = useRouter()
   const locale = (params?.locale as string) || 'en'
   const [requests, setRequests] = useState<OneOnOneRequestSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
+  const [joiningId, setJoiningId] = useState<string | null>(null)
+
+  const join = useCallback(
+    async (requestId: string) => {
+      setJoiningId(requestId)
+      const sessionId = await resolveOneOnOneSession(requestId)
+      if (sessionId) router.push(`/call/${sessionId}`)
+      setJoiningId(null)
+    },
+    [router]
+  )
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -88,6 +101,8 @@ export default function StudentRequestsPanel() {
         const r = group.head
         const status = (r.status || '').toUpperCase()
         const cancellable = status === 'PENDING' || status === 'ACCEPTED'
+        // Confirmed (paid) bookings are joinable — open the next upcoming session.
+        const joinId = status === 'PAID' ? joinableRequestId(group.members) : null
         return (
           <OneOnOneRequestCard
             key={r.seriesId ?? r.requestId}
@@ -96,8 +111,14 @@ export default function StudentRequestsPanel() {
             variant="light"
             series={group.series}
             actions={
-              status === 'ACCEPTED' || cancellable ? (
+              joinId || status === 'ACCEPTED' || cancellable ? (
                 <>
+                  {joinId ? (
+                    <Button size="sm" disabled={joiningId === joinId} onClick={() => join(joinId)}>
+                      <Video className="mr-1.5 h-3.5 w-3.5" />
+                      {joiningId === joinId ? 'Opening…' : 'Join session'}
+                    </Button>
+                  ) : null}
                   {status === 'ACCEPTED' ? (
                     <Button asChild size="sm">
                       <Link

--- a/tutorme-app/src/lib/one-on-one/enter-classroom.ts
+++ b/tutorme-app/src/lib/one-on-one/enter-classroom.ts
@@ -1,0 +1,51 @@
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { toast } from 'sonner'
+import type { OneOnOneRequestSummary } from '@/components/one-on-one/one-on-one-request-card'
+
+/**
+ * Resolve a PAID 1-on-1 booking to its live-session id via `ensure-session`
+ * (which self-heals a missing session). Works for either participant. Returns
+ * the session id, or null (after showing a toast) when it isn't joinable yet.
+ */
+export async function resolveOneOnOneSession(requestId: string): Promise<string | null> {
+  try {
+    const res = await fetchWithCsrf('/api/one-on-one/ensure-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ requestId }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.sessionId) {
+      toast.error(data?.error || "This session isn't ready to join yet. Please try again.")
+      return null
+    }
+    return data.sessionId as string
+  } catch {
+    toast.error('Could not open the classroom. Please try again.')
+    return null
+  }
+}
+
+/**
+ * The session a "Join" action should open for a booking group. For a single
+ * booking that's just its request; for a recurring series it's the soonest
+ * session that hasn't finished yet (falling back to the last one if all are
+ * past), so a tutor/student always lands in the upcoming class. Only PAID
+ * sessions are joinable, so non-paid members are ignored. Returns null when
+ * nothing is joinable.
+ */
+export function joinableRequestId(
+  members: OneOnOneRequestSummary[],
+  now: number = Date.now()
+): string | null {
+  const paid = members.filter(m => (m.status || '').toUpperCase() === 'PAID')
+  if (paid.length === 0) return null
+  const byDate = [...paid].sort(
+    (a, b) => new Date(a.requestedDate).getTime() - new Date(b.requestedDate).getTime()
+  )
+  // "Still joinable" = the session day hasn't fully passed (grace of ~1 day).
+  const GRACE_MS = 24 * 60 * 60 * 1000
+  const upcoming = byDate.find(m => new Date(m.requestedDate).getTime() + GRACE_MS >= now)
+  return (upcoming ?? byDate[byDate.length - 1]).requestId
+}


### PR DESCRIPTION
Fixes two reported issues on the 1-on-1 request cards.

### 1. Unreadable tutor cards (contrast)
The tutor dashboard rendered the cards `variant="dark"` (white text), but they sit on the panel's **white** surface — so they were nearly invisible. Switched the tutor cards to `variant="light"` (dark text on white).

### 2. No way to enter the classroom
Joining a confirmed 1-on-1 was only reachable **buried in the calendar event modal**, so neither party could find it. Added a **"Join session"** button directly on **confirmed (PAID)** bookings — on both the **student Requests tab** and the **tutor dashboard**.

It uses the existing `ensure-session` endpoint (POST `{requestId}` → `{sessionId}`, authorized for either participant, self-heals a missing session) and opens `/call/{sessionId}` — the same room the calendars already link to. For a **recurring series** it opens the *next upcoming* session.

### Bonus fix
Accepting/rejecting a **series** on the tutor dashboard only removed the head card from local state, leaving stale sibling cards. Now every row sharing the `seriesId` is dropped.

New shared helper `lib/one-on-one/enter-classroom.ts` (`resolveOneOnOneSession` + `joinableRequestId`).

> Note: I checked whether the tutor *calendar* was excluding 1-on-1s — it isn't (they surface via the primary CalendarEvent query); the real gap was discoverability, which the card button solves.

typecheck · lint · **596** unit tests · production build — all clean.