### PR TITLE
fix(schedule): reschedule proposals can't get stuck when a voter leaves

### DIFF
--- a/tutorme-app/src/app/api/student/courses/[id]/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/courses/[id]/unenroll/route.ts
@@ -19,6 +19,7 @@ import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { courseEnrollment, courseProgress, course, payment, refund } from '@/lib/db/schema'
 import { notify } from '@/lib/notifications/notify'
+import { reconcileProposalsAfterDeparture } from '@/lib/schedule/reschedule-consent'
 import { sumLlmUsageForStudentCourse } from '@/lib/ai/usage'
 
 export const POST = withCsrf(
@@ -91,6 +92,10 @@ export const POST = withCsrf(
           )
         }
       })
+
+      // Re-evaluate any pending reschedule proposals now that this student is
+      // gone, so their unanswered vote can't leave a proposal stuck.
+      await reconcileProposalsAfterDeparture(studentId, courseId)
 
       // 3. Partial refund request for paid courses.
       let refundInfo: { amount: number; currency: string; status: string } | null = null

--- a/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
@@ -8,6 +8,7 @@ import { withAuth, withCsrf, ValidationError, NotFoundError } from '@/lib/api/mi
 import { drizzleDb } from '@/lib/db/drizzle'
 import { course, courseEnrollment } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
+import { reconcileProposalsAfterDeparture } from '@/lib/schedule/reschedule-consent'
 
 export const POST = withCsrf(
   withAuth(
@@ -58,6 +59,9 @@ export const POST = withCsrf(
           )
         }
       })
