### PR TITLE
fix(docs): make document display URLs durable (never expire)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/SourceDocumentPreview.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/SourceDocumentPreview.tsx
@@ -1,19 +1,14 @@
 import { FileText } from 'lucide-react'
+import { resolveDocDisplayUrl } from '@/lib/storage/doc-url'
 
 export interface ImportedLearningResource {
   fileName: string
   mimeType: string
   fileUrl: string
+  /** Durable GCS object key; when absent the key is recovered from fileUrl. */
+  fileKey?: string
   extractedText?: string
   uploadedAt: string
-}
-
-function getProxiedFileUrl(fileUrl: string): string {
-  // Proxy external URLs so the server can refresh expired GCS signatures
-  if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
-    return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
-  }
-  return fileUrl
 }
 
 export function SourceDocumentPreview({
@@ -23,7 +18,9 @@ export function SourceDocumentPreview({
 }) {
   if (!sourceDocument) return null
 
-  const proxiedUrl = getProxiedFileUrl(sourceDocument.fileUrl)
+  // Durable same-origin URL — streams by key (no signed URL, never expires),
+  // recovering the key from fileUrl when none was persisted. See resolveDocDisplayUrl.
+  const proxiedUrl = resolveDocDisplayUrl(sourceDocument)
 
   if (sourceDocument.mimeType === 'application/pdf') {
     return (

--- a/tutorme-app/src/app/api/proxy-file/route.ts
+++ b/tutorme-app/src/app/api/proxy-file/route.ts
@@ -114,7 +114,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   if (objectKey) {
     // Restrict to known upload prefixes and block path traversal so this can't
     // be used to read arbitrary objects.
-    if (!/^(documents|assets|resources)\//.test(objectKey) || objectKey.includes('..')) {
+    if (!/^(documents|assets|resources|messages)\//.test(objectKey) || objectKey.includes('..')) {
       return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
     }
     if (!isGcsConfigured()) {

--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { resolvePublicUrl } from '@/lib/utils'
 import { FileText, ImageIcon } from 'lucide-react'
 import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
+import { resolveDocDisplayUrl, isDocDisplayable } from '@/lib/storage/doc-url'
 import { cn } from '@/lib/utils'
 
 export type ChatMessageSender = 'tutor' | 'ai' | 'student'
@@ -54,11 +55,9 @@ export function ChatMessageBubble({
   const documentCard = (() => {
     if (!isDocument || !document) return null
     const rawUrl = document.fileUrl || ''
-    const docUrl = document.fileKey
-      ? `/api/proxy-file?key=${encodeURIComponent(document.fileKey)}`
-      : rawUrl
-    const loadable =
-      !!document.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:') && rawUrl.length > 0)
+    // Durable same-origin URL (streams by key, no expiry). See resolveDocDisplayUrl.
+    const docUrl = resolveDocDisplayUrl(document)
+    const loadable = isDocDisplayable(document)
     const docName = document.fileName || 'Task document'
     const isPdf =
       document.mimeType === 'application/pdf' ||

--- a/tutorme-app/src/components/pdf/PDFThumbnail.tsx
+++ b/tutorme-app/src/components/pdf/PDFThumbnail.tsx
@@ -5,6 +5,8 @@ import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 
+import { resolveDocDisplayUrl } from '@/lib/storage/doc-url'
+
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs'
 
 interface PDFThumbnailProps {
@@ -17,13 +19,9 @@ interface PDFThumbnailProps {
 }
 
 function getProxiedPdfUrl(fileUrl: string, fileKey?: string): string {
-  if (fileKey && /^(documents|assets|resources)\//.test(fileKey)) {
-    return `/api/proxy-file?key=${encodeURIComponent(fileKey)}`
-  }
-  if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
-    return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
-  }
-  return fileUrl
+  // Durable same-origin URL (streams by key, recovers key from a stored GCS URL
+  // when no fileKey was persisted). See resolveDocDisplayUrl.
+  return resolveDocDisplayUrl({ fileUrl, fileKey })
 }
 
 export function PDFThumbnail({

--- a/tutorme-app/src/components/pdf/PDFViewer.tsx
+++ b/tutorme-app/src/components/pdf/PDFViewer.tsx
@@ -5,6 +5,7 @@ import { Document, Page, pdfjs } from 'react-pdf'
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 import { FloatingZoomPill } from './FloatingZoomPill'
+import { resolveDocDisplayUrl } from '@/lib/storage/doc-url'
 import { cn } from '@/lib/utils'
 
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs'
@@ -27,17 +28,11 @@ interface PDFViewerProps {
 }
 
 function getProxiedPdfUrl(fileUrl: string, fileKey?: string): string {
-  // Prefer by-key: the server streams the object using the service account's
-  // read access, so an expired/unsignable URL on an old document no longer
-  // breaks loading. Only known upload prefixes are allowed by the proxy.
-  if (fileKey && /^(documents|assets|resources)\//.test(fileKey)) {
-    return `/api/proxy-file?key=${encodeURIComponent(fileKey)}`
-  }
-  // Otherwise use the proxy for external URLs so the server can refresh expired GCS signatures
-  if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
-    return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
-  }
-  return fileUrl
+  // Resolve to a durable same-origin URL — streams by object key (via the
+  // service account, no signed URL), recovering the key from the stored URL when
+  // no fileKey was persisted, so old documents still load after their signature
+  // expires. See resolveDocDisplayUrl.
+  return resolveDocDisplayUrl({ fileUrl, fileKey })
 }
 
 export function PDFViewer({

--- a/tutorme-app/src/components/task/TaskDocumentCard.tsx
+++ b/tutorme-app/src/components/task/TaskDocumentCard.tsx
@@ -17,6 +17,7 @@
 import { useId, useState } from 'react'
 import { FileText, ChevronDown, ChevronRight } from 'lucide-react'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
+import { resolveDocDisplayUrl, isDocDisplayable } from '@/lib/storage/doc-url'
 import { cn } from '@/lib/utils'
 
 export interface TaskDocumentSource {
@@ -54,16 +55,13 @@ export function TaskDocumentCard({
   if (!sourceDocument) return null
 
   const rawUrl = sourceDocument.fileUrl || ''
-  // Prefer streaming by object key through our same-origin proxy: it reads from
-  // storage server-side (no signed/public URL needed), so it works even when GCS
-  // URL signing is misconfigured or a stored URL has expired. Fall back to the
-  // direct URL only when there's no key.
-  const url = sourceDocument.fileKey
-    ? `/api/proxy-file?key=${encodeURIComponent(sourceDocument.fileKey)}`
-    : rawUrl
-  // Without a key, a blob: URL only resolves in the tutor's browser and an empty
-  // URL never reached storage — those are unavailable to the viewer.
-  const loadable = !!sourceDocument.fileKey || (!!rawUrl && !rawUrl.startsWith('blob:'))
+  // Always resolve to a durable same-origin URL: streams by object key through
+  // our proxy (no signed/public URL, so it never expires), recovering the key
+  // from the stored URL when no fileKey was persisted. See resolveDocDisplayUrl.
+  const url = resolveDocDisplayUrl(sourceDocument)
+  // A blob: URL only resolves in the uploader's browser and an empty URL never
+  // reached storage — those are unavailable to the viewer.
+  const loadable = isDocDisplayable(sourceDocument)
   const name = sourceDocument.fileName || 'Task document'
   const isPdf =
     sourceDocument.mimeType === 'application/pdf' ||

--- a/tutorme-app/src/lib/storage/doc-url.ts
+++ b/tutorme-app/src/lib/storage/doc-url.ts
@@ -1,0 +1,112 @@
+/**
+ * Durable document URL resolution — client-safe (no server-only imports, so it
+ * can run in browser components).
+ *
+ * Stored documents must NEVER be displayed via a raw GCS signed URL: those carry
+ * a TTL and die (users see "document unavailable" days later). Instead every doc
+ * is served through the same-origin by-key proxy (`/api/proxy-file?key=…`), which
+ * streams the object with the service account's read access — no signature, no
+ * expiry.
+ *
+ * The important trick: we can serve by key even when a `fileKey` was never
+ * persisted, by recovering the object key from a path-style GCS URL. That makes
+ * legacy documents (uploaded before `fileKey` was stored) durable without any
+ * data backfill.
+ *
+ * Keep this file free of `@google-cloud/storage` / node imports.
+ */
+
+/** Object-key prefixes the by-key proxy is allowed to stream (mirror of the
+ *  allowlist in src/app/api/proxy-file/route.ts). */
+export const PROXYABLE_KEY_PREFIXES = ['documents', 'assets', 'resources', 'messages'] as const
+
+const PROXYABLE_KEY_RE = new RegExp(`^(?:${PROXYABLE_KEY_PREFIXES.join('|')})/`)
+
+/** True when `key` is a safe, proxyable object key (known prefix, no traversal). */
+export function isProxyableKey(key: string | null | undefined): key is string {
+  return (
+    typeof key === 'string' && key.length > 0 && !key.includes('..') && PROXYABLE_KEY_RE.test(key)
+  )
+}
+
+/**
+ * Recover the GCS object key from a path-style public/presigned GCS URL
+ * (`https://storage.googleapis.com/<bucket>/<key>?…`). Query params (the
+ * signature) are dropped. Returns null for any non-GCS or virtual-hosted URL.
+ *
+ * Mirror of extractGcsKeyFromPublicUrl in src/lib/storage/gcs.ts — duplicated
+ * here so this module stays client-safe.
+ */
+export function extractStorageKeyFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'storage.googleapis.com') return null
+    const pathParts = parsed.pathname.split('/').filter(Boolean)
+    if (pathParts.length < 2) return null
+    return pathParts.slice(1).join('/') // drop the bucket segment
+  } catch {
+    return null
+  }
+}
+
+export interface DocSource {
+  fileUrl?: string | null
+  fileKey?: string | null
+}
+
+/**
+ * Resolve a document to a durable, same-origin display URL.
+ *
+ * Order of preference:
+ *  1. Stored `fileKey`      → `/api/proxy-file?key=…`   (durable, no expiry)
+ *  2. Key recovered from a  → `/api/proxy-file?key=…`   (durable; rescues docs
+ *     path-style GCS URL                                  saved without a key)
+ *  3. Already a same-origin proxy / API URL → returned unchanged (already durable)
+ *  4. Foreign http(s) URL   → `/api/proxy-file?url=…`   (server re-signs GCS /
+ *                                                         streams; best effort)
+ *  5. blob:/data:/relative  → returned unchanged (transient or already local)
+ *
+ * Returns '' when there is nothing displayable.
+ */
+export function resolveDocDisplayUrl(source: DocSource | null | undefined): string {
+  if (!source) return ''
+  const fileKey = source.fileKey ?? undefined
+  const fileUrl = source.fileUrl ?? ''
+
+  // 1. Stored key.
+  if (isProxyableKey(fileKey)) {
+    return `/api/proxy-file?key=${encodeURIComponent(fileKey)}`
+  }
+
+  if (!fileUrl) return ''
+
+  // 5a. Already same-origin (proxy, serve-upload, or any relative URL) — durable
+  //     or local already; don't wrap it again.
+  if (fileUrl.startsWith('/')) return fileUrl
+  // 5b. Transient client-only URLs — only resolve in the uploader's own browser.
+  if (fileUrl.startsWith('blob:') || fileUrl.startsWith('data:')) return fileUrl
+
+  if (fileUrl.startsWith('http://') || fileUrl.startsWith('https://')) {
+    // 2. Recover the key from a path-style GCS URL → stream by key (durable).
+    const recovered = extractStorageKeyFromUrl(fileUrl)
+    if (isProxyableKey(recovered)) {
+      return `/api/proxy-file?key=${encodeURIComponent(recovered)}`
+    }
+    // 4. Foreign URL — let the server refresh/stream it.
+    return `/api/proxy-file?url=${encodeURIComponent(fileUrl)}`
+  }
+
+  return fileUrl
+}
+
+/**
+ * Whether a document can actually be shown to a viewer other than its uploader.
+ * A blob:/data: URL only resolves in the browser that created it, and an empty
+ * URL never reached storage — both are unavailable elsewhere.
+ */
+export function isDocDisplayable(source: DocSource | null | undefined): boolean {
+  if (!source) return false
+  if (isProxyableKey(source.fileKey ?? undefined)) return true
+  const url = source.fileUrl ?? ''
+  return url.length > 0 && !url.startsWith('blob:') && !url.startsWith('data:')
+}


### PR DESCRIPTION
## Problem
Users report uploaded documents stop loading — "document unavailable" — days after upload.

**Root cause:** display components prefer the durable by-key proxy (`/api/proxy-file?key=…`, service-account read, no TTL) **only when a `fileKey` is stored.** When it isn't, they fall back to the raw GCS **signed URL**, which expires (≤7 days). Keyless cases are common:
- legacy `courseLesson.builderData` / `DeployedMaterial.content` docs saved before `fileKey` was captured
- the `ImportedLearningResource` type had **no `fileKey` field at all**
- `TaskDocumentCard` images & generic files used the raw URL even when a key existed

## Fix
One client-safe resolver — `src/lib/storage/doc-url.ts` `resolveDocDisplayUrl()` — that **always** returns a durable same-origin URL:

1. `fileKey` present → `/api/proxy-file?key=…` (durable)
2. no key, but URL is `storage.googleapis.com/<bucket>/<key>` → **recover the key from the path** → `/api/proxy-file?key=…` — *this makes legacy docs durable with no data backfill*
3. same-origin/relative or existing proxy URL → unchanged
4. foreign http(s) → `/api/proxy-file?url=…` (server re-signs/streams; best effort)
5. `blob:`/`data:` → unchanged (transient, uploader-only)

Routed **every** document render through it: `TaskDocumentCard` (incl. images + generic files), `PDFViewer`, `PDFThumbnail`, `chat-message-bubble`, `SourceDocumentPreview`. Added `messages/` to the by-key proxy allowlist so recovered chat-attachment keys stream too.

No signed URL is ever handed to the browser for a doc with a recoverable key → **it can't expire.**

## Verification
- Resolver logic **10/10** incl. the key case: *no fileKey + expired signature → recovers key → durable by-key proxy*
- `npm run typecheck` clean; lint 0 errors (1 pre-existing `any` warning untouched)
- ⚠️ Full browser render of a real GCS-backed doc not exercised locally (needs a real bucket + auth session; I don't pull prod creds for this). Best confirmed on staging with an old document that was previously expiring.

## Notes / follow-ups (not in this PR)
- Truly unrecoverable docs remain only where the stored URL is **neither** a path-style GCS URL **nor** has a key (foreign/virtual-hosted signed URLs). A read-only audit script exists (`src/scripts/audit-expiring-doc-urls.ts`) to count those against prod.
- Optional belt-and-suspenders: tighten writers to always persist `fileKey` (most already do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)