### PR TITLE
test(builder): extract + test the content-pane visibility rule

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -211,6 +211,7 @@ import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessme
 import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
 import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
 import { nextDmiGate } from '@/lib/assessment/dmi-generate-gate'
+import { resolveDocPaneVisibility } from '@/lib/courses/doc-pane-visibility'
 import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
@@ -7505,22 +7506,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       {}
     )
 
-    // We already defined hasTaskDocument above, so we don't redefine it here.
-    // With no document there is nothing to preview, so the text editor is always
-    // shown and the document pane hidden — a stale per-item view preference (e.g.
-    // left over from a document that was since removed) must never hide the editor
-    // and strand the tutor with no way to type. Once a document is present, the
-    // saved preference applies, defaulting to the document view.
-    const taskTextVisible = !hasTaskDocument
-      ? true
-      : loadedTaskId
-        ? (taskTextVisibleMap[loadedTaskId] ?? false)
-        : false
-    const taskPdfVisible = !hasTaskDocument
-      ? false
-      : loadedTaskId
-        ? (taskPdfVisibleMap[loadedTaskId] ?? true)
-        : true
+    // Which content panes show (text editor / document preview / both). The rule
+    // — including the invariant that a document-less item ALWAYS shows the text
+    // editor so a stale view preference can't strand the tutor — lives in the
+    // tested resolveDocPaneVisibility helper.
+    const taskView = resolveDocPaneVisibility({
+      hasDocument: hasTaskDocument,
+      savedTextVisible: loadedTaskId ? taskTextVisibleMap[loadedTaskId] : undefined,
+      savedPdfVisible: loadedTaskId ? taskPdfVisibleMap[loadedTaskId] : undefined,
+    })
+    const taskTextVisible = taskView.textVisible
+    const taskPdfVisible = taskView.pdfVisible
 
     const setTaskTextVisible = (val: boolean) => {
       if (loadedTaskId) setTaskTextVisibleMap(prev => ({ ...prev, [loadedTaskId]: val }))
@@ -7529,18 +7525,16 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       if (loadedTaskId) setTaskPdfVisibleMap(prev => ({ ...prev, [loadedTaskId]: val }))
     }
 
-    // Same as the task builder: with no document the text editor is always shown
-    // so a stale view preference can't strand the tutor with nothing to type into.
-    const assessmentTextVisible = !hasAssessmentDocument
-      ? true
-      : loadedAssessmentId
-        ? (assessmentTextVisibleMap[loadedAssessmentId] ?? false)
-        : false
-    const assessmentPdfVisible = !hasAssessmentDocument
-      ? false
-      : loadedAssessmentId
-        ? (assessmentPdfVisibleMap[loadedAssessmentId] ?? true)
-        : true
+    // Same rule for the assessment builder, via the same tested helper.
+    const assessmentView = resolveDocPaneVisibility({
+      hasDocument: hasAssessmentDocument,
+      savedTextVisible: loadedAssessmentId
+        ? assessmentTextVisibleMap[loadedAssessmentId]
+        : undefined,
+      savedPdfVisible: loadedAssessmentId ? assessmentPdfVisibleMap[loadedAssessmentId] : undefined,
+    })
+    const assessmentTextVisible = assessmentView.textVisible
+    const assessmentPdfVisible = assessmentView.pdfVisible
 
     const setAssessmentTextVisible = (val: boolean) => {
       if (loadedAssessmentId)

--- a/tutorme-app/src/lib/courses/doc-pane-visibility.test.ts
+++ b/tutorme-app/src/lib/courses/doc-pane-visibility.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDocPaneVisibility } from './doc-pane-visibility'
+
+describe('resolveDocPaneVisibility — no document (the anti-deadlock invariant)', () => {
+  it('always shows the text editor and hides the preview when there is no document', () => {
+    expect(resolveDocPaneVisibility({ hasDocument: false })).toEqual({
+      textVisible: true,
+      pdfVisible: false,
+    })
+  })
+
+  it('ignores a stale "text hidden" preference when there is no document', () => {
+    // Regression: a document was loaded (view switched to Document), then removed.
+    // The leftover savedTextVisible=false must NOT hide the editor.
+    expect(
+      resolveDocPaneVisibility({
+        hasDocument: false,
+        savedTextVisible: false,
+        savedPdfVisible: true,
+      })
+    ).toEqual({ textVisible: true, pdfVisible: false })
+  })
+})
+
+describe('resolveDocPaneVisibility — document present', () => {
+  it('defaults to the document view when no preference is saved', () => {
+    expect(resolveDocPaneVisibility({ hasDocument: true })).toEqual({
+      textVisible: false,
+      pdfVisible: true,
+    })
+  })
+
+  it('honours a saved Text-only preference', () => {
+    expect(
+      resolveDocPaneVisibility({
+        hasDocument: true,
+        savedTextVisible: true,
+        savedPdfVisible: false,
+      })
+    ).toEqual({ textVisible: true, pdfVisible: false })
+  })
+
+  it('honours a saved Split preference (both panes)', () => {
+    expect(
+      resolveDocPaneVisibility({
+        hasDocument: true,
+        savedTextVisible: true,
+        savedPdfVisible: true,
+      })
+    ).toEqual({ textVisible: true, pdfVisible: true })
+  })
+
+  it('honours a saved Document-only preference', () => {
+    expect(
+      resolveDocPaneVisibility({
+        hasDocument: true,
+        savedTextVisible: false,
+        savedPdfVisible: true,
+      })
+    ).toEqual({ textVisible: false, pdfVisible: true })
+  })
+
+  it('falls back per-pane when only one preference is stored', () => {
+    expect(resolveDocPaneVisibility({ hasDocument: true, savedTextVisible: true })).toEqual({
+      textVisible: true,
+      pdfVisible: true, // pdf defaults to true when unset
+    })
+    expect(resolveDocPaneVisibility({ hasDocument: true, savedPdfVisible: false })).toEqual({
+      textVisible: false, // text defaults to false when unset
+      pdfVisible: false,
+    })
+  })
+})
+
+/**
+ * Equivalence check: the helper must reproduce the exact inline derivation it
+ * replaced in CourseBuilder, for every combination of (hasDocument, item loaded,
+ * saved prefs). If this ever drifts, the component and the tests disagree.
+ */
+describe('resolveDocPaneVisibility — matches the original inline derivation', () => {
+  const inlineText = (hasDoc: boolean, loaded: boolean, map: boolean | undefined): boolean =>
+    !hasDoc ? true : loaded ? (map ?? false) : false
+
+  const inlinePdf = (hasDoc: boolean, loaded: boolean, map: boolean | undefined): boolean =>
+    !hasDoc ? false : loaded ? (map ?? true) : true
+
+  it('agrees across all input combinations', () => {
+    const bools = [true, false]
+    const maybe: Array<boolean | undefined> = [true, false, undefined]
+    for (const hasDoc of bools) {
+      for (const loaded of bools) {
+        for (const textMap of maybe) {
+          for (const pdfMap of maybe) {
+            const savedTextVisible = loaded ? textMap : undefined
+            const savedPdfVisible = loaded ? pdfMap : undefined
+            const got = resolveDocPaneVisibility({
+              hasDocument: hasDoc,
+              savedTextVisible,
+              savedPdfVisible,
+            })
+            expect(got.textVisible).toBe(inlineText(hasDoc, loaded, textMap))
+            expect(got.pdfVisible).toBe(inlinePdf(hasDoc, loaded, pdfMap))
+          }
+        }
+      }
+    }
+  })
+})

