### PR TITLE
feat(schedule): tutor pending-reschedule badge with tally + cancel (Phase 2, sub-PR 4b)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TutorPendingRescheduleBanner.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TutorPendingRescheduleBanner.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+/**
+ * TutorPendingRescheduleBanner — shows the tutor their pending reschedule
+ * proposals with an agreement tally (n/m agreed) and a Cancel action. The
+ * session stays at its current time until every student agrees; cancelling
+ * withdraws the proposal. See src/lib/schedule/reschedule-consent.ts.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { CalendarClock, Users, X } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+
+interface TutorProposal {
+  proposalId: string
+  sessionId: string
+  title: string
+  proposedStart: string | null
+  currentStart: string | null
+  agreed: number
+  total: number
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return 'an unspecified time'
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function TutorPendingRescheduleBanner() {
+  const [proposals, setProposals] = useState<TutorProposal[]>([])
+  const [busy, setBusy] = useState<Record<string, boolean>>({})
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tutor/reschedule-proposals')
+      if (!res.ok) return
+      const data = await res.json()
+      setProposals(data.proposals ?? [])
+    } catch {
+      /* non-critical — the badge just stays empty */
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const cancel = useCallback(async (p: TutorProposal) => {
+    setBusy(b => ({ ...b, [p.proposalId]: true }))
+    try {
+      const res = await fetchWithCsrf(`/api/sessions/${p.sessionId}/reschedule`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ proposalId: p.proposalId }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        toast.error(data.error || 'Could not cancel the proposal.')
+        return
+      }
+      toast.success('Reschedule cancelled — the session keeps its current time.')
+      setProposals(list => list.filter(x => x.proposalId !== p.proposalId))
+    } catch {
+      toast.error('Could not cancel the proposal.')
+    } finally {
+      setBusy(b => ({ ...b, [p.proposalId]: false }))
+    }
+  }, [])
+
+  if (proposals.length === 0) return null
+
+  return (
+    <div className="mb-3 flex-shrink-0 space-y-2">
+      {proposals.map(p => (
+        <div
+          key={p.proposalId}
+          className="flex flex-col gap-3 rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex items-start gap-2">
+            <CalendarClock className="mt-0.5 h-5 w-5 shrink-0 text-sky-600" aria-hidden />
+            <div className="text-sm text-sky-900">
+              Reschedule of <span className="font-semibold">“{p.title}”</span> to{' '}
+              <span className="font-semibold">{formatWhen(p.proposedStart)}</span> is awaiting
+              student agreement.
+              <span className="mt-0.5 flex items-center gap-1 text-sky-700">
+                <Users className="h-3.5 w-3.5" aria-hidden />
+                {p.agreed}/{p.total} agreed — it applies once everyone does.
+              </span>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="shrink-0 text-slate-600 hover:bg-slate-100 hover:text-slate-800"
+            disabled={busy[p.proposalId]}
+            onClick={() => cancel(p)}
+          >
+            <X className="mr-1 h-4 w-4" /> Cancel
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -61,6 +61,7 @@ import {
 import { DEFAULT_TIMEZONE, type CalendarView } from './components/InteractiveCalendar'
 import { SessionCalendarPanel } from '@/components/session-calendar-panel'
 import { ModernHeroSection } from './components/ModernHeroSection'
+import { TutorPendingRescheduleBanner } from './components/TutorPendingRescheduleBanner'
 import { CountryFlag } from '@/components/country-flag'
 import { ClassroomDialog } from '@/components/classroom/ClassroomDialog'
 
@@ -725,6 +726,9 @@ function TutorDashboardContent() {
             nextSessionAt={getNextSessionTime() || undefined}
           />
         </div>
+
+        {/* Reschedule proposals awaiting student agreement */}
+        <TutorPendingRescheduleBanner />
 
         {error && (
           <div className="border-destructive/20 bg-destructive/10 text-destructive mb-4 flex-shrink-0 rounded-xl border p-3 text-sm">

--- a/tutorme-app/src/app/api/tutor/reschedule-proposals/route.ts
+++ b/tutorme-app/src/app/api/tutor/reschedule-proposals/route.ts
@@ -1,0 +1,72 @@
+/**
+ * GET /api/tutor/reschedule-proposals
+ *
+ * The tutor's own PENDING reschedule proposals with a per-proposal agreement
+ * tally, for the dashboard "pending — n/m agreed" badge. The tutor cancels via
+ * DELETE /api/sessions/[id]/reschedule. See src/lib/schedule/reschedule-consent.ts.
+ */
+
+import { NextResponse } from 'next/server'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { sessionRescheduleProposal, sessionRescheduleVote, liveSession } from '@/lib/db/schema'
+import { and, eq, inArray } from 'drizzle-orm'
+
+export const GET = withAuth(
+  async (_req, session) => {
+    const tutorId = session.user.id
+
+    const proposals = await drizzleDb
+      .select({
+        proposalId: sessionRescheduleProposal.proposalId,
+        sessionId: sessionRescheduleProposal.sessionId,
+        proposedStart: sessionRescheduleProposal.proposedStart,
+        currentStart: sessionRescheduleProposal.currentStart,
+        title: liveSession.title,
+      })
+      .from(sessionRescheduleProposal)
+      .leftJoin(liveSession, eq(liveSession.sessionId, sessionRescheduleProposal.sessionId))
+      .where(
+        and(
+          eq(sessionRescheduleProposal.proposedBy, tutorId),
+          eq(sessionRescheduleProposal.status, 'PENDING')
+        )
+      )
+
+    if (proposals.length === 0) return NextResponse.json({ proposals: [] })
+
+    const votes = await drizzleDb
+      .select({
+        proposalId: sessionRescheduleVote.proposalId,
+        response: sessionRescheduleVote.response,
+      })
+      .from(sessionRescheduleVote)
+      .where(
+        inArray(
+          sessionRescheduleVote.proposalId,
+          proposals.map(p => p.proposalId)
+        )
+      )
+
+    const tally = new Map<string, { agreed: number; total: number }>()
+    for (const v of votes) {
+      const t = tally.get(v.proposalId) ?? { agreed: 0, total: 0 }
+      t.total += 1
+      if (v.response === 'AGREE') t.agreed += 1
+      tally.set(v.proposalId, t)
+    }
+
+    return NextResponse.json({
+      proposals: proposals.map(p => ({
+        proposalId: p.proposalId,
+        sessionId: p.sessionId,
+        title: p.title || 'Your session',
+        proposedStart: p.proposedStart?.toISOString() ?? null,
+        currentStart: p.currentStart?.toISOString() ?? null,
+        agreed: tally.get(p.proposalId)?.agreed ?? 0,
+        total: tally.get(p.proposalId)?.total ?? 0,
+      })),
+    })
+  },
+  { role: 'TUTOR' }
+)


### PR DESCRIPTION
Phase 2, sub-PR 4b — the optional tutor-facing polish. Completes the consent gate's tutor side.

## What
- **`GET /api/tutor/reschedule-proposals`** — the tutor's PENDING proposals with session title, proposed time, and **n/m agreed** (vote tally).
- **`TutorPendingRescheduleBanner`** on the tutor dashboard — a card per pending proposal ("Reschedule of *X* to <time> is awaiting student agreement · **n/m agreed**") with **Cancel** → `DELETE /api/sessions/[id]/reschedule`.

Now both sides are covered: student agree/disagree (#1062) + tutor pending tally/cancel (this PR).

## Verification
List + tally query on ephemeral Postgres — **7/7**: correct agreed/total per proposal, title join, excludes APPLIED and other tutors' proposals, tutor isolation. Cancel already proven in the #1060 lifecycle harness. Typecheck clean; lint 0 errors. Banner render/click best confirmed on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)