### PR TITLE
fix(dmi): stop source-chooser ↔ format-chooser loop for edited-text assessments

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1428,6 +1428,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [dmiSourceDialog, setDmiSourceDialog] = useState<{
       type: 'task' | 'assessment'
     } | null>(null)
+    // The tutor's content-source pick has to survive the whole DMI resolve chain
+    // (source → format → kind → spec), every stage of which re-invokes
+    // handleGenerateDMI. Threading it as a param alone fails: each downstream
+    // dialog handler drops the arg, which re-opens the source chooser in an
+    // endless loop. So we hold it in a ref and reset it only when a fresh,
+    // user-initiated generate begins.
+    const dmiContentSourceRef = useRef<'document' | 'text' | null>(null)
     const [mcqConfigDialog, setMcqConfigDialog] = useState<{
       type: 'task' | 'assessment'
     } | null>(null)
@@ -3445,12 +3452,20 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       const docExtractedText = normalizeText(sourceDoc?.extractedText || '')
       const typedText = normalizeText(content)
       const sourcesDisagree = !!hasPdf && typedText.length > 0 && typedText !== docExtractedText
-      if (sourcesDisagree && !contentSourceOverride) {
+      // A fresh, user-initiated generate (no in-flight dialog choices) clears any
+      // remembered pick so a stale source can't leak into the new run. Every
+      // downstream re-invocation carries a spec/kind/skip/source arg, so it keeps
+      // the pick alive through the rest of the chain.
+      if (!questionSpec && !documentKindOverride && !skipFormatPrompt && !contentSourceOverride) {
+        dmiContentSourceRef.current = null
+      }
+      const contentSource = contentSourceOverride ?? dmiContentSourceRef.current ?? undefined
+      if (sourcesDisagree && !contentSource) {
         setDmiSourceDialog({ type })
         return
       }
       // 'text' → generate from the typed text and skip the PDF file entirely.
-      const effectiveHasPdf = hasPdf && contentSourceOverride !== 'text'
+      const effectiveHasPdf = hasPdf && contentSource !== 'text'
 
       // Assessment: choose the response format BEFORE spending any LLM tokens.
       // A multiple-choice paper doesn't need the AI to read it — the tutor
@@ -3736,11 +3751,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const handleChooseDmiDocument = () => {
       const type = dmiSourceDialog?.type
       setDmiSourceDialog(null)
+      dmiContentSourceRef.current = 'document'
       if (type) void handleGenerateDMI(type, undefined, undefined, false, 'document')
     }
     const handleChooseDmiTypedText = () => {
       const type = dmiSourceDialog?.type
       setDmiSourceDialog(null)
+      dmiContentSourceRef.current = 'text'
       if (type) void handleGenerateDMI(type, undefined, undefined, false, 'text')
     }
 


### PR DESCRIPTION
## Regression (introduced by #1028)
The content-source chooser fires **before** the format chooser (correct), but the pick was passed only as a function argument. The assessment resolve chain has multiple sequential dialogs — **source → format → kind-confirm → question-spec** — and each downstream handler re-invokes `handleGenerateDMI` **without** the source argument. The source gate is first and re-fires whenever the override is absent, so:

`source → format → source → format → …` **infinite loop.**

Impact: an assessment with a **PDF attached AND its text box edited** to differ from the PDF's extraction — precisely the ambiguity #1028 set out to resolve — could **never complete DMI generation**. (Unedited text never disagrees, so this only bites the edited case; tasks skip the format gate and were never looping.)

## Fix
Persist the tutor's source pick in a `ref` that survives the entire resolve chain, and reset it only when a **fresh, user-initiated** generate begins (all dialog args absent). The gate reads `contentSourceOverride ?? ref`, so every downstream re-invocation keeps the pick and the chooser appears **exactly once**.

Traced clean for: free-response (question_paper), study-material + question-spec, MCQ (ref reset next run), unedited text (no prompt), and tasks.

Guardrail-safe: only affects which tutor-provided content is selected; the generate-dmi route still injects the assessment system prompt + guardrails.

## Verification
Prettier clean (repo's pinned version). 19/-2 lines, one file. Typecheck/Build via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)