### PR TITLE
feat(sessions): answerable assessments in the 1-on-1/group classroom

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -4,13 +4,22 @@
  * The tutor's saved, published tasks that can be deployed into a live session's
  * classroom (the session-classroom deploy panel). Returns enough to build the
  * LiveTask the client emits over `task:deploy`.
+ *
+ * For assessment/homework tasks that carry structured DMI questions, we also
+ * return the *student-safe* `dmiItems` (answers stripped via
+ * `buildStudentDeployPayload`) so the deployed task is answerable in the live
+ * classroom. The answer key is NEVER returned here — it stays in
+ * `BuilderTaskDmi.items` server-side and the `task:complete` handler reloads it
+ * by taskId to auto-grade.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, desc, eq, isNull } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNull } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { builderTask } from '@/lib/db/schema'
+import { builderTask, builderTaskDmi } from '@/lib/db/schema'
+import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 
 export const GET = withAuth(
   async (_req: NextRequest, session) => {
@@ -33,6 +42,32 @@ export const GET = withAuth(
       .orderBy(desc(builderTask.updatedAt))
       .limit(100)
 
+    // Load the latest DMI item set per task in one query, then project each to
+    // its student-safe form. Answer-bearing fields (answer/rubric/pairs/regions)
+    // are dropped by `toStudentDmiItem`; only the prompts + option banks remain.
+    const taskIds = rows.map(r => r.taskId)
+    const safeItemsByTask = new Map<string, StudentDmiItem[]>()
+    if (taskIds.length > 0) {
+      const dmiRows = await drizzleDb
+        .select({
+          taskId: builderTaskDmi.taskId,
+          items: builderTaskDmi.items,
+          updatedAt: builderTaskDmi.updatedAt,
+        })
+        .from(builderTaskDmi)
+        .where(inArray(builderTaskDmi.taskId, taskIds))
+        .orderBy(desc(builderTaskDmi.updatedAt))
+
+      // Keep only the most-recent row per task (rows arrive newest-first).
+      for (const row of dmiRows) {
+        if (safeItemsByTask.has(row.taskId)) continue
+        const rawItems = Array.isArray(row.items) ? (row.items as RawDeployDmiItem[]) : []
+        if (rawItems.length === 0) continue
+        const { dmiItems } = buildStudentDeployPayload(rawItems)
+        safeItemsByTask.set(row.taskId, dmiItems)
+      }
+    }
+
     return NextResponse.json({
       tasks: rows.map(r => ({
         taskId: r.taskId,
@@ -40,6 +75,7 @@ export const GET = withAuth(
         type: (r.type as 'task' | 'assessment' | 'homework') || 'task',
         content: r.content || '',
         lessonId: r.lessonId || null,
+        dmiItems: safeItemsByTask.get(r.taskId) ?? [],
       })),
     })
   },

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -125,7 +125,12 @@ export function SessionClassroom({
               />
             ) : null}
             {showMaterials ? (
-              <SessionDeployedPanel socket={socket} onClose={() => setShowMaterials(false)} />
+              <SessionDeployedPanel
+                sessionId={sessionId}
+                socket={socket}
+                isTutor={isTutor}
+                onClose={() => setShowMaterials(false)}
+              />
             ) : null}
           </div>
         </FallbackBoundary>

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import { toast } from 'sonner'
-import { Loader2, Send, X, FileText } from 'lucide-react'
+import { Loader2, Send, X, FileText, ListChecks } from 'lucide-react'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 
 interface Deployable {
   taskId: string
@@ -11,6 +12,8 @@ interface Deployable {
   type: 'task' | 'assessment' | 'homework'
   content: string
   lessonId: string | null
+  /** Student-safe questions (answers already stripped server-side). */
+  dmiItems: StudentDmiItem[]
 }
 
 /**
@@ -53,8 +56,11 @@ export function SessionDeployPanel({
       return
     }
     setDeployingId(t.taskId)
-    // Same LiveTask shape the course classroom emits (answer key / PCI stay
-    // server-side; a plain deploy carries just the student-visible fields).
+    // Same LiveTask shape the course classroom emits. The student-safe dmiItems
+    // (answers already stripped by the deployables endpoint) ride along so the
+    // task is answerable in the live classroom; the answer key stays server-side
+    // in BuilderTaskDmi and the `task:complete` handler reloads it by taskId to
+    // auto-grade — it is never sent to the client here.
     socket.emit('task:deploy', {
       roomId: sessionId,
       task: {
@@ -63,6 +69,7 @@ export function SessionDeployPanel({
         content: t.content,
         source: t.type,
         lessonId: t.lessonId ?? undefined,
+        dmiItems: t.dmiItems,
         deployedAt: Date.now(),
         polls: [],
         questions: [],
@@ -104,7 +111,15 @@ export function SessionDeployPanel({
                   <FileText className="h-4 w-4 shrink-0 text-slate-400" />
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium text-slate-900">{t.title}</p>
-                    <p className="text-[11px] capitalize text-slate-400">{t.type}</p>
+                    <p className="flex items-center gap-1 text-[11px] capitalize text-slate-400">
+                      {t.type}
+                      {t.dmiItems.length > 0 ? (
+                        <span className="inline-flex items-center gap-0.5 lowercase text-blue-500">
+                          <ListChecks className="h-3 w-3" />
+                          {t.dmiItems.length} q{t.dmiItems.length === 1 ? '' : 's'}
+                        </span>
+                      ) : null}
+                    </p>
                   </div>
                 </div>
                 <button

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { Socket } from 'socket.io-client'
-import { X, FileText } from 'lucide-react'
+import { X, FileText, Loader2, CheckCircle2, ListChecks } from 'lucide-react'
+import { toast } from 'sonner'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
+import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 
 interface SourceDocument {
   fileName: string
@@ -17,6 +20,7 @@ interface DeployedTask {
   title: string
   content?: string
   source?: string
+  dmiItems?: StudentDmiItem[]
   sourceDocument?: SourceDocument
 }
 
@@ -24,13 +28,22 @@ interface DeployedTask {
  * Both-sides panel showing what the tutor has deployed into the session, live.
  * Listens to the same `task:deployed` / `task:updated` room events the course
  * classroom uses (already broadcast for any session id), so it needs no course.
- * Self-contained: it only reads socket events, so it can't affect the whiteboard.
+ *
+ * For a deployed task that carries structured questions (`dmiItems`), students
+ * get answer fields and a Submit that emits `task:complete` — the same event the
+ * course classroom uses, which the server auto-grades against the answer key it
+ * reloads by taskId (never sent to the client). Tutors see the questions
+ * read-only (they authored them).
  */
 export function SessionDeployedPanel({
+  sessionId,
   socket,
+  isTutor,
   onClose,
 }: {
+  sessionId: string
   socket: Socket | null
+  isTutor?: boolean
   onClose: () => void
 }) {
   const [deployed, setDeployed] = useState<DeployedTask[]>([])
@@ -94,7 +107,11 @@ export function SessionDeployedPanel({
                     : 'bg-slate-100 text-slate-600 hover:bg-slate-200')
                 }
               >
-                <FileText className="h-3 w-3" />
+                {t.dmiItems && t.dmiItems.length > 0 ? (
+                  <ListChecks className="h-3 w-3" />
+                ) : (
+                  <FileText className="h-3 w-3" />
+                )}
                 <span className="max-w-[8rem] truncate">{t.title}</span>
               </button>
             ))}
@@ -111,18 +128,319 @@ export function SessionDeployedPanel({
                   </div>
                 ) : active.content ? (
                   <div
-                    className="prose prose-sm max-w-none text-slate-700"
+                    className="prose prose-sm mb-4 max-w-none text-slate-700"
                     // Tutor-authored task content, shown to their own session.
                     dangerouslySetInnerHTML={{ __html: active.content }}
                   />
-                ) : (
+                ) : null}
+
+                {active.dmiItems && active.dmiItems.length > 0 ? (
+                  <DeployedQuestions
+                    key={active.id}
+                    sessionId={sessionId}
+                    taskId={active.id}
+                    items={active.dmiItems}
+                    socket={socket}
+                    isTutor={isTutor}
+                  />
+                ) : !active.sourceDocument && !active.content ? (
                   <p className="text-xs text-slate-400">This item has no preview.</p>
-                )}
+                ) : null}
               </>
             ) : null}
           </div>
         </>
       )}
     </div>
