### PR TITLE
feat(1-on-1): expire overdue unpaid bookings and free the held slot

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -16,3 +16,12 @@ jobs:
             exit 0
           fi
           curl -fsS -m 30 "${{ secrets.SITE_URL }}/api/health" || true
+
+      - name: Sweep expired 1-on-1 holds
+        run: |
+          if [ -z "${{ secrets.SITE_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
+            echo "SITE_URL or CRON_SECRET not set. Skipping 1-on-1 expiry sweep."
+            exit 0
+          fi
+          curl -fsS -m 30 -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "${{ secrets.SITE_URL }}/api/cron/expire-one-on-one" || true

--- a/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
+++ b/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
@@ -1,0 +1,32 @@
+/**
+ * Cron sweep: expire overdue unpaid 1-on-1 holds globally.
+ *
+ * Also runs lazily (when a tutor's availability/requests are viewed) and on boot,
+ * but this endpoint gives a guaranteed cadence. Protect with CRON_SECRET and hit
+ * it on a schedule (the keep-alive workflow does, every 10 min).
+ *
+ * Auth: `Authorization: Bearer <CRON_SECRET>`. Inert (503) until CRON_SECRET is
+ * configured, so it can never be triggered by an anonymous caller.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
+
+export async function GET(req: NextRequest) {
+  const secret = process.env.CRON_SECRET
+  if (!secret) {
+    return NextResponse.json({ error: 'Cron not configured' }, { status: 503 })
+  }
+  const auth = req.headers.get('authorization')
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const expired = await expireOverdueOneOnOneBookings()
+    return NextResponse.json({ ok: true, expired })
+  } catch (error) {
+    console.error('[cron] expire-one-on-one failed:', error)
+    return NextResponse.json({ error: 'Sweep failed' }, { status: 500 })
+  }
+}

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -17,6 +17,7 @@ import { requestedDateFromString, slotInstants } from '@/lib/one-on-one/time'
 import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
 import { getOrCreateConversation } from '@/lib/messaging/conversation'
 import { findConflicts } from '@/lib/schedule/conflicts'
+import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -291,6 +292,13 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       seriesTotal,
     })
   }
+
+  // Lazily expire the viewer's own overdue unpaid holds so the list they see is
+  // accurate and any freed slots are released (best-effort — never block the read).
+  const asStudent = role === 'sent' || session.user.role === 'STUDENT'
+  await expireOverdueOneOnOneBookings(
+    asStudent ? { studentId: session.user.id } : { tutorId: session.user.id }
+  ).catch(() => {})
 
   let requests
   if (role === 'sent' || session.user.role === 'STUDENT') {

--- a/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
+++ b/tutorme-app/src/app/api/public/tutors/[username]/availability/route.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/db/schema'
 import { eq, and, or, gte, lte, asc, isNull } from 'drizzle-orm'
 import { formatInZone, zonedWeekday, zonedWallClockToUtc, zonedDateParts } from '@/lib/time/tz'
+import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ username: string }> }) {
   const { searchParams } = new URL(req.url)
@@ -65,6 +66,11 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
         { status: 200 }
       )
     }
+
+    // Release any of this tutor's overdue unpaid holds first, so a slot that was
+    // held by a lapsed booking shows as open. Awaited (scoped + cheap) so the
+    // freed slot is reflected in the availability we return below.
+    await expireOverdueOneOnOneBookings({ tutorId }).catch(() => {})
 
     const now = new Date()
     const startDate = start ? new Date(start) : now

--- a/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
+++ b/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
@@ -60,6 +60,7 @@ const STATUS_META: Record<string, { label: string; className: string }> = {
   COMPLETED: { label: 'Completed', className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30' },
   REJECTED: { label: 'Declined', className: 'bg-rose-500/15 text-rose-600 ring-rose-500/30' },
   CANCELLED: { label: 'Cancelled', className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30' },
+  EXPIRED: { label: 'Expired', className: 'bg-slate-500/15 text-slate-500 ring-slate-500/30' },
 }
 
 function partyName(p?: OneOnOneParty | null): string {

--- a/tutorme-app/src/lib/db/startup-cleanup.ts
+++ b/tutorme-app/src/lib/db/startup-cleanup.ts
@@ -14,6 +14,7 @@
 
 import { drizzleDb } from './drizzle'
 import { sql } from 'drizzle-orm'
+import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 
 const CLEANUP_SQL = sql.raw(`
 DELETE FROM "LiveSession"
@@ -68,6 +69,18 @@ export async function applyStartupDataCleanup(): Promise<void> {
   } catch (err) {
     console.error(
       '⚠️ [Server] sourceLessonId backfill skipped:',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  try {
+    const count = await expireOverdueOneOnOneBookings()
+    if (count > 0) {
+      console.log(`[Server] Data cleanup: expired ${count} overdue unpaid 1-on-1 booking(s).`)
+    }
+  } catch (err) {
+    console.error(
+      '⚠️ [Server] 1-on-1 expiry sweep skipped:',
       err instanceof Error ? err.message : err
     )
   }

--- a/tutorme-app/src/lib/one-on-one/expire.ts
+++ b/tutorme-app/src/lib/one-on-one/expire.ts
@@ -1,0 +1,110 @@
+/**
+ * Expire overdue 1-on-1 bookings.
+ *
+ * When a tutor accepts a paid request the booking sits in ACCEPTED with a 48h
+ * `paymentDueAt` window while it holds the tutor's slot (an ACCEPTED booking
+ * blocks the time in conflict detection). If the student never pays, the hold
+ * would linger forever. This sweep flips overdue, still-unpaid holds to EXPIRED,
+ * frees the calendar slot, notifies both parties, and pings the tutor's waitlist.
+ *
+ * Free sessions are confirmed (PAID) on accept with no `paymentDueAt`, so they
+ * never match. Runs on boot, lazily when a tutor's availability/requests are
+ * viewed, and from the cron endpoint.
+ */
+
+import { and, eq, isNull, lt, ne, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest, calendarEvent, liveSession } from '@/lib/db/schema'
+import { notify } from '@/lib/notifications/notify'
+import { notifyWaitlistOfOpening } from '@/lib/one-on-one/waitlist'
+
+export async function expireOverdueOneOnOneBookings(
+  opts: { tutorId?: string; studentId?: string } = {}
+): Promise<number> {
+  const now = new Date()
+
+  const conditions = [
+    eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
+    isNull(oneOnOneBookingRequest.paidAt),
+    // `lt(paymentDueAt, now)` also excludes rows where paymentDueAt is null.
+    lt(oneOnOneBookingRequest.paymentDueAt, now),
+  ]
+  if (opts.tutorId) conditions.push(eq(oneOnOneBookingRequest.tutorId, opts.tutorId))
+  if (opts.studentId) conditions.push(eq(oneOnOneBookingRequest.studentId, opts.studentId))
+
+  const overdue = await drizzleDb
+    .select({
+      requestId: oneOnOneBookingRequest.requestId,
+      tutorId: oneOnOneBookingRequest.tutorId,
+      studentId: oneOnOneBookingRequest.studentId,
+      seriesId: oneOnOneBookingRequest.seriesId,
+      calendarEventId: oneOnOneBookingRequest.calendarEventId,
+    })
+    .from(oneOnOneBookingRequest)
+    .where(and(...conditions))
+
+  if (overdue.length === 0) return 0
+
+  // Free each held slot: cancel its calendar event and end the linked session.
+  for (const b of overdue) {
+    if (!b.calendarEventId) continue
+    const [ev] = await drizzleDb
+      .update(calendarEvent)
+      .set({ status: 'CANCELLED', isCancelled: true, updatedAt: now })
+      .where(eq(calendarEvent.eventId, b.calendarEventId))
+      .returning({ externalId: calendarEvent.externalId })
+    if (ev?.externalId) {
+      await drizzleDb
+        .update(liveSession)
+        .set({ status: 'ended', endedAt: now })
+        .where(and(eq(liveSession.sessionId, ev.externalId), ne(liveSession.status, 'ended')))
+    }
+  }
+
+  // Flip them all to EXPIRED.
+  await drizzleDb
+    .update(oneOnOneBookingRequest)
+    .set({ status: 'EXPIRED', updatedAt: now })
+    .where(
+      inArray(
+        oneOnOneBookingRequest.requestId,
+        overdue.map(b => b.requestId)
+      )
+    )
+
+  // Notify once per booking group (a series is one booking).
+  const groups = new Map<string, typeof overdue>()
+  for (const b of overdue) {
+    const key = b.seriesId ?? b.requestId
+    const arr = groups.get(key)
+    if (arr) arr.push(b)
+    else groups.set(key, [b])
+  }
+  for (const members of groups.values()) {
+    const head = members[0]
+    const label = members.length > 1 ? `${members.length}-session series` : 'session'
+    notify({
+      userId: head.studentId,
+      type: 'class',
+      title: '1-on-1 booking expired',
+      message: `Your 1-on-1 ${label} expired because payment wasn't completed in time. The hold has been released — you can book again.`,
+      data: { requestId: head.requestId, seriesId: head.seriesId, type: 'one-on-one-expired' },
+      actionUrl: '/student/tutors',
+    }).catch(() => {})
+    notify({
+      userId: head.tutorId,
+      type: 'class',
+      title: '1-on-1 hold released',
+      message: `An unpaid 1-on-1 ${label} passed its payment window and expired, so the slot is free again.`,
+      data: { requestId: head.requestId, seriesId: head.seriesId, type: 'one-on-one-expired' },
+      actionUrl: '/tutor/dashboard',
+    }).catch(() => {})
+  }
+
+  // Let each affected tutor's waitlist know a slot opened (deduped).
+  for (const tutorId of new Set(overdue.map(b => b.tutorId))) {
+    void notifyWaitlistOfOpening(tutorId)
+  }
+
+  return overdue.length
+}


### PR DESCRIPTION
An accepted **paid** request holds the tutor's slot (an `ACCEPTED` booking blocks the time in conflict detection) with a 48h `paymentDueAt` window. If the student never paid, the hold **lingered forever**. This enforces the window.

### Sweep
New `expireOverdueOneOnOneBookings()`:
- Finds `ACCEPTED` + **unpaid** (`paidAt` null) + **past-due** (`paymentDueAt < now`) bookings.
- Flips them to **`EXPIRED`**, cancels each one's calendar event + ends the linked live session (**freeing the slot**).
- Notifies **both parties** once per booking (a series counts as one), and **pings the tutor's waitlist**.
- Free sessions have no `paymentDueAt`, so they never match.
- Calendar is cancelled **before** the status flip, so a crash mid-sweep leaves the row re-processable rather than `EXPIRED` with a lingering slot-blocking event.

### Triggers (defence in depth)
- **Lazy** — awaited (scoped to the tutor) in the availability endpoint, so a lapsed hold's slot shows open the moment a student views it to book; best-effort in the request list for each viewer's own holds.
- **Boot** — global sweep in startup data cleanup.
- **Cron** — `GET /api/cron/expire-one-on-one` (`Authorization: Bearer $CRON_SECRET`; returns **503 until `CRON_SECRET` is configured**, so it can't be triggered anonymously), wired into the existing every-10-min keep-alive workflow.

Also adds `EXPIRED` status styling to the request card (shown on the student's Requests tab).

> To enable the guaranteed 10-min cadence, set a `CRON_SECRET` GitHub secret (+ env var). Without it, lazy + boot sweeps still cover expiry.

typecheck · lint · **596** unit tests · production build — all clean.