### PR TITLE
feat(1-on-1): tutor reviews/attendance + student rate button

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -53,6 +53,7 @@ import {
   Calendar,
 } from 'lucide-react'
 import { CollapsibleCard } from '@/components/collapsible-card'
+import { TutorReviewsCard } from '@/components/one-on-one/tutor-reviews-card'
 import { REGIONS } from '@/lib/data/tutor-categories'
 import { CountryFlag } from '@/components/country-flag'
 import { useAutoScrollOnExpand } from '@/hooks/use-auto-scroll-on-expand'
@@ -1023,6 +1024,7 @@ export default function TutorSettings() {
             className="scrollbar-hide mt-0 flex h-full flex-col gap-4 overflow-y-auto px-6 pb-4"
           >
             <OneOnOneSettingsCard />
+            <TutorReviewsCard className={SECTION_CARD_CLASS} />
           </TabsContent>
 
           {/* Billing & Payment */}

--- a/tutorme-app/src/app/api/one-on-one/history/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/history/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/one-on-one/history  (tutor only)
+ *
+ * The tutor's recent COMPLETED 1-on-1 sessions with, for each, whether the
+ * student actually showed up (derived from the session's participant rows) and
+ * the student's review if they left one — plus the tutor's overall rating.
+ * Powers the "Your 1-on-1 reviews" card.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, eq, desc, sql } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  oneOnOneBookingRequest,
+  oneOnOneReview,
+  calendarEvent,
+  sessionParticipant,
+  profile,
+} from '@/lib/db/schema'
+
+export const GET = withAuth(
+  async (_req: NextRequest, session) => {
+    const tutorId = session.user.id
+
+    const rows = await drizzleDb
+      .select({
+        requestId: oneOnOneBookingRequest.requestId,
+        requestedDate: oneOnOneBookingRequest.requestedDate,
+        startTime: oneOnOneBookingRequest.startTime,
+        studentName: profile.name,
+        // Attended if a participant row exists for this student on the session.
+        attended: sql<boolean>`${sessionParticipant.participantId} is not null`,
+        rating: oneOnOneReview.rating,
+        comment: oneOnOneReview.comment,
+      })
+      .from(oneOnOneBookingRequest)
+      .leftJoin(profile, eq(profile.userId, oneOnOneBookingRequest.studentId))
+      .leftJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
+      .leftJoin(
+        sessionParticipant,
+        and(
+          eq(sessionParticipant.sessionId, calendarEvent.externalId),
+          eq(sessionParticipant.studentId, oneOnOneBookingRequest.studentId)
+        )
+      )
+      .leftJoin(oneOnOneReview, eq(oneOnOneReview.requestId, oneOnOneBookingRequest.requestId))
+      .where(
+        and(
+          eq(oneOnOneBookingRequest.tutorId, tutorId),
+          eq(oneOnOneBookingRequest.status, 'COMPLETED')
+        )
+      )
+      .orderBy(desc(oneOnOneBookingRequest.requestedDate))
+      .limit(30)
+
+    const [agg] = await drizzleDb
+      .select({
+        avgRating: sql<number>`coalesce(avg(${oneOnOneReview.rating}), 0)`,
+        reviewCount: sql<number>`count(*)::int`,
+      })
+      .from(oneOnOneReview)
+      .where(eq(oneOnOneReview.tutorId, tutorId))
+
+    return NextResponse.json({
+      sessions: rows.map(r => ({
+        requestId: r.requestId,
+        date: r.requestedDate ? new Date(r.requestedDate).toISOString() : null,
+        startTime: r.startTime,
+        studentName: r.studentName || 'Student',
+        attended: !!r.attended,
+        rating: r.rating ?? null,
+        comment: r.comment ?? null,
+      })),
+      averageRating: Math.round(Number(agg?.avgRating ?? 0) * 10) / 10,
+      reviewCount: Number(agg?.reviewCount ?? 0),
+    })
+  },
+  { role: 'TUTOR' }
+)

