### PR TITLE
feat(group-sessions): seat expiry + completion + launcher/lobby parity

### DIFF
--- a/tutorme-app/src/__tests__/integration/group-session-lifecycle.test.ts
+++ b/tutorme-app/src/__tests__/integration/group-session-lifecycle.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test: group-session lifecycle sweeps.
+ *
+ * - expireStaleGroupSeats: a RESERVED seat left unpaid past the window is
+ *   CANCELLED, freeing capacity and re-opening a FULL session; a fresh
+ *   reservation is left alone.
+ * - completeFinishedGroupSessions: an OPEN session past its end → COMPLETED.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, groupSession, groupSessionParticipant } from '@/lib/db/schema'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
+import { completeFinishedGroupSessions } from '@/lib/group-session/complete'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const studentA = crypto.randomUUID()
+const studentB = crypto.randomUUID()
+const userIds = [tutorId, studentA, studentB]
+
+const gsFull = `gs_full_${stamp}` // FULL, holds a stale reservation
+const gsOpen = `gs_open_${stamp}` // OPEN, holds a fresh reservation
+const gsPast = `gs_past_${stamp}` // OPEN, already ended
+const gsIds = [gsFull, gsOpen, gsPast]
+
+const staleSeat = `seat_stale_${stamp}`
+const freshSeat = `seat_fresh_${stamp}`
+
+function gs(id: string, extra: Record<string, unknown>) {
+  return {
+    groupSessionId: id,
+    tutorId,
+    title: 'Algebra clinic',
+    requestedDate: new Date('2026-08-01T00:00:00.000Z'),
+    startTime: '15:00',
+    endTime: '16:00',
+    timezone: 'UTC',
+    capacity: 1,
+    pricePerSeat: 20,
+    status: 'OPEN',
+    ...extra,
+  }
+}
+
+describe('group-session lifecycle sweeps', () => {
+  beforeAll(async () => {
+    const now = Date.now()
+    await drizzleDb.insert(user).values(
+      userIds.map((id, i) => ({
+        userId: id,
+        email: `gs-${i}-${stamp}@ex.com`,
+        role: i === 0 ? ('TUTOR' as const) : ('STUDENT' as const),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }))
+    )
+    await drizzleDb.insert(groupSession).values([
+      gs(gsFull, { status: 'FULL' }),
+      gs(gsOpen, { status: 'OPEN' }),
+      // Ended days ago (past requestedDate + past wall-clock end).
+      gs(gsPast, { status: 'OPEN', requestedDate: new Date('2026-07-10T00:00:00.000Z') }),
+    ])
+    await drizzleDb.insert(groupSessionParticipant).values([
+      // Reserved 40 min ago, never paid → should expire.
+      {
+        participantId: staleSeat,
+        groupSessionId: gsFull,
+        studentId: studentA,
+        status: 'RESERVED',
+        reservedAt: new Date(now - 40 * 60 * 1000),
+      },
+      // Reserved just now → should survive.
+      {
+        participantId: freshSeat,
+        groupSessionId: gsOpen,
+        studentId: studentB,
+        status: 'RESERVED',
+        reservedAt: new Date(now),
+      },
+    ])
+  })
+
+  afterAll(async () => {
+    await drizzleDb
+      .delete(groupSessionParticipant)
+      .where(inArray(groupSessionParticipant.participantId, [staleSeat, freshSeat]))
+    await drizzleDb.delete(groupSession).where(inArray(groupSession.groupSessionId, gsIds))
+    await drizzleDb.delete(user).where(inArray(user.userId, userIds))
+  })
+
+  it('releases a stale reservation, re-opens the FULL session, keeps fresh ones', async () => {
+    const released = await expireStaleGroupSeats()
+    expect(released).toBeGreaterThanOrEqual(1)
+
+    const [stale] = await drizzleDb
+      .select({ status: groupSessionParticipant.status })
+      .from(groupSessionParticipant)
+      .where(eq(groupSessionParticipant.participantId, staleSeat))
+    expect(stale.status).toBe('CANCELLED')
+
+    const [full] = await drizzleDb
+      .select({ status: groupSession.status })
+      .from(groupSession)
+      .where(eq(groupSession.groupSessionId, gsFull))
+    expect(full.status).toBe('OPEN')
+
+    const [fresh] = await drizzleDb
+      .select({ status: groupSessionParticipant.status })
+      .from(groupSessionParticipant)
+      .where(eq(groupSessionParticipant.participantId, freshSeat))
+    expect(fresh.status).toBe('RESERVED')
+  })
+
+  it('marks a finished group session COMPLETED', async () => {
+    await completeFinishedGroupSessions({ tutorId })
+
+    const [past] = await drizzleDb
+      .select({ status: groupSession.status })
+      .from(groupSession)
+      .where(eq(groupSession.groupSessionId, gsPast))
+    expect(past.status).toBe('COMPLETED')
+
+    // A future session is untouched.
+    const [open] = await drizzleDb
+      .select({ status: groupSession.status })
+      .from(groupSession)
+      .where(eq(groupSession.groupSessionId, gsOpen))
+    expect(open.status).toBe('OPEN')
+  })
+})

