### PR TITLE
chore(storage): cheap existence check + clean up derived Office PDFs

### DIFF
--- a/tutorme-app/src/lib/documents/ensure-viewable.ts
+++ b/tutorme-app/src/lib/documents/ensure-viewable.ts
@@ -14,7 +14,7 @@
  * this can never make a deploy worse than before.
  */
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
-import { readFileBuffer, storeFile } from '@/lib/storage/service'
+import { readFileBuffer, storeFile, fileExists } from '@/lib/storage/service'
 import { convertOfficeToPdf } from './office-to-pdf'
 
 const OFFICE_MIMES = new Set([
@@ -55,8 +55,9 @@ export async function ensureViewableSourceDocument<T extends SourceDoc>(doc: T):
     if (isOfficeSourceMime(mimeType, fileName) && fileKey) {
       const convertedKey = officeToPdfKey(fileKey)
 
-      // Reuse a previously-rendered PDF if we already made one for this document.
-      let ready = (await readFileBuffer(convertedKey)) != null
+      // Reuse a previously-rendered PDF if we already made one for this document
+      // (cheap metadata check — never download the PDF just to test existence).
+      let ready = await fileExists(convertedKey)
       if (!ready) {
         const input = await readFileBuffer(fileKey)
         if (input) {

--- a/tutorme-app/src/lib/storage/gcs.ts
+++ b/tutorme-app/src/lib/storage/gcs.ts
@@ -264,10 +264,31 @@ export async function createPresignedDownloadUrl(
  */
 export async function deleteObject(key: string, bucketName?: string): Promise<void> {
   const storage = await getStorage()
-  await storage
-    .bucket(bucketName || BUCKET)
-    .file(key)
-    .delete({ ignoreNotFound: true })
+  const bucket = storage.bucket(bucketName || BUCKET)
+  await bucket.file(key).delete({ ignoreNotFound: true })
+  // Best-effort: also remove the PDF we may have rendered from a raw Office doc
+  // for inline student view (ensureViewableSourceDocument stores it at
+  // `<key>.pdf`), so deleting the source doesn't orphan the derived PDF.
+  if (!key.endsWith('.pdf')) {
+    await bucket
+      .file(`${key}.pdf`)
+      .delete({ ignoreNotFound: true })
+      .catch(() => {})
+  }
+}
+
+/** Cheap existence check (metadata only — no download). */
+export async function objectExists(key: string, bucketName?: string): Promise<boolean> {
+  try {
+    const storage = await getStorage()
+    const [exists] = await storage
+      .bucket(bucketName || BUCKET)
+      .file(key)
+      .exists()
+    return exists
+  } catch {
+    return false
+  }
 }
 
 // ─── Key Generation ───────────────────────────────────────────────────────────

--- a/tutorme-app/src/lib/storage/service.ts
+++ b/tutorme-app/src/lib/storage/service.ts
@@ -13,7 +13,7 @@
  *                       (default: {cwd}/.local-storage)
  */
 
-import { writeFile, mkdir, readFile, unlink } from 'fs/promises'
+import { writeFile, mkdir, readFile, unlink, access } from 'fs/promises'
 import path from 'path'
 
 // ─── Config ───────────────────────────────────────────────────────────────────
@@ -60,6 +60,15 @@ async function deleteLocal(key: string): Promise<void> {
     await unlink(getLocalPath(key))
   } catch {
     // ignore
+  }
+}
+
+async function existsLocal(key: string): Promise<boolean> {
+  try {
+    await access(getLocalPath(key))
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -122,10 +131,14 @@ export async function removeFile(key: string): Promise<void> {
   const { isGcsConfigured, deleteObject } = await getGcsHelpers()
 
   if (isGcsConfigured()) {
+    // deleteObject also removes the `<key>.pdf` sibling rendered from a raw
+    // Office doc (see gcs.ts), so the derived PDF doesn't orphan.
     await deleteObject(key).catch(() => {})
   }
 
   await deleteLocal(key)
+  // Mirror the sibling cleanup for local storage.
+  if (!key.endsWith('.pdf')) await deleteLocal(`${key}.pdf`)
 }
 
 /**
@@ -141,6 +154,18 @@ export async function readFileBuffer(key: string): Promise<Buffer | null> {
   }
 
   return readLocal(key)
+}
+
+/** Cheap existence check (metadata/stat — no download). GCS first, then local. */
+export async function fileExists(key: string): Promise<boolean> {
+  const { isGcsConfigured } = await getGcsHelpers()
+
+  if (isGcsConfigured()) {
+    const { objectExists } = await import('./gcs')
+    if (await objectExists(key)) return true
+  }
+
+  return existsLocal(key)
 }
 
 /**


### PR DESCRIPTION
Two follow-ups to #1058 (deploy-time Office→PDF).

## 1. Cheap existence check (efficiency)
`ensureViewableSourceDocument`'s "already converted?" probe called `readFileBuffer(convertedKey)` — **downloading the entire PDF** just to test existence, then discarding it. On the `course:sync` hydration path (runs `ensureViewableSourceDocument` over every task on each student rejoin) that's a full download per doc, per rejoin.

- Added **`objectExists(key)`** to `gcs.ts` (GCS `file.exists()` — metadata only) and **`fileExists(key)`** to `service.ts` (GCS then local `fs.access`).
- The cache probe now uses `fileExists` → a metadata call instead of a multi-MB download.

## 2. Orphan cleanup
The converted PDF is stored at `<originalKey>.pdf`. When the source doc is deleted, that sibling was left behind.

- **`deleteObject`** (and `removeFile`) now best-effort delete the `<key>.pdf` sibling (skipped when the key is already `.pdf`). All document-deletion paths (asset delete, uploads cleanup, resource delete) funnel through `deleteObject`, so they're all covered.

## Verification
`tsc --noEmit` clean (0 errors). Prettier clean. Existing ensure-viewable tests still 6/6. Best-effort deletes + `try/catch` existence check → no behaviour regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)