### PR TITLE
chore(dmi): log Office→PDF conversion outcomes for prod observability

### DIFF
--- a/tutorme-app/src/app/api/ai/office-to-pdf/route.ts
+++ b/tutorme-app/src/app/api/ai/office-to-pdf/route.ts
@@ -16,7 +16,9 @@ import { convertOfficeToPdf } from '@/lib/documents/office-to-pdf'
 export const runtime = 'nodejs'
 
 export const POST = withCsrf(
-  withAuth(async (request: NextRequest, _session: Session) => {
+  withAuth(async (request: NextRequest, session: Session) => {
+    const startedAt = Date.now()
+    const userId = session?.user?.id ?? 'unknown'
     try {
       const body = await request.json().catch(() => null)
       const fileKey = typeof body?.fileKey === 'string' ? body.fileKey : ''
@@ -25,19 +27,32 @@ export const POST = withCsrf(
       // Only accept keys from our own storage namespaces — never a raw path — so
       // this can't be used to read arbitrary files.
       if (!fileKey || !/^(documents|assets|resources)\//.test(fileKey) || fileKey.includes('..')) {
+        console.warn(
+          `[office-to-pdf] 400 invalid fileKey (user ${userId}): ${fileKey || '(empty)'}`
+        )
         return NextResponse.json({ error: 'A valid document fileKey is required' }, { status: 400 })
       }
 
       const input = await readFileBuffer(fileKey)
       if (!input) {
+        console.warn(`[office-to-pdf] 404 not found (user ${userId}): ${fileKey}`)
         return NextResponse.json({ error: 'Document not found' }, { status: 404 })
       }
 
+      console.info(
+        `[office-to-pdf] request: key=${fileKey} name="${fileName}" ${input.length} bytes (user ${userId})`
+      )
       const pdf = await convertOfficeToPdf(input, fileName)
       if (!pdf) {
+        console.error(
+          `[office-to-pdf] 422 conversion failed: key=${fileKey} after ${Date.now() - startedAt}ms (user ${userId})`
+        )
         return NextResponse.json({ error: 'Could not convert the document' }, { status: 422 })
       }
 
+      console.info(
+        `[office-to-pdf] 200 ok: key=${fileKey} → ${pdf.length} bytes in ${Date.now() - startedAt}ms (user ${userId})`
+      )
       return new NextResponse(new Uint8Array(pdf), {
         status: 200,
         headers: {
@@ -47,6 +62,10 @@ export const POST = withCsrf(
         },
       })
     } catch (err) {
+      console.error(
+        `[office-to-pdf] 500 error after ${Date.now() - startedAt}ms (user ${userId}):`,
+        err instanceof Error ? err.message : err
+      )
       return handleApiError(err, 'Failed to convert document', 'api/ai/office-to-pdf/route.ts')
     }
   })

--- a/tutorme-app/src/lib/documents/office-to-pdf.ts
+++ b/tutorme-app/src/lib/documents/office-to-pdf.ts
@@ -26,6 +26,7 @@ export async function convertOfficeToPdf(input: Buffer, fileName: string): Promi
   const safeName = (path.basename(fileName) || 'document').replace(/[^a-zA-Z0-9._-]/g, '_')
   const workDir = await mkdtemp(path.join(os.tmpdir(), 'off2pdf-'))
   const inputPath = path.join(workDir, safeName)
+  const startedAt = Date.now()
 
   try {
     await writeFile(inputPath, input)
@@ -47,20 +48,49 @@ export async function convertOfficeToPdf(input: Buffer, fileName: string): Promi
     // `soffice` on Debian; fall back to the `libreoffice` alias. HOME is pointed
     // at the temp dir so LibreOffice writes its profile there, not into $HOME.
     const opts = { timeout: CONVERT_TIMEOUT_MS, env: { ...process.env, HOME: workDir } }
+    // Grab a short tail of the failure output — soffice reports unsupported
+    // formats / crashes there, which is otherwise invisible in production.
+    const detail = (e: unknown): string => {
+      const err = e as { message?: string; stderr?: string }
+      return (err?.stderr || err?.message || String(e)).slice(0, 300).replace(/\s+/g, ' ').trim()
+    }
+    let binary = 'soffice'
     try {
       await execAsync(cmd('soffice'), opts)
-    } catch {
-      await execAsync(cmd('libreoffice'), opts)
+    } catch (sofficeErr) {
+      console.warn(
+        `[office-to-pdf] soffice failed for ${safeName}, retrying via libreoffice: ${detail(sofficeErr)}`
+      )
+      binary = 'libreoffice'
+      try {
+        await execAsync(cmd('libreoffice'), opts)
+      } catch (libreErr) {
+        console.error(
+          `[office-to-pdf] LibreOffice conversion FAILED for ${safeName} (${input.length} bytes): ${detail(libreErr)}`
+        )
+        return null
+      }
     }
 
     const pdfPath = path.join(workDir, `${path.basename(inputPath, path.extname(inputPath))}.pdf`)
     try {
       await access(pdfPath)
     } catch {
+      console.error(
+        `[office-to-pdf] ${binary} ran but produced no PDF for ${safeName} (${input.length} bytes)`
+      )
       return null
     }
-    return await readFile(pdfPath)
-  } catch {
+    const pdf = await readFile(pdfPath)
+    console.info(
+      `[office-to-pdf] converted ${safeName} via ${binary}: ${input.length} → ${pdf.length} bytes in ${Date.now() - startedAt}ms`
+    )
+    return pdf
+  } catch (err) {
+    console.error(
+      `[office-to-pdf] unexpected error converting ${safeName}:`,
+      err instanceof Error ? err.message : err
+    )
     return null
   } finally {
     await rm(workDir, { recursive: true, force: true }).catch(() => {})


### PR DESCRIPTION
Follow-up to #1051. The LibreOffice conversion lib swallowed all failures (empty `catch` → `null`), so a `soffice` crash or unsupported format was **invisible** in production. This adds structured `[office-to-pdf]` logging so you can confirm the path is firing and debug any failures from Cloud Run logs.

## Lib (`office-to-pdf.ts`)
- **Success**: logs the binary used (`soffice` vs `libreoffice` fallback), input→output size, and duration.
- **Failure**: logs a trimmed tail of soffice's **stderr/message** (where it reports unsupported formats / crashes) instead of silently returning `null`. Separately logs "ran but produced no PDF" and unexpected errors.

## Route (`/api/ai/office-to-pdf`)
- Logs each **request** (`key`, `name`, bytes, user id) and the **outcome**: `200` with size + timing, or `400`/`404`/`422`/`500` with the reason and elapsed time.

Logging only — **no behavioural change**. `tsc --noEmit` clean, prettier clean.

**How to use**: filter Cloud Run logs for `[office-to-pdf]`. A working generate with "Analyze diagrams" on a `.docx`/`.pptx`/`.doc`/`.ppt` should show a `request:` line followed by `200 ok … → N bytes in Xms`; a failure shows the soffice error tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)