### PR TITLE
fix(tutor): stop 500 on /courses/enrolled from invalid 'cancelled' enum literal

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/enrolled/route.ts
@@ -54,9 +54,12 @@ export const GET = withAuth(
       )
       .orderBy(desc(enrollmentCount))
 
-    // Get session counts for each course. `total` counts every non-cancelled
-    // session (so a course whose sessions are all past/ended still shows a real
-    // number rather than 0); `upcoming` counts only the actionable ones.
+    // Get session counts for each course. `total` counts every session (so a
+    // course whose sessions are all past/ended still shows a real number rather
+    // than 0); `upcoming` counts only the actionable ones. There is no
+    // 'cancelled' LiveSessionStatus — cancelling a session sets it to 'ended' —
+    // so the old `status <> 'cancelled'` filter both errored (invalid enum
+    // literal) and excluded nothing; `total` is simply the full count.
     const courseIds = courses.map(c => c.courseId)
     let sessionCounts: { courseId: string; total: number; upcoming: number }[] = []
 
@@ -64,7 +67,7 @@ export const GET = withAuth(
       const sessions = await drizzleDb
         .select({
           courseId: liveSession.courseId,
-          total: sql<number>`count(*) filter (where ${liveSession.status} <> 'cancelled')::int`,
+          total: sql<number>`count(*)::int`,
           upcoming: sql<number>`count(*) filter (where ${liveSession.status} in ('scheduled', 'active', 'live', 'paused'))::int`,
         })
         .from(liveSession)


### PR DESCRIPTION
## Bug
`GET /api/tutor/courses/enrolled` returns **500** — `invalid input value for enum "LiveSessionStatus": "cancelled"`.

The `total` count used `count(*) filter (where status <> 'cancelled')`, but `LiveSessionStatus` has **no `'cancelled'`** value (`scheduled/active/ended/preparing/live/paused`); a cancelled session is set to `'ended'`. Postgres rejects the literal → the whole query (and endpoint) errors. The filter also excluded nothing, since no row is ever `'cancelled'`.

## Fix
`total` → `count(*)::int` (every session, including past/ended — the documented intent). `upcoming` (valid enum values) unchanged.

## Verification (ephemeral Postgres, before/after)
```
OLD `status <> 'cancelled'` → invalid input value for enum "LiveSessionStatus": "cancelled"  (repros the 500)
NEW count(*)                → total=5 (all), upcoming=3 (scheduled/live/paused), no error
```
Typecheck clean; lint 0.

Found incidentally while running the reschedule staging pass (the tutor dashboard was logging this 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)