### PR TITLE
feat(1-on-1): per-tutor toggle for recurring bookings

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
   OneOnOneRequestCard,
   groupIntoSeries,
 } from '@/components/one-on-one/one-on-one-request-card'
+import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
 import { CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TabsContent } from '@/components/ui/tabs'
@@ -252,6 +253,7 @@ function TutorDashboardContent() {
   const [oneOnOneRequests, setOneOnOneRequests] = useState<OneOnOneRequest[]>([])
   const [rescheduleRequestId, setRescheduleRequestId] = useState<string | null>(null)
   const [respondingRequestId, setRespondingRequestId] = useState<string | null>(null)
+  const [joiningRequestId, setJoiningRequestId] = useState<string | null>(null)
 
   const [classroomDialogOpen, setClassroomDialogOpen] = useState(false)
   const [classroomCourse, setClassroomCourse] = useState<EnrolledCourse | null>(null)
@@ -485,7 +487,13 @@ function TutorDashboardContent() {
           body: JSON.stringify({ requestId, action }),
         })
         if (res.ok) {
-          setOneOnOneRequests(prev => prev.filter(r => r.requestId !== requestId))
+          // Accepting/rejecting a series resolves ALL its rows — drop every
+          // sibling that shares the seriesId, not just the head that was clicked.
+          setOneOnOneRequests(prev => {
+            const responded = prev.find(r => r.requestId === requestId)
+            const sid = responded?.seriesId
+            return prev.filter(r => (sid ? r.seriesId !== sid : r.requestId !== requestId))
+          })
           toast.success(`Request ${action === 'accept' ? 'accepted' : 'rejected'}`)
         } else {
           const data = await res.json().catch(() => ({}))
@@ -498,6 +506,16 @@ function TutorDashboardContent() {
       }
     },
     []
