### PR TITLE
feat(one-on-one): course selection in student 1-on-1 signup

### DIFF
--- a/tutorme-app/src/app/[locale]/u/[username]/page.tsx
+++ b/tutorme-app/src/app/[locale]/u/[username]/page.tsx
@@ -1695,6 +1695,7 @@ export default function PublicTutorPage() {
         tutor={tutor}
         username={normalizedUsername}
         locale={locale}
+        courses={(data?.courses ?? []).map(c => ({ id: c.id, name: c.name }))}
       />
 
       <Dialog

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { eq, and, or, inArray } from 'drizzle-orm'
+import { eq, and, or, inArray, isNull } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { oneOnOneBookingRequest, profile, user } from '@/lib/db/schema'
+import { oneOnOneBookingRequest, profile, user, course } from '@/lib/db/schema'
 import { notify } from '@/lib/notifications/notify'
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
@@ -39,6 +39,8 @@ const requestSchema = z.object({
     .max(20),
   duration: z.number().min(30).max(180), // minutes: 30-180
   studentNotes: z.string().max(1000).optional(),
+  // Optional: a published course of the tutor this session is about.
+  courseId: z.string().min(1).optional(),
 })
 
 export const POST = withCsrf(
@@ -164,6 +166,25 @@ export const POST = withCsrf(
     const seriesId = isSeries ? nanoid() : null
     const studentNotes = validated.studentNotes?.trim() || null
 
+    // Validate the optional course: it must be a published course of THIS tutor.
+    // A mismatch silently drops the linkage rather than failing the booking.
+    let courseId: string | null = null
+    if (validated.courseId) {
+      const [c] = await drizzleDb
+        .select({ courseId: course.courseId })
+        .from(course)
+        .where(
+          and(
+            eq(course.courseId, validated.courseId),
+            eq(course.creatorId, validated.tutorId),
+            eq(course.isPublished, true),
+            isNull(course.deletedAt)
+          )
+        )
+        .limit(1)
+      courseId = c?.courseId ?? null
+    }
+
     const rows = slots.map((slot, i) => ({
       requestId: nanoid(),
       tutorId: validated.tutorId,
@@ -176,6 +197,7 @@ export const POST = withCsrf(
       costPerSession,
       status: 'PENDING' as const,
       studentNotes,
+      courseId,
       seriesId,
       seriesIndex: isSeries ? i : null,
       createdAt: new Date(),

--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -28,6 +28,7 @@ import {
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
+import { CourseCombobox, type CourseOption } from '@/components/course/course-combobox'
 
 // Time slot constants (same as VariantScheduleEditor)
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const
@@ -101,6 +102,9 @@ interface CalendarBookingDialogProps {
   }
   username: string
   locale: string
+  /** The tutor's published courses, so the student can say which one this
+   *  session is about. Optional — the picker only shows when there are some. */
+  courses?: CourseOption[]
 }
 
 export function CalendarBookingDialog({
@@ -109,6 +113,7 @@ export function CalendarBookingDialog({
   tutor,
   username,
   locale,
+  courses = [],
 }: CalendarBookingDialogProps) {
   const { data: session } = useSession()
   const router = useRouter()
@@ -128,6 +133,8 @@ export function CalendarBookingDialog({
   const [recurringWeeks, setRecurringWeeks] = useState(1)
   // Optional note the student sends the tutor ("why I want this session").
   const [studentNotes, setStudentNotes] = useState('')
+  // Optional course the student wants this 1-on-1 to be about.
+  const [courseId, setCourseId] = useState<string | null>(null)
 
   // Calendar week navigation
   const [weekOffset, setWeekOffset] = useState(0)
@@ -448,6 +455,7 @@ export function CalendarBookingDialog({
           proposedSlots,
           duration: 60,
           ...(studentNotes.trim() ? { studentNotes: studentNotes.trim() } : {}),
+          ...(courseId ? { courseId } : {}),
         }),
       })
 
@@ -947,6 +955,24 @@ export function CalendarBookingDialog({
                         </span>
                       </div>
                     </div>
+
+                    {/* Optional course this session is about */}
+                    {courses.length > 0 ? (
+                      <div className="mt-4">
+                        <label className="mb-1.5 block text-sm font-semibold text-white">
+                          Course <span className="font-normal text-white/50">(optional)</span>
+                        </label>
+                        <CourseCombobox
+                          options={courses}
+                          value={courseId}
+                          onChange={setCourseId}
+                          placeholder="Which course is this about?"
+                        />
+                        <p className="mt-1 text-[11px] text-white/50">
+                          Lets your tutor line up the right lessons and tasks for your session.
+                        </p>
+                      </div>
+                    ) : null}
 
                     {/* Optional note to the tutor */}
                     <div className="mt-4">

--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -234,6 +234,9 @@ export const oneOnOneBookingRequest = pgTable(
     tutorNotes: text('tutorNotes'),
     // The student's note to the tutor when requesting ("why I want this session").
     studentNotes: text('studentNotes'),
+    // Optional course the student wants this session to be about (a published
+    // course of the tutor). Nullable; helps the tutor prepare + deploy material.
+    courseId: text('courseId').references(() => course.courseId, { onDelete: 'set null' }),
     // Recurring bookings: N weekly sessions requested together share one seriesId
     // (null = a standalone single session). seriesIndex is the 0-based week offset.
     seriesId: text('seriesId'),


### PR DESCRIPTION
## Task 3 — course selection in 1-on-1 signup

_(Re-opened against `main`; the original #1071 was auto-closed when its stacked base branch merged + deleted.)_

When a student requests a 1-on-1, they can now indicate **which of the tutor's courses** it's about:
- The **same compact `CourseCombobox`** (from #1070) — search + popover, no course-card clutter. The list is the tutor's **published** courses, taken from the public-profile data the page **already loaded** (no extra fetch).
- `CalendarBookingDialog` gains an optional `courses` prop and sends `courseId`.
- `POST /api/one-on-one/request` validates the course is a **published course of that tutor** (a mismatch silently drops the link rather than failing the booking) and persists `OneOnOneBookingRequest.courseId` (schema column; the `ADD COLUMN` ALTER shipped with #1070).

## Verification
- `tsc --noEmit` clean (against post-#1070 main) · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)