### PR TITLE
test(1-on-1): lifecycle + money-path coverage (+ DRY refactors)

### DIFF
--- a/tutorme-app/src/__tests__/integration/one-on-one-lifecycle.test.ts
+++ b/tutorme-app/src/__tests__/integration/one-on-one-lifecycle.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration test: 1-on-1 lifecycle sweeps + series total.
+ *
+ * - expireOverdueOneOnOneBookings: an ACCEPTED, unpaid, past-due hold flips to
+ *   EXPIRED and its calendar event is cancelled (slot freed). A series with no
+ *   payment window set is left alone.
+ * - completeFinishedOneOnOneSessions: a PAID session past its end flips to
+ *   COMPLETED.
+ * - unpaidSeriesTotal: sums every ACCEPTED, unpaid session in a series.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  user,
+  liveSession,
+  calendarEvent,
+  oneOnOneBookingRequest,
+  notification,
+} from '@/lib/db/schema'
+import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
+import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
+import { unpaidSeriesTotal } from '@/lib/one-on-one/series-total'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const studentId = crypto.randomUUID()
+const userIds = [tutorId, studentId]
+
+const expireReqId = `oo_expire_${stamp}`
+const expireEventId = `ce_expire_${stamp}`
+const expireSessionId = `ls_expire_${stamp}`
+
+const completeReqId = `oo_complete_${stamp}`
+const completeEventId = `ce_complete_${stamp}`
+const completeSessionId = `ls_complete_${stamp}`
+
+const seriesId = `series_${stamp}`
+const seriesReqIds = [`oo_s0_${stamp}`, `oo_s1_${stamp}`, `oo_s2_${stamp}`]
+
+const reqIds = [expireReqId, completeReqId, ...seriesReqIds]
+const eventIds = [expireEventId, completeEventId]
+const sessionIds = [expireSessionId, completeSessionId]
+
+function event(id: string, sessionId: string, start: Date, end: Date) {
+  return {
+    eventId: id,
+    tutorId,
+    title: '1-on-1',
+    type: 'CONSULTATION' as const,
+    status: 'CONFIRMED' as const,
+    startTime: start,
+    endTime: end,
+    timezone: 'UTC',
+    isAllDay: false,
+    isRecurring: false,
+    isVirtual: true,
+    maxAttendees: 2,
+    createdBy: tutorId,
+    isCancelled: false,
+    studentId,
+    externalId: sessionId,
+  }
+}
+
+function booking(id: string, extra: Record<string, unknown>) {
+  return {
+    requestId: id,
+    tutorId,
+    studentId,
+    requestedDate: new Date('2026-07-15T00:00:00.000Z'),
+    startTime: '15:00',
+    endTime: '16:00',
+    timezone: 'UTC',
+    durationMinutes: 60,
+    costPerSession: 45,
+    status: 'ACCEPTED' as const,
+    ...extra,
+  }
+}
+
+describe('1-on-1 lifecycle sweeps', () => {
+  beforeAll(async () => {
+    const now = Date.now()
+    await drizzleDb.insert(user).values([
+      {
+        userId: tutorId,
+        email: `oo-tutor-${stamp}@ex.com`,
+        role: 'TUTOR',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: studentId,
+        email: `oo-stu-${stamp}@ex.com`,
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    await drizzleDb.insert(liveSession).values([
+      {
+        sessionId: expireSessionId,
+        tutorId,
+        title: 'expire',
+        category: 'general',
+        status: 'scheduled',
+        scheduledAt: new Date(now + 24 * 3600 * 1000),
+      },
+      {
+        sessionId: completeSessionId,
+        tutorId,
+        title: 'complete',
+        category: 'general',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-07-10T15:00:00.000Z'),
+      },
+    ])
+    await drizzleDb
+      .insert(calendarEvent)
+      .values([
+        event(
+          expireEventId,
+          expireSessionId,
+          new Date(now + 24 * 3600 * 1000),
+          new Date(now + 25 * 3600 * 1000)
+        ),
+        event(
+          completeEventId,
+          completeSessionId,
+          new Date('2026-07-10T15:00:00.000Z'),
+          new Date('2026-07-10T16:00:00.000Z')
+        ),
+      ])
+    await drizzleDb.insert(oneOnOneBookingRequest).values([
+      // Overdue, unpaid → should EXPIRE.
+      booking(expireReqId, {
+        status: 'ACCEPTED',
+        paidAt: null,
+        paymentDueAt: new Date(now - 60 * 60 * 1000),
+        calendarEventId: expireEventId,
+      }),
+      // Paid, ended days ago → should COMPLETE.
+      booking(completeReqId, {
+        status: 'PAID',
+        paidAt: new Date(now - 3 * 24 * 3600 * 1000),
+        calendarEventId: completeEventId,
+        requestedDate: new Date('2026-07-10T00:00:00.000Z'),
+      }),
+      // Series: 3 ACCEPTED unpaid, no payment window → left alone by expiry.
+      booking(seriesReqIds[0], { seriesId, seriesIndex: 0, status: 'ACCEPTED', paidAt: null }),
+      booking(seriesReqIds[1], { seriesId, seriesIndex: 1, status: 'ACCEPTED', paidAt: null }),
+      booking(seriesReqIds[2], { seriesId, seriesIndex: 2, status: 'ACCEPTED', paidAt: null }),
+    ])
+  })
+
+  afterAll(async () => {
+    await drizzleDb
+      .delete(oneOnOneBookingRequest)
+      .where(inArray(oneOnOneBookingRequest.requestId, reqIds))
+    await drizzleDb.delete(calendarEvent).where(inArray(calendarEvent.eventId, eventIds))
+    await drizzleDb.delete(liveSession).where(inArray(liveSession.sessionId, sessionIds))
+    await drizzleDb.delete(notification).where(inArray(notification.userId, userIds))
+    await drizzleDb.delete(user).where(inArray(user.userId, userIds))
+  })
+
+  it('sums every accepted, unpaid session in a series', async () => {
+    const { count, total } = await unpaidSeriesTotal(seriesId)
+    expect(count).toBe(3)
+    expect(total).toBe(135)
+  })
+
+  it('expires an overdue unpaid hold and cancels its calendar event', async () => {
+    await expireOverdueOneOnOneBookings({ studentId })
+
+    const [expired] = await drizzleDb
+      .select({ status: oneOnOneBookingRequest.status })
+      .from(oneOnOneBookingRequest)
+      .where(eq(oneOnOneBookingRequest.requestId, expireReqId))
+    expect(expired.status).toBe('EXPIRED')
+
+    const [ev] = await drizzleDb
+      .select({ isCancelled: calendarEvent.isCancelled })
+      .from(calendarEvent)
+      .where(eq(calendarEvent.eventId, expireEventId))
+    expect(ev.isCancelled).toBe(true)
+
+    // A series with no payment window is not touched by the expiry sweep.
+    const [seriesHead] = await drizzleDb
+      .select({ status: oneOnOneBookingRequest.status })
+      .from(oneOnOneBookingRequest)
+      .where(eq(oneOnOneBookingRequest.requestId, seriesReqIds[0]))
+    expect(seriesHead.status).toBe('ACCEPTED')
+  })
+
+  it('marks a paid, finished session COMPLETED', async () => {
+    await completeFinishedOneOnOneSessions({ studentId })
+
+    const [done] = await drizzleDb
+      .select({ status: oneOnOneBookingRequest.status })
+      .from(oneOnOneBookingRequest)
+      .where(eq(oneOnOneBookingRequest.requestId, completeReqId))
+    expect(done.status).toBe('COMPLETED')
+  })
+})

--- a/tutorme-app/src/__tests__/integration/one-on-one-refund.test.ts
+++ b/tutorme-app/src/__tests__/integration/one-on-one-refund.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration test: series refund is a single, correct refund.
+ *
+ * A recurring series is paid in ONE transaction (amount = Σ costPerSession) keyed
+ * to the head request. Cancelling refunds that one payment once — 85% (a 15% fee
+ * retained) — and a second attempt refunds nothing (no over-refund).
+ *
+ * The payment gateway is mocked; the DB is real. Requires DATABASE_URL (setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray } from 'drizzle-orm'
+
+vi.mock('@/lib/payments/factory', () => ({
+  getPaymentGateway: () => ({
+    refundPayment: async () => ({ refundId: 'gw-refund-test', status: 'COMPLETED' }),
+  }),
+}))
+
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, payment, refund } from '@/lib/db/schema'
+import { refundPaidOneOnOne, computeOneOnOneRefund } from '@/lib/payments/refund-one-on-one'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const studentId = crypto.randomUUID()
+const userIds = [tutorId, studentId]
+const headRequestId = `oo_refund_${stamp}`
+const paymentId = `pay_${stamp}`
+const SERIES_TOTAL = 135 // 3 × 45
+
+describe('series refund', () => {
+  beforeAll(async () => {
+    await drizzleDb.insert(user).values([
+      {
+        userId: tutorId,
+        email: `rf-tutor-${stamp}@ex.com`,
+        role: 'TUTOR',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: studentId,
+        email: `rf-stu-${stamp}@ex.com`,
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ])
+    // One payment covering the whole series, keyed to the head request.
+    await drizzleDb.insert(payment).values({
+      paymentId,
+      amount: SERIES_TOTAL,
+      currency: 'USD',
+      status: 'COMPLETED',
+      gateway: 'HITPAY',
+      tutorId,
+      gatewayPaymentId: 'gw_pay_123',
+      metadata: { type: 'one-on-one', requestId: headRequestId, seriesId: `series_${stamp}` },
+    })
+  })
+
+  afterAll(async () => {
+    await drizzleDb.delete(refund).where(eq(refund.paymentId, paymentId))
+    await drizzleDb.delete(payment).where(eq(payment.paymentId, paymentId))
+    await drizzleDb.delete(user).where(inArray(user.userId, userIds))
+  })
+
+  it('refunds the whole series once (85%), then nothing on a repeat', async () => {
+    const expected = computeOneOnOneRefund(SERIES_TOTAL) // { amount: 114.75, fee: 20.25 }
+
+    const first = await refundPaidOneOnOne(headRequestId, 'Cancelled by student')
+    expect(first.refunded).toBe(true)
+    expect(first.amount).toBe(expected.amount)
+    expect(first.fee).toBe(expected.fee)
+
+    // Exactly one refund row, and the payment is now REFUNDED.
+    const refundRows = await drizzleDb.select().from(refund).where(eq(refund.paymentId, paymentId))
+    expect(refundRows).toHaveLength(1)
+    expect(refundRows[0].amount).toBe(expected.amount)
+
+    const [pay] = await drizzleDb
+      .select({ status: payment.status })
+      .from(payment)
+      .where(eq(payment.paymentId, paymentId))
+    expect(pay.status).toBe('REFUNDED')
+
+    // A second cancel finds no COMPLETED payment → no over-refund.
+    const second = await refundPaidOneOnOne(headRequestId, 'Cancelled by student')
+    expect(second.refunded).toBe(false)
+    const stillOne = await drizzleDb.select().from(refund).where(eq(refund.paymentId, paymentId))
+    expect(stillOne).toHaveLength(1)
+  })
+})

--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -16,6 +16,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Loader2, ArrowLeft, Video, CalendarClock } from 'lucide-react'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
+import { formatCountdown } from '@/lib/one-on-one/format'
 
 type Phase = 'checking' | 'lobby' | 'joining' | 'inRoom' | 'ended' | 'error'
 
@@ -37,15 +38,6 @@ interface VideoInfo {
 
 const EARLY_ENTRY_MS = 20 * 60 * 1000
 const LOBBY_POLL_MS = 20_000
-
-function countdown(toMs: number, now: number): string {
-  const s = Math.max(0, Math.round((toMs - now) / 1000))
-  const h = Math.floor(s / 3600)
-  const m = Math.floor((s % 3600) / 60)
-  const sec = s % 60
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
-}
 
 export default function OneOnOneCallPage() {
   const { data: session } = useSession()
@@ -210,7 +202,7 @@ export default function OneOnOneCallPage() {
               {now && Number.isFinite(startMs) && now >= startMs ? 'Room opens in' : 'Starts in'}
             </p>
             <p className="mt-1 font-mono text-3xl font-bold tabular-nums text-white">
-              {now && Number.isFinite(opensAtMs) ? countdown(opensAtMs, now) : '—:—'}
+              {now && Number.isFinite(opensAtMs) ? formatCountdown(opensAtMs, now) : '—:—'}
             </p>
             {startLabel ? <p className="mt-2 text-xs text-white/50">{startLabel}</p> : null}
           </div>

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { eq, and, or, inArray, isNull } from 'drizzle-orm'
+import { eq, and, or, inArray } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, profile, user } from '@/lib/db/schema'
 import { notify } from '@/lib/notifications/notify'
@@ -19,6 +19,7 @@ import { getOrCreateConversation } from '@/lib/messaging/conversation'
 import { findConflicts } from '@/lib/schedule/conflicts'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
+import { unpaidSeriesTotal } from '@/lib/one-on-one/series-total'
 import {
   isSlotWithinStudentAvailability,
   studentHasAvailabilityConfigured,
@@ -269,20 +270,10 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     let seriesCount = 1
     let seriesTotal = Number(requestRow.costPerSession || 0)
     if (requestRow.seriesId) {
-      const seriesRows = await drizzleDb
-        .select({ costPerSession: oneOnOneBookingRequest.costPerSession })
-        .from(oneOnOneBookingRequest)
-        .where(
-          and(
-            eq(oneOnOneBookingRequest.seriesId, requestRow.seriesId),
-            eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
-            isNull(oneOnOneBookingRequest.paidAt)
-          )
-        )
-      if (seriesRows.length > 0) {
-        seriesCount = seriesRows.length
-        seriesTotal =
-          Math.round(seriesRows.reduce((s, r) => s + Number(r.costPerSession || 0), 0) * 100) / 100
+      const series = await unpaidSeriesTotal(requestRow.seriesId)
+      if (series.count > 0) {
+        seriesCount = series.count
+        seriesTotal = series.total
       }
     }
 

--- a/tutorme-app/src/app/api/payments/create/route.ts
+++ b/tutorme-app/src/app/api/payments/create/route.ts
@@ -26,7 +26,8 @@ import {
   groupSessionParticipant,
 } from '@/lib/db/schema'
 import { getPaymentGateway, type GatewayName } from '@/lib/payments'
-import { eq, and, sql, isNull } from 'drizzle-orm'
+import { eq, and, sql } from 'drizzle-orm'
+import { unpaidSeriesTotal } from '@/lib/one-on-one/series-total'
 import { z } from 'zod'
 import { createHash } from 'crypto'
 
@@ -253,22 +254,8 @@ export const POST = withCsrf(
       const seriesId = requestRow.request.seriesId
       let amount = Number(requestRow.request.costPerSession || 0)
       if (seriesId) {
-        const seriesRows = await drizzleDb
-          .select({ costPerSession: oneOnOneBookingRequest.costPerSession })
-          .from(oneOnOneBookingRequest)
-          .where(
-            and(
-              eq(oneOnOneBookingRequest.seriesId, seriesId),
-              eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
-              isNull(oneOnOneBookingRequest.paidAt)
-            )
-          )
-        if (seriesRows.length > 0) {
-          amount =
-            Math.round(
-              seriesRows.reduce((sum, r) => sum + Number(r.costPerSession || 0), 0) * 100
-            ) / 100
-        }
+        const series = await unpaidSeriesTotal(seriesId)
+        if (series.count > 0) amount = series.total
       }
       if (amount <= 0) {
         throw new ValidationError('Invalid payment amount')

--- a/tutorme-app/src/components/communications/student-requests-panel.tsx
+++ b/tutorme-app/src/components/communications/student-requests-panel.tsx
@@ -7,22 +7,17 @@ import { toast } from 'sonner'
 import { Loader2, CalendarClock, Video, Star } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
-import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
+import {
+  resolveOneOnOneSession,
+  joinableRequestId,
+  latestCompletedRequestId,
+} from '@/lib/one-on-one/enter-classroom'
 import { OneOnOneReviewDialog } from '@/components/booking/one-on-one-review-dialog'
 import {
   OneOnOneRequestCard,
   groupIntoSeries,
   type OneOnOneRequestSummary,
 } from '@/components/one-on-one/one-on-one-request-card'
-
-/** The most recent COMPLETED session in a group — the one a "Rate" click reviews. */
-function latestCompletedRequestId(members: OneOnOneRequestSummary[]): string | null {
-  const completed = members.filter(m => (m.status || '').toUpperCase() === 'COMPLETED')
-  if (completed.length === 0) return null
-  return completed.reduce((a, b) =>
-    new Date(a.requestedDate).getTime() >= new Date(b.requestedDate).getTime() ? a : b
-  ).requestId
-}
 
 /**
  * A student's own 1-on-1 booking requests (the `role=sent` view). Renders the

--- a/tutorme-app/src/components/one-on-one/session-launcher.tsx
+++ b/tutorme-app/src/components/one-on-one/session-launcher.tsx
@@ -17,6 +17,7 @@ import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Video, X } from 'lucide-react'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
+import { formatCountdown } from '@/lib/one-on-one/format'
 
 interface LiveSession {
   sessionId: string
@@ -30,15 +31,6 @@ interface LiveSession {
 
 const EARLY_ENTRY_MS = 20 * 60 * 1000
 const POLL_MS = 45_000
-
-function countdown(toMs: number, now: number): string {
-  const s = Math.max(0, Math.round((toMs - now) / 1000))
-  const h = Math.floor(s / 3600)
-  const m = Math.floor((s % 3600) / 60)
-  const sec = s % 60
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
-}
 
 export function SessionLauncher() {
   const { status } = useSession()
@@ -111,7 +103,7 @@ export function SessionLauncher() {
             ) : joinable ? (
               <span className="font-medium text-blue-300">Ready to join</span>
             ) : (
-              <>Starts in {countdown(start, now)}</>
+              <>Starts in {formatCountdown(start, now)}</>
             )}
           </p>
         </div>
@@ -126,7 +118,7 @@ export function SessionLauncher() {
           </button>
         ) : (
           <span className="shrink-0 rounded-xl bg-white/10 px-3 py-2 text-xs font-medium text-white/70">
-            Opens in {countdown(opensAt, now)}
+            Opens in {formatCountdown(opensAt, now)}
           </span>
         )}
 

--- a/tutorme-app/src/lib/one-on-one/enter-classroom.test.ts
+++ b/tutorme-app/src/lib/one-on-one/enter-classroom.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { joinableRequestId, latestCompletedRequestId } from './enter-classroom'
+import type { OneOnOneRequestSummary } from '@/components/one-on-one/one-on-one-request-card'
+
+const NOW = new Date('2026-07-20T12:00:00.000Z').getTime()
+
+function req(o: Partial<OneOnOneRequestSummary> & { requestId: string }): OneOnOneRequestSummary {
+  return {
+    requestedDate: '2026-07-20T00:00:00.000Z',
+    startTime: '15:00',
+    endTime: '16:00',
+    timezone: 'UTC',
+    costPerSession: 45,
+    status: 'PAID',
+    ...o,
+  }
+}
+
+describe('joinableRequestId', () => {
+  it('returns null when no member is paid', () => {
+    const members = [
+      req({ requestId: 'a', status: 'ACCEPTED' }),
+      req({ requestId: 'b', status: 'PENDING' }),
+    ]
+    expect(joinableRequestId(members, NOW)).toBeNull()
+  })
+
+  it('picks the upcoming paid session over a past one', () => {
+    const members = [
+      req({ requestId: 'past', requestedDate: '2026-07-13T00:00:00.000Z' }),
+      req({ requestId: 'next', requestedDate: '2026-07-27T00:00:00.000Z' }),
+    ]
+    expect(joinableRequestId(members, NOW)).toBe('next')
+  })
+
+  it('treats today as still joinable (24h grace)', () => {
+    const members = [req({ requestId: 'today', requestedDate: '2026-07-20T00:00:00.000Z' })]
+    expect(joinableRequestId(members, NOW)).toBe('today')
+  })
+
+  it('falls back to the most recent past session when all are past', () => {
+    const members = [
+      req({ requestId: 'older', requestedDate: '2026-07-10T00:00:00.000Z' }),
+      req({ requestId: 'recent', requestedDate: '2026-07-15T00:00:00.000Z' }),
+    ]
+    expect(joinableRequestId(members, NOW)).toBe('recent')
+  })
+
+  it('ignores non-paid members when choosing', () => {
+    const members = [
+      req({
+        requestId: 'unpaid-future',
+        status: 'ACCEPTED',
+        requestedDate: '2026-07-25T00:00:00.000Z',
+      }),
+      req({ requestId: 'paid-future', status: 'PAID', requestedDate: '2026-07-27T00:00:00.000Z' }),
+    ]
+    expect(joinableRequestId(members, NOW)).toBe('paid-future')
+  })
+})
+
+describe('latestCompletedRequestId', () => {
+  it('returns null when nothing is completed', () => {
+    expect(latestCompletedRequestId([req({ requestId: 'a', status: 'PAID' })])).toBeNull()
+  })
+
+  it('returns the most recent completed session', () => {
+    const members = [
+      req({ requestId: 'w1', status: 'COMPLETED', requestedDate: '2026-07-06T00:00:00.000Z' }),
+      req({ requestId: 'w2', status: 'COMPLETED', requestedDate: '2026-07-13T00:00:00.000Z' }),
+      req({ requestId: 'w3-upcoming', status: 'PAID', requestedDate: '2026-07-20T00:00:00.000Z' }),
+    ]
+    expect(latestCompletedRequestId(members)).toBe('w2')
+  })
+})

--- a/tutorme-app/src/lib/one-on-one/enter-classroom.ts
+++ b/tutorme-app/src/lib/one-on-one/enter-classroom.ts
@@ -49,3 +49,15 @@ export function joinableRequestId(
   const upcoming = byDate.find(m => new Date(m.requestedDate).getTime() + GRACE_MS >= now)
   return (upcoming ?? byDate[byDate.length - 1]).requestId
 }
+
+/**
+ * The most recent COMPLETED session in a group — the one a "Rate" click reviews.
+ * Returns null when none are completed.
+ */
+export function latestCompletedRequestId(members: OneOnOneRequestSummary[]): string | null {
+  const completed = members.filter(m => (m.status || '').toUpperCase() === 'COMPLETED')
+  if (completed.length === 0) return null
+  return completed.reduce((a, b) =>
+    new Date(a.requestedDate).getTime() >= new Date(b.requestedDate).getTime() ? a : b
+  ).requestId
+}

--- a/tutorme-app/src/lib/one-on-one/format.test.ts
+++ b/tutorme-app/src/lib/one-on-one/format.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { formatCountdown } from './format'
+
+describe('formatCountdown', () => {
+  const now = 1_000_000_000_000
+
+  it('formats sub-hour durations as MM:SS', () => {
+    expect(formatCountdown(now + 90_000, now)).toBe('01:30')
+    expect(formatCountdown(now + 5_000, now)).toBe('00:05')
+    expect(formatCountdown(now + 59 * 60_000 + 59_000, now)).toBe('59:59')
+  })
+
+  it('formats hour-plus durations as H:MM:SS', () => {
+    expect(formatCountdown(now + 60 * 60_000, now)).toBe('1:00:00')
+    expect(formatCountdown(now + (2 * 3600 + 3 * 60 + 4) * 1000, now)).toBe('2:03:04')
+  })
+
+  it('clamps a past target to zero', () => {
+    expect(formatCountdown(now - 5_000, now)).toBe('00:00')
+    expect(formatCountdown(now, now)).toBe('00:00')
+  })
+})

--- a/tutorme-app/src/lib/one-on-one/format.ts
+++ b/tutorme-app/src/lib/one-on-one/format.ts
@@ -1,0 +1,10 @@
+/** Format the time remaining until `toMs` (measured from `now`) as `H:MM:SS`
+ *  (when an hour or more away) or `MM:SS`. Never negative — clamps to `0:00`. */
+export function formatCountdown(toMs: number, now: number): string {
+  const s = Math.max(0, Math.round((toMs - now) / 1000))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`
+}

--- a/tutorme-app/src/lib/one-on-one/series-total.ts
+++ b/tutorme-app/src/lib/one-on-one/series-total.ts
@@ -1,0 +1,27 @@
+import { and, eq, isNull } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { oneOnOneBookingRequest } from '@/lib/db/schema'
+
+/**
+ * The amount a single payment covers for a recurring series: the sum of every
+ * ACCEPTED, still-unpaid session in it. Shared by the payment-create route (the
+ * charge) and the request GET (the price the payment page shows), so the two can
+ * never disagree. `total` is rounded to cents; `count` is how many sessions.
+ */
+export async function unpaidSeriesTotal(
+  seriesId: string
+): Promise<{ count: number; total: number }> {
+  const rows = await drizzleDb
+    .select({ costPerSession: oneOnOneBookingRequest.costPerSession })
+    .from(oneOnOneBookingRequest)
+    .where(
+      and(
+        eq(oneOnOneBookingRequest.seriesId, seriesId),
+        eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
+        isNull(oneOnOneBookingRequest.paidAt)
+      )
+    )
+  const total =
+    Math.round(rows.reduce((sum, r) => sum + Number(r.costPerSession || 0), 0) * 100) / 100
+  return { count: rows.length, total }
+}


### PR DESCRIPTION
Adds the test coverage the 1-on-1 lifecycle was missing (previously only `groupIntoSeries` was tested), with three small **behaviour-preserving refactors** that remove duplication and make the logic testable.

### Refactors
- **`unpaidSeriesTotal(seriesId)`** — the series-payment sum, now shared by `payments/create` (the charge) and the request `GET` (the price the payment page shows), so the two can't drift.
- **`formatCountdown()`** — one countdown formatter shared by the launcher + lobby (was duplicated).
- **`latestCompletedRequestId()`** — moved out of the panel into `enter-classroom` so it's unit-testable.

### Unit tests (run in `npm run test`)
- `formatCountdown` (MM:SS / H:MM:SS / clamps past → `00:00`).
- `joinableRequestId` + `latestCompletedRequestId` (next-upcoming vs past, non-paid filtering, 24h grace).

### Integration tests (`npm run test:integration`, Postgres) — **verified locally against a real DB**
- `unpaidSeriesTotal` sums the ACCEPTED unpaid series (3 × 45 = **135**).
- **expire**: an overdue unpaid hold → `EXPIRED` + its calendar event cancelled; a series with no payment window is left untouched.
- **complete**: a paid, finished session → `COMPLETED`.
- **refund**: a series refund is **one** 85% refund (15% fee), and a repeat refunds **nothing** (no over-refund).

typecheck · lint · **606** unit tests · production build — all clean. Integration suite run green against a local Postgres (`drizzle-kit push` schema).