### PR TITLE
fix(course-builder): honour picked lesson on Load, clear deleted item, split PDF by fileKey

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4795,6 +4795,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       )
       setCourseBuilderNodes(nextNodes)
       if (mainTab !== 'live') await saveNodesIfPossible(nextNodes)
+      // If the deleted task is the one currently open in the builder, clear it so
+      // its content doesn't stay displayed after removal.
+      if (taskId === loadedTaskId) {
+        setLoadedTaskId(null)
+        setTaskBuilder({
+          title: '',
+          taskContent: '',
+          taskPci: '',
+          details: '',
+          extensions: [],
+          activeExtensionId: null,
+        })
+        setTaskDmiItems([])
+        setTaskDmiVersions([])
+        setTaskSourceDocument(undefined)
+      }
       setSelectedItem(null)
       toast.success('Task removed')
     }
@@ -4822,6 +4838,23 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       )
       setCourseBuilderNodes(nextNodes)
       if (mainTab !== 'live') await saveNodesIfPossible(nextNodes)
+      // If the deleted assessment is the one currently open in the builder, clear
+      // it so its content doesn't stay displayed after removal.
+      if (hwId === loadedAssessmentId) {
+        setLoadedAssessmentId(null)
+        setAssessmentBuilder({
+          title: '',
+          taskContent: '',
+          taskPci: '',
+          details: '',
+          extensions: [],
+          activeExtensionId: null,
+        })
+        setAssessmentDmiItems([])
+        setAssessmentDmiVersions([])
+        setAssessmentSourceDocument(undefined)
+        setAssessmentSourceReferenceOnly(false)
+      }
       setSelectedItem(null)
       toast.success('Assessment removed')
     }
@@ -5789,7 +5822,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       let lessonIndex = -1
       let existingAssess: Assessment | undefined
 
-      if (loadedAssessmentId) {
+      if (loadedAssessmentId && !assetLoadTarget) {
         for (let nIdx = 0; nIdx < nodes.length; nIdx++) {
           for (let lIdx = 0; lIdx < nodes[nIdx].lessons.length; lIdx++) {
             const hw = nodes[nIdx].lessons[lIdx].homework.find(h => h.id === loadedAssessmentId)
@@ -5913,6 +5946,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
 
       setAssetToLoad(asset)
+      // Start every load flow with no explicit target. The kebab "Load" picker
+      // sets it later (to the chosen lesson); the task/assessment "+" flows leave
+      // it null so resolveAssetLoadTarget() falls back to the open item / Lesson 1.
+      setAssetLoadTarget(null)
 
       // If we came from an assessment/task "+" picker, the target context is known,
       // so skip the 'main' choice and go straight to options.
@@ -6199,7 +6236,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                       let existingTaskIndex = -1
                       let existingTask: Task | null = null
 
-                      if (loadedTaskId) {
+                      if (loadedTaskId && !assetLoadTarget) {
                         for (let nIdx = 0; nIdx < nodes.length; nIdx++) {
                           for (let lIdx = 0; lIdx < nodes[nIdx].lessons.length; lIdx++) {
                             const t = nodes[nIdx].lessons[lIdx].tasks.find(
@@ -6250,7 +6287,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         let pdfSplitSucceeded = false
                         let pdfSplitError: string | null = null
 
-                        if (isPdf && assetToLoad.url) {
+                        if (isPdf && (assetToLoad.url || assetToLoad.fileKey)) {
                           // Split + store every page in ONE server request (avoids the
                           // per-page upload burst that tripped the rate limiter).
                           try {
@@ -6307,7 +6344,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                           }
                         }
 
-                        if (isPdf && assetToLoad.url && !pdfSplitSucceeded) {
+                        if (
+                          isPdf &&
+                          (assetToLoad.url || assetToLoad.fileKey) &&
+                          !pdfSplitSucceeded
+                        ) {
                           // Splitting the stored PDF into per-page files failed (e.g. the
                           // link is broken/expired or the object is unreadable). Don't
                           // abort — fall back to splitting the extracted text into
@@ -6447,7 +6488,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
                         let pdfSplitSucceeded = false
 
-                        if (isPdf && assetToLoad.url) {
+                        if (isPdf && (assetToLoad.url || assetToLoad.fileKey)) {
                           // Split + store every page in ONE server request (avoids the
                           // per-page upload burst that tripped the rate limiter).
                           try {
@@ -6496,7 +6537,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         let existingTaskIndex = -1
                         let existingTask: Task | null = null
 
-                        if (loadedTaskId) {
+                        if (loadedTaskId && !assetLoadTarget) {
                           for (let nIdx = 0; nIdx < nodes.length; nIdx++) {
                             for (let lIdx = 0; lIdx < nodes[nIdx].lessons.length; lIdx++) {
                               const t = nodes[nIdx].lessons[lIdx].tasks.find(


### PR DESCRIPTION
Three reported Course Builder bugs.

## 1. Kebab "Load" always loads into Lesson 1
The Tasks/Assessment load handlers resolved the target node/lesson from the **currently-open** item (`loadedTaskId`/`loadedAssessmentId`) *before* the lesson you picked — so an open item overrode the lesson picker.
**Fix:** reset the explicit target at the start of every load flow, and only use the open-item context when no lesson was explicitly picked (`&& !assetLoadTarget`). The kebab picker's choice now wins; the in-task/assessment "+" flow still loads into the current item.

## 2. Deleting a task/assessment leaves its content displayed
`deleteTask`/`deleteAssessment` cleared `selectedItem` but not `loadedTaskId`/`loadedAssessmentId` or the builder content.
**Fix:** when the deleted item is the one currently open, clear the loaded id and reset the builder (content + DMI items/versions + source doc), mirroring the existing blank-slate reset.

## 3. Multi-page PDF as Tasks sometimes doesn't split per page
The per-page split was gated on `assetToLoad.url` — an **expiring signed URL**. When it's empty but a durable `fileKey` exists, it silently fell back to a single task.
**Fix:** run the split when the URL **or** the `fileKey` is present (3 guards). The split endpoint (`/api/tutor/documents/split`) already prefers `key` over `url`, and these handlers already send the key.

## 4. Permanence
`src/lib/documents/split-sections.test.ts` already covers the splitter (form-feed pages, "--- Page N ---" markers, numbered-heading split, single-blob fallback, empty) — locks in #3's behaviour.

## Verification
Prettier clean; one file changed. Typecheck/Build via CI (worktree had no local deps). Diff reviewed: only the three intended load-target guards changed (other `loadedTaskId`/`loadedAssessmentId` usages untouched), each sitting directly above its `resolveAssetLoadTarget()` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)