### PR TITLE
feat(1-on-1): mark finished sessions COMPLETED

### DIFF
--- a/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
+++ b/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
+import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
 
 export async function GET(req: NextRequest) {
   const secret = process.env.CRON_SECRET
@@ -23,8 +24,11 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const expired = await expireOverdueOneOnOneBookings()
-    return NextResponse.json({ ok: true, expired })
+    const [expired, completed] = await Promise.all([
+      expireOverdueOneOnOneBookings(),
+      completeFinishedOneOnOneSessions(),
+    ])
+    return NextResponse.json({ ok: true, expired, completed })
   } catch (error) {
     console.error('[cron] expire-one-on-one failed:', error)
     return NextResponse.json({ error: 'Sweep failed' }, { status: 500 })

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -18,6 +18,7 @@ import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/c
 import { getOrCreateConversation } from '@/lib/messaging/conversation'
 import { findConflicts } from '@/lib/schedule/conflicts'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
+import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -293,12 +294,15 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     })
   }
 
-  // Lazily expire the viewer's own overdue unpaid holds so the list they see is
-  // accurate and any freed slots are released (best-effort — never block the read).
+  // Lazily reconcile the viewer's own bookings so the list is accurate: expire
+  // overdue unpaid holds (freeing slots) and mark finished sessions completed
+  // (best-effort — never block the read).
   const asStudent = role === 'sent' || session.user.role === 'STUDENT'
