### PR TITLE
fix(sessions): session classroom degrades gracefully instead of white-screening

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -20,6 +20,7 @@ import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 import { SessionDeployPanel } from '@/components/one-on-one/session-deploy-panel'
 import { SessionDeployedPanel } from '@/components/one-on-one/session-deployed-panel'
+import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 
 interface SessionClassroomProps {
   sessionId: string
@@ -68,14 +69,21 @@ export function SessionClassroom({
 
   return (
     <div className="relative h-screen w-full bg-slate-950">
-      <EnhancedWhiteboard
-        socket={socket}
-        roomId={sessionId}
-        userId={session?.user?.id}
-        userName={session?.user?.name || undefined}
-        videoOverlay
-        videoComponent={video}
-      />
+      {/* If the whiteboard ever throws, degrade to a plain (working) video call
+          rather than white-screening the join. */}
+      <FallbackBoundary
+        label="session classroom"
+        fallback={<div className="h-screen w-full bg-black">{video}</div>}
+      >
+        <EnhancedWhiteboard
+          socket={socket}
+          roomId={sessionId}
+          userId={session?.user?.id}
+          userName={session?.user?.name || undefined}
+          videoOverlay
+          videoComponent={video}
+        />
+      </FallbackBoundary>
 
       {/* Classroom toolbar: deploy (tutor) + materials (everyone). */}
       <div className="pointer-events-none absolute right-3 top-3 z-40 flex gap-2">
@@ -105,20 +113,22 @@ export function SessionClassroom({
         </button>
       </div>
 
-      {/* Side panels (fail independently of the whiteboard). */}
+      {/* Side panels — wrapped so a panel crash closes to nothing, never the room. */}
       {showDeploy || showMaterials ? (
-        <div className="pointer-events-none absolute bottom-3 right-3 top-16 z-40 flex">
-          {showDeploy && isTutor ? (
-            <SessionDeployPanel
-              sessionId={sessionId}
-              socket={socket}
-              onClose={() => setShowDeploy(false)}
-            />
-          ) : null}
-          {showMaterials ? (
-            <SessionDeployedPanel socket={socket} onClose={() => setShowMaterials(false)} />
-          ) : null}
-        </div>
+        <FallbackBoundary label="session panel" fallback={null}>
+          <div className="pointer-events-none absolute bottom-3 right-3 top-16 z-40 flex">
+            {showDeploy && isTutor ? (
+              <SessionDeployPanel
+                sessionId={sessionId}
+                socket={socket}
+                onClose={() => setShowDeploy(false)}
+              />
+            ) : null}
+            {showMaterials ? (
+              <SessionDeployedPanel socket={socket} onClose={() => setShowMaterials(false)} />
+            ) : null}
+          </div>
+        </FallbackBoundary>
       ) : null}
     </div>
   )

--- a/tutorme-app/src/components/ui/fallback-boundary.tsx
+++ b/tutorme-app/src/components/ui/fallback-boundary.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Component, type ReactNode } from 'react'
+
+interface FallbackBoundaryProps {
+  children: ReactNode
+  /** Rendered instead of children if they throw during render. */
+  fallback: ReactNode
+  /** For logs, e.g. "session classroom". */
+  label?: string
+}
+
+interface FallbackBoundaryState {
+  hasError: boolean
+}
+
+/**
+ * Minimal error boundary that swaps in a caller-provided `fallback` node when its
+ * subtree throws — so a crash in one region degrades gracefully instead of taking
+ * down the whole page. (PanelErrorBoundary renders its own generic message; this
+ * one lets the caller decide the fallback, e.g. a plain video call.)
+ */
+export class FallbackBoundary extends Component<FallbackBoundaryProps, FallbackBoundaryState> {
+  state: FallbackBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): FallbackBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error(`[${this.props.label ?? 'FallbackBoundary'}] render error:`, error)
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children
+  }
+}


### PR DESCRIPTION
Follow-up to the empty-pages crash (#1046). A render error anywhere in the classroom should **never** white-screen the join again.

- **Whiteboard** is wrapped in an error boundary that falls back to a **plain, working video call** (the pre-Phase-A behaviour). A whiteboard bug → video-only; the room is still joinable.
- **Deploy/Materials panels** are wrapped in one that closes to nothing — a panel bug can't take down the room.

New minimal `FallbackBoundary` (renders a **caller-provided fallback** on error, unlike `PanelErrorBoundary` which shows a fixed message).

typecheck · lint · production build — clean.