### PR TITLE
fix(sessions): stop leaking peer answers/scores in group-session classroom

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -186,6 +186,20 @@ export interface LiveTask {
   responses?: Record<string, Record<string, string>>
 }
 
+/**
+ * A room-broadcast-safe view of a task: strips the per-student answer map so
+ * peers in a GROUP session never receive each other's submitted answers over the
+ * wire. `responses` is the only sensitive field on the room task object — deploy
+ * already omits answerKey/pci/pciSpec from it — and the tutor gets answers via
+ * the targeted `task:completed` (live) + their own `room_state` (rejoin), so no
+ * room-wide consumer needs `responses`.
+ */
+function toPublicTask(task: LiveTask): LiveTask {
+  if (!task.responses) return task
+  const { responses: _omit, ...rest } = task
+  return rest
+}
+
 // Environment validation
 function validateEnv() {
   const required = ['NEXTAUTH_SECRET']
@@ -1540,7 +1554,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         // already-deployed tasks, not new deployments, so they shouldn't trigger
         // the tutor's "Deployed to students" confirmation.
         for (const task of syncedTasks) {
-          io.to(roomId).emit('task:updated', { task })
+          io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
         }
 
         socket.emit('course:sync:success', { count: syncedTasks.length })
@@ -1606,15 +1620,23 @@ export async function initEnhancedSocketServer(server: NetServer) {
         room.lastActivity = Date.now()
         void persistRoomToRedis(roomId, room)
         const studentName = room.students.get(studentId)?.name || 'A student'
-        io.to(roomId).emit('task:completed', {
+        // The completion event carries the student's answers, so it must NOT be
+        // broadcast to the room — in a group session that would hand every
+        // student their peers' answers. Send it only to the tutor (live grading
+        // + Insights) and the submitting student (their own). The room-wide
+        // completion COUNT still propagates via the answer-free task:updated
+        // below, so peers' progress indicators keep working.
+        const completedPayload = {
           taskId,
           studentId,
           studentName,
           completedAt: Date.now(),
           totalCompleted: task.completedBy.length,
           answers: answers ?? {},
-        })
-        io.to(roomId).emit('task:updated', { task })
+        }
+        if (room.tutorId) emitToUser(room.tutorId, 'task:completed', completedPayload)
+        emitToUser(studentId, 'task:completed', completedPayload)
+        io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
 
         // The server received and accepted the submission — confirm to the
         // student. (DB persistence below is best-effort and self-healing.) If
@@ -1795,18 +1817,19 @@ export async function initEnhancedSocketServer(server: NetServer) {
               console.warn('[task:complete] auto-grade failed (non-critical):', gradeErr)
             }
 
-            // Push the auto-grade outcome to the room: the student sees their own
-            // score + per-question result, and the tutor's live view updates.
-            // This is deliberately student-safe — `questionResults` carries
-            // correct/needs-review flags but never the answer key (see
-            // AutoGradeQuestionResult), the same projection the REST quiz results
-            // use — so broadcasting it leaks nothing the student shouldn't see.
-            io.to(roomId).emit('task:graded', {
+            // Push the auto-grade outcome only to the tutor (live view) and the
+            // submitting student (their own score + per-question result) — never
+            // to peers, so a group session doesn't reveal one student's result to
+            // the others. `questionResults` is student-safe by design (correct/
+            // needs-review flags, never the answer key — see AutoGradeQuestionResult).
+            const gradedPayload = {
               taskId,
               studentId,
               score: autoScore,
               questionResults: autoResults,
-            })
+            }
+            if (tutorId) emitToUser(tutorId, 'task:graded', gradedPayload)
+            emitToUser(studentId, 'task:graded', gradedPayload)
 
             // 5) The submission itself. onConflictDoNothing preserves the
             //    one-per-(task,student) rule and never overwrites a graded row.
@@ -2316,7 +2339,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
           room.lastActivity = Date.now()
           void persistRoomToRedis(roomId, room)
           io.to(roomId).emit('insight:sent', { taskId, type: 'poll', item: poll })
-          io.to(roomId).emit('task:updated', { task })
+          io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
           return
         }
 
@@ -2332,7 +2355,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         room.lastActivity = Date.now()
         void persistRoomToRedis(roomId, room)
         io.to(roomId).emit('insight:sent', { taskId, type: 'question', item: question })
-        io.to(roomId).emit('task:updated', { task })
+        io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
       }
     )
 
@@ -2371,7 +2394,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
           room.lastActivity = Date.now()
           void persistRoomToRedis(roomId, room)
           io.to(roomId).emit('insight:response', { taskId, type: 'poll', item: poll })
-          io.to(roomId).emit('task:updated', { task })
+          io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
           return
         }
 
@@ -2391,7 +2414,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         room.lastActivity = Date.now()
         void persistRoomToRedis(roomId, room)
         io.to(roomId).emit('insight:response', { taskId, type: 'question', item: question })
-        io.to(roomId).emit('task:updated', { task })
+        io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
       }
     )
 
@@ -2420,7 +2443,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         }
         room.lastActivity = Date.now()
         void persistRoomToRedis(roomId, room)
-        io.to(roomId).emit('task:updated', { task })
+        io.to(roomId).emit('task:updated', { task: toPublicTask(task) })
       }
     )
 
@@ -2548,9 +2571,12 @@ async function addStudentToRoom(socket: Socket, room: ClassRoom) {
     state: studentState,
   })
 
+  // Students hydrate from public tasks only — `toPublicTask` drops the
+  // per-student answer map so a group-session joiner never receives peers'
+  // answers on join. (The tutor path below keeps `responses` for grading.)
   const refreshedTasks = await Promise.all(
     room.tasks.map(async task => ({
-      ...task,
+      ...toPublicTask(task),
       sourceDocument: task.sourceDocument
         ? await refreshDocumentUrls(task.sourceDocument)
         : undefined,


### PR DESCRIPTION
## The leak

In a **group** session, the deployed-assessment socket events reached every student, not just the tutor — so a student could read their **peers' submitted answers and scores** straight off the socket (even though the UI only rendered their own). Harmless in 1-on-1; a real privacy issue for groups.

`LiveTask.responses` (the `studentId → {itemId → answer}` map) is the only sensitive field on the room task object — deploy already omits `answerKey`/`pci`/`pciSpec` — so the fix is server-side and targeted.

## Four vectors, all closed

| Event | Before | After |
|-------|--------|-------|
| `task:completed` | broadcast to room **with `answers`** | tutor + submitting student only (`emitToUser`) |
| `task:graded` | broadcast to room with score + `questionResults` | tutor + submitter only |
| `task:updated` | broadcast the mutated task incl. `responses` | `toPublicTask(task)` strips the answer map (7 emit sites) |
| `room_state` (join) | replayed `responses` to every joiner | student join path uses `toPublicTask`; **tutor path keeps `responses`** for its live grading view |

The room-wide **completion count** still propagates via the now answer-free `task:updated`, so peers' progress indicators keep working.

## No client changes
The tutor (live Responses panel + course-classroom Insights, which reads `answers` off `task:completed`) and the submitting student still receive their events unchanged. Only peers stop receiving data that was never theirs to see.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors
- `vitest` socket-server suites: 5/5 pass · `next build`: success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)