### PR TITLE
feat(sessions): classroom assessment polish — structured answering + grading feedback

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -64,7 +64,7 @@ export function SessionClassroom({
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
   // room_state replay instead of missing everything that happened before.
-  const { tasks, responsesByTask, myCompletedTaskIds } = useSessionRoomState(
+  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask } = useSessionRoomState(
     socket,
     session?.user?.id
   )
@@ -155,6 +155,7 @@ export function SessionClassroom({
                 isTutor={isTutor}
                 tasks={tasks}
                 completedTaskIds={myCompletedTaskIds}
+                resultByTask={myResultByTask}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -2,12 +2,16 @@
 
 import { useMemo, useState } from 'react'
 import type { Socket } from 'socket.io-client'
-import { X, FileText, Loader2, CheckCircle2, ListChecks } from 'lucide-react'
+import { X, FileText, Loader2, CheckCircle2, XCircle, Clock, ListChecks } from 'lucide-react'
 import { toast } from 'sonner'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
+import { resolvePublicUrl } from '@/lib/utils'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
-import type { SessionRoomTask } from '@/components/one-on-one/use-session-room-state'
+import type {
+  SessionRoomTask,
+  SessionGradeResult,
+} from '@/components/one-on-one/use-session-room-state'
 
 /**
  * Both-sides panel showing what the tutor has deployed into the session, live.
@@ -26,6 +30,7 @@ export function SessionDeployedPanel({
   isTutor,
   tasks,
   completedTaskIds,
+  resultByTask,
   onClose,
 }: {
   sessionId: string
@@ -33,6 +38,7 @@ export function SessionDeployedPanel({
   isTutor?: boolean
   tasks: SessionRoomTask[]
   completedTaskIds: Set<string>
+  resultByTask: Record<string, SessionGradeResult>
   onClose: () => void
 }) {
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -110,6 +116,7 @@ export function SessionDeployedPanel({
                     socket={socket}
                     isTutor={isTutor}
                     alreadySubmitted={completedTaskIds.has(active.id)}
+                    result={resultByTask[active.id]}
                   />
                 ) : !active.sourceDocument && !active.content ? (
                   <p className="text-xs text-slate-400">This item has no preview.</p>
@@ -136,6 +143,7 @@ function DeployedQuestions({
   socket,
   isTutor,
   alreadySubmitted,
+  result,
 }: {
   sessionId: string
   taskId: string
@@ -143,6 +151,7 @@ function DeployedQuestions({
   socket: Socket | null
   isTutor?: boolean
   alreadySubmitted?: boolean
+  result?: SessionGradeResult
 }) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
@@ -202,15 +211,7 @@ function DeployedQuestions({
   }
 
   if (submitted) {
-    return (
-      <div className="flex flex-col items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-8 text-center">
-        <CheckCircle2 className="h-6 w-6 text-emerald-500" />
-        <p className="text-sm font-semibold text-emerald-800">Submitted</p>
-        <p className="text-xs text-emerald-700">
-          Your tutor has your answers. They’ll appear in your feedback.
-        </p>
-      </div>
-    )
+    return <SubmittedResult items={items} result={result} />
   }
 
   return (
@@ -244,6 +245,79 @@ function DeployedQuestions({
           )}
         </button>
       </div>
+    </div>
+  )
+}
+
+/**
+ * The student's post-submit view. Shows their auto-grade score and a per-question
+ * outcome once the grade lands (via task:graded), degrading to a plain "submitted"
+ * acknowledgement while it's pending or when the task can't be auto-scored. Never
+ * shows the correct answer — only the student's own right/wrong/needs-review.
+ */
+function SubmittedResult({
+  items,
+  result,
+}: {
+  items: StudentDmiItem[]
+  result?: SessionGradeResult
+}) {
+  const resultById = useMemo(() => {
+    const map = new Map<string, { correct: boolean; needsReview?: boolean }>()
+    for (const r of result?.questionResults ?? []) {
+      map.set(r.questionId, { correct: r.correct, needsReview: r.needsReview })
+    }
+    return map
+  }, [result])
+
+  const hasScore = result && typeof result.score === 'number'
+  const graded = (result?.questionResults?.length ?? 0) > 0
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-6 text-center">
+        <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+        <p className="text-sm font-semibold text-emerald-800">Submitted</p>
+        {hasScore ? (
+          <p className="text-2xl font-bold text-emerald-700">{Math.round(result!.score!)}%</p>
+        ) : (
+          <p className="text-xs text-emerald-700">
+            Your tutor has your answers. They’ll appear in your feedback.
+          </p>
+        )}
+      </div>
+
+      {graded ? (
+        <ol className="space-y-1.5">
+          {items.map((it, idx) => {
+            const r = resultById.get(it.id)
+            return (
+              <li
+                key={it.id}
+                className="flex items-start gap-2 rounded-lg border border-slate-200 px-2.5 py-2 text-xs"
+              >
+                {r?.needsReview ? (
+                  <Clock className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                ) : r?.correct ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                ) : (
+                  <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-rose-400" />
+                )}
+                <span className="min-w-0 text-slate-700">
+                  <span className="font-medium text-slate-500">
+                    {it.questionLabel || it.questionNumber || idx + 1}.
+                  </span>{' '}
+                  {r?.needsReview
+                    ? 'Sent to your tutor to review'
+                    : r?.correct
+                      ? 'Correct'
+                      : 'Incorrect'}
+                </span>
+              </li>
+            )
+          })}
+        </ol>
+      ) : null}
     </div>
   )
 }
@@ -402,9 +476,92 @@ function SessionDmiAnswerField({
     )
   }
 
-  // Long / matching / drag_drop / hotspot / anything else — free-text fallback so
-  // the student is never stuck. (Matching/hotspot degrade to describing the
-  // answer; those go to the tutor for review rather than auto-marking.)
+  // Matching & drag-and-drop — assign each prompt to a bank option via a
+  // dropdown. Both store the same JSON map { prompt: choice } the course
+  // classroom uses, so the tutor's review renders them identically.
+  if (
+    (type === 'matching' || type === 'drag_drop') &&
+    item.matchPrompts &&
+    item.matchPrompts.length > 0
+  ) {
+    const bank = (item.matchBank ?? []).slice().sort((a, b) => a.localeCompare(b))
+    let map: Record<string, string> = {}
+    try {
+      const parsed = value ? JSON.parse(value) : {}
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) map = parsed
+    } catch {
+      map = {}
+    }
+    const setMatch = (prompt: string, choice: string) =>
+      onValueChange(JSON.stringify({ ...map, [prompt]: choice }))
+    return (
+      <div className="space-y-2">
+        {item.matchPrompts.map(prompt => (
+          <div key={prompt} className="flex items-center gap-2 text-sm">
+            <span className="min-w-0 flex-1 text-slate-800">{prompt}</span>
+            <span className="shrink-0 text-slate-300">→</span>
+            <select
+              value={map[prompt] ?? ''}
+              onChange={e => setMatch(prompt, e.target.value)}
+              className={'w-40 shrink-0 ' + baseField}
+            >
+              <option value="">Choose…</option>
+              {bank.map(b => (
+                <option key={b} value={b}>
+                  {b}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  // Hotspot — click the point on the image; stored as a { x, y } fraction (0–1),
+  // matching the course classroom. The correct region stays tutor-side.
+  if (type === 'hotspot') {
+    const imageUrl = resolvePublicUrl(item.hotspotImageUrl)
+    if (imageUrl) {
+      let point: { x: number; y: number } | null = null
+      try {
+        const parsed = value ? JSON.parse(value) : null
+        if (parsed && typeof parsed.x === 'number' && typeof parsed.y === 'number') point = parsed
+      } catch {
+        point = null
+      }
+      const onPick = (e: React.MouseEvent<HTMLImageElement>) => {
+        const rect = e.currentTarget.getBoundingClientRect()
+        if (!rect.width || !rect.height) return
+        const x = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width))
+        const y = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height))
+        onValueChange(JSON.stringify({ x, y }))
+      }
+      return (
+        <div className="space-y-1">
+          <p className="text-xs text-slate-500">Click the correct spot on the image.</p>
+          <div className="relative inline-block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt="Hotspot"
+              onClick={onPick}
+              className="max-h-[280px] max-w-full cursor-crosshair rounded-md border border-slate-200"
+            />
+            {point ? (
+              <span
+                className="pointer-events-none absolute z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-blue-600 shadow"
+                style={{ left: `${point.x * 100}%`, top: `${point.y * 100}%` }}
+              />
+            ) : null}
+          </div>
+        </div>
+      )
+    }
+  }
+
+  // Long / ordering / anything else — free-text fallback so the student is never
+  // stuck. (Open-ended answers go to the tutor for review rather than auto-marking.)
   return (
     <textarea
       value={value}

--- a/tutorme-app/src/components/one-on-one/session-responses-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-responses-panel.tsx
@@ -106,6 +106,21 @@ export function SessionResponsesPanel({
                         <span className="text-sm font-semibold text-slate-900">
                           {r.studentName}
                         </span>
+                        {typeof r.score === 'number' ? (
+                          <span
+                            className={
+                              'ml-auto rounded-full px-2 py-0.5 text-xs font-bold ' +
+                              (r.score >= 70
+                                ? 'bg-emerald-100 text-emerald-700'
+                                : r.score >= 40
+                                  ? 'bg-amber-100 text-amber-700'
+                                  : 'bg-rose-100 text-rose-700')
+                            }
+                            title="Auto-graded score (tutor can override in grading)"
+                          >
+                            {Math.round(r.score)}%
+                          </span>
+                        ) : null}
                       </div>
                       <ResponseAnswers item={active} answers={r.answers} />
                     </li>

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -3,6 +3,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
+import type { AutoGradeQuestionResult } from '@/lib/grading/auto-grade'
+
+/** The student-safe auto-grade outcome for one submission (no answer key). */
+export interface SessionGradeResult {
+  score: number | null
+  questionResults: AutoGradeQuestionResult[] | null
+}
 
 export interface SessionSourceDocument {
   fileName: string
@@ -27,6 +34,9 @@ export interface SessionStudentResponse {
   studentName: string
   completedAt: number
   answers: Record<string, string>
+  /** The auto-grade outcome, once it lands (via task:graded). */
+  score?: number | null
+  questionResults?: AutoGradeQuestionResult[] | null
 }
 
 interface RoomStatePayload {
@@ -40,6 +50,13 @@ interface TaskCompletedEvent {
   studentName?: string
   completedAt?: number
   answers?: Record<string, string>
+}
+
+interface TaskGradedEvent {
+  taskId: string
+  studentId: string
+  score?: number | null
+  questionResults?: AutoGradeQuestionResult[] | null
 }
 
 /**
@@ -135,15 +152,41 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       )
     }
 
+    // The (student-safe) auto-grade result — merged onto the matching response,
+    // creating a bare entry if the grade somehow beats the completion event.
+    const onGraded = (evt: TaskGradedEvent) => {
+      if (!evt?.taskId || !evt?.studentId) return
+      setResponsesByTask(prev => {
+        const perTask = prev[evt.taskId] ?? {}
+        const existing = perTask[evt.studentId]
+        return {
+          ...prev,
+          [evt.taskId]: {
+            ...perTask,
+            [evt.studentId]: {
+              studentId: evt.studentId,
+              studentName: existing?.studentName || 'Student',
+              completedAt: existing?.completedAt ?? 0,
+              answers: existing?.answers ?? {},
+              score: evt.score ?? null,
+              questionResults: evt.questionResults ?? null,
+            },
+          },
+        }
+      })
+    }
+
     socket.on('room_state', onRoomState)
     socket.on('task:deployed', onDeployed)
     socket.on('task:updated', onUpdated)
     socket.on('task:completed', onCompleted)
+    socket.on('task:graded', onGraded)
     return () => {
       socket.off('room_state', onRoomState)
       socket.off('task:deployed', onDeployed)
       socket.off('task:updated', onUpdated)
       socket.off('task:completed', onCompleted)
+      socket.off('task:graded', onGraded)
     }
   }, [socket])
 
@@ -155,5 +198,18 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     [tasks, myUserId]
   )
 
-  return { tasks, responsesByTask, myCompletedTaskIds }
+  // The current user's own grade per task (for the student's post-submit view).
+  const myResultByTask = useMemo(() => {
+    const out: Record<string, SessionGradeResult> = {}
+    if (!myUserId) return out
+    for (const [taskId, byStudent] of Object.entries(responsesByTask)) {
+      const mine = byStudent[myUserId]
+      if (mine && (mine.score != null || mine.questionResults != null)) {
+        out[taskId] = { score: mine.score ?? null, questionResults: mine.questionResults ?? null }
+      }
+    }
+    return out
+  }, [responsesByTask, myUserId])
+
+  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask }
 }

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1795,6 +1795,19 @@ export async function initEnhancedSocketServer(server: NetServer) {
               console.warn('[task:complete] auto-grade failed (non-critical):', gradeErr)
             }
 
+            // Push the auto-grade outcome to the room: the student sees their own
+            // score + per-question result, and the tutor's live view updates.
+            // This is deliberately student-safe — `questionResults` carries
+            // correct/needs-review flags but never the answer key (see
+            // AutoGradeQuestionResult), the same projection the REST quiz results
+            // use — so broadcasting it leaks nothing the student shouldn't see.
+            io.to(roomId).emit('task:graded', {
+              taskId,
+              studentId,
+              score: autoScore,
+              questionResults: autoResults,
+            })
+
             // 5) The submission itself. onConflictDoNothing preserves the
             //    one-per-(task,student) rule and never overwrites a graded row.
             //    Status stays 'submitted' so the tutor can still review/override.


### PR DESCRIPTION
Three refinements to the deployed-assessment experience in the session classroom (the three "polish" items).

## 1. Native structured answering (client)
- **matching / drag_drop** → a dropdown per prompt, storing the same JSON `{prompt: choice}` map the course classroom uses, so the tutor's review renders identically.
- **hotspot** → click the point on the image, stored as a `{x, y}` fraction (0–1).

Previously all three degraded to a free-text box.

## 2. Student grade feedback (server + client)
After the server auto-grades a submission it emits a **student-safe** `task:graded` (score + per-question correct / needs-review — the `AutoGradeQuestionResult` projection, which *by design never carries the answer key*). The student's post-submit view shows their **score** and a per-question **right / wrong / needs-review** list.

> **Note on "answer reveal":** I did *not* reveal the correct answer. Doing so would require shipping the answer key to the client, which the entire deploy-safety layer exists to prevent, and `answerRevealPolicy` is free-text with no reveal logic anywhere. The student instead sees the answer-key-safe feedback the grader is designed to expose (their own score + which questions they got right).

## 3. Tutor live score (client)
The Responses panel shows each student's auto-graded score as a colour-coded badge as it lands, next to their answers.

## Plumbing
State flows through `useSessionRoomState` — `task:graded` is merged onto the matching response, and `myResultByTask` is exposed for the student's own view — so it survives panel close/reopen and rejoin like the rest of the room state.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors (only pre-existing warnings in socket-server)
- `vitest` assessment + grading + socket suites: 162/162 pass
- `next build`: success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)