### PR TITLE
fix(sessions): hydrate classroom panels from room_state (late-open/rejoin)

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -21,6 +21,7 @@ import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 import { SessionDeployPanel } from '@/components/one-on-one/session-deploy-panel'
 import { SessionDeployedPanel } from '@/components/one-on-one/session-deployed-panel'
 import { SessionResponsesPanel } from '@/components/one-on-one/session-responses-panel'
+import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
 import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 
 type ActivePanel = 'deploy' | 'materials' | 'responses' | null
@@ -59,6 +60,14 @@ export function SessionClassroom({
       : undefined
 
   const { socket } = useSocket(socketOptions)
+
+  // Canonical deployed-task + submission state, owned here (mounted from join)
+  // so the panels — which mount only when opened — hydrate from the join-time
+  // room_state replay instead of missing everything that happened before.
+  const { tasks, responsesByTask, myCompletedTaskIds } = useSessionRoomState(
+    socket,
+    session?.user?.id
+  )
 
   // The call feed rides along as the whiteboard's draggable video overlay.
   const video = (
@@ -133,13 +142,19 @@ export function SessionClassroom({
               />
             ) : null}
             {activePanel === 'responses' && isTutor ? (
-              <SessionResponsesPanel socket={socket} onClose={() => setActivePanel(null)} />
+              <SessionResponsesPanel
+                tasks={tasks}
+                responsesByTask={responsesByTask}
+                onClose={() => setActivePanel(null)}
+              />
             ) : null}
             {activePanel === 'materials' ? (
               <SessionDeployedPanel
                 sessionId={sessionId}
                 socket={socket}
                 isTutor={isTutor}
+                tasks={tasks}
+                completedTaskIds={myCompletedTaskIds}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -1,79 +1,43 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import { X, FileText, Loader2, CheckCircle2, ListChecks } from 'lucide-react'
 import { toast } from 'sonner'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
-
-interface SourceDocument {
-  fileName: string
-  fileUrl: string
-  fileKey?: string
-  mimeType: string
-}
-
-interface DeployedTask {
-  id: string
-  title: string
-  content?: string
-  source?: string
-  dmiItems?: StudentDmiItem[]
-  sourceDocument?: SourceDocument
-}
+import type { SessionRoomTask } from '@/components/one-on-one/use-session-room-state'
 
 /**
  * Both-sides panel showing what the tutor has deployed into the session, live.
- * Listens to the same `task:deployed` / `task:updated` room events the course
- * classroom uses (already broadcast for any session id), so it needs no course.
  *
- * For a deployed task that carries structured questions (`dmiItems`), students
- * get answer fields and a Submit that emits `task:complete` — the same event the
- * course classroom uses, which the server auto-grades against the answer key it
- * reloads by taskId (never sent to the client). Tutors see the questions
- * read-only (they authored them).
+ * The deployed tasks (and, for the student, which they've already completed) are
+ * owned by the classroom via `useSessionRoomState` and passed in — so opening
+ * this panel late, or after a rejoin, still shows everything already deployed.
+ * For a task that carries structured questions (`dmiItems`), students get answer
+ * fields and a Submit that emits `task:complete` (the same event + encoding the
+ * course classroom uses, which the server auto-grades by taskId). Tutors see the
+ * questions read-only.
  */
 export function SessionDeployedPanel({
   sessionId,
   socket,
   isTutor,
+  tasks,
+  completedTaskIds,
   onClose,
 }: {
   sessionId: string
   socket: Socket | null
   isTutor?: boolean
+  tasks: SessionRoomTask[]
+  completedTaskIds: Set<string>
   onClose: () => void
 }) {
-  const [deployed, setDeployed] = useState<DeployedTask[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!socket) return
-    const upsert = (task: DeployedTask) =>
-      setDeployed(prev =>
-        prev.some(t => t.id === task.id)
-          ? prev.map(t => (t.id === task.id ? { ...t, ...task } : t))
-          : [...prev, task]
-      )
-    const onDeployed = (task: DeployedTask) => {
-      if (!task?.id) return
-      upsert(task)
-      setActiveId(task.id)
-    }
-    const onUpdated = (payload: { task: DeployedTask }) => {
-      if (payload?.task?.id) upsert(payload.task)
-    }
-    socket.on('task:deployed', onDeployed)
-    socket.on('task:updated', onUpdated)
-    return () => {
-      socket.off('task:deployed', onDeployed)
-      socket.off('task:updated', onUpdated)
-    }
-  }, [socket])
-
-  const active = deployed.find(t => t.id === activeId) ?? null
+  // Default to the most-recently-deployed task when nothing is selected.
+  const active = tasks.find(t => t.id === activeId) ?? tasks[tasks.length - 1] ?? null
 
   return (
     <div className="pointer-events-auto flex h-full w-96 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
@@ -88,7 +52,7 @@ export function SessionDeployedPanel({
         </button>
       </div>
 
-      {deployed.length === 0 ? (
+      {tasks.length === 0 ? (
         <div className="flex flex-1 items-center justify-center px-6 text-center text-xs text-slate-500">
           Nothing shared yet. When the tutor deploys a task or material, it appears here.
         </div>
@@ -96,13 +60,13 @@ export function SessionDeployedPanel({
         <>
           {/* Tabs of deployed items */}
           <div className="flex flex-wrap gap-1.5 border-b p-2">
-            {deployed.map(t => (
+            {tasks.map(t => (
               <button
                 key={t.id}
                 onClick={() => setActiveId(t.id)}
                 className={
                   'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ' +
-                  (t.id === activeId
+                  (t.id === active?.id
                     ? 'bg-blue-600 text-white'
                     : 'bg-slate-100 text-slate-600 hover:bg-slate-200')
                 }
@@ -113,6 +77,9 @@ export function SessionDeployedPanel({
                   <FileText className="h-3 w-3" />
                 )}
                 <span className="max-w-[8rem] truncate">{t.title}</span>
+                {completedTaskIds.has(t.id) ? (
+                  <CheckCircle2 className="h-3 w-3 text-emerald-400" />
+                ) : null}
               </button>
             ))}
           </div>
@@ -142,6 +109,7 @@ export function SessionDeployedPanel({
                     items={active.dmiItems}
                     socket={socket}
                     isTutor={isTutor}
+                    alreadySubmitted={completedTaskIds.has(active.id)}
                   />
                 ) : !active.sourceDocument && !active.content ? (
                   <p className="text-xs text-slate-400">This item has no preview.</p>
@@ -167,16 +135,19 @@ function DeployedQuestions({
   items,
   socket,
   isTutor,
+  alreadySubmitted,
 }: {
   sessionId: string
   taskId: string
   items: StudentDmiItem[]
   socket: Socket | null
   isTutor?: boolean
+  alreadySubmitted?: boolean
 }) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
-  const [submitted, setSubmitted] = useState(false)
+  const [justSubmitted, setJustSubmitted] = useState(false)
+  const submitted = alreadySubmitted || justSubmitted
 
   const answeredCount = useMemo(
     () => items.filter(it => (answers[it.id] ?? '').trim().length > 0).length,
@@ -210,7 +181,7 @@ function DeployedQuestions({
             toast.error(resp?.error || 'Could not submit — please try again.')
             return
           }
-          setSubmitted(true)
+          setJustSubmitted(true)
           toast.success('Answers submitted')
         }
       )

--- a/tutorme-app/src/components/one-on-one/session-responses-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-responses-panel.tsx
@@ -1,95 +1,39 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
-import type { Socket } from 'socket.io-client'
+import { useMemo, useState } from 'react'
 import { X, Users, CheckCircle2 } from 'lucide-react'
 import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
-
-interface DeployedTaskLite {
-  id: string
-  title: string
-  dmiItems?: StudentDmiItem[]
-}
-
-interface StudentResponse {
-  studentId: string
-  studentName: string
-  completedAt: number
-  answers: Record<string, string>
-}
+import type {
+  SessionRoomTask,
+  SessionStudentResponse,
+} from '@/components/one-on-one/use-session-room-state'
 
 /**
  * Tutor-only, read-only panel: who has answered each deployed task in this live
- * session, and what they answered. It listens to the same room broadcasts the
- * classroom already emits — `task:deployed` (to learn each task's questions) and
- * `task:completed` (which carries the student's name + answers) — so it needs no
- * API and can't affect the whiteboard/video around it. The auto-grade score
- * lands asynchronously in the tutor's grading views; this is the live pulse.
+ * session, and what they answered. The deployed tasks and their submissions are
+ * owned by the classroom (`useSessionRoomState`) and passed in, so opening this
+ * panel late — or after a rejoin — still shows everything already submitted. The
+ * auto-grade score lands asynchronously in the tutor's grading views; this is
+ * the live pulse.
  */
 export function SessionResponsesPanel({
-  socket,
+  tasks,
+  responsesByTask,
   onClose,
 }: {
-  socket: Socket | null
+  tasks: SessionRoomTask[]
+  responsesByTask: Record<string, Record<string, SessionStudentResponse>>
   onClose: () => void
 }) {
-  const [tasks, setTasks] = useState<DeployedTaskLite[]>([])
-  // taskId -> studentId -> response
-  const [responses, setResponses] = useState<Record<string, Record<string, StudentResponse>>>({})
   const [activeId, setActiveId] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!socket) return
-    const upsertTask = (task: DeployedTaskLite) => {
-      if (!task?.id) return
-      setTasks(prev =>
-        prev.some(t => t.id === task.id)
-          ? prev.map(t => (t.id === task.id ? { ...t, ...task } : t))
-          : [...prev, task]
-      )
-      setActiveId(cur => cur ?? task.id)
-    }
-    const onDeployed = (task: DeployedTaskLite) => upsertTask(task)
-    const onUpdated = (payload: { task: DeployedTaskLite }) => {
-      if (payload?.task?.id) upsertTask(payload.task)
-    }
-    const onCompleted = (evt: {
-      taskId: string
-      studentId: string
-      studentName?: string
-      completedAt?: number
-      answers?: Record<string, string>
-    }) => {
-      if (!evt?.taskId || !evt?.studentId) return
-      setActiveId(cur => cur ?? evt.taskId)
-      setResponses(prev => ({
-        ...prev,
-        [evt.taskId]: {
-          ...(prev[evt.taskId] ?? {}),
-          [evt.studentId]: {
-            studentId: evt.studentId,
-            studentName: evt.studentName || 'Student',
-            completedAt: evt.completedAt || 0,
-            answers: evt.answers ?? {},
-          },
-        },
-      }))
-    }
-    socket.on('task:deployed', onDeployed)
-    socket.on('task:updated', onUpdated)
-    socket.on('task:completed', onCompleted)
-    return () => {
-      socket.off('task:deployed', onDeployed)
-      socket.off('task:updated', onUpdated)
-      socket.off('task:completed', onCompleted)
-    }
-  }, [socket])
-
-  const active = tasks.find(t => t.id === activeId) ?? null
+  // Only tasks with questions can gather responses.
+  const answerable = useMemo(() => tasks.filter(t => (t.dmiItems?.length ?? 0) > 0), [tasks])
+  const active =
+    answerable.find(t => t.id === activeId) ?? answerable[answerable.length - 1] ?? null
   const activeResponses = useMemo(
-    () => (activeId ? Object.values(responses[activeId] ?? {}) : []),
-    [responses, activeId]
+    () => (active ? Object.values(responsesByTask[active.id] ?? {}) : []),
+    [responsesByTask, active]
   )
 
   return (
@@ -105,7 +49,7 @@ export function SessionResponsesPanel({
         </button>
       </div>
 
-      {tasks.length === 0 ? (
+      {answerable.length === 0 ? (
         <div className="flex flex-1 items-center justify-center px-6 text-center text-xs text-slate-500">
           Deploy a task with questions, and student answers will stream in here as they submit.
         </div>
@@ -113,15 +57,15 @@ export function SessionResponsesPanel({
         <>
           {/* Deployed-task tabs with a live answered-count. */}
           <div className="flex flex-wrap gap-1.5 border-b p-2">
-            {tasks.map(t => {
-              const count = Object.keys(responses[t.id] ?? {}).length
+            {answerable.map(t => {
+              const count = Object.keys(responsesByTask[t.id] ?? {}).length
               return (
                 <button
                   key={t.id}
                   onClick={() => setActiveId(t.id)}
                   className={
                     'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ' +
-                    (t.id === activeId
+                    (t.id === active?.id
                       ? 'bg-blue-600 text-white'
                       : 'bg-slate-100 text-slate-600 hover:bg-slate-200')
                   }
@@ -132,7 +76,9 @@ export function SessionResponsesPanel({
                     <span
                       className={
                         'rounded-full px-1.5 text-[10px] font-bold ' +
-                        (t.id === activeId ? 'bg-white/25 text-white' : 'bg-blue-100 text-blue-700')
+                        (t.id === active?.id
+                          ? 'bg-white/25 text-white'
+                          : 'bg-blue-100 text-blue-700')
                       }
                     >
                       {count}
@@ -178,7 +124,7 @@ function ResponseAnswers({
   item,
   answers,
 }: {
-  item: DeployedTaskLite
+  item: SessionRoomTask
   answers: Record<string, string>
 }) {
   const dmiItems = item.dmiItems ?? []

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -1,0 +1,159 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
+
+export interface SessionSourceDocument {
+  fileName: string
+  fileUrl: string
+  fileKey?: string
+  mimeType: string
+}
+
+/** A deployed task as the classroom knows it (student-safe — no answer key). */
+export interface SessionRoomTask {
+  id: string
+  title: string
+  content?: string
+  source?: string
+  dmiItems?: StudentDmiItem[]
+  sourceDocument?: SessionSourceDocument
+  completedBy?: string[]
+}
+
+export interface SessionStudentResponse {
+  studentId: string
+  studentName: string
+  completedAt: number
+  answers: Record<string, string>
+}
+
+interface RoomStatePayload {
+  students?: Array<{ userId: string; name?: string }>
+  tasks?: Array<SessionRoomTask & { responses?: Record<string, Record<string, string>> }>
+}
+
+interface TaskCompletedEvent {
+  taskId: string
+  studentId: string
+  studentName?: string
+  completedAt?: number
+  answers?: Record<string, string>
+}
+
+/**
+ * The single source of truth for a session classroom's deployed tasks and their
+ * submissions — held here in the always-mounted classroom, not in the panels.
+ *
+ * The panels (Materials, Responses) mount only when the user opens them, so if
+ * they subscribed to socket events themselves they'd miss everything that
+ * happened before they opened (a task deployed earlier, an answer already
+ * submitted) and everything after a rejoin. This hook subscribes from the
+ * classroom, which is mounted from join, so it captures the join-time
+ * `room_state` replay as well as the live `task:*` events — and the panels just
+ * render its output.
+ */
+export function useSessionRoomState(socket: Socket | null, myUserId: string | undefined) {
+  const [tasks, setTasks] = useState<SessionRoomTask[]>([])
+  // taskId -> studentId -> response
+  const [responsesByTask, setResponsesByTask] = useState<
+    Record<string, Record<string, SessionStudentResponse>>
+  >({})
+
+  useEffect(() => {
+    if (!socket) return
+
+    const upsertTask = (t: SessionRoomTask) => {
+      if (!t?.id) return
+      setTasks(prev =>
+        prev.some(x => x.id === t.id)
+          ? prev.map(x => (x.id === t.id ? { ...x, ...t } : x))
+          : [...prev, t]
+      )
+    }
+
+    // Join-time replay: hydrate both the deployed tasks and any submissions that
+    // already happened (task.responses), naming students from the roster.
+    const onRoomState = (state: RoomStatePayload) => {
+      if (!Array.isArray(state?.tasks)) return
+      const nameById = new Map((state.students ?? []).map(s => [s.userId, s.name || 'Student']))
+      setTasks(prev => {
+        const byId = new Map(prev.map(t => [t.id, t]))
+        for (const t of state.tasks!) {
+          if (t?.id) byId.set(t.id, { ...byId.get(t.id), ...t })
+        }
+        return Array.from(byId.values())
+      })
+      setResponsesByTask(prev => {
+        const next = { ...prev }
+        for (const t of state.tasks!) {
+          if (!t?.id || !t.responses || typeof t.responses !== 'object') continue
+          const perStudent = { ...(next[t.id] ?? {}) }
+          for (const [sid, answers] of Object.entries(t.responses)) {
+            // Don't clobber a richer live entry that already arrived.
+            if (perStudent[sid]) continue
+            perStudent[sid] = {
+              studentId: sid,
+              studentName: nameById.get(sid) || 'Student',
+              completedAt: 0,
+              answers: (answers as Record<string, string>) ?? {},
+            }
+          }
+          next[t.id] = perStudent
+        }
+        return next
+      })
+    }
+
+    const onDeployed = (t: SessionRoomTask) => upsertTask(t)
+    const onUpdated = (payload: { task: SessionRoomTask }) => {
+      if (payload?.task?.id) upsertTask(payload.task)
+    }
+    const onCompleted = (evt: TaskCompletedEvent) => {
+      if (!evt?.taskId || !evt?.studentId) return
+      setResponsesByTask(prev => ({
+        ...prev,
+        [evt.taskId]: {
+          ...(prev[evt.taskId] ?? {}),
+          [evt.studentId]: {
+            studentId: evt.studentId,
+            studentName: evt.studentName || 'Student',
+            completedAt: evt.completedAt || 0,
+            answers: evt.answers ?? {},
+          },
+        },
+      }))
+      // Reflect the completion on the task so the student's own submitted state
+      // survives a panel close/reopen.
+      setTasks(prev =>
+        prev.map(t =>
+          t.id === evt.taskId
+            ? { ...t, completedBy: Array.from(new Set([...(t.completedBy ?? []), evt.studentId])) }
+            : t
+        )
+      )
+    }
+
+    socket.on('room_state', onRoomState)
+    socket.on('task:deployed', onDeployed)
+    socket.on('task:updated', onUpdated)
+    socket.on('task:completed', onCompleted)
+    return () => {
+      socket.off('room_state', onRoomState)
+      socket.off('task:deployed', onDeployed)
+      socket.off('task:updated', onUpdated)
+      socket.off('task:completed', onCompleted)
+    }
+  }, [socket])
+
+  const myCompletedTaskIds = useMemo(
+    () =>
+      new Set(
+        tasks.filter(t => myUserId && (t.completedBy ?? []).includes(myUserId)).map(t => t.id)
+      ),
+    [tasks, myUserId]
+  )
+
+  return { tasks, responsesByTask, myCompletedTaskIds }
+}


### PR DESCRIPTION
## The bug

The **Materials** and **Responses** panels mount only when the user opens them. Because they subscribed to socket events from *inside* themselves, they missed everything that happened before they opened:

- A student who opened **Materials** *after* a task was deployed saw **nothing**.
- A tutor who opened **Responses** after a student had already answered (or after a rejoin) saw **no submissions** — reading as "nobody answered" when they had.

The server already broadcasts a full `room_state` replay on join (tasks + each task's `completedBy` + `responses`), but nothing at the right level was listening for it.

## The fix

Lift the deployed-task + submission state into the **classroom**, which is mounted from join, via a new `useSessionRoomState` hook. It hydrates from the join-time `room_state` replay and keeps up via the live `task:deployed` / `task:updated` / `task:completed` events. The panels become presentational:

- `SessionDeployedPanel` takes `tasks` + the student's `completedTaskIds` → a deployed task is present on open, and an already-answered task shows as **submitted** (survives close/reopen and rejoin).
- `SessionResponsesPanel` takes `tasks` + `responsesByTask` → prior submissions are visible immediately.

This also de-duplicates the `task:deployed`/`updated` listeners the two panels each had.

## No server changes

`room_state` already carried everything needed — the panels just weren't listening at the right level.

## Verification

- `tsc --noEmit` clean · `eslint` clean on all 4 files
- `vitest` assessment + grading: 157/157 pass
- `next build`: success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)