### PR TITLE
feat(group-sessions): let tutors build a session around a course

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -16,6 +16,7 @@ import {
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { CourseCombobox, type CourseOption } from '@/components/course/course-combobox'
 
 interface GroupSessionItem {
   groupSessionId: string
@@ -60,6 +61,31 @@ export default function TutorGroupSessionsPage() {
   const [form, setForm] = useState(emptyForm)
   const [creating, setCreating] = useState(false)
   const [cancelId, setCancelId] = useState<string | null>(null)
+  const [courses, setCourses] = useState<CourseOption[]>([])
+  const [coursesLoading, setCoursesLoading] = useState(true)
+  const [courseId, setCourseId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/tutor/courses', { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => {
+        if (!active) return
+        const list = Array.isArray(d?.courses) ? d.courses : []
+        setCourses(
+          list.map((c: { id: string; name: string; isPublished?: boolean }) => ({
+            id: c.id,
+            name: c.name,
+            isPublished: !!c.isPublished,
+          }))
+        )
+      })
+      .catch(() => active && setCourses([]))
+      .finally(() => active && setCoursesLoading(false))
+    return () => {
+      active = false
+    }
+  }, [])
 
   const load = useCallback(async () => {
     try {
@@ -96,12 +122,14 @@ export default function TutorGroupSessionsPage() {
           endTime: form.endTime,
           capacity: Number(form.capacity),
           pricePerSeat: form.free ? 0 : Number(form.pricePerSeat),
+          courseId: courseId || undefined,
         }),
       })
       const data = await res.json().catch(() => ({}))
       if (res.ok) {
         toast.success('Group session created')
         setForm(emptyForm)
+        setCourseId(null)
         load()
       } else {
         toast.error(data.error || 'Could not create the session')
@@ -206,6 +234,22 @@ export default function TutorGroupSessionsPage() {
                 onChange={e => setForm({ ...form, description: e.target.value })}
               />
             </label>
+            <div className="text-sm font-medium text-slate-700 sm:col-span-2">
+              Course (optional)
+              <div className="mt-1">
+                <CourseCombobox
+                  options={courses}
+                  value={courseId}
+                  onChange={setCourseId}
+                  loading={coursesLoading}
+                  placeholder="Build this session around a course…"
+                />
+              </div>
+              <p className="mt-1 text-xs font-normal text-slate-400">
+                Linking a course lets you deploy its lessons, tasks and assessments live in the
+                room. Published and draft courses are both available.
+              </p>
+            </div>
             <label className="text-sm font-medium text-slate-700">
               Date
               <input

--- a/tutorme-app/src/app/api/group-sessions/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/route.ts
@@ -15,7 +15,8 @@ import { and, desc, eq, gte, inArray } from 'drizzle-orm'
 import { z } from 'zod'
 import { nanoid } from 'nanoid'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { groupSession, profile } from '@/lib/db/schema'
+import { groupSession, profile, course } from '@/lib/db/schema'
+import { isNull } from 'drizzle-orm'
 import { createSession } from '@/lib/sessions/create-session'
 import { dailyProvider } from '@/lib/video/daily-provider'
 import { findConflicts } from '@/lib/schedule/conflicts'
@@ -33,6 +34,8 @@ const createSchema = z.object({
   // 1 seat = a true 1-on-1 (only one student can sign up); up to 50 for a group.
   capacity: z.number().int().min(1).max(50),
   pricePerSeat: z.number().min(0).max(100000),
+  // Optional course this session is built around (published or draft).
+  courseId: z.string().min(1).optional().nullable(),
 })
 
 export async function POST(req: NextRequest) {
@@ -46,6 +49,24 @@ export async function POST(req: NextRequest) {
     const body = createSchema.parse(await req.json())
     if (body.endTime <= body.startTime) {
       return NextResponse.json({ error: 'End time must be after start time' }, { status: 400 })
+    }
+
+    // A named course must belong to this tutor (either publication state is fine).
+    if (body.courseId) {
+      const [owned] = await drizzleDb
+        .select({ courseId: course.courseId })
+        .from(course)
+        .where(
+          and(
+            eq(course.courseId, body.courseId),
+            eq(course.creatorId, session.user.id),
+            isNull(course.deletedAt)
+          )
+        )
+        .limit(1)
+      if (!owned) {
+        return NextResponse.json({ error: 'That course is not one of yours.' }, { status: 400 })
+      }
     }
 
     const [tutorProfile] = await drizzleDb
@@ -105,6 +126,7 @@ export async function POST(req: NextRequest) {
           maxStudents: body.capacity,
           description: body.description,
           timezone,
+          courseId: body.courseId ?? undefined,
           existingRoom: room,
         },
         tx
@@ -117,6 +139,7 @@ export async function POST(req: NextRequest) {
           tutorId: session.user.id,
           title: body.title,
           description: body.description ?? null,
+          courseId: body.courseId ?? null,
           requestedDate: requestedDateFromString(body.date),
           startTime: body.startTime,
           endTime: body.endTime,

--- a/tutorme-app/src/components/course/course-combobox.tsx
+++ b/tutorme-app/src/components/course/course-combobox.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Check, ChevronsUpDown, Search, X, BookOpen } from 'lucide-react'
+
+export interface CourseOption {
+  id: string
+  name: string
+  /** Whether the course is published. When `undefined`, no badge is shown
+   *  (e.g. student-facing lists where every option is already published). */
+  isPublished?: boolean
+}
+
+/**
+ * A compact, searchable single-select for courses that stays out of the way — a
+ * trigger button that opens a small popover with a search box and a scrollable
+ * list, instead of a wall of course cards. When `isPublished` is provided each
+ * option shows an unambiguous Published/Draft badge. Reusable across the group-
+ * session setup and the 1-on-1 signup flows.
+ */
+export function CourseCombobox({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select a course…',
+  loading = false,
+  allowClear = true,
+  disabled = false,
+}: {
+  options: CourseOption[]
+  value: string | null
+  onChange: (id: string | null) => void
+  placeholder?: string
+  loading?: boolean
+  allowClear?: boolean
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const selected = useMemo(() => options.find(o => o.id === value) ?? null, [options, value])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return q ? options.filter(o => o.name.toLowerCase().includes(q)) : options
+  }, [options, query])
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const badge = (isPublished?: boolean) =>
+    isPublished === undefined ? null : (
+      <span
+        className={
+          'ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold ' +
+          (isPublished ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700')
+        }
+      >
+        {isPublished ? 'Published' : 'Draft'}
+      </span>
+    )
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-left text-sm text-gray-900 hover:border-gray-300 focus:border-[#F17623] focus:outline-none disabled:opacity-60"
+      >
+        <BookOpen className="h-4 w-4 shrink-0 text-gray-400" />
+        {selected ? (
+          <>
+            <span className="min-w-0 flex-1 truncate">{selected.name}</span>
+            {badge(selected.isPublished)}
+          </>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-gray-400">{placeholder}</span>
+        )}
+        {allowClear && selected ? (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label="Clear course"
+            onClick={e => {
+              e.stopPropagation()
+              onChange(null)
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation()
+                onChange(null)
+              }
+            }}
+            className="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+          >
+            <X className="h-3.5 w-3.5" />
+          </span>
+        ) : (
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+        )}
+      </button>
+
+      {open ? (
+        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl">
+          <div className="relative border-b p-2">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+            <input
+              autoFocus
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search courses…"
+              className="w-full rounded-md border border-gray-200 bg-white py-1.5 pl-8 pr-2 text-xs text-gray-900 placeholder:text-gray-400 focus:border-[#F17623] focus:outline-none"
+            />
+          </div>
+          <ul className="max-h-56 overflow-y-auto p-1">
+            {loading ? (
+              <li className="px-3 py-6 text-center text-xs text-gray-400">Loading courses…</li>
+            ) : filtered.length === 0 ? (
+              <li className="px-3 py-6 text-center text-xs text-gray-400">
+                {options.length === 0 ? 'No courses yet.' : `No courses match “${query}”.`}
+              </li>
+            ) : (
+              filtered.map(o => (
+                <li key={o.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(o.id)
+                      setOpen(false)
+                      setQuery('')
+                    }}
+                    className={
+                      'flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm hover:bg-gray-50 ' +
+                      (o.id === value ? 'bg-gray-50 font-medium text-gray-900' : 'text-gray-700')
+                    }
+                  >
+                    {o.id === value ? (
+                      <Check className="h-3.5 w-3.5 shrink-0 text-[#F17623]" />
+                    ) : (
+                      <span className="h-3.5 w-3.5 shrink-0" />
+                    )}
+                    <span className="min-w-0 flex-1 truncate">{o.name}</span>
+                    {badge(o.isPublished)}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -349,6 +349,10 @@ export const groupSession = pgTable(
       .references(() => user.userId, { onDelete: 'cascade' }),
     title: text('title').notNull(),
     description: text('description'),
+    // Optional course this session is built around — lets the tutor deploy that
+    // course's structure/tasks in the live room. Nullable (ad-hoc sessions have
+    // none); the course may be published or still a draft.
+    courseId: text('courseId').references(() => course.courseId, { onDelete: 'set null' }),
     requestedDate: timestamp('requestedDate', { withTimezone: true }).notNull(),
     startTime: text('startTime').notNull(),
     endTime: text('endTime').notNull(),

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -234,6 +234,12 @@ ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "seriesId" text;
 ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "seriesIndex" integer;
 CREATE INDEX IF NOT EXISTS "OneOnOneBookingRequest_seriesId_idx" ON "OneOnOneBookingRequest" ("seriesId");
 
+-- Course linkage: a group session or a student's 1-on-1 request can name the
+-- course it's built around, so the tutor can deploy that course in the live room.
+-- Nullable, FK-less text (drift-proof); the app validates ownership/publication.
+ALTER TABLE "GroupSession" ADD COLUMN IF NOT EXISTS "courseId" text;
+ALTER TABLE "OneOnOneBookingRequest" ADD COLUMN IF NOT EXISTS "courseId" text;
+
 -- 0071: student reviews of completed 1-on-1 sessions (one per booking).
 CREATE TABLE IF NOT EXISTS "OneOnOneReview" (
   "id" text PRIMARY KEY NOT NULL,


### PR DESCRIPTION
## Task 2 — course selection for group sessions

Tutors can now attach a **course** to a group session at setup.

- A compact, **searchable `CourseCombobox`** (a popover with search + list, *not* a wall of course cards) lists **all** the tutor's courses — **published and draft** — each with an unambiguous **Published / Draft** badge.
- The chosen course is **ownership-validated**, persisted on `GroupSession.courseId`, and passed through `createSession` so the **LiveSession + CalendarEvent** carry the course — the live room becomes course-aware (its structure can be deployed).

**Reusable:** `src/components/course/course-combobox.tsx` is shared with the 1-on-1 signup flow (Task 3).

**Schema:** `GroupSession.courseId` added to the Drizzle schema and to `startup-schema-fix.ts` (`ADD COLUMN IF NOT EXISTS`) — the migration journal is frozen, so that's how columns reach prod.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors · build via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)