### PR TITLE
fix(schedule): notify all enrolled students on every reschedule path (Phase 1)

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
@@ -1,113 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import {
-  calendarEvent,
-  liveSession,
-  courseEnrollment,
-  sessionParticipant,
-  profile,
-} from '@/lib/db/schema'
-import { eq, and, inArray } from 'drizzle-orm'
+import { calendarEvent, liveSession } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
-import { notify } from '@/lib/notifications/notify'
-
-/** Format an instant in a specific IANA timezone, with the zone labelled. */
-function formatInZone(date: Date, tz: string): string {
-  try {
-    // NB: timeZoneName can't be combined with dateStyle/timeStyle (throws),
-    // so spell out the fields explicitly.
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZone: tz,
-      timeZoneName: 'short',
-    }).format(date)
-  } catch {
-    // Invalid/unknown tz → fall back to UTC, still labelled.
-    try {
-      return new Intl.DateTimeFormat('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZone: 'UTC',
-        timeZoneName: 'short',
-      }).format(date)
-    } catch {
-      return `${date.toISOString().replace('T', ' ').slice(0, 16)} UTC`
-    }
-  }
-}
-
-/**
- * Notify every student of a rescheduled session (in-app + SSE + web push +
- * email, via notify.ts). Students come from the course enrollment (the
- * reliable roster) plus anyone already added as a session participant. The new
- * time is formatted in EACH student's own profile timezone so it reads as their
- * local time; the session's timezone (or UTC) is the fallback.
- * Best-effort: never throws into the reschedule request.
- */
-async function notifyStudentsOfReschedule(opts: {
-  sessionId: string
-  courseId: string | null
-  title: string | null
-  newStart: Date
-  timezone?: string | null
-}): Promise<void> {
-  try {
-    const { sessionId, courseId, title, newStart, timezone } = opts
-    const ids = new Set<string>()
-    if (courseId) {
-      const enrolled = await drizzleDb
-        .select({ studentId: courseEnrollment.studentId })
-        .from(courseEnrollment)
-        .where(eq(courseEnrollment.courseId, courseId))
-      for (const r of enrolled) if (r.studentId) ids.add(r.studentId)
-    }
-    const participants = await drizzleDb
-      .select({ studentId: sessionParticipant.studentId })
-      .from(sessionParticipant)
-      .where(eq(sessionParticipant.sessionId, sessionId))
-    for (const r of participants) if (r.studentId) ids.add(r.studentId)
-
-    const userIds = Array.from(ids)
-    if (userIds.length === 0) return
-
-    // Each student's own timezone (default 'UTC' in schema) → localize per user.
-    const tzRows = await drizzleDb
-      .select({ userId: profile.userId, timezone: profile.timezone })
-      .from(profile)
-      .where(inArray(profile.userId, userIds))
-    const tzByUser = new Map(tzRows.map(r => [r.userId, r.timezone]))
-    const fallbackTz = timezone || 'UTC'
-
-    const name = title || 'Your session'
-    const actionUrl = courseId ? `/student/classroom/${courseId}` : '/student/schedule'
-
-    await Promise.allSettled(
-      userIds.map(userId => {
-        const when = formatInZone(newStart, tzByUser.get(userId) || fallbackTz)
-        return notify({
-          userId,
-          type: 'class',
-          title: 'Session rescheduled',
-          message: `"${name}" has been moved to ${when}.`,
-          data: { sessionId, scheduledAt: newStart.toISOString() },
-          actionUrl,
-        })
-      })
-    )
-  } catch (err) {
-    console.warn('[reschedule] student notification failed (non-critical):', err)
-  }
-}
-
+import { notifyStudentsOfReschedule } from '@/lib/notifications/reschedule'
 export const GET = withAuth(async () => {
   return NextResponse.json(
     {

--- a/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
@@ -10,8 +10,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { verifyCourseOwnership } from '@/lib/api/course-helpers'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { courseSchedule, courseEnrollment } from '@/lib/db/schema'
+import { courseSchedule, course } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
+import { notifyStudentsOfScheduleChange } from '@/lib/notifications/reschedule'
 import crypto from 'crypto'
 
 // GET all schedules for a course
@@ -140,6 +141,16 @@ export const PUT = withCsrf(
         if (body.weeksToSchedule !== undefined) updateData.weeksToSchedule = body.weeksToSchedule
         if (body.maxStudents !== undefined) updateData.maxStudents = body.maxStudents
 
+        // Snapshot the current schedule so we only notify students when the
+        // actual times change (not on a maxStudents rename or a no-op save).
+        const [before] = await drizzleDb
+          .select({ schedule: courseSchedule.schedule })
+          .from(courseSchedule)
+          .where(
+            and(eq(courseSchedule.scheduleId, scheduleId), eq(courseSchedule.courseId, courseId))
+          )
+          .limit(1)
+
         const updated = await drizzleDb
           .update(courseSchedule)
           .set(updateData)
@@ -160,6 +171,20 @@ export const PUT = withCsrf(
 
         if (updated.length === 0) {
           return NextResponse.json({ error: 'Schedule not found' }, { status: 404 })
+        }
+
+        // Notify enrolled students when the schedule times actually changed.
+        // Best-effort — never blocks the save.
+        const scheduleChanged =
+          body.schedule !== undefined &&
+          JSON.stringify(before?.schedule ?? null) !== JSON.stringify(body.schedule)
+        if (scheduleChanged) {
+          const [row] = await drizzleDb
+            .select({ name: course.name })
+            .from(course)
+            .where(eq(course.courseId, courseId))
+            .limit(1)
+          await notifyStudentsOfScheduleChange({ courseId, courseName: row?.name })
         }
 
         return NextResponse.json({ schedule: updated[0] })

--- a/tutorme-app/src/lib/notifications/reschedule.ts
+++ b/tutorme-app/src/lib/notifications/reschedule.ts
@@ -1,0 +1,156 @@
+/**
+ * Reschedule / schedule-change notifications.
+ *
+ * Shared by every path that can move a session or change a course's schedule, so
+ * enrolled students are actually told. The audience is resolved through the
+ * variant family (a session's `courseId` may be the template OR a published
+ * variant, while students enrol under the published id) — without that
+ * expansion the recipient lookup silently returns nobody. See
+ * [[tutorme-template-vs-published-course-ids]].
+ *
+ * All functions are best-effort: they never throw into the caller's request.
+ */
+
+import { drizzleDb } from '@/lib/db/drizzle'
+import { courseEnrollment, sessionParticipant, profile } from '@/lib/db/schema'
+import { eq, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
+import { notify } from '@/lib/notifications/notify'
+
+/** Format an instant in a specific IANA timezone, with the zone labelled. */
+export function formatInZone(date: Date, tz: string): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }
+  try {
+    return new Intl.DateTimeFormat('en-US', { ...opts, timeZone: tz }).format(date)
+  } catch {
+    try {
+      return new Intl.DateTimeFormat('en-US', { ...opts, timeZone: 'UTC' }).format(date)
+    } catch {
+      return `${date.toISOString().replace('T', ' ').slice(0, 16)} UTC`
+    }
+  }
+}
+
+interface Audience {
+  userIds: string[]
+  tzByUser: Map<string, string | null>
+}
+
+/**
+ * Everyone who should hear about a change to this course/session: enrolled
+ * students (across the whole variant family) plus anyone already added as a
+ * session participant, with each user's own timezone for localized formatting.
+ */
+async function resolveAudience(
+  courseId?: string | null,
+  sessionId?: string | null
+): Promise<Audience> {
+  const ids = new Set<string>()
+
+  if (courseId) {
+    const familyIds = await expandToCourseFamily([courseId])
+    const enrolled = await drizzleDb
+      .select({ studentId: courseEnrollment.studentId })
+      .from(courseEnrollment)
+      .where(inArray(courseEnrollment.courseId, familyIds))
+    for (const r of enrolled) if (r.studentId) ids.add(r.studentId)
+  }
+
+  if (sessionId) {
+    const participants = await drizzleDb
+      .select({ studentId: sessionParticipant.studentId })
+      .from(sessionParticipant)
+      .where(eq(sessionParticipant.sessionId, sessionId))
+    for (const r of participants) if (r.studentId) ids.add(r.studentId)
+  }
+
+  const userIds = [...ids]
+  if (userIds.length === 0) return { userIds, tzByUser: new Map() }
+
+  const tzRows = await drizzleDb
+    .select({ userId: profile.userId, timezone: profile.timezone })
+    .from(profile)
+    .where(inArray(profile.userId, userIds))
+  return { userIds, tzByUser: new Map(tzRows.map(r => [r.userId, r.timezone])) }
+}
+
+/**
+ * Notify every student that a specific session was moved to `newStart`.
+ * Returns the number of students notified (0 = no roster / audience empty).
+ */
+export async function notifyStudentsOfReschedule(opts: {
+  sessionId: string
+  courseId?: string | null
+  title: string | null
+  newStart: Date
+  timezone?: string | null
+}): Promise<number> {
+  try {
+    const { sessionId, courseId, title, newStart, timezone } = opts
+    const { userIds, tzByUser } = await resolveAudience(courseId, sessionId)
+    if (userIds.length === 0) return 0
+
+    const fallbackTz = timezone || 'UTC'
+    const name = title || 'Your session'
+    const actionUrl = courseId ? `/student/classroom/${courseId}` : '/student/schedule'
+
+    await Promise.allSettled(
+      userIds.map(userId => {
+        const when = formatInZone(newStart, tzByUser.get(userId) || fallbackTz)
+        return notify({
+          userId,
+          type: 'class',
+          title: 'Session rescheduled',
+          message: `"${name}" has been moved to ${when}.`,
+          data: { sessionId, scheduledAt: newStart.toISOString() },
+          actionUrl,
+        })
+      })
+    )
+    return userIds.length
+  } catch (err) {
+    console.warn('[reschedule] student notification failed (non-critical):', err)
+    return 0
+  }
+}
+
+/**
+ * Notify every enrolled student that a course's recurring schedule changed.
+ * Used by the course-schedule editor, which has no single "new time" to show —
+ * it points students at their sessions to review the update.
+ */
+export async function notifyStudentsOfScheduleChange(opts: {
+  courseId: string
+  courseName?: string | null
+}): Promise<number> {
+  try {
+    const { courseId, courseName } = opts
+    const { userIds } = await resolveAudience(courseId)
+    if (userIds.length === 0) return 0
+
+    const name = courseName || 'your course'
+    await Promise.allSettled(
+      userIds.map(userId =>
+        notify({
+          userId,
+          type: 'class',
+          title: 'Class schedule updated',
+          message: `The schedule for "${name}" has changed. Check your sessions for the new times.`,
+          data: { courseId },
+          actionUrl: `/student/classroom/${courseId}`,
+        })
+      )
+    )
+    return userIds.length
+  } catch (err) {
+    console.warn('[schedule-change] student notification failed (non-critical):', err)
+    return 0
+  }
+}


### PR DESCRIPTION
## Bug
A tutor changed a session's schedule and enrolled students were **not notified** (and, separately, never asked to agree — see Phase 2 below).

## Root causes (both fixed)
1. **Calendar reschedule** (`PATCH /api/tutor/calendar/events/[id]`) resolved recipients with `eq(courseEnrollment.courseId, session.courseId)` — **no variant-family expansion**. A session's `courseId` can be the *template* while students enrol under the *published* variant, so the lookup silently returned **zero recipients**. Same template/published landmine as #992/#997/#1000. → now expands via `expandToCourseFamily`.
2. **Course-schedule editor** (`PUT /api/tutor/courses/[id]/schedules`) **never notified anyone**. → now notifies enrolled students when the schedule times actually change (diffed against the prior value, so no spam on `maxStudents` renames or no-op saves).

Notification logic is extracted into a shared, family-aware module `src/lib/notifications/reschedule.ts` so every reschedule path behaves consistently. Best-effort — never blocks the save.

## Verification (ephemeral Postgres, real app code)
Student enrolled under the **published** variant; notified by the session's **template** courseId:
```
OLD (no family expansion) recipients for template id: 0   ← nobody notified (the bug)
NEW notifyStudentsOfReschedule(template id) recipients: 1  ← student reached ✔
NEW notifyStudentsOfScheduleChange(template id) recipients: 1 ✔
notification rows written for student: 2
  • Session rescheduled — "Session A" has been moved to Aug 1, 2026, 11:00 AM EDT.
  • Class schedule updated — The schedule for "AP Stats" has changed. …
```
Real notification rows written, localized to each student's own timezone. Typecheck clean; lint 0 errors.

## Scope
**Phase 1 (this PR): notification.** Students are now reliably notified on both reschedule paths.

**Phase 2 (next): the consent gate** — a *pending* reschedule that keeps the old time until every enrolled student agrees; any disagree cancels; non-responders leave it pending. Agreed decisions: keep-old-time-until-unanimous, any-disagree-cancels, ship notification first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)