+
+      // A departed student's unanswered vote must not stall a pending reschedule.
+      await reconcileProposalsAfterDeparture(session.user.id, courseRow.courseId)
 
       return NextResponse.json({
         success: true,

--- a/tutorme-app/src/lib/notifications/reschedule.ts
+++ b/tutorme-app/src/lib/notifications/reschedule.ts
@@ -99,7 +99,7 @@ export async function notifyStudentsOfReschedule(opts: {
 
     const fallbackTz = timezone || 'UTC'
     const name = title || 'Your session'
-    const actionUrl = courseId ? `/student/classroom/${courseId}` : '/student/schedule'
+    const actionUrl = courseId ? `/student/classroom/${courseId}` : '/student/dashboard'
 
     await Promise.allSettled(
       userIds.map(userId => {

--- a/tutorme-app/src/lib/schedule/reschedule-consent.ts
+++ b/tutorme-app/src/lib/schedule/reschedule-consent.ts
@@ -207,7 +207,7 @@ export async function proposeReschedule(opts: {
 export type RespondResult =
   | { status: 'PENDING'; agreed: number; total: number }
   | { status: 'APPLIED' }
-  | { status: 'REJECTED'; reason: 'student_disagreed' | 'slot_unavailable' }
+  | { status: 'REJECTED'; reason: 'student_disagreed' | 'slot_unavailable' | 'session_ended' }
   | { status: 'ERROR'; error: string }
 
 /** A student agrees or disagrees. Applies the move on unanimous agreement;
@@ -250,17 +250,49 @@ export async function respondToProposal(opts: {
     return { status: 'REJECTED', reason: 'student_disagreed' }
   }
 
-  // AGREE — apply only when every vote is now AGREE.
-  const votes = await drizzleDb
-    .select({ response: sessionRescheduleVote.response })
-    .from(sessionRescheduleVote)
-    .where(eq(sessionRescheduleVote.proposalId, proposalId))
-  const agreed = votes.filter(v => v.response === 'AGREE').length
-  if (agreed < votes.length) {
-    return { status: 'PENDING', agreed, total: votes.length }
+  // AGREE recorded — re-evaluate against the CURRENT roster.
+  return evaluatePendingProposal(proposal)
+}
+
+/**
+ * Decide a PENDING proposal against the CURRENT roster and apply it when every
+ * still-enrolled voter has agreed. Votes from students who have since left
+ * (unenrolled / seat cancelled) are ignored — otherwise a departed student's
+ * unanswered vote would block unanimous agreement forever. Also closes the
+ * proposal if its session has ended/been removed.
+ */
+async function evaluatePendingProposal(proposal: Proposal): Promise<RespondResult> {
+  // Session gone or ended → the proposal is moot; close it.
+  const [sess] = await drizzleDb
+    .select({ status: liveSession.status })
+    .from(liveSession)
+    .where(eq(liveSession.sessionId, proposal.sessionId))
+    .limit(1)
+  if (!sess || sess.status === 'ended') {
+    await resolveProposal(proposal.proposalId, 'CANCELLED', 'session_ended')
+    return { status: 'REJECTED', reason: 'session_ended' }
   }
 
-  // Everyone agreed — re-check the slot is still free, then move the session.
+  const [votes, roster] = await Promise.all([
+    drizzleDb
+      .select({
+        studentId: sessionRescheduleVote.studentId,
+        response: sessionRescheduleVote.response,
+      })
+      .from(sessionRescheduleVote)
+      .where(eq(sessionRescheduleVote.proposalId, proposal.proposalId)),
+    resolveVoterRoster(proposal.sessionId, proposal.courseId),
+  ])
+  const rosterSet = new Set(roster)
+  // Only votes from students still on the roster count toward the decision.
+  const relevant = votes.filter(v => rosterSet.has(v.studentId))
+  const agreed = relevant.filter(v => v.response === 'AGREE').length
+  // Still someone left to hear from (or nobody valid remains) → stay pending.
+  if (relevant.length === 0 || agreed < relevant.length) {
+    return { status: 'PENDING', agreed, total: relevant.length }
+  }
+
+  // Everyone still enrolled agreed — re-check the slot is free, then move.
   const conflicts = await findConflicts(
     proposal.proposedBy,
     proposal.proposedStart,
@@ -281,6 +313,42 @@ export async function respondToProposal(opts: {
   await resolveProposal(proposal.proposalId, 'APPLIED', 'all_agreed')
   await notifyOutcome(proposal, 'applied')
   return { status: 'APPLIED' }
+}
+
+/**
+ * After a student leaves a course, drop their pending votes and re-evaluate any
+ * affected proposals — so their departure can't leave a proposal stuck one vote
+ * short of unanimous. Best-effort; never throws into the caller.
+ */
+export async function reconcileProposalsAfterDeparture(
+  studentId: string,
+  courseId: string
+): Promise<void> {
+  try {
+    const familyIds = await expandToCourseFamily([courseId])
+    const proposals = await drizzleDb
+      .select()
+      .from(sessionRescheduleProposal)
+      .where(
+        and(
+          eq(sessionRescheduleProposal.status, 'PENDING'),
+          inArray(sessionRescheduleProposal.courseId, familyIds)
+        )
+      )
+    for (const proposal of proposals) {
+      await drizzleDb
+        .delete(sessionRescheduleVote)
+        .where(
+          and(
+            eq(sessionRescheduleVote.proposalId, proposal.proposalId),
+            eq(sessionRescheduleVote.studentId, studentId)
+          )
+        )
+      await evaluatePendingProposal(proposal)
+    }
+  } catch (err) {
+    console.warn('[reschedule] departure reconcile failed (non-critical):', err)
+  }
 }
 
 /** Tutor withdraws a pending proposal; the session keeps its current time. */


### PR DESCRIPTION
Hardening for the consent gate, from auditing the feature after shipping it.

## Gaps closed
- **Stuck proposal (HIGH):** `respondToProposal` counted *all* vote rows, so a student who **unenrolled without voting** left a `PENDING` vote that blocked unanimous agreement **forever** — the reschedule could never apply. Now the decision reconciles against the **current roster** (votes from departed students are ignored) via a shared `evaluatePendingProposal`.
- **Silent departure:** new `reconcileProposalsAfterDeparture()`, hooked into **both** unenroll routes — drops the leaver's votes and re-evaluates, so "everyone remaining already agreed, then the last non-voter leaves" **applies** instead of hanging.
- **Ended session:** a proposal whose session is `ended`/removed is now **closed** (`CANCELLED / session_ended`) rather than moving a dead session.
- **Dead link (LOW):** course-less reschedule notification pointed at `/student/schedule` (doesn't exist) → `/student/dashboard`.

## Verification (ephemeral Postgres, 10 assertions / 4 scenarios)
```
1 departed non-voter's stale vote ignored → applies on next agree  ✔
2 all remaining agreed, last non-voter unenrolls → reconcile applies ✔
3 session ended while pending → proposal CANCELLED, no move          ✔
4 regression: normal unanimous still applies                        ✔
```
Typecheck clean; lint 0.

## Audit notes (not in this PR)
- **Calendar-sync** (`tutor/calendar/sync`) updates `calendarEvent` times but **not** `liveSession.scheduledAt`, so it's **not** an active gate bypass today — flagged as a watch-item if that linkage is ever added.
- A lingering `PENDING` proposal for an ended session is now closed on next interaction; a read-side filter to hide it passively is a minor follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)