--- a/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
+++ b/tutorme-app/src/app/api/cron/expire-one-on-one/route.ts
@@ -1,9 +1,10 @@
 /**
- * Cron sweep: expire overdue unpaid 1-on-1 holds globally.
+ * Cron sweep for 1-on-1 AND group-session lifecycle: expire overdue unpaid 1-on-1
+ * holds and stale group seat reservations, and mark finished sessions COMPLETED.
  *
- * Also runs lazily (when a tutor's availability/requests are viewed) and on boot,
- * but this endpoint gives a guaranteed cadence. Protect with CRON_SECRET and hit
- * it on a schedule (the keep-alive workflow does, every 10 min).
+ * Also runs lazily (when the relevant surfaces are viewed) and on boot, but this
+ * endpoint gives a guaranteed cadence. Protect with CRON_SECRET and hit it on a
+ * schedule (the keep-alive workflow does, every 10 min).
  *
  * Auth: `Authorization: Bearer <CRON_SECRET>`. Inert (503) until CRON_SECRET is
  * configured, so it can never be triggered by an anonymous caller.
@@ -12,6 +13,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
+import { completeFinishedGroupSessions } from '@/lib/group-session/complete'
 
 export async function GET(req: NextRequest) {
   const secret = process.env.CRON_SECRET
@@ -24,13 +27,15 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const [expired, completed] = await Promise.all([
+    const [expired, completed, seatsReleased, groupsCompleted] = await Promise.all([
       expireOverdueOneOnOneBookings(),
       completeFinishedOneOnOneSessions(),
+      expireStaleGroupSeats(),
+      completeFinishedGroupSessions(),
     ])
-    return NextResponse.json({ ok: true, expired, completed })
+    return NextResponse.json({ ok: true, expired, completed, seatsReleased, groupsCompleted })
   } catch (error) {
-    console.error('[cron] expire-one-on-one failed:', error)
+    console.error('[cron] session lifecycle sweep failed:', error)
     return NextResponse.json({ error: 'Sweep failed' }, { status: 500 })
   }
 }

--- a/tutorme-app/src/app/api/group-sessions/[id]/join/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/[id]/join/route.ts
@@ -21,6 +21,7 @@ import { countActiveSeats, admitPaidSeat } from '@/lib/group-session/seats'
 import { getOrCreateConversation } from '@/lib/messaging/conversation'
 import { notifyWaitlistOfOpening } from '@/lib/one-on-one/waitlist'
 import { bookingInstants } from '@/lib/one-on-one/time'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
 
 async function load(id: string) {
   const [gs] = await drizzleDb
@@ -49,6 +50,10 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     if (start.getTime() <= Date.now()) {
       return NextResponse.json({ error: 'This session has already started' }, { status: 400 })
     }
+
+    // Release any abandoned reservations first so the capacity check below sees
+    // seats freed by students who never completed checkout.
+    await expireStaleGroupSeats({ groupSessionId: id }).catch(() => {})
 
     // Re-use an existing seat if the student already holds one.
     const [existing] = await drizzleDb

--- a/tutorme-app/src/app/api/group-sessions/browse/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/browse/route.ts
@@ -13,8 +13,12 @@ import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { groupSession, profile, user } from '@/lib/db/schema'
 import { countActiveSeats } from '@/lib/group-session/seats'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
 
 export const GET = withAuth(async (_req: NextRequest) => {
+  // Release abandoned reservations first so seat counts are accurate.
+  await expireStaleGroupSeats().catch(() => {})
+
   const now = new Date()
   const startOfTodayUtc = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())

--- a/tutorme-app/src/app/api/group-sessions/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/route.ts
@@ -21,6 +21,8 @@ import { dailyProvider } from '@/lib/video/daily-provider'
 import { findConflicts } from '@/lib/schedule/conflicts'
 import { slotInstants, requestedDateFromString } from '@/lib/one-on-one/time'
 import { countActiveSeats } from '@/lib/group-session/seats'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
+import { completeFinishedGroupSessions } from '@/lib/group-session/complete'
 
 const createSchema = z.object({
   title: z.string().min(1).max(120),
@@ -144,6 +146,12 @@ export async function POST(req: NextRequest) {
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions, req)
   if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Keep statuses/seat counts current before listing (best-effort).
+  await Promise.all([
+    expireStaleGroupSeats().catch(() => {}),
+    completeFinishedGroupSessions().catch(() => {}),
+  ])
 
   const tutorId = new URL(req.url).searchParams.get('tutorId')
 

--- a/tutorme-app/src/app/api/one-on-one/live-now/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/live-now/route.ts
@@ -1,40 +1,55 @@
 /**
  * GET /api/one-on-one/live-now
  *
- * The current user's most imminent confirmed 1-on-1 session — live now or
- * starting soon — for the global Session Launcher. Works for either participant.
- * Returns null when nothing is near, so the launcher stays hidden.
+ * The current user's most imminent confirmed session — 1-on-1 OR group session,
+ * live now or starting soon — for the global Session Launcher. Works for either
+ * participant. Returns null when nothing is near, so the launcher stays hidden.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, eq, or, gte, lte } from 'drizzle-orm'
+import { and, eq, or, gte, lte, inArray } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { oneOnOneBookingRequest, calendarEvent, liveSession, profile } from '@/lib/db/schema'
+import {
+  oneOnOneBookingRequest,
+  calendarEvent,
+  liveSession,
+  groupSession,
+  groupSessionParticipant,
+  profile,
+} from '@/lib/db/schema'
 
-// How early the launcher appears, and how late it lingers after the end.
 const LOOKAHEAD_MS = 30 * 60 * 1000 // 30 min before start
 const LINGER_AFTER_END_MS = 15 * 60 * 1000 // 15 min after end
-// Must match the join endpoint's early-entry window so "Join" only enables when
-// the room will actually accept the student.
+// Must match the join endpoint's early-entry window.
 const EARLY_ENTRY_MS = 20 * 60 * 1000
+
+interface Candidate {
+  sessionId: string
+  scheduledAt: Date | null
+  durationMinutes: number | null
+  status: string | null
+  isGroup: boolean
+  tutorId: string
+  /** 1-on-1: the other party (for the "1-on-1 with X" label). */
+  studentId: string | null
+  /** Group: the session title. */
+  title: string | null
+}
 
 export const GET = withAuth(async (_req: NextRequest, session) => {
   const userId = session.user.id
   const now = Date.now()
-
-  // Candidate window: sessions scheduled from a few hours ago (so a long/late
-  // session still counts) up to the lookahead. End is checked precisely below.
   const from = new Date(now - 4 * 60 * 60 * 1000)
   const until = new Date(now + LOOKAHEAD_MS)
 
-  const rows = await drizzleDb
+  // 1-on-1 sessions the user is in (either side).
+  const oneOnOnes = await drizzleDb
     .select({
       sessionId: liveSession.sessionId,
       scheduledAt: liveSession.scheduledAt,
       durationMinutes: liveSession.durationMinutes,
       status: liveSession.status,
-      requestId: oneOnOneBookingRequest.requestId,
       tutorId: oneOnOneBookingRequest.tutorId,
       studentId: oneOnOneBookingRequest.studentId,
     })
@@ -53,37 +68,96 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
         lte(liveSession.scheduledAt, until)
       )
     )
