### PR TITLE
feat(schedule): tutor calendar handles pending-consent reschedules (Phase 2, sub-PR 4)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -904,10 +904,29 @@ export function InteractiveCalendar({
             prev.map(e => (e.id === draggedEvent.id ? { ...draggedEvent, date: previousDate } : e))
           )
           if (res.status === 409) {
+            // Includes the consent gate for 1-on-1s (requiresConsent) as well as
+            // real time-slot conflicts — err.error carries the right message.
             toast.error(err.error || 'That time conflicts with another session.')
           } else {
             toast.error(err.error || 'Failed to reschedule')
           }
+          return
+        }
+
+        const data = await res.json().catch(() => ({}))
+        if (data.pendingConsent) {
+          // The session did NOT move — a proposal was created and it stays at its
+          // current time until every enrolled student agrees. Revert the
+          // optimistic move so the calendar reflects reality.
+          setEvents(prev =>
+            prev.map(e => (e.id === draggedEvent.id ? { ...draggedEvent, date: previousDate } : e))
+          )
+          const n = typeof data.voterCount === 'number' ? data.voterCount : 0
+          toast.info(
+            n > 0
+              ? `Reschedule proposed — waiting for ${n} student${n === 1 ? '' : 's'} to agree.`
+              : 'Reschedule proposed — waiting for students to agree.'
+          )
           return
         }
 
@@ -1902,7 +1921,22 @@ export function InteractiveCalendar({
                                                 const err = await res.json().catch(() => ({}))
                                                 throw new Error(err.error || 'Reschedule failed')
                                               }
-                                              toast.success(`${ev.title} rescheduled successfully`)
+                                              const patchData = await res.json().catch(() => ({}))
+                                              if (patchData.pendingConsent) {
+                                                const n =
+                                                  typeof patchData.voterCount === 'number'
+                                                    ? patchData.voterCount
+                                                    : 0
+                                                toast.info(
+                                                  n > 0
+                                                    ? `Reschedule proposed — waiting for ${n} student${n === 1 ? '' : 's'} to agree.`
+                                                    : 'Reschedule proposed — waiting for students to agree.'
+                                                )
+                                              } else {
+                                                toast.success(
+                                                  `${ev.title} rescheduled successfully`
+                                                )
+                                              }
                                               // Refresh events
                                               const refreshed = await fetch(
                                                 `/api/tutor/calendar/events?start=${encodeURIComponent(


### PR DESCRIPTION
Phase 2, sub-PR 4 — the tutor side of the consent gate, so the calendar never falsely shows a move.

## Why
With #1061, dragging a **rostered** session returns `{ pendingConsent, voterCount }` (a proposal was created; the session stays put) and a **1-on-1** returns 409. The old calendar code kept the optimistic move and toasted "Rescheduled" — a lie.

## What
Both reschedule call sites in `InteractiveCalendar` (drag + "reschedule to suggested time"):
- **pendingConsent** → revert the optimistic move + `toast.info("Reschedule proposed — waiting for N students to agree.")`
- **1-on-1 (409)** → already reverts and shows the "use Reschedule to propose" message via the existing error path
- **solo / no roster** → moves directly + success toast, as before

## Verification
The API contract is DB-verified in #1061/#1060 (PATCH returns `pendingConsent` for rostered, 409 for 1-on-1). This PR maps those to toast + revert; typecheck clean, lint 0 errors. Full drag-in-browser flow best confirmed on staging.

## Batch
Ships with **#1061** (gate) + **#1062** (student agree/disagree UI) as the complete consent-gate feature. A tutor-facing "pending (n/m agreed) + cancel" badge on the session is a nice follow-up (sub-PR 4b) but not required for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)