+  )
+}
+
+/**
+ * The answer sheet for a deployed task's structured questions. Students fill it
+ * in and submit once; tutors see the same prompts read-only. Answer encoding
+ * mirrors the course-classroom feedback page so the server's auto-grader (which
+ * compares by item id) scores it the same way.
+ */
+function DeployedQuestions({
+  sessionId,
+  taskId,
+  items,
+  socket,
+  isTutor,
+}: {
+  sessionId: string
+  taskId: string
+  items: StudentDmiItem[]
+  socket: Socket | null
+  isTutor?: boolean
+}) {
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  const answeredCount = useMemo(
+    () => items.filter(it => (answers[it.id] ?? '').trim().length > 0).length,
+    [answers, items]
+  )
+
+  const submit = () => {
+    if (!socket) {
+      toast.error('Still connecting — try again in a moment.')
+      return
+    }
+    // Only send non-empty answers, keyed by item id (the grader matches by id).
+    const payload: Record<string, string> = {}
+    for (const it of items) {
+      const v = (answers[it.id] ?? '').trim()
+      if (v.length > 0) payload[it.id] = v
+    }
+    if (Object.keys(payload).length === 0) {
+      toast.error('Answer at least one question before submitting.')
+      return
+    }
+    setSubmitting(true)
+    socket
+      .timeout(20000)
+      .emit(
+        'task:complete',
+        { roomId: sessionId, taskId, answers: payload },
+        (err: unknown, resp?: { ok: boolean; error?: string }) => {
+          setSubmitting(false)
+          if (err || !resp?.ok) {
+            toast.error(resp?.error || 'Could not submit — please try again.')
+            return
+          }
+          setSubmitted(true)
+          toast.success('Answers submitted')
+        }
+      )
+  }
+
+  if (isTutor) {
+    return (
+      <div className="space-y-4">
+        {items.map((it, idx) => (
+          <QuestionBlock key={it.id} item={it} index={idx}>
+            <p className="text-[11px] italic text-slate-400">
+              Students answer this live; you’ll see responses in your grading views.
+            </p>
+          </QuestionBlock>
+        ))}
+      </div>
+    )
+  }
+
+  if (submitted) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-8 text-center">
+        <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+        <p className="text-sm font-semibold text-emerald-800">Submitted</p>
+        <p className="text-xs text-emerald-700">
+          Your tutor has your answers. They’ll appear in your feedback.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {items.map((it, idx) => (
+        <QuestionBlock key={it.id} item={it} index={idx}>
+          <SessionDmiAnswerField
+            item={it}
+            value={answers[it.id] ?? ''}
+            onValueChange={next => setAnswers(prev => ({ ...prev, [it.id]: next }))}
+          />
+        </QuestionBlock>
+      ))}
+
+      <div className="sticky bottom-0 -mx-4 border-t bg-white/95 px-4 py-3 backdrop-blur">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting}
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+        >
+          {submitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <>
+              Submit answers
+              <span className="text-xs font-normal text-blue-100">
+                ({answeredCount}/{items.length})
+              </span>
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function QuestionBlock({
+  item,
+  index,
+  children,
+}: {
+  item: StudentDmiItem
+  index: number
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 p-3">
+      <div className="mb-2 flex items-start gap-2">
+        <span className="mt-0.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-slate-100 px-1 text-[11px] font-semibold text-slate-600">
+          {item.questionLabel || item.questionNumber || index + 1}
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-slate-800">{item.questionText}</p>
+          {typeof item.marks === 'number' && item.marks > 0 ? (
+            <p className="mt-0.5 text-[11px] text-slate-400">
+              {item.marks} mark{item.marks === 1 ? '' : 's'}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * A single answer field. Encoding matches the course-classroom feedback page so
+ * the shared server auto-grader scores it identically:
+ *   - mcq → the option LETTER (A, B, …)
+ *   - true_false → the option text ('True' / 'False')
+ *   - multiple_response → JSON array string of selected option texts
+ *   - short / fill_blank / long / other → raw text
+ */
+function SessionDmiAnswerField({
+  item,
+  value,
+  onValueChange,
+}: {
+  item: StudentDmiItem
+  value: string
+  onValueChange: (next: string) => void
+}) {
+  const type = normalizeDmiQuestionType(item.questionType)
+  const options =
+    item.options && item.options.length > 0
+      ? item.options
+      : type === 'true_false'
+        ? ['True', 'False']
+        : []
+  const baseField =
+    'w-full rounded-md border border-slate-300 bg-white p-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none'
+
+  // Multiple choice — clickable LETTER chips (A–…); the letter is stored.
+  if (type === 'mcq' && options.length > 0) {
+    return (
+      <div className="space-y-1.5">
+        {options.map((opt, i) => {
+          const letter = String.fromCharCode(65 + i)
+          const selected = value === letter
+          return (
+            <button
+              key={letter}
+              type="button"
+              onClick={() => onValueChange(letter)}
+              className={
+                'flex w-full items-center gap-2 rounded-lg border px-2.5 py-1.5 text-left text-sm transition-colors ' +
+                (selected
+                  ? 'border-blue-500 bg-blue-50 text-blue-900'
+                  : 'border-slate-200 text-slate-700 hover:border-blue-300')
+              }
+            >
+              <span
+                className={
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ' +
+                  (selected ? 'bg-blue-600 text-white' : 'bg-slate-100 text-slate-600')
+                }
+              >
+                {letter}
+              </span>
+              <span className="min-w-0">{opt}</span>
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  // True / False — radios.
+  if (type === 'true_false' && options.length > 0) {
+    return (
+      <div className="space-y-1.5">
+        {options.map(opt => (
+          <label key={opt} className="flex items-center gap-2 text-sm text-slate-800">
+            <input
+              type="radio"
+              name={`dmi-${item.id}`}
+              checked={value === opt}
+              onChange={() => onValueChange(opt)}
+              className="h-4 w-4 accent-blue-600"
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    )
+  }
+
+  // Multi-select — checkboxes; stored as a JSON array string of option texts.
+  if (type === 'multiple_response' && options.length > 0) {
+    let selected: string[] = []
+    try {
+      const parsed = value ? JSON.parse(value) : []
+      if (Array.isArray(parsed)) selected = parsed.filter((v): v is string => typeof v === 'string')
+    } catch {
+      selected = []
+    }
+    const toggle = (opt: string) => {
+      const next = selected.includes(opt) ? selected.filter(o => o !== opt) : [...selected, opt]
+      onValueChange(JSON.stringify(next))
+    }
+    return (
+      <div className="space-y-1.5">
+        {options.map(opt => (
+          <label key={opt} className="flex items-center gap-2 text-sm text-slate-800">
+            <input
+              type="checkbox"
+              checked={selected.includes(opt)}
+              onChange={() => toggle(opt)}
+              className="h-4 w-4 accent-blue-600"
+            />
+            <span>{opt}</span>
+          </label>
+        ))}
+      </div>
+    )
+  }
+
+  // Short / fill-in — single-line input.
+  if (type === 'short' || type === 'fill_blank') {
+    return (
+      <input
+        type="text"
+        value={value}
+        onChange={e => onValueChange(e.target.value)}
+        placeholder={type === 'fill_blank' ? 'Fill in the blank…' : 'Type your answer…'}
+        className={baseField}
+      />
+    )
+  }
+
+  // Long / matching / drag_drop / hotspot / anything else — free-text fallback so
+  // the student is never stuck. (Matching/hotspot degrade to describing the
+  // answer; those go to the tutor for review rather than auto-marking.)
+  return (
+    <textarea
+      value={value}
+      onChange={e => onValueChange(e.target.value)}
+      rows={3}
+      placeholder="Type your answer…"
+      className={baseField + ' resize-y'}
+    />
   )
 }


### PR DESCRIPTION
## What

Completes the deploy → **answer → submit → grade** loop in the 1-on-1 / group session classroom. Previously a deployed task showed only its content HTML — students could read it but not answer. Now a tutor can deploy a saved assessment and the student answers + submits inline, graded server-side.

## How

- **`/api/one-on-one/deployables`** — for each published task, load its latest `BuilderTaskDmi.items` and return the **student-safe** `dmiItems` (answers stripped via `buildStudentDeployPayload`). The answer key is **never** returned to the client; it stays in `BuilderTaskDmi` and the `task:complete` handler reloads it by `taskId` to auto-grade.
- **Deploy panel** — carries `dmiItems` in the `task:deploy` emit (the server already broadcasts `task.dmiItems` to the room, without the answer key), and shows a "N qs" hint.
- **Deployed panel** — students get answer fields (mcq letter chips, true/false radios, multiple-response checkboxes, short/fill inputs, long/free-text) and a Submit that emits `task:complete` with answers keyed by item id — the **same event + encoding** the course classroom's feedback page uses, so the shared auto-grader scores it identically. Tutors see the questions read-only.

## Why it's safe / no new grading path

`task:complete` already reloads `BuilderTaskDmi.items` by `taskId` and persists a graded `TaskSubmission` (from #1044's self-heal work). A saved task therefore grades automatically — this PR only makes the questions reach the student and the answers reach that existing handler. Answer keys never touch the client.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all four changed files
- `vitest` deploy-safety + grading suites: 31/31 pass
- `next build`: success (exit 0)

## ⚠️ Do NOT auto-merge

Per request, this needs a **live two-client smoke test first**: tutor deploys an assessment → student sees questions in **Materials** → answers → **Submit** → confirm the graded `TaskSubmission` lands in the tutor's grading view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)