### PR TITLE
feat(sessions): multi-tab live events + post-submit answer reveal

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -250,10 +250,35 @@ function DeployedQuestions({
 }
 
 /**
+ * Present a stored answer-key value readably. mcq keys are often a bare letter
+ * ("B") — expand to "B. <option>" using the item's options; multiple_response
+ * keys may be a JSON array — join them; everything else shows as-is.
+ */
+function formatCorrectAnswer(item: StudentDmiItem, raw: string | undefined): string | null {
+  if (raw == null || raw.trim().length === 0) return null
+  const type = normalizeDmiQuestionType(item.questionType)
+  if (type === 'mcq' && item.options && item.options.length > 0 && /^[A-Za-z]$/.test(raw.trim())) {
+    const idx = raw.trim().toUpperCase().charCodeAt(0) - 65
+    if (idx >= 0 && idx < item.options.length)
+      return `${raw.trim().toUpperCase()}. ${item.options[idx]}`
+  }
+  if (type === 'multiple_response') {
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed.filter(v => typeof v === 'string').join(', ') || raw
+    } catch {
+      // fall through
+    }
+  }
+  return raw
+}
+
+/**
  * The student's post-submit view. Shows their auto-grade score and a per-question
  * outcome once the grade lands (via task:graded), degrading to a plain "submitted"
- * acknowledgement while it's pending or when the task can't be auto-scored. Never
- * shows the correct answer — only the student's own right/wrong/needs-review.
+ * acknowledgement while it's pending or when the task can't be auto-scored. When
+ * the tutor's answer-reveal policy permits it, `result.correctAnswers` is present
+ * and the correct answer is shown under each question.
  */
 function SubmittedResult({
   items,
@@ -270,6 +295,7 @@ function SubmittedResult({
     return map
   }, [result])
 
+  const correctAnswers = result?.correctAnswers ?? null
   const hasScore = result && typeof result.score === 'number'
   const graded = (result?.questionResults?.length ?? 0) > 0
 
@@ -291,6 +317,10 @@ function SubmittedResult({
         <ol className="space-y-1.5">
           {items.map((it, idx) => {
             const r = resultById.get(it.id)
+            // Only reveal the correct answer where it adds something — i.e. the
+            // student didn't already get it right.
+            const reveal =
+              correctAnswers && !r?.correct ? formatCorrectAnswer(it, correctAnswers[it.id]) : null
             return (
               <li
                 key={it.id}
@@ -312,6 +342,9 @@ function SubmittedResult({
                     : r?.correct
                       ? 'Correct'
                       : 'Incorrect'}
+                  {reveal ? (
+                    <span className="mt-0.5 block text-emerald-700">Answer: {reveal}</span>
+                  ) : null}
                 </span>
               </li>
             )

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -5,10 +5,13 @@ import type { Socket } from 'socket.io-client'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import type { AutoGradeQuestionResult } from '@/lib/grading/auto-grade'
 
-/** The student-safe auto-grade outcome for one submission (no answer key). */
+/** The auto-grade outcome for one submission. `correctAnswers` is present only
+ *  when the tutor's answer-reveal policy permits it and the student has
+ *  submitted; it reaches the submitter + tutor only, never peers. */
 export interface SessionGradeResult {
   score: number | null
   questionResults: AutoGradeQuestionResult[] | null
+  correctAnswers?: Record<string, string> | null
 }
 
 export interface SessionSourceDocument {
@@ -37,6 +40,7 @@ export interface SessionStudentResponse {
   /** The auto-grade outcome, once it lands (via task:graded). */
   score?: number | null
   questionResults?: AutoGradeQuestionResult[] | null
+  correctAnswers?: Record<string, string> | null
 }
 
 interface RoomStatePayload {
@@ -57,6 +61,7 @@ interface TaskGradedEvent {
   studentId: string
   score?: number | null
   questionResults?: AutoGradeQuestionResult[] | null
+  correctAnswers?: Record<string, string> | null
 }
 
 /**
@@ -170,6 +175,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
               answers: existing?.answers ?? {},
               score: evt.score ?? null,
               questionResults: evt.questionResults ?? null,
+              correctAnswers: evt.correctAnswers ?? null,
             },
           },
         }
@@ -205,7 +211,11 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     for (const [taskId, byStudent] of Object.entries(responsesByTask)) {
       const mine = byStudent[myUserId]
       if (mine && (mine.score != null || mine.questionResults != null)) {
-        out[taskId] = { score: mine.score ?? null, questionResults: mine.questionResults ?? null }
+        out[taskId] = {
+          score: mine.score ?? null,
+          questionResults: mine.questionResults ?? null,
+          correctAnswers: mine.correctAnswers ?? null,
+        }
       }
     }
     return out

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -821,6 +821,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
   io.on('connection', socket => {
     console.log(`Authenticated client connected: ${socket.id}`)
     setUserSocket(socket.data.userId, socket.id)
+    // Join a per-user room so `emitToUser` can fan a message out to ALL of a
+    // user's open tabs (userSocketMap only tracks the latest socket).
+    if (socket.data.userId) socket.join(`user:${socket.data.userId}`)
 
     // Apply token-bucket limiting to every incoming event packet.
     socket.use((_packet, next) => rateLimitMiddleware(socket, next))
@@ -878,6 +881,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         return
       }
       setUserSocket(userId, socket.id)
+      socket.join(`user:${userId}`)
 
       if (name !== undefined) socket.data.name = name
       socket.join(roomId)
@@ -1799,6 +1803,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
             // there's no answer key. This feeds the tutor's live Understanding.
             let autoScore: number | null = null
             let autoResults: ReturnType<typeof autoGradeDmi>['questionResults'] = null
+            let correctAnswers: Record<string, string> | null = null
             try {
               const [dmi] = await drizzleDb
                 .select({ items: builderTaskDmi.items })
@@ -1807,15 +1812,39 @@ export async function initEnhancedSocketServer(server: NetServer) {
                 .orderBy(desc(builderTaskDmi.updatedAt))
                 .limit(1)
               if (dmi?.items) {
-                const graded = autoGradeDmi(
-                  dmi.items as { id: string; answer?: string; marks?: number }[],
-                  (answers ?? {}) as Record<string, string>
-                )
+                const items = dmi.items as { id: string; answer?: string; marks?: number }[]
+                const graded = autoGradeDmi(items, (answers ?? {}) as Record<string, string>)
                 // score is the marks-weighted percentage (0–100); maxScore stays
                 // 100 to preserve the app-wide percentage contract. The raw marks
                 // total is surfaced in the tutor DMI view, not the submission row.
                 autoScore = graded.score
                 autoResults = graded.questionResults
+
+                // Answer reveal: once the student has submitted, expose the
+                // correct answers UNLESS the tutor set the policy to 'hidden'
+                // (unset defaults to reveal — matching the REST assignments
+                // contract's 'instant' default). These reach only the submitter +
+                // tutor via the private task:graded below, never peers.
+                const [bt] = await drizzleDb
+                  .select({ metadata: builderTask.metadata })
+                  .from(builderTask)
+                  .where(eq(builderTask.taskId, taskId))
+                  .limit(1)
+                const reveal = (bt?.metadata as { answerReveal?: string } | null)?.answerReveal
+                if (reveal !== 'hidden') {
+                  const key: Record<string, string> = {}
+                  for (const it of items) {
+                    if (
+                      it &&
+                      typeof it.id === 'string' &&
+                      typeof it.answer === 'string' &&
+                      it.answer.trim()
+                    ) {
+                      key[it.id] = it.answer
+                    }
+                  }
+                  if (Object.keys(key).length > 0) correctAnswers = key
+                }
               }
             } catch (gradeErr) {
               console.warn('[task:complete] auto-grade failed (non-critical):', gradeErr)
@@ -1831,6 +1860,10 @@ export async function initEnhancedSocketServer(server: NetServer) {
               studentId,
               score: autoScore,
               questionResults: autoResults,
+              // Correct answers per item when the reveal policy permits (null
+              // otherwise). Safe here: the tutor owns the key, and the student
+              // has already submitted. Never sent to peers (this event is private).
+              correctAnswers,
             }
             if (tutorId) emitToUser(tutorId, 'task:graded', gradedPayload)
             emitToUser(studentId, 'task:graded', gradedPayload)
@@ -2689,11 +2722,10 @@ export function getUserSocketId(userId: string): string | undefined {
 }
 
 export function emitToUser(userId: string, event: string, data: unknown) {
-  if (!ioRef) return
-  const socketId = userSocketMap.get(userId)
-  if (socketId) {
-    ioRef.to(socketId).emit(event, data)
-  }
+  if (!ioRef || !userId) return
+  // Emit to the user's room (every open tab), not just the latest socket, so a
+  // tutor with the classroom in one tab and Insights in another both update.
+  ioRef.to(`user:${userId}`).emit(event, data)
 }
 
 /**


### PR DESCRIPTION
The last two optional threads for the session classroom.

## 1. Multi-tab fan-out
`emitToUser` addressed only a user's **latest** socket (`userSocketMap`), so a tutor with the classroom open in one tab and Insights in another only saw the live `task:completed` / `task:graded` events in whichever tab connected last.

- Each socket now joins a `user:<id>` room on connect.
- `emitToUser` broadcasts to that room → **every open tab** updates.
- App-wide improvement (also benefits mention notifications); the only other caller is a notification, and none relied on single-socket delivery.

## 2. Post-submit answer reveal
When the tutor's answer-reveal policy (`builderTask.metadata.answerReveal`) is anything other than `'hidden'` (unset **defaults to reveal**, matching the REST assignments contract's `'instant'` default), the auto-grade step now includes the correct answers in the **private** `task:graded` payload, and the student's post-submit view shows the correct answer under each question they didn't get right (mcq letters expand to `B. <option>`).

**Safe by construction:**
- `task:graded` reaches only the submitter + tutor (never peers — per the #1059 group-privacy fix).
- It fires **only after submission**, so the key is never exposed before the student answers.
- The tutor owns the key anyway; the student sees it only for the reveal.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors
- `vitest` socket + assessment + grading: 162/162 pass
- `next build`: success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)