### PR TITLE
feat(schedule): student agree/disagree UI for reschedules (Phase 2, sub-PR 3)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/PendingRescheduleBanner.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/PendingRescheduleBanner.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+/**
+ * PendingRescheduleBanner — shows the student any pending session-reschedule
+ * proposals from their tutor, with Agree / Disagree. The session keeps its
+ * current time until everyone agrees; a single disagree cancels the change.
+ * See src/lib/schedule/reschedule-consent.ts.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { CalendarClock, Check, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+
+interface Proposal {
+  proposalId: string
+  sessionId: string
+  title: string
+  tutorName: string
+  currentStart: string | null
+  proposedStart: string | null
+  proposedEnd: string | null
+  myVote: 'PENDING' | 'AGREE' | 'DISAGREE'
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return 'an unspecified time'
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function PendingRescheduleBanner() {
+  const [proposals, setProposals] = useState<Proposal[]>([])
+  const [busy, setBusy] = useState<Record<string, boolean>>({})
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/student/reschedule-proposals')
+      if (!res.ok) return
+      const data = await res.json()
+      // Only surface proposals the student hasn't answered yet.
+      setProposals((data.proposals ?? []).filter((p: Proposal) => p.myVote === 'PENDING'))
+    } catch {
+      /* non-critical — the banner just stays empty */
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const respond = useCallback(async (p: Proposal, response: 'AGREE' | 'DISAGREE') => {
+    setBusy(b => ({ ...b, [p.proposalId]: true }))
+    try {
+      const res = await fetchWithCsrf(`/api/sessions/${p.sessionId}/reschedule/respond`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposalId: p.proposalId, response }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast.error(data.error || 'Could not submit your response.')
+        return
+      }
+      if (response === 'AGREE') {
+        toast.success(
+          data.status === 'APPLIED'
+            ? 'Everyone agreed — the session has been moved.'
+            : 'Thanks — waiting on the other students.'
+        )
+      } else {
+        toast.success('Noted — the session keeps its current time.')
+      }
+      // Remove the answered proposal from the banner.
+      setProposals(list => list.filter(x => x.proposalId !== p.proposalId))
+    } catch {
+      toast.error('Could not submit your response.')
+    } finally {
+      setBusy(b => ({ ...b, [p.proposalId]: false }))
+    }
+  }, [])
+
+  if (proposals.length === 0) return null
+
+  return (
+    <div className="mb-4 flex-shrink-0 space-y-2">
+      {proposals.map(p => (
+        <div
+          key={p.proposalId}
+          className="flex flex-col gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex items-start gap-2">
+            <CalendarClock className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" aria-hidden />
+            <div className="text-sm text-amber-900">
+              <span className="font-semibold">{p.tutorName}</span> proposed moving{' '}
+              <span className="font-semibold">“{p.title}”</span> to{' '}
+              <span className="font-semibold">{formatWhen(p.proposedStart)}</span>
+              {p.currentStart && (
+                <span className="text-amber-700"> (currently {formatWhen(p.currentStart)})</span>
+              )}
+              . It won’t change until everyone agrees.
+            </div>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+              disabled={busy[p.proposalId]}
+              onClick={() => respond(p, 'AGREE')}
+            >
+              <Check className="mr-1 h-4 w-4" /> Agree
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-red-600 hover:bg-red-50 hover:text-red-700"
+              disabled={busy[p.proposalId]}
+              onClick={() => respond(p, 'DISAGREE')}
+            >
+              <X className="mr-1 h-4 w-4" /> Disagree
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/student/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/page.tsx
@@ -20,6 +20,7 @@ import {
   DashboardCalendar,
 } from './components'
 import { StudentHeroSection } from './components/StudentHeroSection'
+import { PendingRescheduleBanner } from './components/PendingRescheduleBanner'
 import { StudentDashboardProvider, useStudentDashboard } from './components/StudentDashboardContext'
 import type { DashboardClass, DashboardData } from './types'
 import { getDashboardStrings } from './dashboard-strings'
@@ -214,6 +215,9 @@ function StudentDashboardContent() {
         <div className="mb-4 flex-shrink-0">
           <StudentHeroSection stats={stats} statsLoading={statsLoading} />
         </div>
+
+        {/* Pending reschedule proposals awaiting this student's agree/disagree */}
+        <PendingRescheduleBanner />
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-0.5">
           <DashboardCalendar

--- a/tutorme-app/src/app/api/student/reschedule-proposals/route.ts
+++ b/tutorme-app/src/app/api/student/reschedule-proposals/route.ts
@@ -1,0 +1,61 @@
+/**
+ * GET /api/student/reschedule-proposals
+ *
+ * The pending session-reschedule proposals awaiting THIS student's response
+ * (agree/disagree). Feeds the dashboard banner; the student acts via
+ * POST /api/sessions/[id]/reschedule/respond. See the consent gate in
+ * src/lib/schedule/reschedule-consent.ts.
+ */
+
+import { NextResponse } from 'next/server'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  sessionRescheduleProposal,
+  sessionRescheduleVote,
+  liveSession,
+  profile,
+} from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+
+export const GET = withAuth(async (_req, session) => {
+  const studentId = session.user.id
+
+  const rows = await drizzleDb
+    .select({
+      proposalId: sessionRescheduleProposal.proposalId,
+      sessionId: sessionRescheduleProposal.sessionId,
+      currentStart: sessionRescheduleProposal.currentStart,
+      proposedStart: sessionRescheduleProposal.proposedStart,
+      proposedEnd: sessionRescheduleProposal.proposedEnd,
+      title: liveSession.title,
+      tutorName: profile.name,
+      myVote: sessionRescheduleVote.response,
+    })
+    .from(sessionRescheduleVote)
+    .innerJoin(
+      sessionRescheduleProposal,
+      eq(sessionRescheduleProposal.proposalId, sessionRescheduleVote.proposalId)
+    )
+    .leftJoin(liveSession, eq(liveSession.sessionId, sessionRescheduleProposal.sessionId))
+    .leftJoin(profile, eq(profile.userId, sessionRescheduleProposal.proposedBy))
+    .where(
+      and(
+        eq(sessionRescheduleVote.studentId, studentId),
+        eq(sessionRescheduleProposal.status, 'PENDING')
+      )
+    )
+
+  return NextResponse.json({
+    proposals: rows.map(r => ({
+      proposalId: r.proposalId,
+      sessionId: r.sessionId,
+      title: r.title || 'Your session',
+      tutorName: r.tutorName || 'Your tutor',
+      currentStart: r.currentStart?.toISOString() ?? null,
+      proposedStart: r.proposedStart?.toISOString() ?? null,
+      proposedEnd: r.proposedEnd?.toISOString() ?? null,
+      myVote: r.myVote,
+    })),
+  })
+})

--- a/tutorme-app/src/lib/schedule/reschedule-consent.ts
+++ b/tutorme-app/src/lib/schedule/reschedule-consent.ts
@@ -166,7 +166,7 @@ export async function proposeReschedule(opts: {
           sessionId: session.sessionId,
           proposedStart: proposedStart.toISOString(),
         },
-        actionUrl: '/student/schedule',
+        actionUrl: '/student/dashboard',
       })
     })
   )
