### PR TITLE
feat(sessions): surface the linked course on session + request cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { Users, Loader2, CalendarDays, ArrowUpRight } from 'lucide-react'
+import { Users, Loader2, CalendarDays, ArrowUpRight, BookOpen } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { bookGroupSeat } from '@/lib/group-session/book-seat'
 
@@ -22,6 +22,7 @@ interface BrowseSession {
   seatsLeft: number
   tutorName?: string | null
   tutorUsername?: string | null
+  courseName?: string | null
 }
 
 function formatDate(iso: string): string {
@@ -132,6 +133,12 @@ export default function StudentGroupSessionsPage() {
                           ? '1-on-1 · 1 seat'
                           : `${gs.seatsLeft} of ${gs.capacity} seats left`}
                     </span>
+                    {gs.courseName ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                        <BookOpen className="h-3 w-3" />
+                        {gs.courseName}
+                      </span>
+                    ) : null}
                   </div>
                   {gs.description ? (
                     <p className="mt-1 line-clamp-2 text-sm text-slate-500">{gs.description}</p>

--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -12,6 +12,7 @@ import {
   Inbox,
   Clock,
   CheckCircle2,
+  BookOpen,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -32,6 +33,8 @@ interface GroupSessionItem {
   status: string
   seatsLeft: number
   liveSessionId?: string | null
+  courseName?: string | null
+  coursePublished?: boolean | null
 }
 
 const emptyForm = {
@@ -374,6 +377,15 @@ export default function TutorGroupSessionsPage() {
                         <span>
                           {gs.capacity - gs.seatsLeft}/{gs.capacity} booked
                         </span>
+                        {gs.courseName ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                            <BookOpen className="h-3 w-3" />
+                            {gs.courseName}
+                            {gs.coursePublished === false ? (
+                              <span className="text-blue-400">· draft</span>
+                            ) : null}
+                          </span>
+                        ) : null}
                       </div>
                     </div>
                     {!cancelled ? (

--- a/tutorme-app/src/app/api/group-sessions/browse/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/browse/route.ts
@@ -11,7 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { and, asc, eq, gte } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { groupSession, profile, user } from '@/lib/db/schema'
+import { groupSession, profile, user, course } from '@/lib/db/schema'
 import { countActiveSeats } from '@/lib/group-session/seats'
 import { expireStaleGroupSeats } from '@/lib/group-session/expire-seats'
 
@@ -41,10 +41,12 @@ export const GET = withAuth(async (_req: NextRequest) => {
       tutorName: profile.name,
       tutorUsername: profile.username,
       tutorImage: user.image,
+      courseName: course.name,
     })
     .from(groupSession)
     .leftJoin(profile, eq(profile.userId, groupSession.tutorId))
     .leftJoin(user, eq(user.userId, groupSession.tutorId))
+    .leftJoin(course, eq(course.courseId, groupSession.courseId))
     .where(and(eq(groupSession.status, 'OPEN'), gte(groupSession.requestedDate, startOfTodayUtc)))
     .orderBy(asc(groupSession.requestedDate))
     .limit(100)

--- a/tutorme-app/src/app/api/group-sessions/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/route.ts
@@ -192,7 +192,7 @@ export async function GET(req: NextRequest) {
       )
       .orderBy(desc(groupSession.requestedDate))
     const withSeats = await withSeatsLeft(rows)
-    return NextResponse.json({ sessions: withSeats })
+    return NextResponse.json({ sessions: await attachCourseName(withSeats) })
   }
 
   // Tutor viewing their own sessions.
@@ -204,7 +204,27 @@ export async function GET(req: NextRequest) {
     .from(groupSession)
     .where(eq(groupSession.tutorId, session.user.id))
     .orderBy(desc(groupSession.requestedDate))
-  return NextResponse.json({ sessions: await withSeatsLeft(rows) })
+  return NextResponse.json({ sessions: await attachCourseName(await withSeatsLeft(rows)) })
+}
+
+/** Attach the linked course's name (published state) to each session so the
+ *  cards can show what a session is about. One query for the whole page. */
+async function attachCourseName<T extends { courseId: string | null }>(
+  rows: T[]
+): Promise<(T & { courseName: string | null; coursePublished: boolean | null })[]> {
+  const ids = [...new Set(rows.map(r => r.courseId).filter((x): x is string => !!x))]
+  const byId = new Map<string, { name: string; isPublished: boolean }>()
+  if (ids.length > 0) {
+    const cs = await drizzleDb
+      .select({ courseId: course.courseId, name: course.name, isPublished: course.isPublished })
+      .from(course)
+      .where(inArray(course.courseId, ids))
+    for (const c of cs) byId.set(c.courseId, { name: c.name, isPublished: c.isPublished })
+  }
+  return rows.map(r => {
+    const c = r.courseId ? byId.get(r.courseId) : undefined
+    return { ...r, courseName: c?.name ?? null, coursePublished: c?.isPublished ?? null }
+  })
 }
 
 function todayUtc(): string {

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -368,5 +368,21 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     throw new ValidationError('Invalid role parameter')
   }
 
+  // Attach the linked course's name so the request card can show what the
+  // session is about (one query for the whole list).
+  const courseIds = [...new Set(requests.map(r => r.courseId).filter((x): x is string => !!x))]
+  const nameById = new Map<string, string>()
+  if (courseIds.length > 0) {
+    const cs = await drizzleDb
+      .select({ courseId: course.courseId, name: course.name })
+      .from(course)
+      .where(inArray(course.courseId, courseIds))
+    for (const c of cs) nameById.set(c.courseId, c.name)
+  }
+  requests = requests.map(r => ({
+    ...r,
+    courseName: r.courseId ? (nameById.get(r.courseId) ?? null) : null,
+  }))
+
   return NextResponse.json({ requests })
 })

--- a/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
+++ b/tutorme-app/src/components/one-on-one/one-on-one-request-card.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { Calendar, Clock, CreditCard, Repeat, Timer } from 'lucide-react'
+import { Calendar, Clock, CreditCard, Repeat, Timer, BookOpen } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 export interface OneOnOneParty {
@@ -23,6 +23,7 @@ export interface OneOnOneRequestSummary {
   durationMinutes?: number | null
   currency?: string | null
   studentNotes?: string | null
+  courseName?: string | null
   seriesId?: string | null
   seriesIndex?: number | null
   createdAt?: string | null
@@ -288,6 +289,19 @@ export function OneOnOneRequestCard({
           ) : null}
         </div>
       )}
+
+      {/* the course the student wants this session to be about */}
+      {request.courseName ? (
+        <div
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+            dark ? 'bg-white/10 text-white/80' : 'bg-blue-50 text-blue-700'
+          )}
+        >
+          <BookOpen className="h-3 w-3" />
+          {request.courseName}
+        </div>
+      ) : null}
 
       {/* student's note to the tutor ("why I want this session") */}
       {request.studentNotes?.trim() ? (


### PR DESCRIPTION
## Fills the gap left by Tasks 2/3

Those tasks let a tutor/student **attach** a course to a session, but nothing on the read side **showed** it — so the linkage was invisible after being set. Now it appears wherever a session does:

- **`GET /api/group-sessions`** returns course name + published state → the tutor's group-session cards show a **course chip** (with a `· draft` hint).
- **`GET /api/group-sessions/browse`** joins the course → the **student browse** cards show which course each open session is about.
- **`GET /api/one-on-one/request`** returns each request's course name → the tutor's **1-on-1 request card** shows the course the student picked, so they know what to prepare.

Read-only enrichment (one extra query per list); no schema changes.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors · request-card unit test 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)