### PR TITLE
feat(booking): students book 24/7 by default; parents block specific slots

### DIFF
--- a/tutorme-app/src/app/[locale]/parent/students/[studentId]/availability/AvailabilityEditor.tsx
+++ b/tutorme-app/src/app/[locale]/parent/students/[studentId]/availability/AvailabilityEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Loader2, Check } from 'lucide-react'
+import { Loader2, Ban } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 
@@ -33,21 +33,24 @@ interface AvailabilityEditorProps {
 }
 
 /**
- * Parent-facing weekly availability editor for a child. Persists to
- * /api/parent/students/[studentId]/availability, which writes to the same
- * StudentAvailability table (keyed by the child's studentId) that the rest of
- * the app reads, so tutor scheduling and calendars stay consistent.
+ * Parent-facing weekly availability editor for a child.
+ *
+ * Model: the child can book 24/7 by DEFAULT. The parent taps hours to BLOCK
+ * them; a blocked hour writes an isAvailable=false row to StudentAvailability
+ * (via /api/parent/students/[studentId]/availability), which the booking backend
+ * treats as off-limits. Tapping a blocked hour again re-opens it.
  */
 export function AvailabilityEditor({ studentId, studentName }: AvailabilityEditorProps) {
   const [loading, setLoading] = useState(true)
   const [savingKey, setSavingKey] = useState<string | null>(null)
-  const [available, setAvailable] = useState<Set<string>>(new Set())
+  // Hours the parent has BLOCKED (everything else is bookable by default).
+  const [blocked, setBlocked] = useState<Set<string>>(new Set())
   const [selectedDay, setSelectedDay] = useState<number>(() => new Date().getDay())
 
   const timezone = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC', [])
   const endpoint = `/api/parent/students/${studentId}/availability`
 
-  // Load the child's saved availability
+  // Load the child's saved blocks (rows explicitly marked unavailable).
   useEffect(() => {
     let cancelled = false
     setLoading(true)
@@ -57,9 +60,9 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
         if (cancelled) return
         const set = new Set<string>()
         for (const a of data?.availability ?? []) {
-          if (a.isAvailable) set.add(`${a.dayOfWeek}-${a.startTime}`)
+          if (a.isAvailable === false) set.add(`${a.dayOfWeek}-${a.startTime}`)
         }
-        setAvailable(set)
+        setBlocked(set)
       })
       .catch(() => {
         if (!cancelled) toast.error("Could not load this student's availability")
@@ -77,13 +80,13 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
       const key = slotKey(day, hour)
       const startTime = `${pad(hour)}:00`
       const endTime = `${pad(hour + 1)}:00`
-      const currentlyAvailable = available.has(key)
-      const next = !currentlyAvailable
+      const currentlyBlocked = blocked.has(key)
+      const willBlock = !currentlyBlocked
 
       // Optimistic
-      setAvailable(prev => {
+      setBlocked(prev => {
         const s = new Set(prev)
-        if (next) s.add(key)
+        if (willBlock) s.add(key)
         else s.delete(key)
         return s
       })
@@ -104,15 +107,16 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
             startTime,
             endTime,
             timezone,
-            isAvailable: next,
+            // Blocking a slot marks it unavailable; re-opening marks it available.
+            isAvailable: !willBlock,
           }),
         })
         if (!res.ok) throw new Error('save failed')
       } catch {
         // Revert on failure
-        setAvailable(prev => {
+        setBlocked(prev => {
           const s = new Set(prev)
-          if (currentlyAvailable) s.add(key)
+          if (currentlyBlocked) s.add(key)
           else s.delete(key)
           return s
         })
@@ -121,11 +125,11 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
         setSavingKey(null)
       }
     },
-    [available, timezone, endpoint]
+    [blocked, timezone, endpoint]
   )
 
   const dayLong = DAYS.find(d => d.idx === selectedDay)?.long ?? ''
-  const availableCount = available.size
+  const blockedCount = blocked.size
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-1">
@@ -135,11 +139,12 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
             {studentName ? `${studentName}'s Availability` : 'Availability'}
           </h3>
           <p className="text-xs text-gray-500">