@@ -335,7 +335,7 @@ async function notifyOutcome(
         title: copy.title,
         message: copy.body(when),
         data: { type: `reschedule-${outcome}`, sessionId: proposal.sessionId },
-        actionUrl: '/student/schedule',
+        actionUrl: '/student/dashboard',
       })
     })
   )


### PR DESCRIPTION
Phase 2, sub-PR 3. The student side of the consent gate.

## What
- **`GET /api/student/reschedule-proposals`** — the student's PENDING proposals (session title, tutor name, current + proposed times, their own vote).
- **`PendingRescheduleBanner`** on the student dashboard — an amber card per pending proposal with **Agree / Disagree**, calling `POST /api/sessions/[id]/reschedule/respond`; removes the card and toasts the outcome (applied / waiting / kept).
- Fixes the proposal notification `actionUrl` to `/student/dashboard` (the real page — `/student/schedule` doesn't exist), so the notification deep-links to the banner.

## Verification
List-endpoint query on ephemeral Postgres — **6/6**: surfaces the student's pending proposal with title + tutor name, excludes resolved proposals, non-voters see none. Typecheck clean; lint 0 errors. Banner render + click flow best confirmed on staging (needs auth + a seeded proposal).

## Batching
Recommended to ship together with **#1061** (the calendar-drag gate) so the behavior change lands with its UI. I'm also doing **sub-PR 4** (tutor pending/cancel UI + graceful drag-response handling) next — the tutor's drag returns `{ pendingConsent }` / 409, which the calendar UI should surface cleanly. Plan: merge #1061 + this + sub-PR 4 together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)