### PR TITLE
feat(forms): highlight empty required fields inline in red (wave 1)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateCourseDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateCourseDialog.tsx
@@ -32,6 +32,7 @@ export function CreateCourseDialog({
   const [creating, setCreating] = useState(false)
   const [courseName, setCourseName] = useState('')
   const [apiError, setApiError] = useState<string | null>(null)
+  const [nameError, setNameError] = useState<string | null>(null)
 
   const charCount = courseName.length
   const isAtLimit = charCount >= MAX_LENGTH
@@ -40,9 +41,11 @@ export function CreateCourseDialog({
   const handleSubmit = async () => {
     const trimmed = courseName.trim()
     if (!trimmed) {
-      toast.error('Please enter a course name')
+      // Highlight the empty field inline (red) instead of only warning.
+      setNameError('Please enter a course name')
       return
     }
+    setNameError(null)
 
     setCreating(true)
     setApiError(null)
@@ -84,6 +87,7 @@ export function CreateCourseDialog({
     if (!next) {
       setApiError(null)
       setCourseName('')
+      setNameError(null)
     }
     onOpenChange(next)
   }
@@ -118,12 +122,18 @@ export function CreateCourseDialog({
                 if (value.length <= MAX_LENGTH) {
                   setCourseName(value)
                   if (apiError) setApiError(null)
+                  if (nameError) setNameError(null)
                 }
               }}
               placeholder="Course name"
               disabled={creating}
               maxLength={MAX_LENGTH}
-              className="h-12 w-full rounded-lg border border-gray-300 bg-white px-4 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+              aria-invalid={!!nameError}
+              className={`h-12 w-full rounded-lg border bg-white px-4 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 ${
+                nameError
+                  ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
+                  : 'border-gray-300 focus:border-blue-500 focus:ring-blue-500/20'
+              }`}
               onKeyDown={e => {
                 if (e.key === 'Enter' && courseName.trim() && !creating) {
                   e.preventDefault()
@@ -131,6 +141,11 @@ export function CreateCourseDialog({
                 }
               }}
             />
+            {nameError && (
+              <p className="text-xs font-medium text-red-600" role="alert">
+                {nameError}
+              </p>
+            )}
             <div className="flex justify-end">
               <span
                 className={`text-xs font-medium ${

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateSessionForm.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateSessionForm.tsx
@@ -60,6 +60,11 @@ export const CreateSessionForm = React.forwardRef<CreateSessionFormRef, CreateSe
       isSubmitting: () => creating,
     }))
     const [apiError, setApiError] = useState<string | null>(null)
+    const [fieldErrors, setFieldErrors] = useState<{
+      title?: string
+      date?: string
+      time?: string
+    }>({})
     const timeOptions = useTimeOptions()
 
     const [form, setForm] = useState({
@@ -96,18 +101,17 @@ export const CreateSessionForm = React.forwardRef<CreateSessionFormRef, CreateSe
     }, [open, initialDate])
 
     const handleSubmit = async () => {
-      if (!form.title.trim()) {
-        toast.error('Please enter a session title')
+      // Highlight every empty required field at once (red + inline) so the tutor
+      // can find them, instead of a one-at-a-time toast.
+      const errs: { title?: string; date?: string; time?: string } = {}
+      if (!form.title.trim()) errs.title = 'Please enter a session title'
+      if (!form.date) errs.date = 'Please select a date'
+      if (!form.time) errs.time = 'Please select a time'
+      if (Object.keys(errs).length > 0) {
+        setFieldErrors(errs)
         return
       }
-      if (!form.date) {
-        toast.error('Please select a date')
-        return
-      }
-      if (!form.time) {
-        toast.error('Please select a time')
-        return
-      }
+      setFieldErrors({})
 
       setCreating(true)
       setApiError(null)
@@ -183,10 +187,13 @@ export const CreateSessionForm = React.forwardRef<CreateSessionFormRef, CreateSe
             <Label className="text-gray-900">Class Title *</Label>
             <Input
               value={form.title}
-              onChange={e => setForm({ ...form, title: e.target.value })}
+              onChange={e => {
+                setForm({ ...form, title: e.target.value })
+                if (fieldErrors.title) setFieldErrors(prev => ({ ...prev, title: undefined }))
+              }}
               placeholder="e.g., AP Calculus - Limits"
               disabled={creating}
-              aria-invalid={!!apiError}
+              errorMessage={fieldErrors.title}
             />
           </div>
 
@@ -206,18 +213,28 @@ export const CreateSessionForm = React.forwardRef<CreateSessionFormRef, CreateSe
               <Input
                 type="date"
                 value={form.date}
-                onChange={e => setForm({ ...form, date: e.target.value })}
+                onChange={e => {
+                  setForm({ ...form, date: e.target.value })
+                  if (fieldErrors.date) setFieldErrors(prev => ({ ...prev, date: undefined }))
+                }}
                 disabled={creating}
+                errorMessage={fieldErrors.date}
               />
             </div>
             <div>
               <Label className="text-gray-900">Time *</Label>
               <Select
                 value={form.time}
-                onValueChange={v => setForm({ ...form, time: v })}
+                onValueChange={v => {
+                  setForm({ ...form, time: v })
+                  if (fieldErrors.time) setFieldErrors(prev => ({ ...prev, time: undefined }))
+                }}
                 disabled={creating}
               >
-                <SelectTrigger>
+                <SelectTrigger
+                  aria-invalid={!!fieldErrors.time}
+                  className={fieldErrors.time ? 'border-destructive' : undefined}
+                >
                   <SelectValue placeholder="Select time" />
                 </SelectTrigger>
                 <SelectContent>
@@ -228,6 +245,11 @@ export const CreateSessionForm = React.forwardRef<CreateSessionFormRef, CreateSe
                   ))}
                 </SelectContent>
               </Select>
+              {fieldErrors.time && (
+                <p className="text-destructive mt-1 text-xs" role="alert">
+                  {fieldErrors.time}
+                </p>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
**Request #1:** "throughout the platform, if a user fails to fill out a space, don't just warn — highlight those areas red so they can easily find them."

This is a **platform-wide initiative (~39 forms)**, so this PR is **wave 1**: it establishes the reusable pattern and converts two high-traffic, self-contained forms as the reference. Follow-up waves convert the rest.

## The pattern
Per field: hold an error state, set it on submit (**highlighting every empty field at once**, not one toast at a time), render it in red, and clear it on change.
- Fields using the shared **`Input`** just pass `errorMessage={err}` — it already renders a red border + red message.
- Custom-styled inputs / **`Select`** get a conditional `border-destructive` (red) + a red `<p>` message + `aria-invalid`.

## Converted in this wave
- **`CreateCourseDialog`** — the name field turns red inline (was a toast); clears as you type; resets on close.
- **`CreateSessionForm`** — validates title, date, and time together; each turns red inline (title/date via `Input.errorMessage`, time via a red `Select` trigger + message).

## Verification
`tsc --noEmit` clean (0 errors). Prettier clean. Lint warnings present are all pre-existing.

## Rollout (remaining, for follow-up waves)
Highest-traffic next: **student / tutor / parent signup**, **login**, **1-on-1 booking dialog**, then the long tail (quiz/resource/settings/onboarding/etc. — ~35 forms). The shared `Textarea`/`Select` could also gain first-class `errorMessage` support to make conversions terser. I'll continue these in waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)