-            Tap the hours your child is free. Tutors use this when scheduling 1-on-1s.
+            Your child can book any time by default. Tap an hour to block it — tutors won&apos;t be
+            able to schedule 1-on-1s then.
           </p>
         </div>
-        <span className="rounded-full bg-orange-100 px-2.5 py-1 text-xs font-medium text-orange-700">
-          {availableCount} slot{availableCount === 1 ? '' : 's'} marked free
+        <span className="rounded-full bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700">
+          {blockedCount} hour{blockedCount === 1 ? '' : 's'} blocked
         </span>
       </div>
 
@@ -173,7 +178,7 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
           <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
             {HOURS.map(h => {
               const key = slotKey(selectedDay, h)
-              const isFree = available.has(key)
+              const isBlocked = blocked.has(key)
               const isSaving = savingKey === key
               return (
                 <button
@@ -181,17 +186,18 @@ export function AvailabilityEditor({ studentId, studentName }: AvailabilityEdito
                   type="button"
                   disabled={isSaving}
                   onClick={() => void toggleSlot(selectedDay, h)}
+                  title={isBlocked ? 'Blocked — tap to allow' : 'Allowed — tap to block'}
                   className={cn(
                     'flex items-center justify-center gap-1 rounded-lg border px-2 py-2 text-xs font-medium transition-colors disabled:opacity-60',
-                    isFree
-                      ? 'border-emerald-300 bg-emerald-50 text-emerald-700'
-                      : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50'
+                    isBlocked
+                      ? 'border-red-300 bg-red-50 text-red-700'
+                      : 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
                   )}
                 >
                   {isSaving ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : isFree ? (
-                    <Check className="h-3 w-3" />
+                  ) : isBlocked ? (
+                    <Ban className="h-3 w-3" />
                   ) : null}
                   {hourLabel(h)}
                 </button>

--- a/tutorme-app/src/app/api/one-on-one/request/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/request/route.ts
@@ -20,10 +20,7 @@ import { findConflicts } from '@/lib/schedule/conflicts'
 import { expireOverdueOneOnOneBookings } from '@/lib/one-on-one/expire'
 import { completeFinishedOneOnOneSessions } from '@/lib/one-on-one/complete'
 import { unpaidSeriesTotal } from '@/lib/one-on-one/series-total'
-import {
-  isSlotWithinStudentAvailability,
-  studentHasAvailabilityConfigured,
-} from '@/lib/student-availability'
+import { isSlotWithinStudentAvailability } from '@/lib/student-availability'
 
 const requestSchema = z.object({
   tutorId: z.string().min(1),
@@ -105,23 +102,17 @@ export const POST = withCsrf(
       )
     }
 
-    // A student with no availability configured can't book — otherwise the
-    // per-slot check below is skipped and a tutor could be booked out of hours.
-    if (!(await studentHasAvailabilityConfigured(session.user.id))) {
-      throw new ValidationError(
-        'Set your availability before requesting a 1-on-1 — ask your parent to add your available hours.'
-      )
-    }
-
+    // Students can book any time by default (24/7). Only slots a parent has
+    // explicitly blocked are off-limits — enforced per-slot below.
     const tutorTimezone = tutorProfile.timezone || 'UTC'
     const tutorBuffer = tutorProfile.bufferMinutes ?? 0
     const isSeriesRequest = validated.proposedSlots.length > 1
 
-    // Every proposed time must (a) fall within the student's availability (managed
-    // by their parent) and (b) not clash with the tutor's already-confirmed
-    // schedule. The tutor-conflict check uses the SAME detector the tutor's accept
-    // runs, so a time that passes here won't be un-acceptable later — a student
-    // can no longer propose a slot (or a series week) the tutor can never accept.
+    // Every proposed time must (a) not fall on an hour the parent has BLOCKED and
+    // (b) not clash with the tutor's already-confirmed schedule. The tutor-conflict
+    // check uses the SAME detector the tutor's accept runs, so a time that passes
+    // here won't be un-acceptable later — a student can no longer propose a slot
+    // (or a series week) the tutor can never accept.
     for (const slot of validated.proposedSlots) {
       const withinAvailability = await isSlotWithinStudentAvailability(
         session.user.id,
@@ -131,7 +122,7 @@ export const POST = withCsrf(
       )
       if (!withinAvailability) {
         throw new ValidationError(
-          'One or more of your proposed times are outside your available hours. Ask your parent to update your availability, or choose a different time.'
+          'One or more of your proposed times have been blocked by your parent. Please choose a different time, or ask them to allow it.'
         )
       }
 

--- a/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/reschedule/route.ts
@@ -15,10 +15,7 @@ import { z } from 'zod'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { oneOnOneBookingRequest, calendarEvent, liveSession, profile } from '@/lib/db/schema'
 import { findConflicts } from '@/lib/schedule/conflicts'
-import {
-  isSlotWithinStudentAvailability,
-  studentHasAvailabilityConfigured,
-} from '@/lib/student-availability'
+import { isSlotWithinStudentAvailability } from '@/lib/student-availability'
 import { notify } from '@/lib/notifications/notify'
 import { slotInstants, requestedDateFromString } from '@/lib/one-on-one/time'
 
@@ -85,11 +82,8 @@ async function validateSlot(
   startTime: string,
   endTime: string
 ): Promise<string | null> {
-  if (!(await studentHasAvailabilityConfigured(booking.studentId))) {
-    return 'The student has no availability set — they must add their available hours first.'
-  }
   if (!(await isSlotWithinStudentAvailability(booking.studentId, date, startTime, endTime))) {
-    return "That time is outside the student's available hours."
+    return "That time has been blocked by the student's parent — pick another, or ask them to allow it."
   }
   if (endTime <= startTime) return 'The end time must be after the start time.'
   // Resolve the proposed wall-clock slot in the booking's own timezone.

--- a/tutorme-app/src/app/api/one-on-one/respond/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/respond/route.ts
@@ -8,10 +8,7 @@ import { createSession } from '@/lib/sessions/create-session'
 import { notify } from '@/lib/notifications/notify'
 import { z } from 'zod'
 import { findConflicts, findAlternativeSlots } from '@/lib/schedule/conflicts'
-import {
-  isSlotWithinStudentAvailability,
-  studentHasAvailabilityConfigured,
-} from '@/lib/student-availability'
+import { isSlotWithinStudentAvailability } from '@/lib/student-availability'
 import { slotInstants } from '@/lib/one-on-one/time'
 import { CORE_BOOKING_COLUMNS, CORE_BOOKING_RETURNING } from '@/lib/one-on-one/columns'
 import { getOrCreateConversation } from '@/lib/messaging/conversation'
@@ -82,18 +79,8 @@ export async function PATCH(request: NextRequest) {
       : [existingRequest]
 
     if (validated.action === 'accept') {
-      // The student must have availability configured — otherwise the slot checks
-      // below are skipped and the tutor could accept an out-of-hours time.
-      if (!(await studentHasAvailabilityConfigured(existingRequest.studentId))) {
-        return NextResponse.json(
-          {
-            error:
-              'This student has no availability set. Ask them (or their parent) to add their available hours before accepting.',
-          },
-          { status: 400 }
-        )
-      }
-
+      // Students are bookable 24/7 by default; only parent-blocked hours are
+      // rejected, per-slot below.
       const [tutorProfileRow] = await drizzleDb
         .select({ bufferMinutes: profile.bufferMinutes, oneOnOneFree: profile.oneOnOneFree })
         .from(profile)
@@ -126,7 +113,7 @@ export async function PATCH(request: NextRequest) {
           const which = isSeries ? ` for the ${slotDate} session` : ''
           return NextResponse.json(
             {
-              error: `That time${which} is outside the student's available hours. Ask the student's parent to update their availability, or accept a different slot.`,
+              error: `That time${which} has been blocked by the student's parent. Ask them to allow it, or accept a different slot.`,
             },
             { status: 400 }
           )

--- a/tutorme-app/src/app/api/parent/students/[studentId]/availability/route.ts
+++ b/tutorme-app/src/app/api/parent/students/[studentId]/availability/route.ts
@@ -22,7 +22,6 @@ import { getParamAsync } from '@/lib/api/params'
 import { getFamilyAccountForParent } from '@/lib/api/parent-helpers'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { studentAvailability, studentAvailabilityException } from '@/lib/db/schema'
-import { defaultStudentAvailabilitySlots } from '@/lib/student-availability-defaults'
 
 export const dynamic = 'force-dynamic'
 
@@ -56,43 +55,13 @@ export const GET = withAuth(
     if ('error' in resolved) return resolved.error
     const { studentId } = resolved
 
-    let availability = await drizzleDb
+    // Students are free to book 24/7 by DEFAULT — we no longer seed a restrictive
+    // baseline. An empty result means "nothing blocked"; the parent blocks
+    // specific hours by tapping them (which writes an isAvailable=false row).
+    const availability = await drizzleDb
       .select()
       .from(studentAvailability)
       .where(eq(studentAvailability.studentId, studentId))
-
-    // First time: seed the default (8am–9pm free, every day) so the parent
-    // starts from a sensible baseline. Idempotent.
-    if (availability.length === 0) {
-      const now = new Date()
-      await drizzleDb
-        .insert(studentAvailability)
-        .values(
-          defaultStudentAvailabilitySlots().map(s => ({
-            availabilityId: crypto.randomUUID(),
-            studentId,
-            dayOfWeek: s.dayOfWeek,
-            startTime: s.startTime,
-            endTime: s.endTime,
-            timezone: 'UTC',
-            isAvailable: true,
-            createdAt: now,
-            updatedAt: now,
-          }))
-        )
-        .onConflictDoNothing({
-          target: [
-            studentAvailability.studentId,
-            studentAvailability.dayOfWeek,
-            studentAvailability.startTime,
-            studentAvailability.endTime,
-          ],
-        })
-      availability = await drizzleDb
-        .select()
-        .from(studentAvailability)
-        .where(eq(studentAvailability.studentId, studentId))
-    }
 
     const exceptions = await drizzleDb
       .select()

--- a/tutorme-app/src/lib/student-availability.test.ts
+++ b/tutorme-app/src/lib/student-availability.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { slotOverlapsBlockedHours } from './student-availability'
+
+// 2026-06-15 is a Monday → getUTCDay() === 1.
+const MON = '2026-06-15'
+
+describe('slotOverlapsBlockedHours — free 24/7 by default', () => {
+  it('is bookable when nothing is blocked', () => {
+    expect(slotOverlapsBlockedHours(new Set(), MON, '14:00', '15:00')).toBe(false)
+    // even at 3am
+    expect(slotOverlapsBlockedHours(new Set(), MON, '03:00', '04:00')).toBe(false)
+  })
+})
+
+describe('slotOverlapsBlockedHours — parent-blocked hours', () => {
+  const blocked = new Set(['1-14:00', '1-15:00']) // Mon 2–4pm blocked
+
+  it('blocks a slot that overlaps a blocked hour', () => {
+    expect(slotOverlapsBlockedHours(blocked, MON, '14:00', '15:00')).toBe(true)
+    expect(slotOverlapsBlockedHours(blocked, MON, '14:30', '15:30')).toBe(true) // partial overlap
+    expect(slotOverlapsBlockedHours(blocked, MON, '13:30', '14:30')).toBe(true) // spills into 14:00
+  })
+
+  it('allows a slot outside the blocked hours', () => {
+    expect(slotOverlapsBlockedHours(blocked, MON, '10:00', '11:00')).toBe(false)
+    expect(slotOverlapsBlockedHours(blocked, MON, '16:00', '17:00')).toBe(false)
+    expect(slotOverlapsBlockedHours(blocked, MON, '13:00', '14:00')).toBe(false) // ends exactly at 14:00
+  })
+
+  it('only blocks on the matching day of week', () => {
+    const TUE = '2026-06-16' // Tuesday → day 2
+    expect(slotOverlapsBlockedHours(blocked, TUE, '14:00', '15:00')).toBe(false)
+  })
+})
+
+describe('slotOverlapsBlockedHours — invalid ranges are treated as unbookable', () => {
+  it('rejects an end <= start', () => {
+    expect(slotOverlapsBlockedHours(new Set(), MON, '15:00', '15:00')).toBe(true)
+    expect(slotOverlapsBlockedHours(new Set(), MON, '16:00', '15:00')).toBe(true)
+  })
+  it('rejects an unparseable time', () => {
+    expect(slotOverlapsBlockedHours(new Set(), MON, 'oops', '15:00')).toBe(true)
+  })
+})

--- a/tutorme-app/src/lib/student-availability.ts
+++ b/tutorme-app/src/lib/student-availability.ts
@@ -1,7 +1,12 @@
 /**
  * Read helpers for a student's weekly availability (StudentAvailability),
- * which is managed by the student's parent. Used by the booking backend so a
- * 1-on-1 can only be scheduled within the hours the parent marked free.
+ * which is managed by the student's parent.
+ *
+ * Model: a student is free to book 24/7 BY DEFAULT. A parent can BLOCK specific
+ * weekly hours (rows with `isAvailable = false`); only those hours are off-limits
+ * and require the parent to re-open them. Hours with no row — or a row marked
+ * available — are bookable. So the booking backend enforces a blacklist, not a
+ * whitelist.
  */
 
 import { eq } from 'drizzle-orm'
@@ -11,12 +16,10 @@ import { studentAvailability } from '@/lib/db/schema'
 const pad = (n: number) => String(n).padStart(2, '0')
 
 /**
- * The set of free hour keys ("<dayOfWeek>-HH:00", e.g. "1-14:00") a student is
- * marked available for. Returns `null` when the student has NO availability
- * configured at all, so callers can choose not to enforce (rather than block a
- * student whose parent hasn't set any availability yet).
+ * The set of hour keys ("<dayOfWeek>-HH:00", e.g. "1-14:00") a parent has
+ * explicitly BLOCKED for a student. Empty when nothing is blocked (the default).
  */
-export async function getStudentFreeHourSet(studentId: string): Promise<Set<string> | null> {
+export async function getStudentBlockedHourSet(studentId: string): Promise<Set<string>> {
   const rows = await drizzleDb
     .select({
       dayOfWeek: studentAvailability.dayOfWeek,
@@ -26,53 +29,50 @@ export async function getStudentFreeHourSet(studentId: string): Promise<Set<stri
     .from(studentAvailability)
     .where(eq(studentAvailability.studentId, studentId))
 
-  if (rows.length === 0) return null
-
-  const free = new Set<string>()
+  const blocked = new Set<string>()
   for (const r of rows) {
-    if (r.isAvailable) free.add(`${r.dayOfWeek}-${r.startTime}`)
+    if (r.isAvailable === false) blocked.add(`${r.dayOfWeek}-${r.startTime}`)
   }
-  return free
+  return blocked
 }
 
 /**
- * Whether a proposed session time falls within the student's available hours.
- *  - date: "YYYY-MM-DD"
+ * Pure check: does [startTime, endTime) on `date` overlap any parent-blocked
+ * hour? Returns true (unbookable) for a blocked overlap OR an invalid range.
+ *  - date: "YYYY-MM-DD" (weekday parsed as UTC so it doesn't shift with the
+ *    server timezone)
  *  - startTime / endTime: "HH:mm"
- *
- * Returns true when the student has no availability configured (not enforced),
- * or when every clock hour the session overlaps is marked free; false otherwise.
  */
-/**
- * Whether the student has ANY availability configured at all. Used to enforce
- * that a 1-on-1 can't be requested/accepted for a student whose availability is
- * unset (which would otherwise skip the slot check entirely).
- */
-export async function studentHasAvailabilityConfigured(studentId: string): Promise<boolean> {
-  return (await getStudentFreeHourSet(studentId)) !== null
+export function slotOverlapsBlockedHours(
+  blocked: ReadonlySet<string>,
+  date: string,
+  startTime: string,
+  endTime: string
+): boolean {
+  const [sh, sm] = startTime.split(':').map(Number)
+  const [eh, em] = endTime.split(':').map(Number)
+  const startMin = sh * 60 + (sm || 0)
+  const endMin = eh * 60 + (em || 0)
+  if (!Number.isFinite(startMin) || !Number.isFinite(endMin) || endMin <= startMin) return true
+  if (blocked.size === 0) return false
+
+  const day = new Date(`${date}T00:00:00.000Z`).getUTCDay()
+  for (let h = Math.floor(startMin / 60); h * 60 < endMin; h++) {
+    if (blocked.has(`${day}-${pad(h)}:00`)) return true
+  }
+  return false
 }
 
+/**
+ * Whether a proposed session time is bookable for the student — i.e. it does NOT
+ * fall on an hour the parent has blocked. Free by default (nothing blocked).
+ */
 export async function isSlotWithinStudentAvailability(
   studentId: string,
   date: string,
   startTime: string,
   endTime: string
 ): Promise<boolean> {
-  const free = await getStudentFreeHourSet(studentId)
-  if (free === null) return true // no availability configured → don't block
-
-  // Day-of-week of the calendar date itself — parse as UTC so it doesn't shift
-  // with the server's timezone (a plain YYYY-MM-DD has a fixed weekday).
-  const day = new Date(`${date}T00:00:00.000Z`).getUTCDay()
-  const [sh, sm] = startTime.split(':').map(Number)
-  const [eh, em] = endTime.split(':').map(Number)
-  const startMin = sh * 60 + (sm || 0)
-  const endMin = eh * 60 + (em || 0)
-  if (!Number.isFinite(startMin) || !Number.isFinite(endMin) || endMin <= startMin) return false
-
-  // Every clock hour the session overlaps must be marked free.
-  for (let h = Math.floor(startMin / 60); h * 60 < endMin; h++) {
-    if (!free.has(`${day}-${pad(h)}:00`)) return false
-  }
-  return true
+  const blocked = await getStudentBlockedHourSet(studentId)
+  return !slotOverlapsBlockedHours(blocked, date, startTime, endTime)
 }


### PR DESCRIPTION
**Request #3:** let students book 1-on-1 (and group) sessions freely; only require parental permission when a parent has turned OFF that time slot; default to 24/7 availability.

## Before
- A 1-on-1 was **blocked entirely** until a parent configured availability — "Set your availability before requesting a 1-on-1 — ask your parent to add your available hours." (`request`, `respond`, `reschedule`).
- The model was a **whitelist**: only the parent's marked-available hours were bookable; a first-time parent view **seeded a restrictive 8am–9pm** default.
- (Group-session join already had no availability gate.)

## After — blacklist / default-allow
- **`student-availability.ts`**: `getStudentBlockedHourSet` (rows with `isAvailable=false`) + a **pure, tested** `slotOverlapsBlockedHours`. A slot is bookable **unless** it overlaps a parent-blocked hour. Removed `studentHasAvailabilityConfigured` / `getStudentFreeHourSet`.
- **1-on-1 request/respond/reschedule**: removed the "must have availability configured" gate; the per-slot message now reads "…has been blocked by your parent. Please choose another time, or ask them to allow it."
- **Parent availability GET**: no longer seeds 8am–9pm — an empty config means **nothing blocked (24/7)**.
- **Parent `AvailabilityEditor`**: inverted the grid to **"available by default, tap to block"** — blocked hours show red with a `Ban` icon; a tap POSTs `isAvailable=false` (the block). Copy updated ("Your child can book any time by default. Tap an hour to block it.").

## Edge cases
- **Students with no parent**: no rows → nothing blocked → bookable 24/7 (no change needed).
- **Existing seeded students** (old 8am–9pm rows, all `isAvailable=true`): those are *available* rows, so nothing is blocked → they too become 24/7-bookable, matching the new default. Parents re-restrict by tapping hours to block.

## Verification
`vitest` 6/6 on the slot logic. `tsc --noEmit` clean (0 errors). Prettier clean. Net −53 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)