-    .orderBy(liveSession.scheduledAt)
 
-  // Pick the soonest session that is still within its live window.
-  const pick = rows.find(r => {
-    if (!r.scheduledAt) return false
-    const start = new Date(r.scheduledAt).getTime()
-    const end = start + (r.durationMinutes ?? 60) * 60 * 1000
+  // Group sessions the user holds a paid seat in.
+  const groupAsStudent = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      tutorId: groupSession.tutorId,
+      title: groupSession.title,
+    })
+    .from(groupSessionParticipant)
+    .innerJoin(
+      groupSession,
+      eq(groupSession.groupSessionId, groupSessionParticipant.groupSessionId)
+    )
+    .innerJoin(liveSession, eq(liveSession.sessionId, groupSession.liveSessionId))
+    .where(
+      and(
+        eq(groupSessionParticipant.studentId, userId),
+        eq(groupSessionParticipant.status, 'PAID'),
+        inArray(groupSession.status, ['OPEN', 'FULL', 'COMPLETED']),
+        gte(liveSession.scheduledAt, from),
+        lte(liveSession.scheduledAt, until)
+      )
+    )
+
+  // Group sessions the user hosts.
+  const groupAsTutor = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      tutorId: groupSession.tutorId,
+      title: groupSession.title,
+    })
+    .from(groupSession)
+    .innerJoin(liveSession, eq(liveSession.sessionId, groupSession.liveSessionId))
+    .where(
+      and(
+        eq(groupSession.tutorId, userId),
+        inArray(groupSession.status, ['OPEN', 'FULL']),
+        gte(liveSession.scheduledAt, from),
+        lte(liveSession.scheduledAt, until)
+      )
+    )
+
+  const candidates: Candidate[] = [
+    ...oneOnOnes.map(r => ({ ...r, isGroup: false, title: null as string | null })),
+    ...groupAsStudent.map(r => ({ ...r, isGroup: true, studentId: null as string | null })),
+    ...groupAsTutor.map(r => ({ ...r, isGroup: true, studentId: null as string | null })),
+  ]
+    .filter(c => c.scheduledAt)
+    .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
+
+  // Soonest one still within its live window.
+  const pick = candidates.find(c => {
+    const start = new Date(c.scheduledAt!).getTime()
+    const end = start + (c.durationMinutes ?? 60) * 60 * 1000
     return now <= end + LINGER_AFTER_END_MS
   })