+  )
+
+  const handleJoinOneOnOne = useCallback(
+    async (requestId: string) => {
+      setJoiningRequestId(requestId)
+      const sessionId = await resolveOneOnOneSession(requestId)
+      if (sessionId) router.push(`/call/${sessionId}`)
+      setJoiningRequestId(null)
+    },
+    [router]
   )
 
   const handleOpenSessionsModal = useCallback(async (course: EnrolledCourse) => {
@@ -1021,7 +1039,7 @@ function TutorDashboardContent() {
                           key={request.seriesId ?? request.requestId}
                           request={request}
                           perspective="tutor"
-                          variant="dark"
+                          variant="light"
                           series={group.series}
                           actions={
                             request.status === 'PENDING' ? (
@@ -1049,13 +1067,31 @@ function TutorDashboardContent() {
                                 </Button>
                               </>
                             ) : (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => setRescheduleRequestId(request.requestId)}
-                              >
-                                Reschedule
-                              </Button>
+                              <>
+                                {(() => {
+                                  const joinId =
+                                    request.status === 'PAID'
+                                      ? joinableRequestId(group.members)
+                                      : null
+                                  return joinId ? (
+                                    <Button
+                                      size="sm"
+                                      disabled={joiningRequestId === joinId}
+                                      onClick={() => handleJoinOneOnOne(joinId)}
+                                    >
+                                      <Video className="mr-1.5 h-3.5 w-3.5" />
+                                      {joiningRequestId === joinId ? 'Opening…' : 'Join session'}
+                                    </Button>
+                                  ) : null
+                                })()}
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => setRescheduleRequestId(request.requestId)}
+                                >
+                                  Reschedule
+                                </Button>
+                              </>
                             )
                           }
                         />

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -98,6 +98,7 @@ function OneOnOneSettingsCard() {
   const [settings, setSettings] = useState({
     oneOnOneEnabled: true,
     oneOnOneFree: false,
+    oneOnOneRecurringEnabled: true,
     hourlyRate: 50,
     sessionDuration: 60,
     bufferMinutes: 0,
@@ -119,6 +120,7 @@ function OneOnOneSettingsCard() {
         setSettings({
           oneOnOneEnabled: data.oneOnOneEnabled ?? true,
           oneOnOneFree: data.oneOnOneFree ?? false,
+          oneOnOneRecurringEnabled: data.oneOnOneRecurringEnabled ?? true,
           hourlyRate: data.hourlyRate ?? 50,
           sessionDuration: data.sessionDuration ?? 60,
           bufferMinutes: data.bufferMinutes ?? 0,
@@ -141,6 +143,7 @@ function OneOnOneSettingsCard() {
         body: JSON.stringify({
           oneOnOneEnabled: settings.oneOnOneEnabled,
           oneOnOneFree: settings.oneOnOneFree,
+          oneOnOneRecurringEnabled: settings.oneOnOneRecurringEnabled,
           hourlyRate: settings.hourlyRate,
           bufferMinutes: settings.bufferMinutes,
         }),
@@ -213,6 +216,23 @@ function OneOnOneSettingsCard() {
                 checked={settings.oneOnOneFree}
                 onCheckedChange={checked =>
                   setSettings(prev => ({ ...prev, oneOnOneFree: checked }))
+                }
+              />
+            </div>
+
+            {/* Recurring bookings toggle */}
+            <div className="flex items-center justify-between rounded-[12px] border p-4 transition-all hover:bg-slate-50 hover:shadow-sm">
+              <div>
+                <p className="font-medium">Allow recurring bookings</p>
+                <p className="text-sm text-gray-500">
+                  Let students book a weekly series (several sessions at once) instead of a single
+                  session. When off, students can only book one session at a time.
+                </p>
+              </div>
+              <Switch
+                checked={settings.oneOnOneRecurringEnabled}
+                onCheckedChange={checked =>
+                  setSettings(prev => ({ ...prev, oneOnOneRecurringEnabled: checked }))
                 }
               />
             </div>

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -52,6 +52,7 @@ export const POST = withCsrf(
         hourlyRate: true,
         oneOnOneEnabled: true,
         oneOnOneFree: true,
+        oneOnOneRecurringEnabled: true,
         currency: true,
         timezone: true,
       },
@@ -61,6 +62,11 @@ export const POST = withCsrf(
 
     if (!tutorProfile.oneOnOneEnabled) {
       throw new ValidationError('Tutor does not offer one-on-one sessions')
+    }
+
+    // Recurring series are only allowed when the tutor opts in.
+    if (tutorProfile.oneOnOneRecurringEnabled === false && validated.proposedSlots.length > 1) {
+      throw new ValidationError('This tutor only accepts single-session bookings.')
     }
 
     // Free tutors need no rate; paid tutors must have one set.

--- a/tutorme-app/src/app/api/one-on-one/settings/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/settings/route.ts
@@ -32,6 +32,7 @@ export async function GET(req: NextRequest) {
         hourlyRate: profile.hourlyRate,
         oneOnOneEnabled: profile.oneOnOneEnabled,
         oneOnOneFree: profile.oneOnOneFree,
+        oneOnOneRecurringEnabled: profile.oneOnOneRecurringEnabled,
         bufferMinutes: profile.bufferMinutes,
       })
       .from(profile)
@@ -46,6 +47,7 @@ export async function GET(req: NextRequest) {
       hourlyRate: tutorProfile[0].hourlyRate || 50, // Default $50/hour
       oneOnOneEnabled: tutorProfile[0].oneOnOneEnabled ?? true,
       oneOnOneFree: tutorProfile[0].oneOnOneFree ?? false,
+      oneOnOneRecurringEnabled: tutorProfile[0].oneOnOneRecurringEnabled ?? true,
       sessionDuration: 60, // Default 1 hour
       bufferMinutes: tutorProfile[0].bufferMinutes ?? 0, // gap around bookings
     })
@@ -64,7 +66,8 @@ export async function PATCH(req: NextRequest) {
     }
 
     const body = await req.json()
-    const { hourlyRate, oneOnOneEnabled, oneOnOneFree, bufferMinutes } = body
+    const { hourlyRate, oneOnOneEnabled, oneOnOneFree, oneOnOneRecurringEnabled, bufferMinutes } =
+      body
     const tutorId = session.user.id
 
     // Clamp the buffer to a sane 0–120 minute range when provided.
@@ -80,6 +83,8 @@ export async function PATCH(req: NextRequest) {
         hourlyRate: hourlyRate !== undefined ? hourlyRate : undefined,
         oneOnOneEnabled: oneOnOneEnabled !== undefined ? oneOnOneEnabled : undefined,
         oneOnOneFree: oneOnOneFree !== undefined ? !!oneOnOneFree : undefined,
+        oneOnOneRecurringEnabled:
+          oneOnOneRecurringEnabled !== undefined ? !!oneOnOneRecurringEnabled : undefined,
         bufferMinutes: buffer,
         updatedAt: new Date(),
       })

--- a/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
@@ -275,6 +275,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
       pricingIncomplete: !isFree && !hasHourlyRate,
       currency: tutorProfile.currency || 'USD',
       timezone: tutorProfile.timezone || 'UTC',
+      // Whether this tutor lets students book a recurring weekly series.
+      recurringEnabled: tutorProfile.oneOnOneRecurringEnabled ?? true,
       slots,
     })
   } catch (error: any) {

--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -86,6 +86,8 @@ interface AvailabilityData {
   reason?: string
   currency: string
   timezone: string
+  /** Whether this tutor allows booking a recurring weekly series. */
+  recurringEnabled?: boolean
   slots: TimeSlot[]
 }
 
@@ -476,6 +478,13 @@ export function CalendarBookingDialog({
     }
   }
 
+  // If the tutor doesn't allow a recurring series, keep the booking to one week.
+  useEffect(() => {
+    if (availability?.recurringEnabled === false && recurringWeeks !== 1) {
+      setRecurringWeeks(1)
+    }
+  }, [availability?.recurringEnabled, recurringWeeks])
+
   // Generate all recurring dates for display
   const recurringDates = useMemo(() => {
     if (!selectedSlot) return []
@@ -633,24 +642,27 @@ export function CalendarBookingDialog({
                 <>
                   {/* Legend + recurring weeks container */}
                   <div className="shrink-0 rounded-[14px] border border-[rgba(226,232,240,0.9)] bg-white px-5 py-4 shadow-[0_10px_24px_rgba(15,23,42,0.16)]">
-                    <div className="flex flex-wrap items-center gap-3">
-                      <span className="text-sm font-semibold text-[#1F2933]">
-                        Book recurring sessions for
-                      </span>
-                      <input
-                        type="number"
-                        min={1}
-                        max={20}
-                        value={recurringWeeks}
-                        onChange={e => {
-                          const val = parseInt(e.target.value, 10)
-                          const v = Math.max(1, Math.min(20, Number.isNaN(val) ? 1 : val))
-                          setRecurringWeeks(v)
-                        }}
-                        className="border-input h-9 w-12 rounded-lg border bg-white px-1 text-center text-sm text-[#1F2933] [appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                      />
-                      <span className="text-sm font-semibold text-[#1F2933]">weeks.</span>
-                    </div>
+                    {/* Recurring-weeks picker — only when the tutor allows a series. */}
+                    {availability?.recurringEnabled !== false && (
+                      <div className="flex flex-wrap items-center gap-3">
+                        <span className="text-sm font-semibold text-[#1F2933]">
+                          Book recurring sessions for
+                        </span>
+                        <input
+                          type="number"
+                          min={1}
+                          max={20}
+                          value={recurringWeeks}
+                          onChange={e => {
+                            const val = parseInt(e.target.value, 10)
+                            const v = Math.max(1, Math.min(20, Number.isNaN(val) ? 1 : val))
+                            setRecurringWeeks(v)
+                          }}
+                          className="border-input h-9 w-12 rounded-lg border bg-white px-1 text-center text-sm text-[#1F2933] [appearance:textfield] focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                        />
+                        <span className="text-sm font-semibold text-[#1F2933]">weeks.</span>
+                      </div>
+                    )}
                     <div className="mt-2 flex flex-wrap items-center gap-3 text-xs font-medium text-slate-600">
                       <span className="flex items-center gap-1">
                         <span className="inline-block h-3 w-3 rounded-sm border border-blue-600 bg-blue-600" />

--- a/tutorme-app/src/components/communications/student-requests-panel.tsx
+++ b/tutorme-app/src/components/communications/student-requests-panel.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { Loader2, CalendarClock } from 'lucide-react'
+import { Loader2, CalendarClock, Video } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
 import {
   OneOnOneRequestCard,
   groupIntoSeries,
@@ -20,10 +21,22 @@ import {
  */
 export default function StudentRequestsPanel() {
   const params = useParams()
+  const router = useRouter()
   const locale = (params?.locale as string) || 'en'
   const [requests, setRequests] = useState<OneOnOneRequestSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
+  const [joiningId, setJoiningId] = useState<string | null>(null)
+
+  const join = useCallback(
+    async (requestId: string) => {
+      setJoiningId(requestId)
+      const sessionId = await resolveOneOnOneSession(requestId)
+      if (sessionId) router.push(`/call/${sessionId}`)
+      setJoiningId(null)
+    },
+    [router]
+  )
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -88,6 +101,8 @@ export default function StudentRequestsPanel() {
         const r = group.head
         const status = (r.status || '').toUpperCase()
         const cancellable = status === 'PENDING' || status === 'ACCEPTED'
+        // Confirmed (paid) bookings are joinable — open the next upcoming session.
+        const joinId = status === 'PAID' ? joinableRequestId(group.members) : null
         return (
           <OneOnOneRequestCard
             key={r.seriesId ?? r.requestId}
@@ -96,8 +111,14 @@ export default function StudentRequestsPanel() {
             variant="light"
             series={group.series}
             actions={
-              status === 'ACCEPTED' || cancellable ? (
+              joinId || status === 'ACCEPTED' || cancellable ? (
                 <>
+                  {joinId ? (
+                    <Button size="sm" disabled={joiningId === joinId} onClick={() => join(joinId)}>
+                      <Video className="mr-1.5 h-3.5 w-3.5" />
+                      {joiningId === joinId ? 'Opening…' : 'Join session'}
+                    </Button>
+                  ) : null}
                   {status === 'ACCEPTED' ? (
                     <Button asChild size="sm">
                       <Link

--- a/tutorme-app/src/lib/db/schema/tables/auth.ts
+++ b/tutorme-app/src/lib/db/schema/tables/auth.ts
@@ -93,6 +93,9 @@ export const profile = pgTable(
     // When true, 1-on-1 sessions are offered free: booking skips payment and a
     // tutor-accepted request is confirmed immediately (no gateway needed).
     oneOnOneFree: boolean('oneOnOneFree').notNull().default(false),
+    // When true, students may book a recurring weekly series (N sessions at once);
+    // when false, only single sessions are allowed.
+    oneOnOneRecurringEnabled: boolean('oneOnOneRecurringEnabled').notNull().default(true),
     // Minutes of gap the tutor wants around 1-on-1 bookings, enforced in
     // conflict detection so back-to-back sessions can't be double-booked.
     bufferMinutes: integer('bufferMinutes'),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -216,6 +216,9 @@ ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "status" text NOT NULL DEFAULT 'acti
 -- 0069: per-tutor buffer (minutes) enforced around 1-on-1 bookings.
 ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "bufferMinutes" integer;
 
+-- Per-tutor toggle: allow students to book a recurring weekly series (default on).
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "oneOnOneRecurringEnabled" boolean NOT NULL DEFAULT true;
+
 -- 0070: pending reschedule proposal fields (propose → accept/decline).
 ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedDate" timestamptz;
 ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "rescheduleProposedStart" text;

--- a/tutorme-app/src/lib/one-on-one/enter-classroom.ts
+++ b/tutorme-app/src/lib/one-on-one/enter-classroom.ts
@@ -1,0 +1,51 @@
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { toast } from 'sonner'
+import type { OneOnOneRequestSummary } from '@/components/one-on-one/one-on-one-request-card'
+
+/**
+ * Resolve a PAID 1-on-1 booking to its live-session id via `ensure-session`
+ * (which self-heals a missing session). Works for either participant. Returns
+ * the session id, or null (after showing a toast) when it isn't joinable yet.
+ */
+export async function resolveOneOnOneSession(requestId: string): Promise<string | null> {
+  try {
+    const res = await fetchWithCsrf('/api/one-on-one/ensure-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ requestId }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok || !data?.sessionId) {
+      toast.error(data?.error || "This session isn't ready to join yet. Please try again.")
+      return null
+    }
+    return data.sessionId as string
+  } catch {
+    toast.error('Could not open the classroom. Please try again.')
+    return null
+  }
+}
+
+/**
+ * The session a "Join" action should open for a booking group. For a single
+ * booking that's just its request; for a recurring series it's the soonest
+ * session that hasn't finished yet (falling back to the last one if all are
+ * past), so a tutor/student always lands in the upcoming class. Only PAID
+ * sessions are joinable, so non-paid members are ignored. Returns null when
+ * nothing is joinable.
+ */
+export function joinableRequestId(
+  members: OneOnOneRequestSummary[],
+  now: number = Date.now()
+): string | null {
+  const paid = members.filter(m => (m.status || '').toUpperCase() === 'PAID')
+  if (paid.length === 0) return null
+  const byDate = [...paid].sort(
+    (a, b) => new Date(a.requestedDate).getTime() - new Date(b.requestedDate).getTime()
+  )
+  // "Still joinable" = the session day hasn't fully passed (grace of ~1 day).
+  const GRACE_MS = 24 * 60 * 60 * 1000
+  const upcoming = byDate.find(m => new Date(m.requestedDate).getTime() + GRACE_MS >= now)
+  return (upcoming ?? byDate[byDate.length - 1]).requestId
+}


### PR DESCRIPTION
Adds a tutor setting to allow or disallow **recurring weekly series**. Some tutors only want single sessions — this lets them turn the series option off.

- **schema**: `profile.oneOnOneRecurringEnabled` (boolean, **default true** so existing tutors are unchanged); ensured in `startup-schema-fix.ts`.
- **settings API** (`/api/one-on-one/settings`): GET returns it, PATCH persists it.
- **settings UI**: an **"Allow recurring bookings"** switch in the 1-on-1 settings card (next to "Offer sessions for free").
- **availability API**: exposes `recurringEnabled` to the booking dialog.
- **booking dialog**: hides the "Book recurring sessions for N weeks" control (and forces 1 week) when the tutor has it off.
- **request API**: authoritative guard — rejects a multi-week booking to a tutor who disallows recurring (`"This tutor only accepts single-session bookings."`), so the rule holds even if the client is bypassed.

typecheck · lint · **596** unit tests · production build — all clean.