### PR TITLE
feat(1-on-1): pre-join lobby on the call page

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -3,24 +3,48 @@
 /**
  * Dedicated two-way video room for a 1-on-1 session — used by BOTH the student
  * and the tutor (the course classrooms are role-specific and can't host a
- * course-less 1-on-1). Mints a join token via /api/class/rooms/[id]/join (which
- * grants the student a broadcast-capable token for capacity-2 sessions) and
- * renders DailyVideoFrame in two-way mode so each person sees the other's video.
+ * course-less 1-on-1).
+ *
+ * Flow: check session status → if it isn't open yet, show a pre-join LOBBY with a
+ * live countdown that brings you in automatically the moment the room opens (or
+ * the tutor starts early); once open, mint a join token via
+ * /api/class/rooms/[id]/join and render DailyVideoFrame in two-way mode.
  */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { Loader2, ArrowLeft } from 'lucide-react'
+import { Loader2, ArrowLeft, Video, CalendarClock } from 'lucide-react'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 
-interface JoinState {
-  loading: boolean
-  roomUrl?: string | null
-  token?: string | null
+type Phase = 'checking' | 'lobby' | 'joining' | 'inRoom' | 'ended' | 'error'
+
+interface LobbyInfo {
+  title: string
+  withName: string
+  scheduledAt: string | null
+  opensAt: string | null
+  viewerIsTutor: boolean
+}
+
+interface VideoInfo {
+  roomUrl: string | null
+  token: string | null
   isTutor?: boolean
   twoWay?: boolean
   error?: string
+}
+
+const EARLY_ENTRY_MS = 20 * 60 * 1000
+const LOBBY_POLL_MS = 20_000
+
+function countdown(toMs: number, now: number): string {
+  const s = Math.max(0, Math.round((toMs - now) / 1000))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
 }
 
 export default function OneOnOneCallPage() {
@@ -28,83 +52,210 @@ export default function OneOnOneCallPage() {
   const params = useParams()
   const router = useRouter()
   const sessionId = (params?.sessionId as string) || ''
-  const [state, setState] = useState<JoinState>({ loading: true })
 
-  useEffect(() => {
-    if (!sessionId) return
-    let cancelled = false
-    // Bound the whole join so a stuck request (e.g. an unresponsive video
-    // provider) can't spin forever — abort after 30s and surface a retryable
-    // error instead of an endless loader.
+  const [phase, setPhase] = useState<Phase>('checking')
+  const [lobby, setLobby] = useState<LobbyInfo | null>(null)
+  const [video, setVideo] = useState<VideoInfo | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [now, setNow] = useState(0)
+  const joinStarted = useRef(false)
+
+  /** Mint a token and enter the room (the original join flow). */
+  const runJoin = useCallback(async () => {
+    if (joinStarted.current) return
+    joinStarted.current = true
+    setPhase('joining')
+
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 30000)
-    ;(async () => {
-      try {
-        const csrfRes = await fetch('/api/csrf', {
-          credentials: 'include',
-          signal: controller.signal,
-        })
-        const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
-        const res = await fetch(`/api/class/rooms/${sessionId}/join`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
-          signal: controller.signal,
-        })
-        const data = await res.json().catch(() => ({}))
-        if (cancelled) return
-        if (!res.ok) {
-          setState({ loading: false, error: data?.error || 'Could not join the session.' })
-          return
-        }
-        const tutorId = data?.session?.tutorId
-        const isTutor =
-          tutorId && session?.user?.id
-            ? tutorId === session.user.id
-            : session?.user?.role === 'TUTOR'
-        setState({
-          loading: false,
-          roomUrl: data?.roomUrl ?? null,
-          token: data?.token ?? null,
-          isTutor,
-          // Server flags 1-on-1 (capacity 2) as two-way; default true on this route.
-          twoWay: data?.twoWay ?? true,
-          error: data?.videoError || undefined,
-        })
-      } catch (err) {
-        if (cancelled) return
-        const timedOut = err instanceof DOMException && err.name === 'AbortError'
-        setState({
-          loading: false,
-          error: timedOut
-            ? 'Joining is taking too long. Please check your connection and try again.'
-            : 'Could not join the session.',
-        })
-      } finally {
-        clearTimeout(timeoutId)
+    try {
+      const csrfRes = await fetch('/api/csrf', {
+        credentials: 'include',
+        signal: controller.signal,
+      })
+      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
+      const res = await fetch(`/api/class/rooms/${sessionId}/join`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
+        signal: controller.signal,
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setErrorMsg(data?.error || 'Could not join the session.')
+        setPhase('error')
+        return
       }
-    })()
-    return () => {
-      cancelled = true
+      const tutorId = data?.session?.tutorId
+      const isTutor =
+        tutorId && session?.user?.id ? tutorId === session.user.id : session?.user?.role === 'TUTOR'
+      if (!data?.roomUrl) {
+        setErrorMsg(data?.videoError || 'No video room is available for this session yet.')
+        setPhase('error')
+        return
+      }
+      setVideo({
+        roomUrl: data.roomUrl,
+        token: data.token ?? null,
+        isTutor,
+        twoWay: data?.twoWay ?? true,
+        error: data?.videoError || undefined,
+      })
+      setPhase('inRoom')
+    } catch (err) {
+      const timedOut = err instanceof DOMException && err.name === 'AbortError'
+      setErrorMsg(
+        timedOut
+          ? 'Joining is taking too long. Please check your connection and try again.'
+          : 'Could not join the session.'
+      )
+      setPhase('error')
+    } finally {
       clearTimeout(timeoutId)
-      controller.abort()
     }
   }, [sessionId, session?.user?.id, session?.user?.role])
 
-  if (state.loading) {
+  /** Check status; open the room if joinable, otherwise show the lobby. */
+  const checkStatus = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/one-on-one/session-status?sessionId=${encodeURIComponent(sessionId)}`,
+        { credentials: 'include' }
+      )
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        // No status (e.g. an odd/legacy session) — fall back to attempting the join.
+        void runJoin()
+        return
+      }
+      if (data.ended) {
+        setPhase('ended')
+        return
+      }
+      setLobby({
+        title: data.title,
+        withName: data.withName,
+        scheduledAt: data.scheduledAt,
+        opensAt: data.opensAt,
+        viewerIsTutor: !!data.viewerIsTutor,
+      })
+      if (data.joinable) void runJoin()
+      else setPhase('lobby')
+    } catch {
+      void runJoin()
+    }
+  }, [sessionId, runJoin])
+
+  // Initial status check.
+  useEffect(() => {
+    if (!sessionId) return
+    checkStatus()
+  }, [sessionId, checkStatus])
+
+  // In the lobby: tick the countdown, auto-enter when the window opens, and poll
+  // so a tutor starting early pulls the student straight in.
+  useEffect(() => {
+    if (phase !== 'lobby') return
+    setNow(Date.now())
+    const opensAtMs = lobby?.opensAt ? new Date(lobby.opensAt).getTime() : Infinity
+
+    const tick = setInterval(() => {
+      const t = Date.now()
+      setNow(t)
+      if (t >= opensAtMs) void runJoin()
+    }, 1000)
+    const poll = setInterval(checkStatus, LOBBY_POLL_MS)
+    return () => {
+      clearInterval(tick)
+      clearInterval(poll)
+    }
+  }, [phase, lobby?.opensAt, checkStatus, runJoin])
+
+  // --- Render ---
+
+  if (phase === 'checking' || phase === 'joining') {
     return (
-      <div className="flex h-screen w-full items-center justify-center bg-slate-950">
+      <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950">
         <Loader2 className="h-8 w-8 animate-spin text-white/70" />
+        {phase === 'joining' ? <p className="text-sm text-white/50">Joining…</p> : null}
       </div>
     )
   }
 
-  if (!state.roomUrl) {
+  if (phase === 'lobby' && lobby) {
+    const opensAtMs = lobby.opensAt ? new Date(lobby.opensAt).getTime() : NaN
+    const startMs = lobby.scheduledAt ? new Date(lobby.scheduledAt).getTime() : NaN
+    const startLabel = Number.isFinite(startMs)
+      ? new Date(startMs).toLocaleString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+        })
+      : null
+    return (
+      <div className="flex h-screen w-full flex-col items-center justify-center bg-slate-950 px-6 text-center text-white">
+        <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
+          <span className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-500/15">
+            <Video className="h-6 w-6 text-blue-300" />
+          </span>
+          <h1 className="text-lg font-semibold">{lobby.title}</h1>
+          <p className="mt-1 text-sm text-white/60">
+            with <span className="capitalize">{lobby.withName}</span>
+          </p>
+
+          <div className="mt-6 rounded-2xl bg-black/30 p-5">
+            <p className="text-xs font-medium uppercase tracking-wide text-white/40">
+              {now && Number.isFinite(startMs) && now >= startMs ? 'Room opens in' : 'Starts in'}
+            </p>
+            <p className="mt-1 font-mono text-3xl font-bold tabular-nums text-white">
+              {now && Number.isFinite(opensAtMs) ? countdown(opensAtMs, now) : '—:—'}
+            </p>
+            {startLabel ? <p className="mt-2 text-xs text-white/50">{startLabel}</p> : null}
+          </div>
+
+          <p className="mt-5 flex items-center justify-center gap-2 text-xs text-white/50">
+            <CalendarClock className="h-3.5 w-3.5" />
+            We&apos;ll bring you in automatically when it opens.
+          </p>
+
+          <button
+            onClick={() => router.back()}
+            className="mt-6 inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/80 hover:bg-white/10"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Go back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (phase === 'ended') {
+    return (
+      <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
+        <p className="text-lg font-semibold">This session has ended</p>
+        <p className="max-w-md text-sm text-white/70">
+          The 1-on-1 is over. You can leave a review from your dashboard.
+        </p>
+        <button
+          onClick={() => router.back()}
+          className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-medium hover:bg-white/10"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Go back
+        </button>
+      </div>
+    )
+  }
+
+  if (phase === 'error' || !video?.roomUrl) {
     return (
       <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
         <p className="text-lg font-semibold">Couldn’t start the session</p>
         <p className="max-w-md text-sm text-white/70">
-          {state.error || 'No video room is available for this session yet.'}
+          {errorMsg || 'No video room is available for this session yet.'}
         </p>
         <button
           onClick={() => router.back()}
@@ -120,10 +271,10 @@ export default function OneOnOneCallPage() {
   return (
     <div className="h-screen w-full bg-black">
       <DailyVideoFrame
-        roomUrl={state.roomUrl}
-        token={state.token}
-        isTutor={state.isTutor}
-        twoWay={state.twoWay}
+        roomUrl={video.roomUrl}
+        token={video.token}
+        isTutor={video.isTutor}
+        twoWay={video.twoWay}
         className="h-full w-full rounded-none border-0"
       />
     </div>

--- a/tutorme-app/src/app/api/one-on-one/session-status/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/session-status/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/one-on-one/session-status?sessionId=…
+ *
+ * Lightweight, read-only status for the /call pre-join lobby: when the session
+ * opens, whether it's live, and who it's with — without attempting the actual
+ * join. Authorized to the session's two participants only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { liveSession, calendarEvent, oneOnOneBookingRequest, profile } from '@/lib/db/schema'
+
+// Match the join endpoint's early-entry window and the launcher's grace.
+const EARLY_ENTRY_MS = 20 * 60 * 1000
+const LINGER_AFTER_END_MS = 15 * 60 * 1000
+
+export const GET = withAuth(async (req: NextRequest, session) => {
+  const sessionId = new URL(req.url).searchParams.get('sessionId')
+  if (!sessionId) {
+    return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
+  }
+  const userId = session.user.id
+
+  const [ls] = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      title: liveSession.title,
+      tutorId: liveSession.tutorId,
+    })
+    .from(liveSession)
+    .where(eq(liveSession.sessionId, sessionId))
+    .limit(1)
+
+  if (!ls) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+
+  // Confirm this is a 1-on-1 (has a booking linked via its calendar event) and
+  // that the caller is one of its two participants.
+  const [booking] = await drizzleDb
+    .select({
+      studentId: oneOnOneBookingRequest.studentId,
+      tutorId: oneOnOneBookingRequest.tutorId,
+      status: oneOnOneBookingRequest.status,
+    })
+    .from(oneOnOneBookingRequest)
+    .innerJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
+    .where(eq(calendarEvent.externalId, sessionId))
+    .limit(1)
+
+  if (!booking) {
+    return NextResponse.json({ error: 'Not a 1-on-1 session' }, { status: 404 })
+  }
+  const isTutor = booking.tutorId === userId
+  if (booking.studentId !== userId && !isTutor) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+  }
+
+  const now = Date.now()
+  const start = ls.scheduledAt ? new Date(ls.scheduledAt).getTime() : NaN
+  const end = Number.isFinite(start) ? start + (ls.durationMinutes ?? 60) * 60 * 1000 : NaN
+  const opensAt = Number.isFinite(start) ? start - EARLY_ENTRY_MS : NaN
+  const live = ls.status === 'active'
+
+  const otherPartyId = isTutor ? booking.studentId : booking.tutorId
+  const [other] = await drizzleDb
+    .select({ name: profile.name })
+    .from(profile)
+    .where(eq(profile.userId, otherPartyId))
+    .limit(1)
+
+  return NextResponse.json({
+    sessionId: ls.sessionId,
+    title: ls.title || '1-on-1 Session',
+    withName: other?.name || (isTutor ? 'your student' : 'your tutor'),
+    viewerIsTutor: isTutor,
+    scheduledAt: Number.isFinite(start) ? new Date(start).toISOString() : null,
+    opensAt: Number.isFinite(opensAt) ? new Date(opensAt).toISOString() : null,
+    live,
+    // The tutor may always enter; a student once the session is live or inside
+    // the 20-min entry window.
+    joinable: isTutor || live || (Number.isFinite(opensAt) && now >= opensAt),
+    ended: Number.isFinite(end) && now > end + LINGER_AFTER_END_MS,
+  })
+})


### PR DESCRIPTION
Opening a 1-on-1 session link **before** its entry window used to hit a dead error page ("Couldn't start the session"). Now the `/call` page shows a **lobby that brings you in automatically**.

- **`GET /api/one-on-one/session-status`** — read-only lobby status for a 1-on-1 session (`opensAt`, `live`, `ended`, other party), authorized to its two participants.
- **`/call/[sessionId]`** reworked into a phase machine: **checking → lobby → joining → in-room** (plus *ended* / *error*). The lobby shows the session, who it's with, and a **live countdown** to when the room opens, then **auto-enters** at the window — and **polls** so a tutor starting early pulls the student straight in. Past sessions get a clean **"This session has ended"** screen instead of a video failure.

Complements the global **Session Launcher** (#1024): the launcher gets you here on time; the lobby gracefully handles anyone who arrives early from a link.

typecheck · lint · **596** unit tests · production build — all clean.