### PR TITLE
feat(sessions): deploy tasks/materials in the 1-on-1/group classroom (Phase B)

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/one-on-one/deployables  (tutor only)
+ *
+ * The tutor's saved, published tasks that can be deployed into a live session's
+ * classroom (the session-classroom deploy panel). Returns enough to build the
+ * LiveTask the client emits over `task:deploy`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask } from '@/lib/db/schema'
+
+export const GET = withAuth(
+  async (_req: NextRequest, session) => {
+    const rows = await drizzleDb
+      .select({
+        taskId: builderTask.taskId,
+        title: builderTask.title,
+        type: builderTask.type,
+        content: builderTask.content,
+        lessonId: builderTask.lessonId,
+      })
+      .from(builderTask)
+      .where(
+        and(
+          eq(builderTask.tutorId, session.user.id),
+          eq(builderTask.status, 'published'),
+          isNull(builderTask.deletedAt)
+        )
+      )
+      .orderBy(desc(builderTask.updatedAt))
+      .limit(100)
+
+    return NextResponse.json({
+      tasks: rows.map(r => ({
+        taskId: r.taskId,
+        title: r.title || 'Untitled task',
+        type: (r.type as 'task' | 'assessment' | 'homework') || 'task',
+        content: r.content || '',
+        lessonId: r.lessonId || null,
+      })),
+    })
+  },
+  { role: 'TUTOR' }
+)

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -14,9 +14,12 @@
 
 import { useState, type ComponentProps } from 'react'
 import { useSession } from 'next-auth/react'
+import { Send, FolderOpen } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
+import { SessionDeployPanel } from '@/components/one-on-one/session-deploy-panel'
+import { SessionDeployedPanel } from '@/components/one-on-one/session-deployed-panel'
 
 type Pages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
 
