### PR TITLE
feat(guardrails): warn on curriculum/subject mismatch in assessments

### DIFF
--- a/tutorme-app/src/app/api/ai/generate-dmi/route.ts
+++ b/tutorme-app/src/app/api/ai/generate-dmi/route.ts
@@ -26,9 +26,11 @@ import {
 } from '@/lib/assessment/document-signals'
 import {
   runAssessmentGuardrails,
+  checkCurriculumMatch,
   GUARDRAILED_TEMPERATURE,
   type GuardrailViolation,
 } from '@/lib/ai/guardrails'
+import { classifyDocumentCurriculum } from '@/lib/assessment/curriculum-classify'
 import { z } from 'zod'
 
 export const maxDuration = 60
@@ -602,6 +604,24 @@ export async function POST(request: NextRequest) {
         { title, questions: questions.map(q => ({ questionText: q.questionText })) },
         { sourceContent: content, confidence: confidence?.level }
       ).violations
+
+      // CURRIC-1/2: warn if the document's exam board or subject doesn't match
+      // the course (e.g. an A-Level past paper in an AP course). Layer 1 is a
+      // deterministic marker scan; layer 2 is a best-effort AI subject check that
+      // only runs when a board/subject hint is present, and never blocks.
+      if (content && (examBody || subject)) {
+        const classification = await classifyDocumentCurriculum(content)
+        const curriculumWarnings = checkCurriculumMatch({
+          extractedText: content,
+          expectedBoard: examBody,
+          expectedSubject: subject,
+          aiBoard: classification?.board,
+          aiSubject: classification?.subject,
+          aiConfidence: classification?.confidence,
+        })
+        guardrailWarnings = [...guardrailWarnings, ...curriculumWarnings]
+      }
+
       if (guardrailWarnings.length > 0) {
         console.warn(
           `[guardrails] generate-dmi assessment violations (${guardrailWarnings.length}):`,

--- a/tutorme-app/src/lib/ai/guardrails/curriculum.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/curriculum.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { detectExamBoards, normalizeBoard, checkCurriculumMatch } from './curriculum'
+
+describe('detectExamBoards', () => {
+  it('detects A-Level / IGCSE from a Cambridge/Edexcel paper', () => {
+    const d = detectExamBoards('Cambridge Assessment International Education — Pearson Edexcel')
+    expect(d.families).toContain('A Level')
+    expect(d.families).toContain('IGCSE')
+    expect(d.markers.length).toBeGreaterThan(0)
+  })
+
+  it('pins A Level from a GCE / syllabus code', () => {
+    const d = detectExamBoards('GCE Advanced Level  9709/12  Paper 1 Pure Mathematics')
+    expect(d.families).toContain('A Level')
+  })
+
+  it('detects AP from College Board / Advanced Placement', () => {
+    const d = detectExamBoards('AP® Statistics Exam — College Board — Advanced Placement Program')
+    expect(d.families).toEqual(['AP'])
+  })
+
+  it('detects IB', () => {
+    expect(detectExamBoards('International Baccalaureate Diploma Programme').families).toContain(
+      'IB'
+    )
+  })
+
+  it('returns no families for plain prose (no false positives)', () => {
+    const d = detectExamBoards('This worksheet reviews the central limit theorem and sampling.')
+    expect(d.families).toEqual([])
+  })
+})
+
+describe('normalizeBoard', () => {
+  it('maps common board spellings to a family', () => {
+    expect(normalizeBoard('AP')).toBe('AP')
+    expect(normalizeBoard('A Level')).toBe('A Level')
+    expect(normalizeBoard('a-level')).toBe('A Level')
+    expect(normalizeBoard('IGCSE')).toBe('IGCSE')
+    expect(normalizeBoard('IB')).toBe('IB')
+    expect(normalizeBoard('HKDSE')).toBeNull()
+  })
+})
+
+describe('checkCurriculumMatch — layer 1 (board markers)', () => {
+  it('warns: A-Level past paper attached to an AP course', () => {
+    const v = checkCurriculumMatch({
+      extractedText: 'Cambridge International AS & A Level  9709/13  Paper 1',
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-1')).toBe(true)
+    expect(v[0].severity).toBe('warning')
+  })
+
+  it('does NOT warn when the detected family includes the expected board', () => {
+    // Cambridge → {A Level, IGCSE}; course is A Level → no conflict.
+    const v = checkCurriculumMatch({
+      extractedText: 'Cambridge International AS & A Level 9709/12',
+      expectedBoard: 'A Level',
+      expectedSubject: 'A Level Mathematics',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-1')).toBe(false)
+  })
+
+  it('warns: IGCSE paper in an A-Level course (level mismatch)', () => {
+    const v = checkCurriculumMatch({
+      extractedText: 'IGCSE Mathematics 0580/22',
+      expectedBoard: 'A Level',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-1')).toBe(true)
+  })
+
+  it('does NOT warn when no board markers are present', () => {
+    const v = checkCurriculumMatch({
+      extractedText: 'A set of practice questions on hypothesis testing.',
+      expectedBoard: 'AP',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-1')).toBe(false)
+  })
+
+  it('does NOT warn when the course board is not a detectable one', () => {
+    const v = checkCurriculumMatch({
+      extractedText: 'Cambridge International A Level 9709',
+      expectedBoard: 'HKDSE',
+    })
+    expect(v).toHaveLength(0)
+  })
+})
+
+describe('checkCurriculumMatch — layer 2 (AI subject)', () => {
+  it('warns on a clearly different subject at high confidence', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+      aiSubject: 'Biology',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(true)
+  })
+
+  it('does NOT warn when subjects overlap (board words stripped)', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+      aiSubject: 'Statistics',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(false)
+  })
+
+  it('does NOT warn on subject mismatch below high confidence', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+      aiSubject: 'Biology',
+      aiConfidence: 'medium',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/ai/guardrails/curriculum.ts
+++ b/tutorme-app/src/lib/ai/guardrails/curriculum.ts
@@ -1,0 +1,228 @@
+/**
+ * Curriculum / exam-board mismatch guardrail (warn-only).
+ *
+ * Catches the case where a tutor attaches a document whose exam board or subject
+ * doesn't match the course — e.g. an A-Level past paper uploaded to an "AP
+ * Statistics" course. Two layers, both non-blocking:
+ *
+ *  1. Deterministic board-marker scan (this file, `detectExamBoards`). Past
+ *     papers are self-labeling ("Cambridge International", "Edexcel", "College
+ *     Board", syllabus codes …). Cheap, high-precision, no AI. Catches the exact
+ *     wrong-board case.
+ *  2. AI subject relevance (fed in via `aiBoard`/`aiSubject`, classified
+ *     separately in src/lib/assessment/curriculum-classify.ts). Catches a
+ *     wrong-subject-entirely upload that shares the course's region/board.
+ *
+ * Never blocks — returns `GuardrailViolation[]` surfaced as `guardrailWarnings`.
+ * The tutor decides; cross-curriculum use (an A-Level paper as extra AP practice)
+ * stays possible on purpose.
+ */
+
+import type { GuardrailViolation } from './validate'
+
+/** Board families this guardrail can reason about (the detectable ones). */
+export type ExamBoardFamily = 'AP' | 'A Level' | 'IGCSE' | 'IB'
+
+const DETECTABLE: readonly ExamBoardFamily[] = ['AP', 'A Level', 'IGCSE', 'IB']
+
+/**
+ * High-precision text markers → the board family/families they imply.
+ *
+ * Some markers are shared: Cambridge/Edexcel/AQA run BOTH A-Level and IGCSE, so
+ * those map to both families and only conflict with a non-UK board (AP/IB).
+ * Level-specific markers (GCE A Level, "IGCSE", Cambridge syllabus codes — 9xxx
+ * for A/AS, 0xxx for IGCSE) pin a single family.
+ */
+interface BoardMarker {
+  re: RegExp
+  families: ExamBoardFamily[]
+  label: string
+}
+
+const BOARD_MARKERS: BoardMarker[] = [
+  // AP (US / College Board)
+  { re: /\badvanced placement\b/i, families: ['AP'], label: 'Advanced Placement' },
+  { re: /\bcollege board\b/i, families: ['AP'], label: 'College Board' },
+  // IB
+  {
+    re: /\binternational baccalaureate\b/i,
+    families: ['IB'],
+    label: 'International Baccalaureate',
+  },
+  { re: /\bdiploma programme\b/i, families: ['IB'], label: 'IB Diploma Programme' },
+  // UK boards — run both A Level and IGCSE
+  {
+    re: /\bcambridge\s+(?:assessment\s+)?international\b/i,
+    families: ['A Level', 'IGCSE'],
+    label: 'Cambridge International',
+  },
+  {
+    re: /\buniversity\s+of\s+cambridge\s+international\s+examinations\b/i,
+    families: ['A Level', 'IGCSE'],
+    label: 'Cambridge International Examinations',
+  },
+  { re: /\bCAIE\b/, families: ['A Level', 'IGCSE'], label: 'CAIE' },
+  { re: /\b(?:pearson\s+)?edexcel\b/i, families: ['A Level', 'IGCSE'], label: 'Edexcel' },
+  { re: /\bAQA\b/, families: ['A Level', 'IGCSE'], label: 'AQA' },
+  { re: /\bWJEC\b/, families: ['A Level', 'IGCSE'], label: 'WJEC' },
+  // A-Level specific
+  {
+    re: /\bGCE\b[^.\n]{0,20}\b(?:Advanced|AS)\b/i,
+    families: ['A Level'],
+    label: 'GCE Advanced Level',
+  },
+  { re: /\bAS\s*(?:and|\/|&)\s*A\s*Level\b/i, families: ['A Level'], label: 'AS & A Level' },
+  { re: /\b9\d{3}\/\d{2}\b/, families: ['A Level'], label: 'Cambridge A-Level syllabus code' },
+  // IGCSE specific
+  { re: /\bIGCSE\b/i, families: ['IGCSE'], label: 'IGCSE' },
+  {
+    re: /\binternational\s+general\s+certificate\s+of\s+secondary\s+education\b/i,
+    families: ['IGCSE'],
+    label: 'IGCSE',
+  },
+  { re: /\b0\d{3}\/\d{2}\b/, families: ['IGCSE'], label: 'Cambridge IGCSE syllabus code' },
+]
+
+export interface DetectedBoard {
+  /** The distinct marker labels that matched (e.g. ["Edexcel", "GCE Advanced Level"]). */
+  markers: string[]
+  /** Union of board families implied by the matched markers. */
+  families: ExamBoardFamily[]
+}
+
+/**
+ * Scan document text for exam-board markers. Returns the matched marker labels
+ * and the union of implied board families (empty when nothing distinctive is
+ * found — the common, no-signal case).
+ */
+export function detectExamBoards(text: string | null | undefined): DetectedBoard {
+  const markers: string[] = []
+  const families = new Set<ExamBoardFamily>()
+  if (!text) return { markers, families: [] }
+  for (const m of BOARD_MARKERS) {
+    if (m.re.test(text)) {
+      if (!markers.includes(m.label)) markers.push(m.label)
+      m.families.forEach(f => families.add(f))
+    }
+  }
+  return { markers, families: [...families] }
+}
+
+/** Normalize a board string from the course/AI to a canonical family, if it is one. */
+export function normalizeBoard(board: string | null | undefined): ExamBoardFamily | null {
+  if (!board) return null
+  const b = board.trim().toLowerCase()
+  if (/\bap\b|advanced placement|college board/.test(b)) return 'AP'
+  if (/\bib\b|baccalaureate|diploma programme/.test(b)) return 'IB'
+  if (/igcse/.test(b)) return 'IGCSE'
+  if (/\ba[-\s]?level|gce|as[-\s]?level/.test(b)) return 'A Level'
+  return null
+}
+
+/** Words to strip before comparing subjects, so "AP Statistics" ≈ "Statistics". */
+const SUBJECT_STOPWORDS = new Set([
+  'ap',
+  'ib',
+  'igcse',
+  'gcse',
+  'a',
+  'as',
+  'level',
+  'gce',
+  'hl',
+  'sl',
+  'higher',
+  'standard',
+  'ordinary',
+  'advanced',
+  'placement',
+  'paper',
+  'past',
+  'exam',
+  'examination',
+  'international',
+  'course',
+  'the',
+  'and',
+  'of',
+  'in',
+])
+
+/** Content-bearing subject tokens (board words / filler removed). */
+function subjectTokens(subject: string | null | undefined): Set<string> {
+  const out = new Set<string>()
+  if (!subject) return out
+  for (const tok of subject.toLowerCase().split(/[^a-z]+/)) {
+    if (tok.length > 1 && !SUBJECT_STOPWORDS.has(tok)) out.add(tok)
+  }
+  return out
+}
+
+export interface CurriculumCheckInput {
+  /** Extracted document text (drives the deterministic board scan). */
+  extractedText?: string | null
+  /** Course's expected board, from the course category (examBody / getCategoryBoard). */
+  expectedBoard?: string | null
+  /** Course's expected subject (the category/subject, e.g. "AP Statistics"). */
+  expectedSubject?: string | null
+  /** AI-classified board for the document (layer 2), if available. */
+  aiBoard?: string | null
+  /** AI-classified subject for the document (layer 2), if available. */
+  aiSubject?: string | null
+  /** AI classification confidence — only 'high' triggers a subject warning. */
+  aiConfidence?: 'high' | 'medium' | 'low' | null
+}
+
+const RULE_BOARD = 'CURRIC-1'
+const RULE_SUBJECT = 'CURRIC-2'
+
+/**
+ * Warn-only curriculum/subject mismatch check.
+ *
+ *  - CURRIC-1 (deterministic): the document carries markers of a board the course
+ *    is not. High precision — only fires when the expected board is a detectable
+ *    one and appears in NONE of the matched markers' families.
+ *  - CURRIC-2 (AI, high-confidence only): the document's subject is disjoint from
+ *    the course subject (a wrong-subject upload the board scan can't catch).
+ */
+export function checkCurriculumMatch(input: CurriculumCheckInput): GuardrailViolation[] {
+  const violations: GuardrailViolation[] = []
+  const expectedFamily = normalizeBoard(input.expectedBoard)
+
+  // ── Layer 1: deterministic board markers ──────────────────────────────────
+  if (expectedFamily && DETECTABLE.includes(expectedFamily)) {
+    const detected = detectExamBoards(input.extractedText)
+    if (detected.families.length > 0 && !detected.families.includes(expectedFamily)) {
+      const detectedList = detected.families.join(' / ')
+      const markerList = detected.markers.slice(0, 3).join(', ')
+      violations.push({
+        ruleId: RULE_BOARD,
+        severity: 'warning',
+        message:
+          `This document carries ${detectedList} markers (found: ${markerList}), but the course ` +
+          `is ${expectedFamily}. Verify it belongs in this course before deploying — attach ` +
+          `anyway if this cross-curriculum material is intentional.`,
+      })
+    }
+  }
+
+  // ── Layer 2: AI subject relevance (high confidence only) ───────────────────
+  if (input.aiConfidence === 'high') {
+    const want = subjectTokens(input.expectedSubject)
+    const got = subjectTokens(input.aiSubject)
+    if (want.size > 0 && got.size > 0) {
+      const overlap = [...got].some(t => want.has(t))
+      if (!overlap) {
+        violations.push({
+          ruleId: RULE_SUBJECT,
+          severity: 'warning',
+          message:
+            `This document appears to be about ${input.aiSubject}, but the course subject is ` +
+            `${input.expectedSubject}. Confirm the document matches the course topic.`,
+        })
+      }
+    }
+  }
+
+  return violations
+}

--- a/tutorme-app/src/lib/ai/guardrails/index.ts
+++ b/tutorme-app/src/lib/ai/guardrails/index.ts
@@ -42,6 +42,15 @@ export {
 export { stripEvaluationLayer, findEvaluationLeaks } from './serialize'
 
 export {
+  checkCurriculumMatch,
+  detectExamBoards,
+  normalizeBoard,
+  type ExamBoardFamily,
+  type DetectedBoard,
+  type CurriculumCheckInput,
+} from './curriculum'
+
+export {
   resolvePciComposition,
   inferDocumentKindFromProvenance,
   assessmentVariantAddendum,
@@ -61,6 +70,7 @@ import {
   type TaskValidationContext,
   type AssessmentValidationContext,
 } from './validate'
+import { checkCurriculumMatch, type CurriculumCheckInput } from './curriculum'
 
 export type GuardrailDomain = 'task' | 'assessment'
 
@@ -108,5 +118,11 @@ export function runAssessmentGuardrails(
   ctx?: AssessmentValidationContext
 ): GuardrailRunResult {
   const violations = validateAssessmentOutput(parsed, ctx)
+  return { violations, hasBlocking: violations.some(v => v.severity === 'error') }
+}
+
+/** Run the warn-only curriculum/subject mismatch check and summarize. */
+export function runCurriculumGuardrails(input: CurriculumCheckInput): GuardrailRunResult {
+  const violations = checkCurriculumMatch(input)
   return { violations, hasBlocking: violations.some(v => v.severity === 'error') }
 }

--- a/tutorme-app/src/lib/assessment/curriculum-classify.ts
+++ b/tutorme-app/src/lib/assessment/curriculum-classify.ts
@@ -1,0 +1,68 @@
+/**
+ * Lightweight AI classification of a document's exam board + subject, for the
+ * curriculum-mismatch guardrail (layer 2). Deliberately isolated from the DMI
+ * extraction prompt so that heavily-tuned prompt stays untouched.
+ *
+ * Best-effort and non-blocking: any failure (no API key, timeout, unparseable
+ * response) returns null and the guardrail simply skips its subject layer.
+ */
+
+import { generateWithKimi } from '@/lib/ai/kimi'
+import { parseLlmJson } from '@/lib/ai/llm-response'
+
+export interface CurriculumClassification {
+  /** Exam board the document appears to belong to, or null if unclear. */
+  board: string | null
+  /** Primary subject of the document, or null if unclear. */
+  subject: string | null
+  confidence: 'high' | 'medium' | 'low'
+}
+
+const SYSTEM_PROMPT =
+  'You classify an academic document by its exam board and subject. Respond with ONLY a JSON ' +
+  'object (no prose, no code fences) of shape ' +
+  '{"board": string|null, "subject": string|null, "confidence": "high"|"medium"|"low"}. ' +
+  'board is the exam board/curriculum the document belongs to if identifiable (e.g. "AP", ' +
+  '"A Level", "IGCSE", "IB", or a national board), else null. subject is the primary subject ' +
+  '(e.g. "Statistics", "Biology"), else null. confidence reflects how sure you are from the text. ' +
+  'Judge only from the content; do not guess wildly — use null and lower confidence when unsure.'
+
+/** How much of the document to send — the header/first questions are plenty to
+ *  identify board + subject, and keeps the call fast and cheap. */
+const EXCERPT_CHARS = 4000
+
+/**
+ * Classify the document's board/subject. Returns null on any failure so callers
+ * can treat "no signal" and "call failed" identically (skip the subject layer).
+ */
+export async function classifyDocumentCurriculum(
+  text: string | null | undefined
+): Promise<CurriculumClassification | null> {
+  const excerpt = (text ?? '').trim().slice(0, EXCERPT_CHARS)
+  if (excerpt.length < 40) return null // too little to classify meaningfully
+
+  try {
+    const raw = await generateWithKimi(excerpt, {
+      systemPrompt: SYSTEM_PROMPT,
+      temperature: 0.2,
+      maxTokens: 120,
+      timeoutMs: 15000,
+      retries: 0,
+      usageContext: { feature: 'curriculum-classify' },
+    })
+    const parsed = parseLlmJson<Partial<CurriculumClassification>>(raw)
+    if (!parsed) return null
+    const confidence =
+      parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low'
+        ? parsed.confidence
+        : 'low'
+    return {
+      board: typeof parsed.board === 'string' && parsed.board.trim() ? parsed.board.trim() : null,
+      subject:
+        typeof parsed.subject === 'string' && parsed.subject.trim() ? parsed.subject.trim() : null,
+      confidence,
+    }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Problem
A tutor can create an "AP Statistics" course but inadvertently attach an **A-Level past paper** as the assessment source. Nothing flags it today.

## Approach — warn, don't block
Confirmed direction: **warn-only** + **board-marker scan + AI subject check**. Hard-blocking would be wrong — AP and A-Level Statistics overlap, and a tutor may *intentionally* use an A-Level paper as extra practice. Matches the existing warn-only guardrail precedent (#145).

Surfaced through the **existing** `guardrailWarnings` → `toast.warning` path in CourseBuilder, so **no UI changes**.

## Two layers
- **CURRIC-1 — deterministic board markers** (`src/lib/ai/guardrails/curriculum.ts`). Past papers are self-labeling; scan extracted text for high-precision markers (Cambridge International, Edexcel/Pearson, College Board, Advanced Placement, International Baccalaureate, IGCSE, Cambridge syllabus codes 9xxx/0xxx …) → warn when the detected board family excludes the course's board. Free, no AI, catches the exact case. Shared UK markers map to *both* A-Level and IGCSE, so they only conflict with a non-UK board — avoids false positives.
- **CURRIC-2 — AI subject relevance** (`src/lib/assessment/curriculum-classify.ts`). A small, isolated Kimi call labels the document's board/subject; warn on a clearly disjoint subject at **high confidence only**. Best-effort: returns `null` on any failure and skips silently. **The tuned DMI extraction prompt is left untouched.**

Hook point: `src/app/api/ai/generate-dmi/route.ts` (assessment path), where `examBody`, `subject`, and extracted `content` are already in scope.

## What the tutor sees
> Guardrail CURRIC-1: This document carries A Level / IGCSE markers (found: Cambridge International, AS & A Level, Cambridge A-Level syllabus code), but the course is AP. Verify it belongs in this course before deploying — attach anyway if this cross-curriculum material is intentional.

## Verification
- **14 new unit tests**; full guardrail suite **53 passing**; typecheck clean; lint 0 errors
- Drove the **real module** with a Cambridge A-Level Statistics past-paper header against an AP Statistics course → emits the exact CURRIC-1 toast text; a genuine **AP paper → 0 warnings** (no false positive)
- ⚠️ The full HTTP endpoint (auth + live Kimi) and browser toast render not exercised locally — best confirmed on staging by generating an assessment from a mismatched paper

## Non-goals
No blocking, no DB migration, no PDF re-parsing, no change to the DMI prompt or the document display/storage work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)