### PR TITLE
feat(sessions): private per-student whiteboards (Task 6) — needs live test

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-boards.tsx
+++ b/tutorme-app/src/components/one-on-one/session-boards.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Users, PenTool } from 'lucide-react'
+import { useSocket } from '@/hooks/use-socket'
+import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
+import { FallbackBoundary } from '@/components/ui/fallback-boundary'
+
+/**
+ * Private per-participant whiteboards, layered additively over the shared board.
+ *
+ * Each private board lives on its OWN socket sub-room (`<sessionId>:board:<owner>`)
+ * reached through a `forceNew` connection, so its room_state and whiteboard
+ * deltas never bleed into the main session socket (whiteboard events carry no
+ * roomId, so a shared connection couldn't tell the boards apart). A student draws
+ * on their own board; the tutor can open any student's board read-only to watch
+ * it live. The shared collaborative board underneath is untouched.
+ */
+export function boardRoomId(sessionId: string, ownerId: string): string {
+  return `${sessionId}:board:${ownerId}`
+}
+
+/** One isolated board on its own connection. Editable for its owner, read-only
+ *  when the tutor is viewing someone else's. */
+function IsolatedBoard({
+  sessionId,
+  ownerId,
+  viewerId,
+  viewerName,
+  viewerIsTutor,
+  readOnly,
+}: {
+  sessionId: string
+  ownerId: string
+  viewerId: string
+  viewerName?: string
+  viewerIsTutor?: boolean
+  readOnly?: boolean
+}) {
+  const socketOptions =
+    sessionId && viewerId
+      ? {
+          roomId: boardRoomId(sessionId, ownerId),
+          userId: viewerId,
+          name: viewerName || (viewerIsTutor ? 'Tutor' : 'Student'),
+          role: viewerIsTutor ? ('tutor' as const) : ('student' as const),
+          forceNew: true,
+        }
+      : undefined
+  const { socket } = useSocket(socketOptions)
+
+  return (
+    <EnhancedWhiteboard
+      socket={socket}
+      roomId={boardRoomId(sessionId, ownerId)}
+      userId={viewerId}
+      userName={viewerName || undefined}
+      readOnly={readOnly}
+      videoOverlay={false}
+    />
+  )
+}
+
+interface BoardTarget {
+  /** Whose board this is. */
+  ownerId: string
+  ownerName: string
+  /** True when the current user owns it (editable); false = tutor viewing. */
+  mine: boolean
+}
+
+/**
+ * The full-area overlay that hosts a private board above the classroom. The
+ * user's OWN board stays mounted once opened (hidden, not unmounted) so its
+ * content survives toggling; a tutor's view of a student's board mounts on demand.
+ */
+export function SessionBoardsOverlay({
+  sessionId,
+  userId,
+  userName,
+  isTutor,
+  target,
+  ownBoardEverOpened,
+  onClose,
+}: {
+  sessionId: string
+  userId: string
+  userName?: string
+  isTutor?: boolean
+  target: BoardTarget | null
+  ownBoardEverOpened: boolean
+  onClose: () => void
+}) {
+  const viewingStudent = target && !target.mine ? target : null
+  const showOwn = !!target?.mine
+
+  if (!target && !ownBoardEverOpened) return null
+
+  return (
+    <div
+      className={
+        'pointer-events-auto absolute inset-2 z-30 flex flex-col overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-2xl ' +
+        (target ? '' : 'hidden')
+      }
+    >
+      <div className="flex items-center justify-between border-b bg-slate-50 px-4 py-2">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-800">
+          <PenTool className="h-4 w-4 text-slate-500" />
+          {target?.mine ? 'My board' : target ? `${target.ownerName}'s board` : 'Board'}
+          {target && !target.mine ? (
+            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-medium text-slate-600">
+              read-only
+            </span>
+          ) : null}
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close board"
+          className="rounded-full p-1 text-slate-400 hover:bg-slate-200 hover:text-slate-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {/* Own board — kept mounted once opened so its strokes persist across
+            toggles; shown only when it's the active target. */}
+        {ownBoardEverOpened && userId ? (
+          <div className={'absolute inset-0 ' + (showOwn ? '' : 'hidden')}>
+            <FallbackBoundary
+              label="my board"
+              fallback={<div className="h-full w-full bg-white" />}
+            >
+              <IsolatedBoard
+                sessionId={sessionId}
+                ownerId={userId}
+                viewerId={userId}
+                viewerName={userName}
+                viewerIsTutor={isTutor}
+              />
+            </FallbackBoundary>
+          </div>
+        ) : null}
+
+        {/* A student's board — tutor only, mounted on demand, read-only. */}
+        {viewingStudent && userId ? (
+          <div className="absolute inset-0">
+            <FallbackBoundary
+              label="student board"
+              fallback={<div className="h-full w-full bg-white" />}
+            >
+              <IsolatedBoard
+                key={viewingStudent.ownerId}
+                sessionId={sessionId}
+                ownerId={viewingStudent.ownerId}
+                viewerId={userId}
+                viewerName={userName}
+                viewerIsTutor={isTutor}
+                readOnly
+              />
+            </FallbackBoundary>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Tutor-only dropdown to pick a student whose board to watch. Sits under the
+ * "Boards" toolbar button.
+ */
+export function BoardsPicker({
+  students,
+  onPick,
+  onClose,
+}: {
+  students: Array<{ userId: string; name: string }>
+  onPick: (s: { userId: string; name: string }) => void
+  onClose: () => void
+}) {
+  return (
+    <div className="pointer-events-auto absolute right-0 top-full mt-1 w-56 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="flex items-center gap-1.5 text-xs font-semibold text-slate-700">
+          <Users className="h-3.5 w-3.5" /> Student boards
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-0.5 text-slate-400 hover:bg-slate-100"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {students.length === 0 ? (
+        <p className="px-3 py-6 text-center text-xs text-slate-400">No students have joined yet.</p>
+      ) : (
+        <ul className="max-h-64 overflow-y-auto p-1">
+          {students.map(s => (
+            <li key={s.userId}>
+              <button
+                onClick={() => onPick(s)}
+                className="w-full truncate rounded-md px-2.5 py-2 text-left text-sm text-slate-700 hover:bg-slate-50"
+              >
+                {s.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/** Small helper hook: track whether the user's own board has ever been opened. */
+export function useOwnBoardOpened(active: boolean): boolean {
+  const [opened, setOpened] = useState(false)
+  if (active && !opened) setOpened(true)
+  return opened
+}

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -14,17 +14,27 @@
 
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { Send, FolderOpen, Users, Pencil } from 'lucide-react'
+import { Send, FolderOpen, Users, Pencil, PenTool, LayoutGrid } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 import { SessionDeployPanel } from '@/components/one-on-one/session-deploy-panel'
 import { SessionDeployedPanel } from '@/components/one-on-one/session-deployed-panel'
 import { SessionResponsesPanel } from '@/components/one-on-one/session-responses-panel'
+import {
+  SessionBoardsOverlay,
+  BoardsPicker,
+  useOwnBoardOpened,
+} from '@/components/one-on-one/session-boards'
 import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
 import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 
 type ActivePanel = 'deploy' | 'materials' | 'responses' | null
+interface BoardTarget {
+  ownerId: string
+  ownerName: string
+  mine: boolean
+}
 
 interface SessionClassroomProps {
   sessionId: string
@@ -51,6 +61,12 @@ export function SessionClassroom({
   const [activePanel, setActivePanel] = useState<ActivePanel>(null)
   const toggle = (panel: Exclude<ActivePanel, null>) =>
     setActivePanel(cur => (cur === panel ? null : panel))
+  // Private-board overlay: whose board is open (own = editable, student = tutor
+  // viewing read-only), plus the tutor's student-board picker.
+  const [boardTarget, setBoardTarget] = useState<BoardTarget | null>(null)
+  const [showBoardsPicker, setShowBoardsPicker] = useState(false)
+  const myId = session?.user?.id ?? ''
+  const ownBoardOpened = useOwnBoardOpened(boardTarget?.mine === true)
 
   // useSocket keys its effect on the option fields (not object identity), so an
   // inline object is safe — the compiler memoizes and the socket only reconnects
@@ -70,10 +86,8 @@ export function SessionClassroom({
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
   // room_state replay instead of missing everything that happened before.
-  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask } = useSessionRoomState(
-    socket,
-    session?.user?.id
-  )
+  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students } =
+    useSessionRoomState(socket, session?.user?.id)
 
   // The call feed rides along as the whiteboard's draggable video overlay.
   const video = (
@@ -140,7 +154,48 @@ export function SessionClassroom({
                 Edit course
               </a>
             ) : null}
+            <div className="pointer-events-auto relative">
+              <button
+                type="button"
+                onClick={() => setShowBoardsPicker(v => !v)}
+                title="View a student's board"
+                className="inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+              >
+                <LayoutGrid className="h-3.5 w-3.5" />
+                Boards
+              </button>
+              {showBoardsPicker ? (
+                <BoardsPicker
+                  students={students}
+                  onPick={s => {
+                    setBoardTarget({ ownerId: s.userId, ownerName: s.name, mine: false })
+                    setShowBoardsPicker(false)
+                  }}
+                  onClose={() => setShowBoardsPicker(false)}
+                />
+              ) : null}
+            </div>
           </>
+        ) : null}
+        {myId ? (
+          <button
+            type="button"
+            onClick={() =>
+              setBoardTarget(cur =>
+                cur?.mine ? null : { ownerId: myId, ownerName: 'Me', mine: true }
+              )
+            }
+            title="Your own private whiteboard"
+            className={
+              'pointer-events-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur ' +
+              (boardTarget?.mine
+                ? 'bg-blue-600 text-white hover:bg-blue-500'
+                : 'bg-white/90 text-slate-800 hover:bg-white')
+            }
+          >
+            <PenTool className="h-3.5 w-3.5" />
+            My board
+          </button>
         ) : null}
         <button
           type="button"
@@ -151,6 +206,18 @@ export function SessionClassroom({
           Materials
         </button>
       </div>
+
+      {/* Private-board overlay — sits above the shared board (which stays mounted
+          so the call audio keeps running). Own board stays alive once opened. */}
+      <SessionBoardsOverlay
+        sessionId={sessionId}
+        userId={myId}
+        userName={session?.user?.name || undefined}
+        isTutor={isTutor}
+        target={boardTarget}
+        ownBoardEverOpened={ownBoardOpened}
+        onClose={() => setBoardTarget(null)}
+      />
 
       {/* Side panels — wrapped so a panel crash closes to nothing, never the room. */}
       {activePanel ? (

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -82,9 +82,20 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
   const [responsesByTask, setResponsesByTask] = useState<
     Record<string, Record<string, SessionStudentResponse>>
   >({})
+  // The student roster (for the tutor's board viewer), from room_state + joins.
+  const [students, setStudents] = useState<Array<{ userId: string; name: string }>>([])
 
   useEffect(() => {
     if (!socket) return
+
+    const mergeStudents = (incoming: Array<{ userId: string; name?: string }>) =>
+      setStudents(prev => {
+        const byId = new Map(prev.map(s => [s.userId, s]))
+        for (const s of incoming) {
+          if (s?.userId) byId.set(s.userId, { userId: s.userId, name: s.name || 'Student' })
+        }
+        return Array.from(byId.values())
+      })
 
     const upsertTask = (t: SessionRoomTask) => {
       if (!t?.id) return
@@ -98,6 +109,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     // Join-time replay: hydrate both the deployed tasks and any submissions that
     // already happened (task.responses), naming students from the roster.
     const onRoomState = (state: RoomStatePayload) => {
+      if (Array.isArray(state?.students)) mergeStudents(state.students)
       if (!Array.isArray(state?.tasks)) return
       const nameById = new Map((state.students ?? []).map(s => [s.userId, s.name || 'Student']))
       setTasks(prev => {
@@ -182,17 +194,23 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       })
     }
 
+    const onStudentJoined = (data: { userId: string; name?: string }) => {
+      if (data?.userId) mergeStudents([data])
+    }
+
     socket.on('room_state', onRoomState)
     socket.on('task:deployed', onDeployed)
     socket.on('task:updated', onUpdated)
     socket.on('task:completed', onCompleted)
     socket.on('task:graded', onGraded)
+    socket.on('student_joined', onStudentJoined)
     return () => {
       socket.off('room_state', onRoomState)
       socket.off('task:deployed', onDeployed)
       socket.off('task:updated', onUpdated)
       socket.off('task:completed', onCompleted)
       socket.off('task:graded', onGraded)
+      socket.off('student_joined', onStudentJoined)
     }
   }, [socket])
 
@@ -221,5 +239,5 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     return out
   }, [responsesByTask, myUserId])
 
-  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask }
+  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students }
 }

--- a/tutorme-app/src/hooks/use-socket.ts
+++ b/tutorme-app/src/hooks/use-socket.ts
@@ -13,6 +13,10 @@ interface UseSocketOptions {
   name: string
   role: 'student' | 'tutor'
   tutorId?: string
+  /** Force an independent connection (its own Manager) instead of sharing the
+   *  default one. Used for private-board sub-rooms so their room_state /
+   *  whiteboard events never bleed into the main session socket. */
+  forceNew?: boolean
   onStudentJoined?: (student: StudentState) => void
   onStudentLeft?: (userId: string) => void
   onStudentStateUpdate?: (data: { userId: string; state: StudentState }) => void
@@ -63,6 +67,7 @@ export function useSocket(options?: UseSocketOptions) {
         reconnectionAttempts: 50,
         reconnectionDelay: 1000,
         reconnectionDelayMax: 5000,
+        forceNew: options?.forceNew ?? false,
       })
       if (cancelled) {
         socket.disconnect()
@@ -185,7 +190,14 @@ export function useSocket(options?: UseSocketOptions) {
         socketRef.current = null
       }
     }
-  }, [options?.roomId, options?.userId, options?.name, options?.role, options?.tutorId])
+  }, [
+    options?.roomId,
+    options?.userId,
+    options?.name,
+    options?.role,
+    options?.tutorId,
+    options?.forceNew,
+  ])
 
   // Send chat message
   const sendChatMessage = useCallback((text: string) => {


### PR DESCRIPTION
## Task 6 — private student whiteboards (your pick: additive, keep the shared board)

Each participant gets their **own private whiteboard**, and the tutor can **watch any student's board live** — the shared collaborative board is untouched.

### The isolation problem (and fix)
Whiteboard delta events carry **no roomId**, and `useSocket` shares one connection — so a naive multi-room approach would cross-contaminate **strokes and `room_state`** between boards. Each private board therefore lives on its **own socket sub-room** (`<sessionId>:board:<owner>`) reached via a new **`forceNew`** option on `useSocket` (a fully independent connection). Board events never bleed into the main session socket.

### What's here
- **`useSocket`** — `forceNew` option.
- **`session-boards.tsx`** — `IsolatedBoard` (own sub-room), `SessionBoardsOverlay` (full-area overlay above the shared board; the own board stays mounted once opened so strokes persist across toggles; **the shared board + call audio keep running underneath**), `BoardsPicker` (tutor picks a student to watch, read-only).
- **`useSessionRoomState`** — exposes the student roster.
- **`SessionClassroom`** — **"My board"** toggle (everyone) + tutor **"Boards"** viewer.

## ⚠️ Do NOT auto-merge — needs a live two-client test
This is multi-socket whiteboard sync, and the whiteboard has a crash history. Please smoke-test before merge: student opens **My board** and draws → tutor opens **Boards → that student** and sees the strokes live; toggling **My board** off/on preserves content; the shared board + video keep working throughout.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors · `next build` success (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)