### PR TITLE
feat(1-on-1): global Session Launcher — students can always find the way in

### DIFF
--- a/tutorme-app/src/app/[locale]/layout.tsx
+++ b/tutorme-app/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@/components/ui/theme-provider'
 import { Toaster } from 'sonner'
 import { PWAInstallPrompt } from '@/components/pwa/PWAInstallPrompt'
 import { FloatingVideoOverlay } from '@/components/class/floating-video-overlay'
+import { SessionLauncher } from '@/components/one-on-one/session-launcher'
 import { NavigationOverlayProvider } from '@/components/navigation/NavigationOverlay'
 
 type Props = {
@@ -30,6 +31,7 @@ export default async function LocaleLayout({ children, params }: Props) {
     <ThemeProvider defaultTheme="aura" defaultMode="system">
       <NavigationOverlayProvider>{children}</NavigationOverlayProvider>
       <FloatingVideoOverlay />
+      <SessionLauncher />
       <PWAInstallPrompt />
       <Toaster position="top-right" />
     </ThemeProvider>

--- a/tutorme-app/src/app/api/one-on-one/live-now/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/live-now/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/one-on-one/live-now
+ *
+ * The current user's most imminent confirmed 1-on-1 session — live now or
+ * starting soon — for the global Session Launcher. Works for either participant.
+ * Returns null when nothing is near, so the launcher stays hidden.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq, or, gte, lte } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest, calendarEvent, liveSession, profile } from '@/lib/db/schema'
+
+// How early the launcher appears, and how late it lingers after the end.
+const LOOKAHEAD_MS = 30 * 60 * 1000 // 30 min before start
+const LINGER_AFTER_END_MS = 15 * 60 * 1000 // 15 min after end
+// Must match the join endpoint's early-entry window so "Join" only enables when
+// the room will actually accept the student.
+const EARLY_ENTRY_MS = 20 * 60 * 1000
+
+export const GET = withAuth(async (_req: NextRequest, session) => {
+  const userId = session.user.id
+  const now = Date.now()
+
+  // Candidate window: sessions scheduled from a few hours ago (so a long/late
+  // session still counts) up to the lookahead. End is checked precisely below.
+  const from = new Date(now - 4 * 60 * 60 * 1000)
+  const until = new Date(now + LOOKAHEAD_MS)
+
+  const rows = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      requestId: oneOnOneBookingRequest.requestId,
+      tutorId: oneOnOneBookingRequest.tutorId,
+      studentId: oneOnOneBookingRequest.studentId,
+    })
+    .from(oneOnOneBookingRequest)
+    .innerJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
+    .innerJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
+    .where(
+      and(
+        eq(oneOnOneBookingRequest.status, 'PAID'),
+        or(
+          eq(oneOnOneBookingRequest.studentId, userId),
+          eq(oneOnOneBookingRequest.tutorId, userId)
+        ),
+        eq(calendarEvent.isCancelled, false),
+        gte(liveSession.scheduledAt, from),
+        lte(liveSession.scheduledAt, until)
+      )
+    )
+    .orderBy(liveSession.scheduledAt)
+
+  // Pick the soonest session that is still within its live window.
+  const pick = rows.find(r => {
+    if (!r.scheduledAt) return false
+    const start = new Date(r.scheduledAt).getTime()
+    const end = start + (r.durationMinutes ?? 60) * 60 * 1000
+    return now <= end + LINGER_AFTER_END_MS
+  })
+
+  if (!pick || !pick.scheduledAt) {
+    return NextResponse.json({ session: null })
+  }
+
+  const start = new Date(pick.scheduledAt).getTime()
+  const isTutor = pick.tutorId === userId
+  const otherPartyId = isTutor ? pick.studentId : pick.tutorId
+  const [other] = await drizzleDb
+    .select({ name: profile.name })
+    .from(profile)
+    .where(eq(profile.userId, otherPartyId))
+    .limit(1)
+
+  return NextResponse.json({
+    session: {
+      sessionId: pick.sessionId,
+      requestId: pick.requestId,
+      scheduledAt: new Date(pick.scheduledAt).toISOString(),
+      withName: other?.name || (isTutor ? 'your student' : 'your tutor'),
+      viewerIsTutor: isTutor,
+      // Live if the session is active, or if we're inside the 20-min entry window.
+      joinable: pick.status === 'active' || now >= start - EARLY_ENTRY_MS,
+      live: pick.status === 'active',
+    },
+  })
+})