-  await expireOverdueOneOnOneBookings(
-    asStudent ? { studentId: session.user.id } : { tutorId: session.user.id }
-  ).catch(() => {})
+  const scope = asStudent ? { studentId: session.user.id } : { tutorId: session.user.id }
+  await Promise.all([
+    expireOverdueOneOnOneBookings(scope).catch(() => {}),
+    completeFinishedOneOnOneSessions(scope).catch(() => {}),
+  ])
 
   let requests
   if (role === 'sent' || session.user.role === 'STUDENT') {

--- a/tutorme-app/src/app/api/one-on-one/review/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/review/route.ts
@@ -30,7 +30,8 @@ function isReviewable(booking: {
   endTime: string
   timezone: string | null
 }): boolean {
-  if (booking.status !== 'PAID') return false
+  // A finished session may be PAID (not yet swept) or already COMPLETED.
+  if (booking.status !== 'PAID' && booking.status !== 'COMPLETED') return false
   const { end } = bookingInstants(booking)
   return Number.isFinite(end.getTime()) && end.getTime() < Date.now()
 }

--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -122,11 +122,11 @@ export const GET = withAuth(
       : []
 
     // --- 1-on-1 sessions the student has PAID for (no courseId; keyed by
-    // studentId). Only PAID bookings are surfaced so a session becomes visible/
-    // joinable exactly when payment clears. ---
+    // studentId). Surfaced once payment clears (PAID) and kept after the session
+    // finishes (COMPLETED) so the past session stays on the calendar to review. ---
     const oneOnOneFilters = [
       eq(calendarEvent.studentId, studentId),
-      eq(oneOnOneBookingRequest.status, 'PAID'),
+      inArray(oneOnOneBookingRequest.status, ['PAID', 'COMPLETED']),
       eq(calendarEvent.isCancelled, false),
       isNull(calendarEvent.deletedAt),
     ]

--- a/tutorme-app/src/app/api/student/dashboard-stats/route.ts
+++ b/tutorme-app/src/app/api/student/dashboard-stats/route.ts
@@ -31,7 +31,13 @@ import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 // A booking that was rejected by the tutor or expired never became a booking, so
 // it is excluded from "Total Bookings". Everything else (incl. cancelled) counts
 // as a booking the student actually placed.
-const BOOKED_STATUSES: BookingRequestStatus[] = ['PENDING', 'ACCEPTED', 'PAID', 'CANCELLED']
+const BOOKED_STATUSES: BookingRequestStatus[] = [
+  'PENDING',
+  'ACCEPTED',
+  'PAID',
+  'CANCELLED',
+  'COMPLETED',
+]
 const ACTIVE_LIVE_SESSION_STATUSES: LiveSessionStatus[] = LIVE_SESSION_OPEN_STATUSES
 
 export const dynamic = 'force-dynamic'

--- a/tutorme-app/src/lib/db/schema/enums.ts
+++ b/tutorme-app/src/lib/db/schema/enums.ts
@@ -71,6 +71,9 @@ export const bookingRequestStatusEnum = pgEnum('BookingRequestStatus', [
   'EXPIRED',
   'PAID',
   'CANCELLED',
+  // A paid session whose scheduled time has passed (marked by the completion
+  // sweep). Distinguishes a finished session from an upcoming confirmed one.
+  'COMPLETED',
 ])
 export type BookingRequestStatus = (typeof bookingRequestStatusEnum.enumValues)[number]
 

--- a/tutorme-app/src/lib/db/startup-cleanup.ts
+++ b/tutorme-app/src/lib/db/startup-cleanup.ts
@@ -15,6 +15,7 @@
 import { drizzleDb } from './drizzle'
 import { sql } from 'drizzle-orm'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
+import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
 
 const CLEANUP_SQL = sql.raw(`
 DELETE FROM "LiveSession"
@@ -81,6 +82,18 @@ export async function applyStartupDataCleanup(): Promise<void> {
   } catch (err) {
     console.error(
       '⚠️ [Server] 1-on-1 expiry sweep skipped:',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  try {
+    const count = await completeFinishedOneOnOneSessions()
+    if (count > 0) {
+      console.log(`[Server] Data cleanup: completed ${count} finished 1-on-1 session(s).`)
+    }
+  } catch (err) {
+    console.error(
+      '⚠️ [Server] 1-on-1 completion sweep skipped:',
       err instanceof Error ? err.message : err
     )
   }

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -365,6 +365,16 @@ export async function applyStartupSchemaFixes(): Promise<void> {
     console.error('[SchemaFix] ❌ Failed to ensure tables:', err?.message)
   }
 
+  // Add the COMPLETED booking status. ALTER TYPE ... ADD VALUE must run on its
+  // own (not inside the batched DDL above), so keep it in a separate statement.
+  try {
+    await drizzleDb.execute(
+      sql.raw(`ALTER TYPE "BookingRequestStatus" ADD VALUE IF NOT EXISTS 'COMPLETED'`)
+    )
+  } catch (err: any) {
+    console.error('[SchemaFix] ❌ Failed to add COMPLETED booking status:', err?.message)
+  }
+
   try {
     console.log('[SchemaFix] Checking for schema drift...')
 

--- a/tutorme-app/src/lib/one-on-one/complete.ts
+++ b/tutorme-app/src/lib/one-on-one/complete.ts
@@ -1,0 +1,84 @@
+/**
+ * Mark finished 1-on-1 sessions COMPLETED.
+ *
+ * A paid booking otherwise stays PAID forever, so a past session still reads as
+ * an upcoming "Confirmed" booking, keeps offering a (pointless) Join button, and
+ * never nudges the student for a review. This flips a PAID booking to COMPLETED
+ * once its scheduled end (plus a grace period, so a session running a little long
+ * isn't cut off) has passed.
+ *
+ * Per-session, not per-series: each week of a series finishes — and becomes
+ * reviewable — at its own time. Reviews accept PAID or COMPLETED (see the review
+ * route), so this transition never blocks a review.
+ *
+ * Runs lazily when a party views their requests, on boot, and from the cron sweep.
+ */
+
+import { and, eq, lte, inArray, isNotNull } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest } from '@/lib/db/schema'
+import { notify } from '@/lib/notifications/notify'
+import { bookingInstants } from '@/lib/one-on-one/time'
+
+/** Grace after the scheduled end before a session counts as finished. */
+const COMPLETION_GRACE_MS = 60 * 60 * 1000 // 1 hour
+
+export async function completeFinishedOneOnOneSessions(
+  opts: { tutorId?: string; studentId?: string } = {}
+): Promise<number> {
+  const now = Date.now()
+
+  const conditions = [
+    eq(oneOnOneBookingRequest.status, 'PAID'),
+    isNotNull(oneOnOneBookingRequest.paidAt),
+    // Coarse pre-filter: only bookings whose calendar date is today or past
+    // (widened a day so a far-east-timezone session that already ended isn't
+    // missed). The exact end instant is checked in JS below.
+    lte(oneOnOneBookingRequest.requestedDate, new Date(now + 24 * 60 * 60 * 1000)),
+  ]
+  if (opts.tutorId) conditions.push(eq(oneOnOneBookingRequest.tutorId, opts.tutorId))
+  if (opts.studentId) conditions.push(eq(oneOnOneBookingRequest.studentId, opts.studentId))
+
+  const candidates = await drizzleDb
+    .select({
+      requestId: oneOnOneBookingRequest.requestId,
+      studentId: oneOnOneBookingRequest.studentId,
+      tutorId: oneOnOneBookingRequest.tutorId,
+      requestedDate: oneOnOneBookingRequest.requestedDate,
+      startTime: oneOnOneBookingRequest.startTime,
+      endTime: oneOnOneBookingRequest.endTime,
+      timezone: oneOnOneBookingRequest.timezone,
+    })
+    .from(oneOnOneBookingRequest)
+    .where(and(...conditions))
+
+  const finished = candidates.filter(b => {
+    const { end } = bookingInstants(b)
+    return Number.isFinite(end.getTime()) && end.getTime() + COMPLETION_GRACE_MS < now
+  })
+  if (finished.length === 0) return 0
+
+  await drizzleDb
+    .update(oneOnOneBookingRequest)
+    .set({ status: 'COMPLETED', updatedAt: new Date() })
+    .where(
+      inArray(
+        oneOnOneBookingRequest.requestId,
+        finished.map(b => b.requestId)
+      )
+    )
+
+  // Nudge each student to review the session they just had.
+  for (const b of finished) {
+    notify({
+      userId: b.studentId,
+      type: 'class',
+      title: 'How was your 1-on-1?',
+      message: 'Your session is complete — leave a quick review to help other students.',
+      data: { requestId: b.requestId, type: 'one-on-one-review-prompt' },
+      actionUrl: '/student/dashboard',
+    }).catch(() => {})
+  }
+
+  return finished.length
+}


### PR DESCRIPTION
A paid booking stayed `PAID` forever — so a **past** session read as an upcoming "Confirmed" booking, still offered a (pointless) **Join** button, and never nudged the student for a **review**. This adds a `COMPLETED` status and a sweep that transitions a paid session once its scheduled end has passed.

- **enum**: add `COMPLETED` to `BookingRequestStatus`; `ALTER TYPE … ADD VALUE IF NOT EXISTS` in `startup-schema-fix.ts` (run **standalone**, since ADD VALUE can't be batched with the other DDL).
- **sweep** `completeFinishedOneOnOneSessions()`: `PAID` + past-end (+ **1h grace** so a session running long isn't cut off) → `COMPLETED`, **per session** (each week of a series finishes at its own time), and **nudges the student to review**. Runs **lazily** on request views, **on boot**, and from the **cron** endpoint (which now sweeps expiry + completion).
- **reviews**: `isReviewable` now accepts `PAID` **or** `COMPLETED`, so completing never blocks a review.
- **student calendar** keeps `COMPLETED` sessions visible (so the past session stays on the calendar with its **Rate** button); dashboard **"Total Bookings"** counts `COMPLETED`.
- **Join** already filters to `PAID`, so a finished session no longer offers a Join button; the card shows a **"Completed"** badge.

First-deploy safety: the enum value is added at boot before the sweep writes it, and any early lazy sweep before the value exists is caught best-effort.

typecheck · lint · **596** unit tests · production build — all clean.