@@ -38,6 +41,8 @@ export function SessionClassroom({
   const { data: session } = useSession()
   const [pages, setPages] = useState<Pages>([])
   const [pageIndex, setPageIndex] = useState(0)
+  const [showDeploy, setShowDeploy] = useState(false)
+  const [showMaterials, setShowMaterials] = useState(false)
 
   // useSocket keys its effect on the option fields (not object identity), so an
   // inline object is safe — the compiler memoizes and the socket only reconnects
@@ -66,7 +71,7 @@ export function SessionClassroom({
   )
 
   return (
-    <div className="h-screen w-full bg-slate-950">
+    <div className="relative h-screen w-full bg-slate-950">
       <EnhancedWhiteboard
         socket={socket}
         roomId={sessionId}
@@ -79,6 +84,50 @@ export function SessionClassroom({
         videoOverlay
         videoComponent={video}
       />
+
+      {/* Classroom toolbar: deploy (tutor) + materials (everyone). */}
+      <div className="pointer-events-none absolute right-3 top-3 z-40 flex gap-2">
+        {isTutor ? (
+          <button
+            type="button"
+            onClick={() => {
+              setShowDeploy(v => !v)
+              setShowMaterials(false)
+            }}
+            className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+          >
+            <Send className="h-3.5 w-3.5" />
+            Deploy
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => {
+            setShowMaterials(v => !v)
+            setShowDeploy(false)
+          }}
+          className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+        >
+          <FolderOpen className="h-3.5 w-3.5" />
+          Materials
+        </button>
+      </div>
+
+      {/* Side panels (fail independently of the whiteboard). */}
+      {showDeploy || showMaterials ? (
+        <div className="pointer-events-none absolute bottom-3 right-3 top-16 z-40 flex">
+          {showDeploy && isTutor ? (
+            <SessionDeployPanel
+              sessionId={sessionId}
+              socket={socket}
+              onClose={() => setShowDeploy(false)}
+            />
+          ) : null}
+          {showMaterials ? (
+            <SessionDeployedPanel socket={socket} onClose={() => setShowMaterials(false)} />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { toast } from 'sonner'
+import { Loader2, Send, X, FileText } from 'lucide-react'
+
+interface Deployable {
+  taskId: string
+  title: string
+  type: 'task' | 'assessment' | 'homework'
+  content: string
+  lessonId: string | null
+}
+
+/**
+ * Tutor-only panel to deploy one of their saved tasks into the live session — the
+ * same `task:deploy` socket event a course classroom uses, so the server persists
+ * it (under the ad-hoc anchor for a course-less session) and broadcasts it to the
+ * room. Self-contained: if the fetch or socket is unavailable it just shows an
+ * empty/disabled state, never affecting the whiteboard/video around it.
+ */
+export function SessionDeployPanel({
+  sessionId,
+  socket,
+  onClose,
+}: {
+  sessionId: string
+  socket: Socket | null
+  onClose: () => void
+}) {
+  const [items, setItems] = useState<Deployable[]>([])
+  const [loading, setLoading] = useState(true)
+  const [deployingId, setDeployingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/one-on-one/deployables', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : { tasks: [] }))
+      .then(d => {
+        if (active) setItems(Array.isArray(d.tasks) ? d.tasks : [])
+      })
+      .catch(() => active && setItems([]))
+      .finally(() => active && setLoading(false))
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const deploy = (t: Deployable) => {
+    if (!socket) {
+      toast.error('Still connecting — try again in a moment.')
+      return
+    }
+    setDeployingId(t.taskId)
+    // Same LiveTask shape the course classroom emits (answer key / PCI stay
+    // server-side; a plain deploy carries just the student-visible fields).
+    socket.emit('task:deploy', {
+      roomId: sessionId,
+      task: {
+        id: t.taskId,
+        title: t.title,
+        content: t.content,
+        source: t.type,
+        lessonId: t.lessonId ?? undefined,
+        deployedAt: Date.now(),
+        polls: [],
+        questions: [],
+      },
+    })
+    toast.success(`Deployed "${t.title}"`)
+    setTimeout(() => setDeployingId(null), 800)
+  }
+
+  return (
+    <div className="pointer-events-auto flex h-full w-80 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="text-sm font-semibold text-slate-900">Deploy a task</h3>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {loading ? (
+          <div className="flex justify-center py-10">
+            <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-10 text-center text-xs text-slate-500">
+            No saved tasks to deploy yet. Create tasks in the course builder first.
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {items.map(t => (
+              <li
+                key={t.taskId}
+                className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 p-2.5"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <FileText className="h-4 w-4 shrink-0 text-slate-400" />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-900">{t.title}</p>
+                    <p className="text-[11px] capitalize text-slate-400">{t.type}</p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => deploy(t)}
+                  disabled={deployingId === t.taskId}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-blue-600 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+                >
+                  <Send className="h-3 w-3" />
+                  Deploy
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { X, FileText } from 'lucide-react'
+import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
+
+interface SourceDocument {
+  fileName: string
+  fileUrl: string
+  fileKey?: string
+  mimeType: string
+}
+
+interface DeployedTask {
+  id: string
+  title: string
+  content?: string
+  source?: string
+  sourceDocument?: SourceDocument
+}
+
+/**
+ * Both-sides panel showing what the tutor has deployed into the session, live.
+ * Listens to the same `task:deployed` / `task:updated` room events the course
+ * classroom uses (already broadcast for any session id), so it needs no course.
+ * Self-contained: it only reads socket events, so it can't affect the whiteboard.
+ */
+export function SessionDeployedPanel({
+  socket,
+  onClose,
+}: {
+  socket: Socket | null
+  onClose: () => void
+}) {
+  const [deployed, setDeployed] = useState<DeployedTask[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!socket) return
+    const upsert = (task: DeployedTask) =>
+      setDeployed(prev =>
+        prev.some(t => t.id === task.id)
+          ? prev.map(t => (t.id === task.id ? { ...t, ...task } : t))
+          : [...prev, task]
+      )
+    const onDeployed = (task: DeployedTask) => {
+      if (!task?.id) return
+      upsert(task)
+      setActiveId(task.id)
+    }
+    const onUpdated = (payload: { task: DeployedTask }) => {
+      if (payload?.task?.id) upsert(payload.task)
+    }
+    socket.on('task:deployed', onDeployed)
+    socket.on('task:updated', onUpdated)
+    return () => {
+      socket.off('task:deployed', onDeployed)
+      socket.off('task:updated', onUpdated)
+    }
+  }, [socket])
+
+  const active = deployed.find(t => t.id === activeId) ?? null
+
+  return (
+    <div className="pointer-events-auto flex h-full w-96 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="text-sm font-semibold text-slate-900">Materials</h3>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {deployed.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center text-xs text-slate-500">
+          Nothing shared yet. When the tutor deploys a task or material, it appears here.
+        </div>
+      ) : (
+        <>
+          {/* Tabs of deployed items */}
+          <div className="flex flex-wrap gap-1.5 border-b p-2">
+            {deployed.map(t => (
+              <button
+                key={t.id}
+                onClick={() => setActiveId(t.id)}
+                className={
+                  'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ' +
+                  (t.id === activeId
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-slate-100 text-slate-600 hover:bg-slate-200')
+                }
+              >
+                <FileText className="h-3 w-3" />
+                <span className="max-w-[8rem] truncate">{t.title}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Active item */}
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            {active ? (
+              <>
+                <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
+                {active.sourceDocument ? (
+                  <div className="h-[60vh] w-full">
+                    <TaskDocumentCard sourceDocument={active.sourceDocument} alwaysOpen />
+                  </div>
+                ) : active.content ? (
+                  <div
+                    className="prose prose-sm max-w-none text-slate-700"
+                    // Tutor-authored task content, shown to their own session.
+                    dangerouslySetInnerHTML={{ __html: active.content }}
+                  />
+                ) : (
+                  <p className="text-xs text-slate-400">This item has no preview.</p>
+                )}
+              </>
+            ) : null}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
**Phase B** — brings the real-time **deploy** flow into the 1-on-1/group session classroom, so it gets materials like a course classroom (on top of Phase A's video + whiteboard). Builds on the persistence foundation (#1044).

### Tutor — deploy
A **"Deploy"** button opens a panel listing the tutor's saved published tasks (`GET /api/one-on-one/deployables`). Deploying emits the **same `task:deploy` socket event** a course classroom uses — the server persists it (under the ad-hoc anchor for a course-less session, per #1044) and broadcasts `task:deployed` to the room.

### Everyone — materials
A **"Materials"** button opens a panel that listens for `task:deployed` / `task:updated` and renders the item: **documents via the existing `TaskDocumentCard`** (PDF/image viewer), otherwise the task content. Both parties see it live.

### Safety
The deploy/materials panels are **self-contained overlays that fail independently** — a hiccup there can't take down the shipped whiteboard/video.

### Deferred (follow-on)
The live **DMI answer/submission UI** (students answering assessments in-session) — the deepest part of the course feedback page. This PR delivers **deploy → both see the material/task**.

typecheck · lint · **645** unit tests · production build — clean.

> ⚠️ Real-time deploy can't be verified in CI — needs a **two-client smoke test** (tutor deploys → student's Materials panel shows it).