### PR TITLE
fix(guardrails): don't flag related subjects as a curriculum mismatch

### DIFF
--- a/tutorme-app/src/lib/ai/guardrails/curriculum.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/curriculum.test.ts
@@ -118,4 +118,45 @@ describe('checkCurriculumMatch — layer 2 (AI subject)', () => {
     })
     expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(false)
   })
+
+  // Subject-family bridge: related fields are not a mismatch.
+  it('does NOT warn: Mathematics document in an AP Statistics course (stats ⊂ math)', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+      aiSubject: 'Mathematics',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(false)
+  })
+
+  it('does NOT warn: Calculus document in a Mathematics course', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'A Level',
+      expectedSubject: 'A Level Mathematics',
+      aiSubject: 'Calculus',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(false)
+  })
+
+  it('still warns: Biology document in an AP Statistics course (unrelated)', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Statistics',
+      aiSubject: 'Biology',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(true)
+  })
+
+  it('still warns: Chemistry document in a Biology course (distinct sciences)', () => {
+    const v = checkCurriculumMatch({
+      expectedBoard: 'AP',
+      expectedSubject: 'AP Biology',
+      aiSubject: 'Chemistry',
+      aiConfidence: 'high',
+    })
+    expect(v.some(x => x.ruleId === 'CURRIC-2')).toBe(true)
+  })
 })

--- a/tutorme-app/src/lib/ai/guardrails/curriculum.ts
+++ b/tutorme-app/src/lib/ai/guardrails/curriculum.ts
@@ -158,6 +158,58 @@ function subjectTokens(subject: string | null | undefined): Set<string> {
   return out
 }
 
+/**
+ * Subject families — related fields that should NOT be flagged as a mismatch.
+ * Statistics is part of Mathematics, so "AP Statistics" vs a "Mathematics" paper
+ * is not a wrong-subject upload. Kept intentionally tight: only genuine
+ * parent/child/synonym relationships, so distinct subjects (Biology vs
+ * Chemistry, Spanish vs French) still warn.
+ */
+const SUBJECT_FAMILY_GROUPS: string[][] = [
+  [
+    'mathematics',
+    'math',
+    'maths',
+    'statistics',
+    'stats',
+    'statistical',
+    'calculus',
+    'algebra',
+    'geometry',
+    'trigonometry',
+    'mechanics',
+    'probability',
+  ],
+  ['english', 'literature', 'composition', 'rhetoric'],
+  ['computer', 'computing', 'programming', 'informatics'],
+]
+
+const TOKEN_TO_FAMILY = new Map<string, string>()
+SUBJECT_FAMILY_GROUPS.forEach((group, i) =>
+  group.forEach(tok => TOKEN_TO_FAMILY.set(tok, `fam${i}`))
+)
+
+/** The subject families spanned by a token set (empty when none are known). */
+function subjectFamilies(tokens: Set<string>): Set<string> {
+  const fams = new Set<string>()
+  for (const tok of tokens) {
+    const fam = TOKEN_TO_FAMILY.get(tok)
+    if (fam) fams.add(fam)
+  }
+  return fams
+}
+
+/**
+ * Whether two subjects are related — a shared content token OR a shared subject
+ * family (so Statistics ≈ Mathematics). Related subjects are not a mismatch.
+ */
+function subjectsRelated(want: Set<string>, got: Set<string>): boolean {
+  if ([...got].some(t => want.has(t))) return true
+  const wantFams = subjectFamilies(want)
+  if (wantFams.size === 0) return false
+  return [...subjectFamilies(got)].some(f => wantFams.has(f))
+}
+
 export interface CurriculumCheckInput {
   /** Extracted document text (drives the deterministic board scan). */
   extractedText?: string | null
@@ -211,8 +263,9 @@ export function checkCurriculumMatch(input: CurriculumCheckInput): GuardrailViol
     const want = subjectTokens(input.expectedSubject)
     const got = subjectTokens(input.aiSubject)
     if (want.size > 0 && got.size > 0) {
-      const overlap = [...got].some(t => want.has(t))
-      if (!overlap) {
+      // Related subjects (shared token or subject family, e.g. Statistics ⊂
+      // Mathematics) are not a mismatch — only warn when they're truly disjoint.
+      if (!subjectsRelated(want, got)) {
         violations.push({
           ruleId: RULE_SUBJECT,
           severity: 'warning',


### PR DESCRIPTION
## Problem
Follow-up to #1035. The CURRIC-2 subject check compared tokens for any overlap, so an "AP Statistics" course + a **Mathematics** document warned — a false positive, since Statistics ⊂ Mathematics.

## Fix
A tight subject-family bridge: two subjects are "related" (no warning) when they share a token **or** a subject family.
- **math**: mathematics, math(s), statistics, stats, calculus, algebra, geometry, trigonometry, mechanics, probability
- **english/literature**: english, literature, composition, rhetoric
- **computing**: computer, computing, programming, informatics

Kept intentionally narrow — only genuine parent/child/synonym relationships — so distinct subjects still warn.

## Verification
- **4 new unit tests** (18 curriculum / **57 guardrail total, all pass**); typecheck clean; lint 0 errors
- Mathematics & Calculus in a stats/math course → **no warning**; Biology in AP Statistics and Chemistry in AP Biology → **still warn**

🤖 Generated with [Claude Code](https://claude.com/claude-code)