--- a/tutorme-app/src/components/communications/student-requests-panel.tsx
+++ b/tutorme-app/src/components/communications/student-requests-panel.tsx
@@ -4,15 +4,25 @@ import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { Loader2, CalendarClock, Video } from 'lucide-react'
+import { Loader2, CalendarClock, Video, Star } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
+import { OneOnOneReviewDialog } from '@/components/booking/one-on-one-review-dialog'
 import {
   OneOnOneRequestCard,
   groupIntoSeries,
   type OneOnOneRequestSummary,
 } from '@/components/one-on-one/one-on-one-request-card'
+
+/** The most recent COMPLETED session in a group — the one a "Rate" click reviews. */
+function latestCompletedRequestId(members: OneOnOneRequestSummary[]): string | null {
+  const completed = members.filter(m => (m.status || '').toUpperCase() === 'COMPLETED')
+  if (completed.length === 0) return null
+  return completed.reduce((a, b) =>
+    new Date(a.requestedDate).getTime() >= new Date(b.requestedDate).getTime() ? a : b
+  ).requestId
+}
 
 /**
  * A student's own 1-on-1 booking requests (the `role=sent` view). Renders the
@@ -27,6 +37,7 @@ export default function StudentRequestsPanel() {
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [joiningId, setJoiningId] = useState<string | null>(null)
+  const [reviewRequestId, setReviewRequestId] = useState<string | null>(null)
 
   const join = useCallback(
     async (requestId: string) => {
@@ -103,6 +114,8 @@ export default function StudentRequestsPanel() {
         const cancellable = status === 'PENDING' || status === 'ACCEPTED'
         // Confirmed (paid) bookings are joinable — open the next upcoming session.
         const joinId = status === 'PAID' ? joinableRequestId(group.members) : null
+        // Finished sessions are reviewable — rate the most recent completed one.
+        const reviewId = status === 'COMPLETED' ? latestCompletedRequestId(group.members) : null
         return (
           <OneOnOneRequestCard
             key={r.seriesId ?? r.requestId}
@@ -111,12 +124,22 @@ export default function StudentRequestsPanel() {
             variant="light"
             series={group.series}
             actions={
-              joinId || status === 'ACCEPTED' || cancellable ? (
+              joinId || reviewId || status === 'ACCEPTED' || cancellable ? (
                 <>
                   {joinId ? (
                     <Button size="sm" disabled={joiningId === joinId} onClick={() => join(joinId)}>
                       <Video className="mr-1.5 h-3.5 w-3.5" />
                       {joiningId === joinId ? 'Opening…' : 'Join session'}
+                    </Button>
+                  ) : null}
+                  {reviewId ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setReviewRequestId(reviewId)}
+                    >
+                      <Star className="mr-1.5 h-3.5 w-3.5" />
+                      Rate
                     </Button>
                   ) : null}
                   {status === 'ACCEPTED' ? (
@@ -145,6 +168,17 @@ export default function StudentRequestsPanel() {
           />
         )
       })}
+
+      {reviewRequestId ? (
+        <OneOnOneReviewDialog
+          requestId={reviewRequestId}
+          open={!!reviewRequestId}
+          onOpenChange={open => {
+            if (!open) setReviewRequestId(null)
+          }}
+          onSubmitted={load}
+        />
+      ) : null}
     </div>
   )
 }

--- a/tutorme-app/src/components/one-on-one/tutor-reviews-card.tsx
+++ b/tutorme-app/src/components/one-on-one/tutor-reviews-card.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Star, Loader2, MessageSquare, UserCheck, UserX } from 'lucide-react'
+import { CollapsibleCard } from '@/components/collapsible-card'
+import { cn } from '@/lib/utils'
+
+interface HistorySession {
+  requestId: string
+  date: string | null
+  startTime: string
+  studentName: string
+  attended: boolean
+  rating: number | null
+  comment: string | null
+}
+
+interface HistoryData {
+  sessions: HistorySession[]
+  averageRating: number
+  reviewCount: number
+}
+
+function Stars({ value, className }: { value: number; className?: string }) {
+  return (
+    <span className={cn('inline-flex items-center gap-0.5', className)}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Star
+          key={i}
+          className={cn(
+            'h-3.5 w-3.5',
+            i <= Math.round(value) ? 'fill-amber-400 text-amber-400' : 'text-slate-300'
+          )}
+        />
+      ))}
+    </span>
+  )
+}
+
+function dateLabel(iso: string | null): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function TutorReviewsCard({ className }: { className?: string }) {
+  const [data, setData] = useState<HistoryData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let active = true
+    ;(async () => {
+      try {
+        const res = await fetch('/api/one-on-one/history', { credentials: 'include' })
+        const json = res.ok ? await res.json() : null
+        if (active) setData(json)
+      } catch {
+        if (active) setData(null)
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return (
+    <CollapsibleCard
+      className={className}
+      title="Your 1-on-1 Reviews"
+      icon={<Star className="h-5 w-5 text-slate-900" />}
+      defaultOpen
+    >
+      <div className="space-y-4 p-6">
+        {/* Summary */}
+        <div className="flex items-center justify-between rounded-[12px] border bg-slate-50 p-4">
+          <div>
+            <p className="text-sm font-medium text-slate-700">Average rating</p>
+            <p className="text-xs text-slate-500">
+              Across {data?.reviewCount ?? 0} review{(data?.reviewCount ?? 0) === 1 ? '' : 's'}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-2xl font-bold tabular-nums text-slate-900">
+              {(data?.averageRating ?? 0).toFixed(1)}
+            </span>
+            <Stars value={data?.averageRating ?? 0} />
+          </div>
+        </div>
+
+        {/* Recent sessions */}
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+          </div>
+        ) : !data || data.sessions.length === 0 ? (
+          <div className="rounded-[12px] border border-dashed py-8 text-center text-sm text-slate-500">
+            No completed 1-on-1 sessions yet. Reviews and attendance will show up here.
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {data.sessions.map(s => (
+              <li key={s.requestId} className="rounded-[12px] border p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold capitalize text-slate-900">
+                      {s.studentName}
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      {dateLabel(s.date)}
+                      {s.startTime ? ` · ${s.startTime}` : ''}
+                    </p>
+                  </div>
+                  <span
+                    className={cn(
+                      'inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                      s.attended
+                        ? 'bg-emerald-500/10 text-emerald-600'
+                        : 'bg-rose-500/10 text-rose-600'
+                    )}
+                  >
+                    {s.attended ? (
+                      <>
+                        <UserCheck className="h-3 w-3" /> Attended
+                      </>
+                    ) : (
+                      <>
+                        <UserX className="h-3 w-3" /> No-show
+                      </>
+                    )}
+                  </span>
+                </div>
+
+                {s.rating != null ? (
+                  <div className="mt-2 border-t pt-2">
+                    <Stars value={s.rating} />
+                    {s.comment ? (
+                      <p className="mt-1 flex gap-1.5 text-xs text-slate-600">
+                        <MessageSquare className="mt-0.5 h-3 w-3 shrink-0 text-slate-400" />
+                        <span className="italic">“{s.comment}”</span>
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </CollapsibleCard>
+  )
+}


### PR DESCRIPTION
The three minor polish items rounding out the 1-on-1 flow.

### 1 + 2 — Tutor reviews & attendance (no-show tracking)
- **`GET /api/one-on-one/history`** — a tutor's recent **COMPLETED** sessions, each with: the student's **review** (rating + comment, if left) and whether the **student showed up** — attendance **derived on read** from session participant rows (only students get a participant row on join), so **no schema change** — plus the tutor's **average rating**.
- New **"Your 1-on-1 Reviews"** card on the tutor settings → 1-on-1 tab: average rating, and a list of recent sessions each with an **Attended / No-show** chip and the rating/comment.

### 3 — Student rate button
- The **Requests tab** card now shows a **"Rate"** action on a completed booking, opening the existing review dialog (rates the most recent completed session of a series). Previously reviews were only reachable from the dashboard calendar.

typecheck · lint · **596** unit tests · production build — all clean.