--- a/tutorme-app/src/components/one-on-one/session-launcher.tsx
+++ b/tutorme-app/src/components/one-on-one/session-launcher.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+/**
+ * Global Session Launcher.
+ *
+ * Polls for the current user's most imminent confirmed 1-on-1 and, when one is
+ * live or starting soon, floats an always-visible "Join" banner anywhere in the
+ * app — with a live countdown that auto-enables Join at the 20-min entry window.
+ * Solves the "I can't find where to join" problem: the way in comes to you.
+ *
+ * Hidden while a call overlay is already open (you're in the room), and
+ * dismissible per session for the current tab.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import { Video, X } from 'lucide-react'
+import { useVideoOverlayStore } from '@/stores/video-overlay-store'
+
+interface LiveSession {
+  sessionId: string
+  requestId: string
+  scheduledAt: string
+  withName: string
+  viewerIsTutor: boolean
+  joinable: boolean
+  live: boolean
+}
+
+const EARLY_ENTRY_MS = 20 * 60 * 1000
+const POLL_MS = 45_000
+
+function countdown(toMs: number, now: number): string {
+  const s = Math.max(0, Math.round((toMs - now) / 1000))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
+}
+
+export function SessionLauncher() {
+  const { status } = useSession()
+  const router = useRouter()
+  const overlayOpen = useVideoOverlayStore(s => s.open)
+  const [live, setLive] = useState<LiveSession | null>(null)
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+  const [now, setNow] = useState(() => 0) // 0 until mounted (avoids SSR Date use)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const poll = useCallback(async () => {
+    try {
+      const res = await fetch('/api/one-on-one/live-now', { credentials: 'include' })
+      if (!res.ok) return
+      const data = await res.json()
+      setLive(data?.session ?? null)
+    } catch {
+      /* transient — keep whatever we had */
+    }
+  }, [])
+
+  // Poll only while authenticated.
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      setLive(null)
+      return
+    }
+    poll()
+    pollRef.current = setInterval(poll, POLL_MS)
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [status, poll])
+
+  // 1s ticker for the countdown (only runs when there's a session to show).
+  useEffect(() => {
+    if (!live) return
+    setNow(Date.now())
+    const t = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(t)
+  }, [live])
+
+  if (status !== 'authenticated' || overlayOpen || !live || !now) return null
+  if (dismissed.has(live.sessionId)) return null
+
+  const start = new Date(live.scheduledAt).getTime()
+  const joinable = live.live || now >= start - EARLY_ENTRY_MS
+  const isLive = live.live || now >= start
+  const opensAt = start - EARLY_ENTRY_MS
+
+  const join = () => router.push(`/call/${live.sessionId}`)
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[9998] flex justify-center px-4 sm:inset-x-auto sm:right-4 sm:justify-end">
+      <div className="pointer-events-auto flex w-full max-w-sm items-center gap-3 rounded-2xl border border-white/10 bg-slate-900/95 p-3 pl-4 text-white shadow-[0_16px_48px_-8px_rgba(0,0,0,0.5)] ring-1 ring-white/10 backdrop-blur">
+        <span className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-500/20">
+          {isLive ? (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500/40" />
+          ) : null}
+          <Video className="relative h-4 w-4 text-blue-300" />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold">
+            1-on-1 with <span className="capitalize">{live.withName}</span>
+          </p>
+          <p className="truncate text-xs text-white/60">
+            {isLive ? (
+              <span className="font-medium text-emerald-400">● Live now</span>
+            ) : joinable ? (
+              <span className="font-medium text-blue-300">Ready to join</span>
+            ) : (
+              <>Starts in {countdown(start, now)}</>
+            )}
+          </p>
+        </div>
+
+        {joinable ? (
+          <button
+            type="button"
+            onClick={join}
+            className="shrink-0 rounded-xl bg-blue-600 px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
+          >
+            Join
+          </button>
+        ) : (
+          <span className="shrink-0 rounded-xl bg-white/10 px-3 py-2 text-xs font-medium text-white/70">
+            Opens in {countdown(opensAt, now)}
+          </span>
+        )}
+
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => setDismissed(prev => new Set(prev).add(live.sessionId))}
+          className="shrink-0 rounded-full p-1 text-white/40 hover:bg-white/10 hover:text-white/80"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Students reported **"no way to join"** a 1-on-1. The join itself works (the endpoint authorizes the booked student and lets them in 20 min before start) — the real problem is **discoverability**: the only join affordances were buried in a calendar tab and the Communications "Requests" tab, and arriving early hit a dead error page.

### Fix — the way in comes to you
An always-visible, app-wide **Session Launcher**:

- **`GET /api/one-on-one/live-now`** — the current user's most imminent confirmed 1-on-1 (live now, or starting within 30 min), for either participant; `null` otherwise.
- **`SessionLauncher`** (mounted globally in the locale layout, beside the floating video overlay): polls every 45s and floats a **"1-on-1 with `<name>`"** banner with a **live countdown**. **Join auto-enables at the 20-min entry window** — matching the join endpoint's own gate, so it never opens a session that would bounce the student — flips to a pulsing **"Live now"** once active, and is **dismissible** per session. Hidden while you're already in a call. Works for **students and tutors**.

Now a student anywhere in the app sees their session coming and joins in one click — no hunting, no premature dead-ends. Complements the existing calendar / requests-tab join buttons.

typecheck · lint · **596** unit tests · production build — all clean.