### PR TITLE
chore(dmi): rate-limit + serialise LibreOffice conversions (prod safety)

### DIFF
--- a/tutorme-app/src/app/api/ai/office-to-pdf/route.ts
+++ b/tutorme-app/src/app/api/ai/office-to-pdf/route.ts
@@ -9,7 +9,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import type { Session } from 'next-auth'
-import { withAuth, withCsrf, handleApiError } from '@/lib/api/middleware'
+import { withAuth, withCsrf, withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
 import { readFileBuffer } from '@/lib/storage/service'
 import { convertOfficeToPdf } from '@/lib/documents/office-to-pdf'
 
@@ -20,6 +20,14 @@ export const POST = withCsrf(
     const startedAt = Date.now()
     const userId = session?.user?.id ?? 'unknown'
     try {
+      // LibreOffice conversion is expensive — rate-limit it per user, like the
+      // other AI-generation endpoints, so it can't be spammed.
+      const { response: rateLimited } = await withRateLimitPreset(request, 'aiGenerate', userId)
+      if (rateLimited) {
+        console.warn(`[office-to-pdf] 429 rate limited (user ${userId})`)
+        return rateLimited
+      }
+
       const body = await request.json().catch(() => null)
       const fileKey = typeof body?.fileKey === 'string' ? body.fileKey : ''
       const fileName = typeof body?.fileName === 'string' ? body.fileName : 'document'

--- a/tutorme-app/src/app/api/uploads/documents/route.ts
+++ b/tutorme-app/src/app/api/uploads/documents/route.ts
@@ -9,6 +9,7 @@ import { promisify } from 'util'
 import { Buffer } from 'buffer'
 import { isGcsConfigured, uploadLocalFile, refreshGcsUrl } from '@/lib/storage/gcs'
 import { storeFile } from '@/lib/storage/service'
+import { withConversionSlot } from '@/lib/documents/conversion-limiter'
 
 const execAsync = promisify(exec)
 
@@ -99,17 +100,21 @@ async function convertToPdf(inputPath: string, outputDir: string): Promise<strin
       inputPath,
     ]
 
-    try {
-      await execAsync(`soffice ${baseArgs.map(a => `"${a}"`).join(' ')}`, {
-        timeout: 120000,
-        env: { ...process.env, HOME: outputDir },
-      })
-    } catch {
-      await execAsync(`libreoffice ${baseArgs.map(a => `"${a}"`).join(' ')}`, {
-        timeout: 120000,
-        env: { ...process.env, HOME: outputDir },
-      })
-    }
+    // Share the process-wide conversion gate so an upload conversion and an
+    // on-demand diagram conversion can't run soffice simultaneously and OOM.
+    await withConversionSlot(async () => {
+      try {
+        await execAsync(`soffice ${baseArgs.map(a => `"${a}"`).join(' ')}`, {
+          timeout: 120000,
+          env: { ...process.env, HOME: outputDir },
+        })
+      } catch {
+        await execAsync(`libreoffice ${baseArgs.map(a => `"${a}"`).join(' ')}`, {
+          timeout: 120000,
+          env: { ...process.env, HOME: outputDir },
+        })
+      }
+    })
 
     const baseName = path.basename(inputPath, path.extname(inputPath))
     const pdfPath = path.join(outputDir, `${baseName}.pdf`)

--- a/tutorme-app/src/lib/documents/conversion-limiter.test.ts
+++ b/tutorme-app/src/lib/documents/conversion-limiter.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  withConversionSlot,
+  ConversionBusyError,
+  _conversionLimiterState,
+} from './conversion-limiter'
+
+// A deferred promise whose resolution we control, to hold a slot open.
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>(r => (resolve = r))
+  return { promise, resolve }
+}
+
+describe('withConversionSlot', () => {
+  it('runs a single task immediately and releases the slot', async () => {
+    const result = await withConversionSlot(async () => 42)
+    expect(result).toBe(42)
+    expect(_conversionLimiterState()).toEqual({ active: 0, queued: 0 })
+  })
+
+  it('serialises concurrent tasks (only one active at a time)', async () => {
+    const order: string[] = []
+    const a = deferred()
+
+    // Task A grabs the only slot and holds it until we resolve `a`.
+    const pA = withConversionSlot(async () => {
+      order.push('A:start')
+      await a.promise
+      order.push('A:end')
+      return 'A'
+    })
+
+    // Give A a tick to acquire the slot.
+    await Promise.resolve()
+
+    // Task B must WAIT — it can't start until A releases.
+    const pB = withConversionSlot(async () => {
+      order.push('B:start')
+      return 'B'
+    })
+    await Promise.resolve()
+    expect(order).toEqual(['A:start']) // B has not started
+
+    a.resolve()
+    const [rA, rB] = await Promise.all([pA, pB])
+    expect(rA).toBe('A')
+    expect(rB).toBe('B')
+    expect(order).toEqual(['A:start', 'A:end', 'B:start'])
+    expect(_conversionLimiterState()).toEqual({ active: 0, queued: 0 })
+  })
+
+  it('always releases the slot even when the task throws', async () => {
+    await expect(
+      withConversionSlot(async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+    expect(_conversionLimiterState()).toEqual({ active: 0, queued: 0 })
+
+    // The limiter is not wedged — a subsequent task still runs.
+    await expect(withConversionSlot(async () => 'ok')).resolves.toBe('ok')
+  })
+
+  it('rejects with ConversionBusyError once the wait queue is full', async () => {
+    const hold = deferred()
+    // One task holds the single slot.
+    const holder = withConversionSlot(async () => {
+      await hold.promise
+    })
+    await Promise.resolve()
+
+    // Fill the queue (MAX_QUEUED = 16) — these wait, they don't reject.
+    const queued = Array.from({ length: 16 }, () =>
+      withConversionSlot(async () => 'queued').catch(e => e)
+    )
+    await Promise.resolve()
+
+    // The 17th waiter overflows the queue → rejected immediately.
+    await expect(withConversionSlot(async () => 'overflow')).rejects.toBeInstanceOf(
+      ConversionBusyError
+    )
+
+    // Drain everything cleanly.
+    hold.resolve()
+    await holder
+    await Promise.all(queued)
+    expect(_conversionLimiterState()).toEqual({ active: 0, queued: 0 })
+  })
+})

--- a/tutorme-app/src/lib/documents/conversion-limiter.ts
+++ b/tutorme-app/src/lib/documents/conversion-limiter.ts
@@ -1,0 +1,64 @@
+/**
+ * Process-wide gate for LibreOffice (soffice) conversions.
+ *
+ * Each conversion spawns a memory-heavy soffice process; running several at once
+ * can OOM a small Cloud Run instance and take it down. This serialises them so a
+ * burst degrades to "slower", not "crashed". A bounded wait queue means a large
+ * pile-up is rejected (caller falls back to text) rather than growing unbounded.
+ *
+ * All conversion paths (the on-demand diagram endpoint and the upload route)
+ * share this single limiter because they share the process's memory.
+ */
+
+const MAX_CONCURRENT = 1
+const MAX_QUEUED = 16
+
+let active = 0
+const waiters: Array<() => void> = []
+
+export class ConversionBusyError extends Error {
+  constructor() {
+    super('Document conversion is busy; too many concurrent requests')
+    this.name = 'ConversionBusyError'
+  }
+}
+
+function acquire(): Promise<void> {
+  if (active < MAX_CONCURRENT) {
+    active++
+    return Promise.resolve()
+  }
+  if (waiters.length >= MAX_QUEUED) {
+    return Promise.reject(new ConversionBusyError())
+  }
+  return new Promise<void>(resolve => waiters.push(resolve))
+}
+
+function release(): void {
+  const next = waiters.shift()
+  if (next) {
+    // Hand the slot straight to the next waiter (active stays the same).
+    next()
+  } else {
+    active = Math.max(0, active - 1)
+  }
+}
+
+/**
+ * Run `fn` while holding a conversion slot. Waits (up to the queue bound) if
+ * another conversion is in flight; throws ConversionBusyError if the queue is
+ * full. The slot is always released, even if `fn` throws.
+ */
+export async function withConversionSlot<T>(fn: () => Promise<T>): Promise<T> {
+  await acquire()
+  try {
+    return await fn()
+  } finally {
+    release()
+  }
+}
+
+/** Test-only view of the limiter's internal counters. */
+export function _conversionLimiterState(): { active: number; queued: number } {
+  return { active, queued: waiters.length }
+}

--- a/tutorme-app/src/lib/documents/office-to-pdf.ts
+++ b/tutorme-app/src/lib/documents/office-to-pdf.ts
@@ -16,6 +16,7 @@ import os from 'os'
 import { mkdtemp, writeFile, readFile, rm, access } from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import { withConversionSlot, ConversionBusyError } from './conversion-limiter'
 
 const execAsync = promisify(exec)
 
@@ -55,21 +56,29 @@ export async function convertOfficeToPdf(input: Buffer, fileName: string): Promi
       return (err?.stderr || err?.message || String(e)).slice(0, 300).replace(/\s+/g, ' ').trim()
     }
     let binary = 'soffice'
+    // Serialise soffice process-wide so concurrent conversions can't OOM the
+    // instance; the whole (soffice → libreoffice fallback) attempt holds one slot.
     try {
-      await execAsync(cmd('soffice'), opts)
-    } catch (sofficeErr) {
-      console.warn(
-        `[office-to-pdf] soffice failed for ${safeName}, retrying via libreoffice: ${detail(sofficeErr)}`
-      )
-      binary = 'libreoffice'
-      try {
-        await execAsync(cmd('libreoffice'), opts)
-      } catch (libreErr) {
+      await withConversionSlot(async () => {
+        try {
+          await execAsync(cmd('soffice'), opts)
+        } catch (sofficeErr) {
+          console.warn(
+            `[office-to-pdf] soffice failed for ${safeName}, retrying via libreoffice: ${detail(sofficeErr)}`
+          )
+          binary = 'libreoffice'
+          await execAsync(cmd('libreoffice'), opts)
+        }
+      })
+    } catch (convErr) {
+      if (convErr instanceof ConversionBusyError) {
+        console.warn(`[office-to-pdf] busy: skipped ${safeName} — too many concurrent conversions`)
+      } else {
         console.error(
-          `[office-to-pdf] LibreOffice conversion FAILED for ${safeName} (${input.length} bytes): ${detail(libreErr)}`
+          `[office-to-pdf] LibreOffice conversion FAILED for ${safeName} (${input.length} bytes): ${detail(convErr)}`
         )
-        return null
       }
+      return null
     }
 
     const pdfPath = path.join(workDir, `${path.basename(inputPath, path.extname(inputPath))}.pdf`)


### PR DESCRIPTION
Hardens the conversion path from #1051. `/api/ai/office-to-pdf` spawned a memory-heavy `soffice` process with only auth+CSRF — the most expensive operation was the *unprotected* one, and nothing stopped concurrent conversions from OOMing a small Cloud Run instance.

## Changes
1. **Rate limit** — the endpoint now uses `withRateLimitPreset(request, 'aiGenerate', userId)` (30/min per user), the same preset `generate-dmi` and the other AI routes use. Logs a `429` line.
2. **Concurrency gate** — new `src/lib/documents/conversion-limiter.ts`: `soffice` runs **one at a time** with a bounded wait queue (16). Overflow throws `ConversionBusyError`; callers degrade gracefully — the endpoint falls back to **text-only** generation, the upload route stores the **un-converted** original.
3. **Shared across both conversion paths** — the on-demand endpoint *and* the existing `uploads/documents` route acquire the same process-wide limiter, since they compete for the same memory.
4. **Tests** — 4 unit tests: serialisation (only one active), slot always released on throw, and queue-overflow rejection.

## Verification
`vitest` 4/4 on the limiter. `tsc --noEmit` clean (0 errors). Prettier clean. **No happy-path behaviour change** — only concurrent/abusive load is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)