### PR TITLE
fix(documents): split encrypted PDFs into tasks (ignoreEncryption)

### DIFF
--- a/tutorme-app/src/lib/documents/split-pdf.ts
+++ b/tutorme-app/src/lib/documents/split-pdf.ts
@@ -32,7 +32,12 @@ export async function splitPdfBufferIntoPages(
 
   let sourceDoc: PDFDocument
   try {
-    sourceDoc = await PDFDocument.load(buffer)
+    // ignoreEncryption: many real-world PDFs (exam papers, exported docs) carry
+    // owner-password encryption even when they open fine in a viewer. Without
+    // this, pdf-lib throws on load → the split fails → "load as Tasks" silently
+    // falls back to a single task. We only READ + copy pages here, so ignoring
+    // the (non-content) encryption is safe.
+    sourceDoc = await PDFDocument.load(buffer, { ignoreEncryption: true })
   } catch {
     const err = new Error('File is not a valid PDF') as Error & { code?: string }
     err.code = 'INVALID_PDF'


### PR DESCRIPTION
Fixes "loading a multi-page PDF **as Tasks** doesn't split per page" (while Word docs work).

## Cause
The per-page PDF split (`splitPdfBufferIntoPages`) calls `PDFDocument.load(buffer)`. pdf-lib **throws on encrypted PDFs**, and a lot of real-world PDFs (exam papers, exported/printed-to-PDF docs) carry **owner-password encryption** even though they open fine in any viewer. That throw → the endpoint returns `INVALID_PDF` (400) → the "Load as Tasks" client silently falls back to its text-section split, which for a PDF with no page markers collapses to a **single task**. Word docs never hit this path (they use `splitDocIntoSections` directly), which is why they split correctly.

## Fix
Load with `{ ignoreEncryption: true }`. The code only **reads and copies pages**, so ignoring the (non-content) encryption is safe — and multi-page PDFs now split into one task per page. This is the only `PDFDocument.load` call in the codebase.

## Verification
Prettier clean; one-line change in a shared lib used by both the split endpoint and its diagnostic. Typecheck/Build via CI.

Pairs with #1018 (which relaxed the split to run off the durable `fileKey`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)