-
   if (!pick || !pick.scheduledAt) {
     return NextResponse.json({ session: null })
   }
 
   const start = new Date(pick.scheduledAt).getTime()
-  const isTutor = pick.tutorId === userId
-  const otherPartyId = isTutor ? pick.studentId : pick.tutorId
-  const [other] = await drizzleDb
-    .select({ name: profile.name })
-    .from(profile)
-    .where(eq(profile.userId, otherPartyId))
-    .limit(1)
+  const viewerIsTutor = pick.tutorId === userId
+
+  let title: string
+  if (pick.isGroup) {
+    title = pick.title || 'Group session'
+  } else {
+    const otherId = viewerIsTutor ? pick.studentId : pick.tutorId
+    const [other] = otherId
+      ? await drizzleDb
+          .select({ name: profile.name })
+          .from(profile)
+          .where(eq(profile.userId, otherId))
+          .limit(1)
+      : [null]
+    title = `1-on-1 with ${other?.name || (viewerIsTutor ? 'your student' : 'your tutor')}`
+  }
 
   return NextResponse.json({
     session: {
       sessionId: pick.sessionId,
-      requestId: pick.requestId,
       scheduledAt: new Date(pick.scheduledAt).toISOString(),
-      withName: other?.name || (isTutor ? 'your student' : 'your tutor'),
-      viewerIsTutor: isTutor,
-      // Live if the session is active, or if we're inside the 20-min entry window.
+      title,
+      viewerIsTutor,
       joinable: pick.status === 'active' || now >= start - EARLY_ENTRY_MS,
       live: pick.status === 'active',
     },

--- a/tutorme-app/src/app/api/one-on-one/session-status/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/session-status/route.ts
@@ -7,10 +7,17 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { liveSession, calendarEvent, oneOnOneBookingRequest, profile } from '@/lib/db/schema'
+import {
+  liveSession,
+  calendarEvent,
+  oneOnOneBookingRequest,
+  groupSession,
+  groupSessionParticipant,
+  profile,
+} from '@/lib/db/schema'
 
 // Match the join endpoint's early-entry window and the launcher's grace.
 const EARLY_ENTRY_MS = 20 * 60 * 1000
@@ -40,50 +47,98 @@ export const GET = withAuth(async (req: NextRequest, session) => {
     return NextResponse.json({ error: 'Session not found' }, { status: 404 })
   }
 
-  // Confirm this is a 1-on-1 (has a booking linked via its calendar event) and
-  // that the caller is one of its two participants.
-  const [booking] = await drizzleDb
-    .select({
-      studentId: oneOnOneBookingRequest.studentId,
-      tutorId: oneOnOneBookingRequest.tutorId,
-      status: oneOnOneBookingRequest.status,
-    })
-    .from(oneOnOneBookingRequest)
-    .innerJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
-    .where(eq(calendarEvent.externalId, sessionId))
-    .limit(1)
-
-  if (!booking) {
-    return NextResponse.json({ error: 'Not a 1-on-1 session' }, { status: 404 })
-  }
-  const isTutor = booking.tutorId === userId
-  if (booking.studentId !== userId && !isTutor) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
-  }
-
   const now = Date.now()
   const start = ls.scheduledAt ? new Date(ls.scheduledAt).getTime() : NaN
   const end = Number.isFinite(start) ? start + (ls.durationMinutes ?? 60) * 60 * 1000 : NaN
   const opensAt = Number.isFinite(start) ? start - EARLY_ENTRY_MS : NaN
   const live = ls.status === 'active'
 
-  const otherPartyId = isTutor ? booking.studentId : booking.tutorId
-  const [other] = await drizzleDb
-    .select({ name: profile.name })
-    .from(profile)
-    .where(eq(profile.userId, otherPartyId))
+  // Resolve who the session is with + authorize the caller. Try 1-on-1 (linked via
+  // the calendar event), then a group session (whose liveSessionId is this room).
+  let isTutor = false
+  let title = ls.title || 'Session'
+  let withName = ''
+  let authorized = false
+
+  const [booking] = await drizzleDb
+    .select({
+      studentId: oneOnOneBookingRequest.studentId,
+      tutorId: oneOnOneBookingRequest.tutorId,
+    })
+    .from(oneOnOneBookingRequest)
+    .innerJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
+    .where(eq(calendarEvent.externalId, sessionId))
     .limit(1)
+
+  if (booking) {
+    isTutor = booking.tutorId === userId
+    authorized = booking.studentId === userId || isTutor
+    if (authorized) {
+      title = ls.title || '1-on-1 Session'
+      const otherId = isTutor ? booking.studentId : booking.tutorId
+      const [other] = await drizzleDb
+        .select({ name: profile.name })
+        .from(profile)
+        .where(eq(profile.userId, otherId))
+        .limit(1)
+      withName = other?.name || (isTutor ? 'your student' : 'your tutor')
+    }
+  } else {
+    const [gs] = await drizzleDb
+      .select({
+        groupSessionId: groupSession.groupSessionId,
+        tutorId: groupSession.tutorId,
+        title: groupSession.title,
+      })
+      .from(groupSession)
+      .where(eq(groupSession.liveSessionId, sessionId))
+      .limit(1)
+    if (gs) {
+      isTutor = gs.tutorId === userId
+      if (isTutor) {
+        authorized = true
+        title = gs.title || 'Group session'
+        withName = 'your group'
+      } else {
+        const [seat] = await drizzleDb
+          .select({ id: groupSessionParticipant.participantId })
+          .from(groupSessionParticipant)
+          .where(
+            and(
+              eq(groupSessionParticipant.groupSessionId, gs.groupSessionId),
+              eq(groupSessionParticipant.studentId, userId),
+              eq(groupSessionParticipant.status, 'PAID')
+            )
+          )
+          .limit(1)
+        if (seat) {
+          authorized = true
+          title = gs.title || 'Group session'
+          const [tut] = await drizzleDb
+            .select({ name: profile.name })
+            .from(profile)
+            .where(eq(profile.userId, gs.tutorId))
+            .limit(1)
+          withName = tut?.name || 'your tutor'
+        }
+      }
+    }
+  }
+
+  if (!authorized) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
 
   return NextResponse.json({
     sessionId: ls.sessionId,
-    title: ls.title || '1-on-1 Session',
-    withName: other?.name || (isTutor ? 'your student' : 'your tutor'),
+    title,
+    withName,
     viewerIsTutor: isTutor,
     scheduledAt: Number.isFinite(start) ? new Date(start).toISOString() : null,
     opensAt: Number.isFinite(opensAt) ? new Date(opensAt).toISOString() : null,
     live,
-    // The tutor may always enter; a student once the session is live or inside
-    // the 20-min entry window.
+    // The tutor may always enter; a student once the session is live or inside the
+    // 20-min entry window.
     joinable: isTutor || live || (Number.isFinite(opensAt) && now >= opensAt),
     ended: Number.isFinite(end) && now > end + LINGER_AFTER_END_MS,
   })

--- a/tutorme-app/src/components/one-on-one/session-launcher.tsx
+++ b/tutorme-app/src/components/one-on-one/session-launcher.tsx
@@ -21,9 +21,9 @@ import { formatCountdown } from '@/lib/one-on-one/format'
 
 interface LiveSession {
   sessionId: string
-  requestId: string
   scheduledAt: string
-  withName: string
+  /** Display label, e.g. "1-on-1 with Alice" or a group session's title. */
+  title: string
   viewerIsTutor: boolean
   joinable: boolean
   live: boolean
@@ -94,9 +94,7 @@ export function SessionLauncher() {
         </span>
 
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold">
-            1-on-1 with <span className="capitalize">{live.withName}</span>
-          </p>
+          <p className="truncate text-sm font-semibold">{live.title}</p>
           <p className="truncate text-xs text-white/60">
             {isLive ? (
               <span className="font-medium text-emerald-400">● Live now</span>

--- a/tutorme-app/src/lib/db/startup-cleanup.ts
+++ b/tutorme-app/src/lib/db/startup-cleanup.ts
@@ -16,6 +16,8 @@ import { drizzleDb } from './drizzle'
 import { sql } from 'drizzle-orm'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
+import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
+import { completeFinishedGroupSessions } from '@/lib/group-session/complete'
 
 const CLEANUP_SQL = sql.raw(`
 DELETE FROM "LiveSession"
@@ -94,6 +96,22 @@ export async function applyStartupDataCleanup(): Promise<void> {
   } catch (err) {
     console.error(
       '⚠️ [Server] 1-on-1 completion sweep skipped:',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  try {
+    const released = await expireStaleGroupSeats()
+    if (released > 0) {
+      console.log(`[Server] Data cleanup: released ${released} stale group seat reservation(s).`)
+    }
+    const completed = await completeFinishedGroupSessions()
+    if (completed > 0) {
+      console.log(`[Server] Data cleanup: completed ${completed} finished group session(s).`)
+    }
+  } catch (err) {
+    console.error(
+      '⚠️ [Server] group-session sweep skipped:',
       err instanceof Error ? err.message : err
     )
   }

--- a/tutorme-app/src/lib/group-session/complete.ts
+++ b/tutorme-app/src/lib/group-session/complete.ts
@@ -1,0 +1,58 @@
+/**
+ * Mark finished group sessions COMPLETED.
+ *
+ * An OPEN/FULL group session otherwise lingers in that state forever after it
+ * ends. This flips it to COMPLETED once its scheduled end (plus a grace period,
+ * so a session running long isn't cut off) has passed. `status` is plain text, so
+ * no enum migration is needed. CANCELLED sessions are left as-is.
+ */
+
+import { and, eq, inArray, lte } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { groupSession } from '@/lib/db/schema'
+import { bookingInstants } from '@/lib/one-on-one/time'
+
+/** Grace after the scheduled end before a session counts as finished. */
+const COMPLETION_GRACE_MS = 60 * 60 * 1000
+
+export async function completeFinishedGroupSessions(
+  opts: { tutorId?: string } = {}
+): Promise<number> {
+  const now = Date.now()
+
+  const conditions = [
+    inArray(groupSession.status, ['OPEN', 'FULL']),
+    // Coarse pre-filter (widened a day for far-east timezones); exact end below.
+    lte(groupSession.requestedDate, new Date(now + 24 * 60 * 60 * 1000)),
+  ]
+  if (opts.tutorId) conditions.push(eq(groupSession.tutorId, opts.tutorId))
+
+  const candidates = await drizzleDb
+    .select({
+      groupSessionId: groupSession.groupSessionId,
+      requestedDate: groupSession.requestedDate,
+      startTime: groupSession.startTime,
+      endTime: groupSession.endTime,
+      timezone: groupSession.timezone,
+    })
+    .from(groupSession)
+    .where(and(...conditions))
+
+  const finished = candidates.filter(g => {
+    const { end } = bookingInstants(g)
+    return Number.isFinite(end.getTime()) && end.getTime() + COMPLETION_GRACE_MS < now
+  })
+  if (finished.length === 0) return 0
+
+  await drizzleDb
+    .update(groupSession)
+    .set({ status: 'COMPLETED', updatedAt: new Date() })
+    .where(
+      inArray(
+        groupSession.groupSessionId,
+        finished.map(g => g.groupSessionId)
+      )
+    )
+
+  return finished.length
+}

--- a/tutorme-app/src/lib/group-session/expire-seats.ts
+++ b/tutorme-app/src/lib/group-session/expire-seats.ts
@@ -1,0 +1,72 @@
+/**
+ * Release stale group-session seat reservations.
+ *
+ * Booking a seat in a PAID session creates a RESERVED seat and sends the student
+ * to checkout. If they abandon it, the seat would otherwise hold capacity forever
+ * (countActiveSeats counts RESERVED) — blocking others, and permanently blocking a
+ * 1-seat (true 1-on-1) session. This cancels RESERVED seats left unpaid past a
+ * short window, frees the capacity, re-opens a FULL session, and pings the
+ * waitlist. Free sessions confirm to PAID on reserve, so they never match.
+ */
+
+import { and, eq, inArray, isNull, lt } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { groupSession, groupSessionParticipant } from '@/lib/db/schema'
+import { notifyWaitlistOfOpening } from '@/lib/one-on-one/waitlist'
+
+/** How long a student has to complete checkout before their seat is released. */
+const RESERVATION_TTL_MS = 30 * 60 * 1000
+
+export async function expireStaleGroupSeats(
+  opts: { groupSessionId?: string } = {}
+): Promise<number> {
+  const cutoff = new Date(Date.now() - RESERVATION_TTL_MS)
+
+  const conditions = [
+    eq(groupSessionParticipant.status, 'RESERVED'),
+    isNull(groupSessionParticipant.paidAt),
+    lt(groupSessionParticipant.reservedAt, cutoff),
+  ]
+  if (opts.groupSessionId) {
+    conditions.push(eq(groupSessionParticipant.groupSessionId, opts.groupSessionId))
+  }
+
+  const stale = await drizzleDb
+    .select({
+      participantId: groupSessionParticipant.participantId,
+      groupSessionId: groupSessionParticipant.groupSessionId,
+    })
+    .from(groupSessionParticipant)
+    .where(and(...conditions))
+
+  if (stale.length === 0) return 0
+
+  await drizzleDb
+    .update(groupSessionParticipant)
+    .set({ status: 'CANCELLED', updatedAt: new Date() })
+    .where(
+      inArray(
+        groupSessionParticipant.participantId,
+        stale.map(s => s.participantId)
+      )
+    )
+
+  // Re-open any session that was FULL, and let its waitlist know a seat opened.
+  for (const gsId of new Set(stale.map(s => s.groupSessionId))) {
+    const [gs] = await drizzleDb
+      .select({ status: groupSession.status, tutorId: groupSession.tutorId })
+      .from(groupSession)
+      .where(eq(groupSession.groupSessionId, gsId))
+      .limit(1)
+    if (!gs) continue
+    if (gs.status === 'FULL') {
+      await drizzleDb
+        .update(groupSession)
+        .set({ status: 'OPEN', updatedAt: new Date() })
+        .where(eq(groupSession.groupSessionId, gsId))
+    }
+    if (gs.status !== 'CANCELLED') void notifyWaitlistOfOpening(gs.tutorId)
+  }
+
+  return stale.length
+}


### PR DESCRIPTION
Brings the **Group Sessions** feature up to the same lifecycle + join-discoverability the 1-on-1 flow got this session. Three gaps closed (all confirmed as real during a wiring audit):

### 1. Abandoned seat reservations never expired 🔴
Booking a seat in a paid session created a `RESERVED` seat and sent the student to checkout; if they abandoned it, the seat held capacity **forever** (`countActiveSeats` counts `RESERVED`) — permanently blocking others, and totally blocking a **1-seat** session.
- **`expireStaleGroupSeats`**: cancels `RESERVED` seats left unpaid past **30 min**, frees capacity, re-opens a `FULL` session, pings the waitlist. Free sessions confirm on reserve, so never match.
- Triggers: lazily (join capacity check, browse, list), on boot, and via the cron sweep.

### 2. No COMPLETED transition
- **`completeFinishedGroupSessions`**: past `OPEN`/`FULL` sessions → `COMPLETED` (1h grace; `status` is plain text, no migration).

### 3. Launcher + lobby skipped group sessions
`live-now` (launcher) and `session-status` (lobby) queried only `oneOnOneBookingRequest`.
- Both now also match **group sessions** (as a paid participant or the host), so group students/hosts get the same app-wide **Join** banner + **pre-join lobby** as 1-on-1.
- The launcher now renders a per-session **title** (`"1-on-1 with Alice"` or the group session's title).

### Verification
2 new **integration tests** (run green against a real Postgres via `drizzle-kit push`):
- stale reservation → `CANCELLED`, `FULL` → `OPEN`, fresh reservation kept.
- finished group session → `COMPLETED`, future one untouched.

typecheck · lint · **619** unit tests · production build — all clean. (Integration specs run under `test:integration`, excluded from the unit CI.)