--- a/tutorme-app/src/lib/courses/doc-pane-visibility.ts
+++ b/tutorme-app/src/lib/courses/doc-pane-visibility.ts
@@ -1,0 +1,47 @@
+/**
+ * Which panes the Task / Assessment builder content view shows: the text editor,
+ * the document preview, or both (split).
+ *
+ * The one invariant that matters for tutors: when there is NO document there is
+ * nothing to preview, so the text editor is always shown and the preview hidden.
+ * A stale per-item view preference — e.g. left over from a document that was
+ * later removed — must never hide the editor and strand the tutor with no way to
+ * type. Once a document is present, the saved preference applies, defaulting to
+ * the document view.
+ *
+ * Pure + framework-free so the rule is unit-tested directly, away from the giant
+ * CourseBuilder component. Both builders (task and assessment) route through it.
+ */
+
+export interface DocPaneVisibility {
+  textVisible: boolean
+  pdfVisible: boolean
+}
+
+export interface DocPaneVisibilityInput {
+  /** A document (PDF / image / file) is attached to the active item. */
+  hasDocument: boolean
+  /**
+   * The tutor's saved per-item preference for the text pane, or `undefined` when
+   * none is saved (no item loaded, or the item has no stored preference).
+   */
+  savedTextVisible?: boolean
+  /** The saved per-item preference for the document pane, or `undefined`. */
+  savedPdfVisible?: boolean
+}
+
+export function resolveDocPaneVisibility({
+  hasDocument,
+  savedTextVisible,
+  savedPdfVisible,
+}: DocPaneVisibilityInput): DocPaneVisibility {
+  // No document → the text editor is always available; nothing to preview.
+  if (!hasDocument) {
+    return { textVisible: true, pdfVisible: false }
+  }
+  // Document present → saved preference wins, defaulting to the document view.
+  return {
+    textVisible: savedTextVisible ?? false,
+    pdfVisible: savedPdfVisible ?? true,
+  }
+}


### PR DESCRIPTION
## Why
The task/assessment builders' content view decides text-editor vs document-preview vs split. That logic lived inline in `CourseBuilder.tsx` and just produced a user-visible issue (the "can't type before loading a document" report → #1037). Same rationale as the DMI-gate extraction (#1034): lift non-trivial UI-routing logic into a pure, tested helper so a future refactor can't silently re-hide the editor.

## What
- New **`src/lib/courses/doc-pane-visibility.ts`** → `resolveDocPaneVisibility({ hasDocument, savedTextVisible?, savedPdfVisible? })`, framework-free.
- Both builders route through it — **behaviour-preserving**; `taskTextVisible` / `taskPdfVisible` / `assessment*` names unchanged, so **no JSX changes** downstream.
- **8 tests** locking the invariants:
  - **anti-deadlock**: no document → text editor **always** shown, preview hidden, *ignoring any stale saved preference* (the exact bug class behind #1037);
  - document present → saved preference wins, defaulting to the document view (Text / Split / Document all covered);
  - an **exhaustive sweep** asserting the helper matches the original inline derivation for every `(hasDocument, loaded, saved-prefs)` combination — guarantees the extraction changed nothing.

## Verification
`vitest run doc-pane-visibility.test.ts` → **8 passed**. Prettier clean (repo's pinned version). No tutor-facing behaviour change. Typecheck/Build via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)