### PR TITLE
revert(landing): restore original category search panel design

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -4065,88 +4065,11 @@ const CategorySearchModal = ({
             >
               <X className="h-4 w-4" />
             </button>
-
-            {/* Region & Country dropdowns */}
-            <div className="flex flex-wrap gap-3">
-              <Select
-                value={selectedRegion}
-                onValueChange={v => {
-                  setSelectedRegion(v)
-                  setSelectedCountries([])
-                }}
-              >
-                <SelectTrigger className="h-[30px] w-[160px] rounded-sm border border-slate-700/25 bg-white/30 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
-                  <SelectValue placeholder="Region" />
-                </SelectTrigger>
-                <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
-                  {REGIONS.filter(r => r.id !== 'global').map(region => (
-                    <SelectItem
-                      key={region.id}
-                      value={region.id}
-                      className="mx-1.5 rounded-md text-white hover:bg-white/20"
-                    >
-                      {region.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    disabled={!selectedRegion}
-                    className="inline-flex h-[30px] w-[160px] items-center justify-between rounded-sm border border-slate-700/25 bg-white/30 px-3 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none disabled:cursor-not-allowed disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:opacity-50 disabled:backdrop-blur-none disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-none"
-                  >
-                    <span className="truncate">
-                      {selectedCountries.length > 0
-                        ? `${selectedCountries.length} countr${selectedCountries.length === 1 ? 'y' : 'ies'}`
-                        : 'Country'}
-                    </span>
-                    <svg
-                      className="h-4 w-4 opacity-50"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent
-                  variant="panel"
-                  className="w-[160px] rounded-lg border border-slate-700/25 bg-white/30 p-1.5 text-white shadow-lg backdrop-blur-xl"
-                  align="start"
-                >
-                  <div className="flex flex-col gap-1">
-                    {availableCountries.map(country => (
-                      <label
-                        key={country.code}
-                        className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/20"
-                        onClick={() => toggleCountry(country.code)}
-                      >
-                        <div
-                          className={cn(
-                            'h-4 w-4 rounded-full border-2 transition-colors',
-                            selectedCountries.includes(country.code)
-                              ? 'border-white bg-white'
-                              : 'border-white/50 bg-transparent'
-                          )}
-                        />
-                        <span>{country.name}</span>
-                      </label>
-                    ))}
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
+            <h2 className="mb-1 text-2xl font-bold text-white">{t('browseCategories')}</h2>
+            <p className="mb-3 text-sm text-white/70">{t('selectCategoryPrompt')}</p>
 
             {/* Selected category badges container + Search */}
-            <div className="mb-1 mt-3 flex items-start gap-3">
+            <div className="mb-1 flex items-start gap-3">
               <div className="flex min-w-0 flex-1 flex-col">
                 <div
                   ref={badgeScrollRef}
@@ -4252,17 +4175,83 @@ const CategorySearchModal = ({
               </Button>
             </div>
 
-            {/* Search */}
-            <div className="relative z-10 pb-2 pt-[15px]">
-              <div className="relative mx-auto max-w-md">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-                <Input
-                  placeholder={t('searchCategories')}
-                  value={categorySearch}
-                  onChange={e => setCategorySearch(e.target.value)}
-                  className="h-[34px] border-slate-200 bg-white pl-10 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus-visible:border-slate-300 focus-visible:ring-0 focus-visible:ring-offset-0"
-                />
-              </div>
+            {/* Region & Country dropdowns */}
+            <div className="flex flex-wrap gap-3">
+              <Select
+                value={selectedRegion}
+                onValueChange={v => {
+                  setSelectedRegion(v)
+                  setSelectedCountries([])
+                }}
+              >
+                <SelectTrigger className="h-[30px] w-[160px] rounded-sm border border-slate-700/25 bg-white/30 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
+                  <SelectValue placeholder="Region" />
+                </SelectTrigger>
+                <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
+                  {REGIONS.filter(r => r.id !== 'global').map(region => (
+                    <SelectItem
+                      key={region.id}
+                      value={region.id}
+                      className="mx-1.5 rounded-md text-white hover:bg-white/20"
+                    >
+                      {region.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={!selectedRegion}
+                    className="inline-flex h-[30px] w-[160px] items-center justify-between rounded-sm border border-slate-700/25 bg-white/30 px-3 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none disabled:cursor-not-allowed disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:opacity-50 disabled:backdrop-blur-none disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-none"
+                  >
+                    <span className="truncate">
+                      {selectedCountries.length > 0
+                        ? `${selectedCountries.length} countr${selectedCountries.length === 1 ? 'y' : 'ies'}`
+                        : 'Country'}
+                    </span>
+                    <svg
+                      className="h-4 w-4 opacity-50"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  variant="panel"
+                  className="w-[160px] rounded-lg border border-slate-700/25 bg-white/30 p-1.5 text-white shadow-lg backdrop-blur-xl"
+                  align="start"
+                >
+                  <div className="flex flex-col gap-1">
+                    {availableCountries.map(country => (
+                      <label
+                        key={country.code}
+                        className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/20"
+                        onClick={() => toggleCountry(country.code)}
+                      >
+                        <div
+                          className={cn(
+                            'h-4 w-4 rounded-full border-2 transition-colors',
+                            selectedCountries.includes(country.code)
+                              ? 'border-white bg-white'
+                              : 'border-white/50 bg-transparent'
+                          )}
+                        />
+                        <span>{country.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
             </div>
           </div>
 
@@ -4331,6 +4320,19 @@ const CategorySearchModal = ({
                     <Award className="mr-1.5 h-4 w-4" /> Professional
                   </TabsTrigger>
                 </TabsList>
+              </div>
+
+              {/* Search — placed inside Tabs so it sits under the active tab */}
+              <div className="relative z-10 pb-2 pt-[15px]">
+                <div className="relative mx-auto max-w-md">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    placeholder={t('searchCategories')}
+                    value={categorySearch}
+                    onChange={e => setCategorySearch(e.target.value)}
+                    className="h-[34px] border-slate-200 bg-white pl-10 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus-visible:border-slate-300 focus-visible:ring-0 focus-visible:ring-offset-0"
+                  />
+                </div>
               </div>
 
               <div

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
@@ -186,10 +186,6 @@ export function CourseCategoryPicker({
   }, [nationalExams, filteredUniversityCategories])
 
   // Keep every tab the same height as the (tallest) Global tab.
-  // National and Universities tabs have extra region/country selectors
-  // above the scrollable area, so we deduct that offset to keep total
-  // picker height consistent across all tabs.
-  const SELECTOR_ROW_OFFSET = 50 // height of region/country selector row + gap
   const [baseContentHeight, setBaseContentHeight] = useState<number>(480)
 
   useLayoutEffect(() => {
@@ -199,10 +195,7 @@ export function CourseCategoryPicker({
     }
   }, [categoryTab])
 
-  const globalContentHeight =
-    categoryTab === 'national' || categoryTab === 'universities'
-      ? baseContentHeight - SELECTOR_ROW_OFFSET
-      : baseContentHeight
+  const globalContentHeight = baseContentHeight
 
   const selectCategory = (category: string) => onChange([category])
 
@@ -306,89 +299,84 @@ export function CourseCategoryPicker({
 
   return (
     <div className={cn('flex flex-col gap-6', className)}>
-      {/* Region + Country — only for the country-specific tabs (National +
-            Universities); hidden on the global-board tabs where a country is
-            meaningless and picking one caused the "choose country twice?"
-            confusion. */}
-      {(categoryTab === 'national' || categoryTab === 'universities') && (
-        <div className="flex flex-wrap gap-3">
-          <Select
-            value={selectedRegion}
-            onValueChange={v => {
-              setSelectedRegion(v)
-              setSelectedCountryCode('')
-            }}
-          >
-            <SelectTrigger className="h-[30px] w-[160px] rounded-sm border border-slate-700/25 bg-white/30 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
-              <SelectValue placeholder="Region" />
-            </SelectTrigger>
-            <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
-              {REGIONS.filter(r => r.id !== 'global').map(region => (
-                <SelectItem
-                  key={region.id}
-                  value={region.id}
-                  className="mx-1.5 rounded-md text-white hover:bg-white/20"
-                >
-                  {region.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                disabled={!selectedRegion}
-                className="inline-flex h-[30px] w-[160px] items-center justify-between rounded-sm border border-slate-700/25 bg-white/30 px-3 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none disabled:cursor-not-allowed disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:opacity-50 disabled:backdrop-blur-none disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-none"
+      {/* Region + Country — always visible for all tabs */}
+      <div className="flex flex-wrap gap-3">
+        <Select
+          value={selectedRegion}
+          onValueChange={v => {
+            setSelectedRegion(v)
+            setSelectedCountryCode('')
+          }}
+        >
+          <SelectTrigger className="h-[30px] w-[160px] rounded-sm border border-slate-700/25 bg-white/30 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none focus-visible:outline-none">
+            <SelectValue placeholder="Region" />
+          </SelectTrigger>
+          <SelectContent className="w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-700/25 bg-white/30 bg-none p-1.5 shadow-lg backdrop-blur-xl">
+            {REGIONS.filter(r => r.id !== 'global').map(region => (
+              <SelectItem
+                key={region.id}
+                value={region.id}
+                className="mx-1.5 rounded-md text-white hover:bg-white/20"
               >
-                <span className="truncate">
-                  {selectedCountryCode
-                    ? availableCountries.find(c => c.code === selectedCountryCode)?.name ||
-                      'Country'
-                    : 'Country'}
-                </span>
-                <svg
-                  className="h-4 w-4 opacity-50"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </button>
-            </PopoverTrigger>
-            <PopoverContent
-              className="w-[160px] rounded-lg border border-slate-700/25 bg-white/30 p-1.5 text-white shadow-lg backdrop-blur-xl"
-              align="start"
+                {region.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={!selectedRegion}
+              className="inline-flex h-[30px] w-[160px] items-center justify-between rounded-sm border border-slate-700/25 bg-white/30 px-3 text-sm text-white shadow-sm backdrop-blur-sm transition-all duration-200 hover:border-slate-700/50 hover:bg-white/60 hover:shadow-md focus:outline-none focus-visible:!shadow-none disabled:cursor-not-allowed disabled:border-slate-400/20 disabled:bg-slate-100/20 disabled:text-slate-400 disabled:opacity-50 disabled:backdrop-blur-none disabled:hover:border-slate-400/20 disabled:hover:bg-slate-100/20 disabled:hover:shadow-none"
             >
-              <div className="flex flex-col gap-1">
-                {availableCountries.map(country => (
-                  <button
-                    key={country.code}
-                    onClick={() => setSelectedCountryCode(country.code)}
-                    className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/20"
-                  >
-                    <div
-                      className={cn(
-                        'h-4 w-4 rounded-full border-2 transition-colors',
-                        selectedCountryCode === country.code
-                          ? 'border-white bg-white'
-                          : 'border-white/50 bg-transparent'
-                      )}
-                    />
-                    <span>{country.name}</span>
-                  </button>
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
-        </div>
-      )}
+              <span className="truncate">
+                {selectedCountryCode
+                  ? availableCountries.find(c => c.code === selectedCountryCode)?.name ||
+                    'Country'
+                  : 'Country'}
+              </span>
+              <svg
+                className="h-4 w-4 opacity-50"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            className="w-[160px] rounded-lg border border-slate-700/25 bg-white/30 p-1.5 text-white shadow-lg backdrop-blur-xl"
+            align="start"
+          >
+            <div className="flex flex-col gap-1">
+              {availableCountries.map(country => (
+                <button
+                  key={country.code}
+                  onClick={() => setSelectedCountryCode(country.code)}
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/20"
+                >
+                  <div
+                    className={cn(
+                      'h-4 w-4 rounded-full border-2 transition-colors',
+                      selectedCountryCode === country.code
+                        ? 'border-white bg-white'
+                        : 'border-white/50 bg-transparent'
+                    )}
+                  />
+                  <span>{country.name}</span>
+                </button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
 
       {/* Search + selected badges */}
       <div className="mb-1 flex items-start gap-3">
@@ -485,9 +473,9 @@ export function CourseCategoryPicker({
           ))}
 
           {/* National (checkbox; needs a country) */}
-          <TabsContent value="national" className="mt-0 flex h-full flex-1 flex-col">
+          <TabsContent value="national" className="mt-0">
             {nationalExams.length === 0 ? (
-              <div className="flex h-full flex-col items-center justify-center text-center">
+              <div className="py-12 text-center">
                 <Flag className="mx-auto mb-3 h-12 w-12 text-slate-300" />
                 <p className="text-sm text-white/70">
                   Select a region or country to see national exams.
@@ -499,9 +487,9 @@ export function CourseCategoryPicker({
           </TabsContent>
 
           {/* Universities (needs a region/country) */}
-          <TabsContent value="universities" className="mt-0 flex h-full flex-1 flex-col">
+          <TabsContent value="universities" className="mt-0">
             {filteredUniversityCategories.length === 0 ? (
-              <div className="flex h-full flex-col items-center justify-center text-center">
+              <div className="py-12 text-center">
                 <GraduationCap className="mx-auto mb-3 h-12 w-12 text-slate-300" />
                 <p className="text-sm text-white/70">Select a country to see universities</p>
               </div>

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
@@ -332,8 +332,7 @@ export function CourseCategoryPicker({
             >
               <span className="truncate">
                 {selectedCountryCode
-                  ? availableCountries.find(c => c.code === selectedCountryCode)?.name ||
-                    'Country'
+                  ? availableCountries.find(c => c.code === selectedCountryCode)?.name || 'Country'
                   : 'Country'}
               </span>
               <svg

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -85,6 +85,7 @@ export function TestTaskChat({
   const [pdfPopupOpen, setPdfPopupOpen] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const lastIncomingLen = useRef(0)
+  const isClassroom = mode === 'classroom'
 
   // In classroom mode, sync messages directly from incomingMessages.
   // This ensures messages persist when switching tabs (component remounts).
@@ -263,7 +264,6 @@ export function TestTaskChat({
     onPersist?.(emptyState)
   }
 
-  const isClassroom = mode === 'classroom'
   const accentColor = isClassroom ? 'text-[#F17623]' : 'text-violet-600'
   const accentBg = isClassroom ? 'bg-orange-50/60' : 'bg-violet-50/60'
   const accentBorder = isClassroom ? 'border-orange-100' : 'border-violet-100'

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -84,7 +84,15 @@ export function TestTaskChat({
   const [busy, setBusy] = useState(false)
   const [pdfPopupOpen, setPdfPopupOpen] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const lastIncomingLen = useRef(incomingMessages?.length ?? 0)
+  const lastIncomingLen = useRef(0)
+
+  // In classroom mode, sync messages directly from incomingMessages.
+  // This ensures messages persist when switching tabs (component remounts).
+  useEffect(() => {
+    if (isClassroom && incomingMessages) {
+      setMessages(incomingMessages)
+    }
+  }, [incomingMessages, isClassroom])
 
   useEffect(() => {
     const el = scrollRef.current
@@ -94,14 +102,16 @@ export function TestTaskChat({
   }, [messages, busy])
 
   // Append any new incoming messages from the parent (cross-tab relay).
+  // Only used for non-classroom mode (student tabs).
   useEffect(() => {
+    if (isClassroom) return
     const len = incomingMessages?.length ?? 0
     if (len > lastIncomingLen.current) {
       const newMsgs = incomingMessages!.slice(lastIncomingLen.current)
       setMessages(prev => [...prev, ...newMsgs])
       lastIncomingLen.current = len
     }
-  }, [incomingMessages])
+  }, [incomingMessages, isClassroom])
 
   // Mirror state to the parent's store so a remount (switching Test students)
   // can rehydrate it. Cheap; runs only when the persisted fields change.


### PR DESCRIPTION
Revert the Landing Page CategorySearchModal back to its original design:
- Restore title 'Browse Categories' and subtitle
- Move Region/Country dropdowns below the badges bar
- Move Search input back inside Tabs component (under active tab)

This reverses the changes from commit bb1c4746a which had matched the Landing Page panel to the Course Builder design. The Course Builder's Edit Category and Edit Schedule panels remain untouched.

Fixes: Landing page category dialog layout