### PR TITLE
feat(sessions): rich classroom for 1-on-1/group — video + shared whiteboard (Phase A)

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Loader2, ArrowLeft, Video, CalendarClock } from 'lucide-react'
-import { DailyVideoFrame } from '@/components/class/daily-video-frame'
+import { SessionClassroom } from '@/components/one-on-one/session-classroom'
 import { formatCountdown } from '@/lib/one-on-one/format'
 
 type Phase = 'checking' | 'lobby' | 'joining' | 'inRoom' | 'ended' | 'error'
@@ -36,7 +36,6 @@ interface VideoInfo {
   error?: string
 }
 
-const EARLY_ENTRY_MS = 20 * 60 * 1000
 const LOBBY_POLL_MS = 20_000
 
 export default function OneOnOneCallPage() {
@@ -261,14 +260,12 @@ export default function OneOnOneCallPage() {
   }
 
   return (
-    <div className="h-screen w-full bg-black">
-      <DailyVideoFrame
-        roomUrl={video.roomUrl}
-        token={video.token}
-        isTutor={video.isTutor}
-        twoWay={video.twoWay}
-        className="h-full w-full rounded-none border-0"
-      />
-    </div>
+    <SessionClassroom
+      sessionId={sessionId}
+      roomUrl={video.roomUrl}
+      token={video.token}
+      isTutor={video.isTutor}
+      twoWay={video.twoWay}
+    />
   )
 }

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+/**
+ * The shared classroom for a 1-on-1 or group session — the same rich interface a
+ * course session uses (collaborative whiteboard with the video as an overlay),
+ * rather than a bare video call.
+ *
+ * The whiteboard and video are both keyed by the live-session id: the socket room
+ * is `sessionId`, and EnhancedWhiteboard self-syncs strokes over that room (it
+ * both emits its own and applies remote ones), so two participants sharing the
+ * room mirror each other with no extra wiring. Course-only panels (materials,
+ * task deployment) are intentionally absent — a course-less session has none.
+ */
+
+import { useState, type ComponentProps } from 'react'
+import { useSession } from 'next-auth/react'
+import { useSocket } from '@/hooks/use-socket'
+import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
+import { DailyVideoFrame } from '@/components/class/daily-video-frame'
+
+type Pages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
+
+interface SessionClassroomProps {
+  sessionId: string
+  roomUrl: string
+  token: string | null
+  isTutor?: boolean
+  twoWay?: boolean
+}
+
+export function SessionClassroom({
+  sessionId,
+  roomUrl,
+  token,
+  isTutor,
+  twoWay,
+}: SessionClassroomProps) {
+  const { data: session } = useSession()
+  const [pages, setPages] = useState<Pages>([])
+  const [pageIndex, setPageIndex] = useState(0)
+
+  // useSocket keys its effect on the option fields (not object identity), so an
+  // inline object is safe — the compiler memoizes and the socket only reconnects
+  // when a field actually changes.
+  const socketOptions =
+    sessionId && session?.user?.id
+      ? {
+          roomId: sessionId,
+          userId: session.user.id,
+          name: session.user.name || (isTutor ? 'Tutor' : 'Student'),
+          role: isTutor ? ('tutor' as const) : ('student' as const),
+        }
+      : undefined
+
+  const { socket } = useSocket(socketOptions)
+
+  // The call feed rides along as the whiteboard's draggable video overlay.
+  const video = (
+    <DailyVideoFrame
+      roomUrl={roomUrl}
+      token={token}
+      isTutor={isTutor}
+      twoWay={twoWay}
+      className="h-full w-full rounded-none border-0"
+    />
+  )
+
+  return (
+    <div className="h-screen w-full bg-slate-950">
+      <EnhancedWhiteboard
+        socket={socket}
+        roomId={sessionId}
+        userId={session?.user?.id}
+        userName={session?.user?.name || undefined}
+        pages={pages}
+        currentPageIndex={pageIndex}
+        onPagesChange={setPages}
+        onPageIndexChange={setPageIndex}
+        videoOverlay
+        videoComponent={video}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
**Phase A** of bringing 1-on-1 and group-session rooms onto the same rich classroom the course sessions use (the approved plan: Path 1 = classroom on `/call`, then Phase B = attach materials).

### What changed
`/call/[sessionId]` was a **bare video call**. It's now a **collaborative classroom**: the same `EnhancedWhiteboard` course sessions use, with `DailyVideoFrame` as its draggable **video overlay**.

### Why it's clean
- Both are keyed by the **live-session id**: the socket room is `sessionId`, and the whiteboard **self-syncs** (it emits its own strokes *and* applies remote ones), so two participants mirror each other with **no bespoke sync code**.
- The socket server **already supports course-less sessions** (it anchors ad-hoc sessions to a placeholder course), so **no backend change**.
- The **video is preserved inside** the classroom — the change is additive.

### Scope
- Course-only panels (**materials, task deployment**) are intentionally absent — a course-less session has none. **Phase B** will let a tutor attach a lesson to a session so the materials panel renders.

New `SessionClassroom` component; the `/call` in-room render uses it.

typecheck · lint · production build — clean.

> ⚠️ Real-time whiteboard sync can't be exercised in CI — needs a **two-client smoke test** in the live app (draw on one side, confirm it appears on the other). The video path is unchanged.