### PR TITLE
feat(group-sessions): student browse surface + 1-seat (true 1-on-1) capacity

### DIFF
--- a/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { Users, Loader2, CalendarDays, ArrowUpRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { bookGroupSeat } from '@/lib/group-session/book-seat'
+
+interface BrowseSession {
+  groupSessionId: string
+  title: string
+  description?: string | null
+  requestedDate: string
+  startTime: string
+  endTime: string
+  timezone: string
+  capacity: number
+  pricePerSeat: number
+  currency: string
+  status: string
+  seatsLeft: number
+  tutorName?: string | null
+  tutorUsername?: string | null
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+export default function StudentGroupSessionsPage() {
+  const params = useParams()
+  const locale = (params?.locale as string) || 'en'
+  const [sessions, setSessions] = useState<BrowseSession[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/group-sessions/browse', { credentials: 'include' })
+      const data = res.ok ? await res.json() : { sessions: [] }
+      setSessions(Array.isArray(data.sessions) ? data.sessions : [])
+    } catch {
+      setSessions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const book = async (gs: BrowseSession) => {
+    setBusyId(gs.groupSessionId)
+    const result = await bookGroupSeat(gs.groupSessionId)
+    if (result !== 'redirecting') {
+      load()
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-4 px-3 pb-6 pt-4 lg:px-4">
+      {/* Hero */}
+      <section className="rounded-[20px] bg-gradient-to-br from-[#F97316] to-[#EA580C] p-5 shadow-[0_12px_40px_-4px_rgba(0,0,0,0.22)] ring-1 ring-white/20">
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 backdrop-blur-sm">
+            <Users className="h-5 w-5 text-white" />
+          </span>
+          <div>
+            <h1 className="text-xl font-bold text-white">Group Sessions</h1>
+            <p className="mt-0.5 text-sm text-white/70">
+              Open sessions hosted by tutors — grab a seat before they fill up.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 py-16 text-center text-sm text-slate-500">
+          <CalendarDays className="mx-auto mb-2 h-8 w-8 text-slate-300" />
+          No open group sessions right now. Check back soon.
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {sessions.map(gs => {
+            const full = gs.seatsLeft <= 0
+            return (
+              <li
+                key={gs.groupSessionId}
+                className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-semibold text-slate-900">{gs.title}</div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {gs.tutorUsername ? (
+                      <Link
+                        href={`/${locale}/u/${encodeURIComponent(gs.tutorUsername)}`}
+                        className="inline-flex items-center gap-0.5 font-medium text-blue-600 hover:underline"
+                      >
+                        {gs.tutorName || `@${gs.tutorUsername}`}
+                        <ArrowUpRight className="h-3 w-3" />
+                      </Link>
+                    ) : (
+                      <span className="font-medium capitalize text-slate-600">
+                        {gs.tutorName || 'Tutor'}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600">
+                    <span className="inline-flex items-center gap-1">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {formatDate(gs.requestedDate)} · {gs.startTime}–{gs.endTime} ({gs.timezone})
+                    </span>
+                    <span className="font-medium text-slate-900">
+                      {gs.pricePerSeat > 0 ? `${gs.pricePerSeat} ${gs.currency}/seat` : 'Free'}
+                    </span>
+                    <span className={full ? 'text-slate-400' : 'text-emerald-700'}>
+                      {full
+                        ? 'Full'
+                        : gs.capacity === 1
+                          ? '1-on-1 · 1 seat'
+                          : `${gs.seatsLeft} of ${gs.capacity} seats left`}
+                    </span>
+                  </div>
+                  {gs.description ? (
+                    <p className="mt-1 line-clamp-2 text-sm text-slate-500">{gs.description}</p>
+                  ) : null}
+                </div>
+                <Button
+                  variant="solocorn-book"
+                  className="shrink-0"
+                  disabled={full || busyId === gs.groupSessionId}
+                  onClick={() => book(gs)}
+                >
+                  {busyId === gs.groupSessionId ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  {full ? 'Full' : 'Book a seat'}
+                </Button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/student/layout.tsx
+++ b/tutorme-app/src/app/[locale]/student/layout.tsx
@@ -17,6 +17,7 @@ import {
   Bell,
   ArrowLeft,
   CalendarDays,
+  Users,
   User,
   ChevronRight,
   ChevronLeft,
@@ -40,6 +41,12 @@ const navItems: NavItem[] = [
     label: 'Dashboard',
     icon: LayoutDashboard,
     iconColor: 'text-[#2563EB]',
+  },
+  {
+    href: '/student/group-sessions',
+    label: 'Group Sessions',
+    icon: Users,
+    iconColor: 'text-[#0891B2]',
   },
   {
     href: '/student/tutors',

--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -239,12 +239,15 @@ export default function TutorGroupSessionsPage() {
               Seats
               <input
                 type="number"
-                min={2}
+                min={1}
                 max={50}
                 className={field}
                 value={form.capacity}
                 onChange={e => setForm({ ...form, capacity: e.target.value })}
               />
+              <span className="mt-1 block text-xs font-normal text-slate-400">
+                Set 1 seat for a private 1-on-1.
+              </span>
             </label>
             <label className="text-sm font-medium text-slate-700">
               Price per seat

--- a/tutorme-app/src/app/api/group-sessions/browse/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/browse/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/group-sessions/browse
+ *
+ * All OPEN, upcoming group sessions across every tutor that still has a seat —
+ * the platform-wide browse feed (the tutorId-scoped GET only lists one tutor's).
+ * Each row carries the host's name/username/avatar so students can book or open
+ * the tutor's profile.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, asc, eq, gte } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { groupSession, profile, user } from '@/lib/db/schema'
+import { countActiveSeats } from '@/lib/group-session/seats'
+
+export const GET = withAuth(async (_req: NextRequest) => {
+  const now = new Date()
+  const startOfTodayUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  )
+
+  const rows = await drizzleDb
+    .select({
+      groupSessionId: groupSession.groupSessionId,
+      title: groupSession.title,
+      description: groupSession.description,
+      requestedDate: groupSession.requestedDate,
+      startTime: groupSession.startTime,
+      endTime: groupSession.endTime,
+      timezone: groupSession.timezone,
+      capacity: groupSession.capacity,
+      pricePerSeat: groupSession.pricePerSeat,
+      currency: groupSession.currency,
+      status: groupSession.status,
+      tutorId: groupSession.tutorId,
+      tutorName: profile.name,
+      tutorUsername: profile.username,
+      tutorImage: user.image,
+    })
+    .from(groupSession)
+    .leftJoin(profile, eq(profile.userId, groupSession.tutorId))
+    .leftJoin(user, eq(user.userId, groupSession.tutorId))
+    .where(and(eq(groupSession.status, 'OPEN'), gte(groupSession.requestedDate, startOfTodayUtc)))
+    .orderBy(asc(groupSession.requestedDate))
+    .limit(100)
+
+  const withSeats = await Promise.all(
+    rows.map(async r => ({
+      ...r,
+      seatsLeft: Math.max(0, r.capacity - (await countActiveSeats(r.groupSessionId))),
+    }))
+  )
+
+  // Only surface sessions a student can actually book.
+  return NextResponse.json({ sessions: withSeats.filter(s => s.seatsLeft > 0) })
+})

--- a/tutorme-app/src/app/api/group-sessions/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/route.ts
@@ -28,7 +28,8 @@ const createSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   startTime: z.string().regex(/^\d{2}:\d{2}$/),
   endTime: z.string().regex(/^\d{2}:\d{2}$/),
-  capacity: z.number().int().min(2).max(50),
+  // 1 seat = a true 1-on-1 (only one student can sign up); up to 50 for a group.
+  capacity: z.number().int().min(1).max(50),
   pricePerSeat: z.number().min(0).max(100000),
 })
 

--- a/tutorme-app/src/components/booking/group-sessions-list.tsx
+++ b/tutorme-app/src/components/booking/group-sessions-list.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { Users, Loader2, CalendarDays } from 'lucide-react'
-import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { bookGroupSeat } from '@/lib/group-session/book-seat'
 
 interface GroupSessionItem {
   groupSessionId: string
@@ -61,40 +60,10 @@ export function GroupSessionsList({ tutorId }: { tutorId: string }) {
 
   const bookSeat = async (gs: GroupSessionItem) => {
     setBusyId(gs.groupSessionId)
-    try {
-      // 1. Reserve a seat.
-      const joinRes = await fetch(`/api/group-sessions/${gs.groupSessionId}/join`, {
-        method: 'POST',
-        credentials: 'include',
-      })
-      const joinData = await joinRes.json().catch(() => ({}))
-      if (!joinRes.ok || !joinData.participantId) {
-        toast.error(joinData.error || 'Could not reserve a seat')
-        load()
-        return
-      }
-      // Free session: the seat is already confirmed — no checkout.
-      if (joinData.free || joinData.confirmed) {
-        toast.success("You're booked — this session is free. See you there!")
-        load()
-        return
-      }
-      // 2. Start checkout for that seat.
-      const payRes = await fetchWithCsrf('/api/payments/create', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ groupSessionParticipantId: joinData.participantId }),
-      })
-      const payData = await payRes.json().catch(() => ({}))
-      if (payRes.ok && payData.checkoutUrl) {
-        window.location.href = payData.checkoutUrl
-        return
-      }
-      toast.error(payData.error || 'Could not start checkout')
-    } catch {
-      toast.error('Something went wrong — please try again')
-    } finally {
+    const result = await bookGroupSeat(gs.groupSessionId)
+    // On redirect the page navigates away; otherwise refresh seat counts.
+    if (result !== 'redirecting') {
+      load()
       setBusyId(null)
     }
   }

--- a/tutorme-app/src/lib/group-session/book-seat.ts
+++ b/tutorme-app/src/lib/group-session/book-seat.ts
@@ -1,0 +1,48 @@
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { toast } from 'sonner'
+
+export type BookSeatResult = 'booked' | 'redirecting' | 'error'
+
+/**
+ * Reserve a seat in a group session and, for a paid session, start checkout.
+ * Shared by the tutor-profile list and the browse page. Returns:
+ * - 'booked'      — free/auto-confirmed seat, nothing more to do (reload the list)
+ * - 'redirecting' — sent to the payment gateway (page is navigating away)
+ * - 'error'       — a toast was already shown
+ */
+export async function bookGroupSeat(groupSessionId: string): Promise<BookSeatResult> {
+  try {
+    // 1. Reserve a seat.
+    const joinRes = await fetch(`/api/group-sessions/${groupSessionId}/join`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+    const joinData = await joinRes.json().catch(() => ({}))
+    if (!joinRes.ok || !joinData.participantId) {
+      toast.error(joinData.error || 'Could not reserve a seat')
+      return 'error'
+    }
+    // Free session: the seat is already confirmed — no checkout.
+    if (joinData.free || joinData.confirmed) {
+      toast.success("You're booked — this session is free. See you there!")
+      return 'booked'
+    }
+    // 2. Start checkout for that seat.
+    const payRes = await fetchWithCsrf('/api/payments/create', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ groupSessionParticipantId: joinData.participantId }),
+    })
+    const payData = await payRes.json().catch(() => ({}))
+    if (payRes.ok && payData.checkoutUrl) {
+      window.location.href = payData.checkoutUrl
+      return 'redirecting'
+    }
+    toast.error(payData.error || 'Could not start checkout')
+    return 'error'
+  } catch {
+    toast.error('Something went wrong — please try again')
+    return 'error'
+  }
+}


### PR DESCRIPTION
Two additions to the tutor-hosted **Group Sessions** feature, plus a shared booking helper.

### Wiring audit (item 1) — no change needed
Verified group sessions are already correctly wired: create runs `findConflicts` + `createSession` (they get a `calendarEvent` + `liveSession`), cancel cancels the calendar event and ends the session (frees the slot), and both **conflict detection** and the **availability grid** already see them. They show on the tutor calendar (by tutorId) and the student calendar (paid-seat query). So this PR is just the two additive items.

### Browse surface (item 2)
Students could previously only find a tutor's group sessions on that tutor's public profile — no platform-wide view.
- **`GET /api/group-sessions/browse`** — every `OPEN`, upcoming, seat-available session across all tutors, with host name/username/avatar.
- **`/student/group-sessions`** page + a **"Group Sessions"** entry in the student sidebar — lists them with a **Book a seat** action and a link to the host's profile.

### 1-seat capacity (item 3)
Capacity minimum drops from **2 → 1**, so a tutor can host a **true private 1-on-1** that a single student signs up for (API schema + create form; the browse card labels a 1-seat session **"1-on-1 · 1 seat"**).

### Refactor
Extracted the reserve→pay flow into **`lib/group-session/book-seat.ts`**, shared by the profile list and the browse page.

typecheck · lint · **606** unit tests · production build — all clean.