### PR TITLE
feat(schedule): gate the calendar-drag reschedule path (Phase 2, sub-PR 2)

### DIFF
--- a/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/[id]/route.ts
@@ -6,6 +6,15 @@ import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
 import { notifyStudentsOfReschedule } from '@/lib/notifications/reschedule'
+import { classifySessionForReschedule, proposeReschedule } from '@/lib/schedule/reschedule-consent'
+
+/** 409 response steering the tutor to the 1-on-1 propose/accept flow. */
+const ONE_ON_ONE_GATE = {
+  requiresConsent: true,
+  kind: 'one-on-one',
+  error:
+    'This 1-on-1 can’t be moved directly — use “Reschedule” to propose a new time. The student must agree before it changes.',
+}
 export const GET = withAuth(async () => {
   return NextResponse.json(
     {
@@ -96,6 +105,40 @@ export const PATCH = withCsrf(
           )
         }
 
+        // Consent gate: a session with rostered students can't be moved
+        // directly — propose the change and hold the old time until everyone
+        // agrees. Only audience-free sessions move immediately.
+        const gate = await classifySessionForReschedule({
+          sessionId: eventId,
+          courseId: sess.courseId,
+          calendarEventId: null,
+        })
+        if (gate.kind === 'one_on_one') {
+          return NextResponse.json(ONE_ON_ONE_GATE, { status: 409 })
+        }
+        if (gate.kind === 'consent') {
+          const currentEnd = sess.scheduledAt
+            ? new Date(sess.scheduledAt.getTime() + (sess.durationMinutes ?? sessDuration) * 60000)
+            : null
+          const result = await proposeReschedule({
+            session: {
+              sessionId: eventId,
+              courseId: sess.courseId,
+              tutorId,
+              title: sess.title,
+            },
+            currentStart: sess.scheduledAt ?? null,
+            currentEnd,
+            proposedStart: newStart,
+            proposedEnd: sessEnd,
+          })
+          return NextResponse.json({
+            pendingConsent: result.kind === 'proposed',
+            proposalId: result.kind === 'proposed' ? result.proposalId : undefined,
+            voterCount: result.kind === 'proposed' ? result.voterCount : 0,
+          })
+        }
+
         await drizzleDb
           .update(liveSession)
           .set({ scheduledAt: newStart, durationMinutes: sessDuration })
@@ -161,6 +204,39 @@ export const PATCH = withCsrf(
           },
           { status: 409 }
         )
+      }
+
+      // Consent gate (session-backed events only). A personal calendar event
+      // with no externalId has no roster — it moves directly, as before.
+      if (calEvent.externalId) {
+        const gate = await classifySessionForReschedule({
+          sessionId: calEvent.externalId,
+          courseId: calEvent.courseId,
+          calendarEventId: eventId,
+        })
+        if (gate.kind === 'one_on_one') {
+          return NextResponse.json(ONE_ON_ONE_GATE, { status: 409 })
+        }
+        if (gate.kind === 'consent') {
+          const result = await proposeReschedule({
+            session: {
+              sessionId: calEvent.externalId,
+              courseId: calEvent.courseId,
+              tutorId,
+              title: calEvent.title,
+            },
+            currentStart: calEvent.startTime ?? null,
+            currentEnd: calEvent.endTime ?? null,
+            proposedStart: newStart,
+            proposedEnd: newEnd,
+            timezone: calEvent.timezone,
+          })
+          return NextResponse.json({
+            pendingConsent: result.kind === 'proposed',
+            proposalId: result.kind === 'proposed' ? result.proposalId : undefined,
+            voterCount: result.kind === 'proposed' ? result.voterCount : 0,
+          })
+        }
       }
 
       await drizzleDb

--- a/tutorme-app/src/lib/schedule/reschedule-consent.ts
+++ b/tutorme-app/src/lib/schedule/reschedule-consent.ts
@@ -27,6 +27,7 @@ import {
   sessionParticipant,
   groupSession,
   groupSessionParticipant,
+  oneOnOneBookingRequest,
   profile,
   type RescheduleVoteResponse,
 } from '@/lib/db/schema'
@@ -34,6 +35,35 @@ import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { notify } from '@/lib/notifications/notify'
 import { formatInZone } from '@/lib/notifications/reschedule'
 import { findConflicts } from '@/lib/schedule/conflicts'
+
+/**
+ * Decide how a reschedule of this session must be handled:
+ *  - 'one_on_one' — a confirmed 1-on-1 booking; it has its own propose/accept
+ *    flow, so a direct calendar move is refused and the tutor is routed there.
+ *  - 'consent'    — group/course session with a roster; a proposal is required.
+ *  - 'direct'     — no audience (personal/solo event); move immediately.
+ */
+export async function classifySessionForReschedule(opts: {
+  sessionId: string
+  courseId: string | null
+  calendarEventId?: string | null
+}): Promise<{ kind: 'one_on_one' } | { kind: 'consent'; roster: string[] } | { kind: 'direct' }> {
+  if (opts.calendarEventId) {
+    const [booking] = await drizzleDb
+      .select({ requestId: oneOnOneBookingRequest.requestId })
+      .from(oneOnOneBookingRequest)
+      .where(
+        and(
+          eq(oneOnOneBookingRequest.calendarEventId, opts.calendarEventId),
+          inArray(oneOnOneBookingRequest.status, ['ACCEPTED', 'PAID'])
+        )
+      )
+      .limit(1)
+    if (booking) return { kind: 'one_on_one' }
+  }
+  const roster = await resolveVoterRoster(opts.sessionId, opts.courseId)
+  return roster.length > 0 ? { kind: 'consent', roster } : { kind: 'direct' }
+}
 
 /** Confirmed/paid students who must agree to move this session. */
 export async function resolveVoterRoster(


### PR DESCRIPTION
Phase 2, sub-PR 2. Builds on #1060 (the consent backend). **Closes the calendar-drag bypass** — the path that let a tutor move a rostered session instantly with no consent.

## What
`PATCH /api/tutor/calendar/events/[id]` now classifies the session before doing anything (in **both** the `calendarEvent` path and the standalone-`liveSession` fallback):
- **one_on_one** — a confirmed `OneOnOneBookingRequest` on this event → **409** steering the tutor to the existing Reschedule propose/accept flow. No silent move.
- **consent** — group/course session with a confirmed/paid roster → creates a **reschedule proposal** (sub-PR 1 service); the session **keeps its old time** until every student agrees. No direct move.
- **direct** — personal/solo event, no roster → moves immediately, exactly as before.

New `classifySessionForReschedule()` in the consent service.

## Verification (ephemeral Postgres, real code)
```
rostered group/course (roster across template/published variant) → consent  ✔
confirmed 1-on-1                                                  → one_on_one (blocked) ✔
solo / no roster                                                 → direct  ✔
unconfirmed (PENDING) 1-on-1                                     → direct  ✔
```
4/4 pass; sub-PR 1 already proved the full proposal lifecycle (apply-on-unanimous, disagree-rejects, etc.). Typecheck clean; lint 0. Full HTTP PATCH (auth-gated) best confirmed on staging.

## Behavior change
Dragging a rostered session no longer moves it — it opens a pending proposal (students must agree). Tutors will see this reflected once the UI lands in **sub-PR 3** (student agree/disagree) and **sub-PR 4** (tutor pending/cancel). The API already returns `{ pendingConsent, proposalId, voterCount }` for the client to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)