### PR TITLE
test(dmi): extract the Generate-DMI dialog gate into a tested pure helper

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -210,6 +210,7 @@ import { toStudentDmiItem } from '@/lib/assessment/student-dmi'
 import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
 import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
 import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
+import { nextDmiGate } from '@/lib/assessment/dmi-generate-gate'
 import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
@@ -3456,26 +3457,28 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         dmiContentSourceRef.current = null
       }
 
-      // Assessment: choose the response format BEFORE spending any LLM tokens.
-      // A multiple-choice paper doesn't need the AI to read it — the tutor
-      // configures sections + counts and we build the DMI locally. Free-response
-      // uses the AI flow. (Re-runs that already carry a spec/override or the
-      // explicit skip flag bypass this.)
-      if (type === 'assessment' && !questionSpec && !documentKindOverride && !skipFormatPrompt) {
+      // Route the pre-generation dialog chain via the tested pure gate. Format
+      // BEFORE source: a multiple-choice paper is built locally and never reads
+      // the content, so it returns at the format step and is never asked which
+      // source to use. Free-response then asks the source chooser only when a PDF
+      // is attached AND the text box was edited away from the document's own
+      // extraction (the two genuinely disagree) and no pick has been made yet.
+      // The pick persists in a ref across the rest of the resolve chain
+      // (kind → spec). See dmi-generate-gate.ts + its tests for the invariants.
+      const contentSource = contentSourceOverride ?? dmiContentSourceRef.current ?? undefined
+      const dmiGate = nextDmiGate({
+        type,
+        hasQuestionSpec: !!questionSpec,
+        hasDocumentKindOverride: !!documentKindOverride,
+        skipFormatPrompt: !!skipFormatPrompt,
+        contentSource,
+        sourcesDisagree,
+      })
+      if (dmiGate === 'format') {
         setDmiFormatDialog({ type })
         return
       }
-
-      // Content-source chooser — reached only on the free-response / AI path.
-      // Multiple-choice returns at the format step above and never reads the
-      // content, so the tutor is never asked which source to use for it. When a
-      // PDF is attached AND the text box was edited away from the document's own
-      // extraction, the two sources genuinely disagree — ask which to generate
-      // from instead of silently preferring the PDF. Unedited (auto-filled) text
-      // isn't ambiguous, so we don't nag. The pick persists in a ref across the
-      // rest of the resolve chain (kind → spec).
-      const contentSource = contentSourceOverride ?? dmiContentSourceRef.current ?? undefined
-      if (sourcesDisagree && !contentSource) {
+      if (dmiGate === 'source') {
         setDmiSourceDialog({ type })
         return
       }

--- a/tutorme-app/src/lib/assessment/dmi-generate-gate.test.ts
+++ b/tutorme-app/src/lib/assessment/dmi-generate-gate.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import { nextDmiGate, type DmiGate, type DmiGateInput } from './dmi-generate-gate'
+
+const base: DmiGateInput = {
+  type: 'assessment',
+  hasQuestionSpec: false,
+  hasDocumentKindOverride: false,
+  skipFormatPrompt: false,
+  contentSource: undefined,
+  sourcesDisagree: false,
+}
+
+describe('nextDmiGate — single step', () => {
+  it('asks the format chooser first on a fresh assessment run', () => {
+    expect(nextDmiGate({ ...base })).toBe('format')
+  })
+
+  it('never asks the format chooser for a task (assessment-only)', () => {
+    expect(nextDmiGate({ ...base, type: 'task' })).toBe('proceed')
+  })
+
+  it('skips the format chooser once a spec / kind / skip flag is present', () => {
+    expect(nextDmiGate({ ...base, hasQuestionSpec: true })).toBe('proceed')
+    expect(nextDmiGate({ ...base, hasDocumentKindOverride: true })).toBe('proceed')
+    expect(nextDmiGate({ ...base, skipFormatPrompt: true })).toBe('proceed')
+  })
+
+  it('asks the source chooser only after format is resolved and sources disagree', () => {
+    expect(nextDmiGate({ ...base, skipFormatPrompt: true, sourcesDisagree: true })).toBe('source')
+  })
+
+  it('does not ask the source chooser when the tutor already picked a source', () => {
+    expect(
+      nextDmiGate({
+        ...base,
+        skipFormatPrompt: true,
+        sourcesDisagree: true,
+        contentSource: 'text',
+      })
+    ).toBe('proceed')
+  })
+
+  it('does not ask the source chooser when the sources agree (unedited text)', () => {
+    expect(nextDmiGate({ ...base, skipFormatPrompt: true, sourcesDisagree: false })).toBe('proceed')
+  })
+
+  it('asks the source chooser for a task with a genuine disagreement', () => {
+    expect(nextDmiGate({ ...base, type: 'task', sourcesDisagree: true })).toBe('source')
+  })
+})
+
+describe('nextDmiGate — ordering invariant (regression guard)', () => {
+  // The original loop bug put the source step BEFORE the format step. If both
+  // conditions hold at once, the format step MUST win; deferring the source
+  // question is what lets multiple-choice papers skip it entirely and is what
+  // keeps the chain from ping-ponging source↔format. Do not "simplify" this.
+  it('prefers format over source when both would otherwise fire', () => {
+    expect(nextDmiGate({ ...base, sourcesDisagree: true })).toBe('format')
+  })
+})
+
+/**
+ * Drives the whole pre-generation chain the way CourseBuilder's dialog handlers
+ * do, and asserts it always terminates (never loops) while asking each chooser
+ * at most once.
+ *
+ * Handler model (mirrors CourseBuilder):
+ * - format → 'mcq'  : builds locally, does NOT re-invoke the generator (terminal).
+ * - format → 'free' : re-invoke with skipFormatPrompt = true.
+ * - source → pick   : re-invoke with skipFormatPrompt = true AND the pick set
+ *                     (the pick persists via a ref, so later server-driven
+ *                     re-invocations keep it too).
+ * - proceed         : generation runs; the server may then re-invoke for kind /
+ *                     spec, which we simulate as extra steps.
+ */
+function runChain(opts: {
+  type: 'task' | 'assessment'
+  sourcesDisagree: boolean
+  formatChoice: 'mcq' | 'free'
+  sourcePick?: 'document' | 'text'
+  /** Simulate the server asking for kind then spec after the first proceed. */
+  serverAsks?: Array<'kind' | 'spec'>
+}): { seen: DmiGate[]; ended: 'proceed' | 'mcq' } {
+  let state: DmiGateInput = {
+    type: opts.type,
+    hasQuestionSpec: false,
+    hasDocumentKindOverride: false,
+    skipFormatPrompt: false,
+    contentSource: undefined,
+    sourcesDisagree: opts.sourcesDisagree,
+  }
+  const seen: DmiGate[] = []
+  const serverQueue = [...(opts.serverAsks ?? [])]
+
+  for (let step = 0; step < 20; step++) {
+    const gate = nextDmiGate(state)
+    seen.push(gate)
+
+    if (gate === 'format') {
+      if (opts.formatChoice === 'mcq') return { seen, ended: 'mcq' }
+      state = { ...state, skipFormatPrompt: true }
+      continue
+    }
+    if (gate === 'source') {
+      state = { ...state, skipFormatPrompt: true, contentSource: opts.sourcePick ?? 'text' }
+      continue
+    }
+    // gate === 'proceed' — generation ran. Let the server ask for kind/spec next.
+    const next = serverQueue.shift()
+    if (!next) return { seen, ended: 'proceed' }
+    if (next === 'kind') state = { ...state, hasDocumentKindOverride: true }
+    else state = { ...state, hasQuestionSpec: true }
+  }
+  throw new Error(`chain did not terminate: ${seen.join(' → ')}`)
+}
+
+describe('Generate DMI chain — terminates, no loop (regression guard)', () => {
+  it('assessment + PDF + edited text, free-response: asks format then source once, then proceeds', () => {
+    const { seen, ended } = runChain({
+      type: 'assessment',
+      sourcesDisagree: true,
+      formatChoice: 'free',
+      sourcePick: 'text',
+    })
+    expect(ended).toBe('proceed')
+    expect(seen.filter(g => g === 'format')).toHaveLength(1)
+    expect(seen.filter(g => g === 'source')).toHaveLength(1)
+    expect(seen).toEqual(['format', 'source', 'proceed'])
+  })
+
+  it('assessment + PDF + edited text, MULTIPLE CHOICE: never asks the source chooser', () => {
+    const { seen, ended } = runChain({
+      type: 'assessment',
+      sourcesDisagree: true,
+      formatChoice: 'mcq',
+    })
+    expect(ended).toBe('mcq')
+    expect(seen).not.toContain('source')
+    expect(seen).toEqual(['format'])
+  })
+
+  it('assessment free-response through server kind + spec: no re-prompt, source pick persists', () => {
+    const { seen, ended } = runChain({
+      type: 'assessment',
+      sourcesDisagree: true,
+      formatChoice: 'free',
+      sourcePick: 'document',
+      serverAsks: ['kind', 'spec'],
+    })
+    expect(ended).toBe('proceed')
+    expect(seen.filter(g => g === 'format')).toHaveLength(1)
+    expect(seen.filter(g => g === 'source')).toHaveLength(1)
+    // format, source, proceed(→kind), proceed(→spec), proceed(done)
+    expect(seen).toEqual(['format', 'source', 'proceed', 'proceed', 'proceed'])
+  })
+
+  it('task + PDF + edited text: asks source once (no format), then proceeds', () => {
+    const { seen, ended } = runChain({
+      type: 'task',
+      sourcesDisagree: true,
+      formatChoice: 'free',
+      sourcePick: 'text',
+    })
+    expect(ended).toBe('proceed')
+    expect(seen).toEqual(['source', 'proceed'])
+  })
+
+  it('assessment, unedited text (sources agree): asks only format, then proceeds', () => {
+    const { seen, ended } = runChain({
+      type: 'assessment',
+      sourcesDisagree: false,
+      formatChoice: 'free',
+    })
+    expect(ended).toBe('proceed')
+    expect(seen).toEqual(['format', 'proceed'])
+  })
+})

--- a/tutorme-app/src/lib/assessment/dmi-generate-gate.ts
+++ b/tutorme-app/src/lib/assessment/dmi-generate-gate.ts
@@ -1,0 +1,68 @@
+/**
+ * Pre-network dialog routing for "Generate DMI".
+ *
+ * Generating a DMI resolves through a chain of dialogs, each of which pauses the
+ * flow and re-invokes the generator from the top once answered:
+ *
+ *   format (MCQ vs free-response, assessment only)
+ *     └─ free-response → source (which content: attached PDF vs edited text)
+ *                          └─ proceed → (server may then ask kind → question-spec)
+ *
+ * This helper decides ONLY the next pre-network step. It is deliberately pure
+ * and framework-free so the routing — including the property that the format
+ * step is always resolved before the source step — is unit-tested directly,
+ * away from the giant CourseBuilder component.
+ *
+ * Ordering matters. The source chooser MUST come after the format chooser:
+ * multiple-choice papers are built locally and never read the content, so they
+ * return at the format step and are never asked which source to use. Putting the
+ * source step first (and dropping the pick on each re-invocation) is exactly the
+ * bug that once looped source↔format forever — see the tests.
+ */
+
+export type DmiGate = 'format' | 'source' | 'proceed'
+
+export interface DmiGateInput {
+  type: 'task' | 'assessment'
+  /** A question spec is already chosen (study-material path). */
+  hasQuestionSpec: boolean
+  /** A document-kind override is already chosen (question_paper / study_material). */
+  hasDocumentKindOverride: boolean
+  /** The format step has been answered (or is otherwise not needed). */
+  skipFormatPrompt: boolean
+  /**
+   * The resolved content source: the caller passes `override ?? rememberedPick`
+   * so a choice made earlier in the chain keeps the source step from re-opening.
+   */
+  contentSource: 'document' | 'text' | undefined
+  /**
+   * A PDF is attached AND the typed text was edited away from the document's own
+   * extraction — the two sources genuinely disagree, so we must ask which to use.
+   */
+  sourcesDisagree: boolean
+}
+
+/**
+ * The next pre-network step for a Generate DMI (re-)invocation:
+ * - `'format'`  → open the response-format chooser (assessment, not yet chosen).
+ * - `'source'`  → open the content-source chooser (free-response, sources disagree,
+ *                 no pick yet). Only reachable once the format step is resolved.
+ * - `'proceed'` → no dialog needed; run generation.
+ */
+export function nextDmiGate(input: DmiGateInput): DmiGate {
+  // Format first: a fresh assessment run with no downstream choice yet.
+  if (
+    input.type === 'assessment' &&
+    !input.hasQuestionSpec &&
+    !input.hasDocumentKindOverride &&
+    !input.skipFormatPrompt
+  ) {
+    return 'format'
+  }
+  // Then source: only after format is resolved, and only when the two content
+  // sources genuinely disagree and the tutor hasn't already picked one.
+  if (input.sourcesDisagree && !input.contentSource) {
+    return 'source'
+  }
+  return 'proceed'
+}


### PR DESCRIPTION
## Why
The Generate-DMI **pre-generation dialog routing** (format chooser → source chooser → proceed) lived inline in `handleGenerateDMI` inside the 14k-line `CourseBuilder.tsx`, untested. That exact logic shipped two regressions in the last day:
- **#1031** — a `source ↔ format` infinite loop for edited-text assessments (tutor could never finish generating).
- **#1032** — an unnecessary source prompt for multiple-choice papers.

Both were pure gate-ordering bugs a unit test would have caught.

## What
- New pure, framework-free helper **`src/lib/assessment/dmi-generate-gate.ts`** → `nextDmiGate(input): 'format' | 'source' | 'proceed'`, following the same pattern as the other tested `src/lib/assessment/*` helpers.
- `handleGenerateDMI` now routes through it — **behaviour-preserving** (identical conditions, identical order; `effectiveHasPdf`/`contentSource` unchanged).
- Co-located **`dmi-generate-gate.test.ts`** (13 tests) locking in the invariants:
  - **format resolves before source** — the ordering the loop bug broke (explicit regression guard);
  - **multiple-choice never reaches the source chooser**;
  - the **full chain** (format → free-response → source → server kind → spec) **terminates**, asking each chooser at most once, with the source pick persisting across re-invocations.

## Verification
`vitest run dmi-generate-gate.test.ts` → **13 passed**. Prettier clean (repo's pinned version). No tutor-facing behaviour change. Typecheck/Build via CI.

Guardrail-safe: routing only; the generate-dmi route still injects the assessment system prompt + guardrails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)