### PR TITLE
polish(schedule): hide ended-session proposals + reconcile on group-seat expiry

### DIFF
--- a/tutorme-app/src/app/api/student/reschedule-proposals/route.ts
+++ b/tutorme-app/src/app/api/student/reschedule-proposals/route.ts
@@ -16,7 +16,7 @@ import {
   liveSession,
   profile,
 } from '@/lib/db/schema'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, ne } from 'drizzle-orm'
 
 export const GET = withAuth(async (_req, session) => {
   const studentId = session.user.id
@@ -42,7 +42,9 @@ export const GET = withAuth(async (_req, session) => {
     .where(
       and(
         eq(sessionRescheduleVote.studentId, studentId),
-        eq(sessionRescheduleProposal.status, 'PENDING')
+        eq(sessionRescheduleProposal.status, 'PENDING'),
+        // Hide proposals for a session that has since ended (it's moot).
+        ne(liveSession.status, 'ended')
       )
     )
 

--- a/tutorme-app/src/app/api/tutor/reschedule-proposals/route.ts
+++ b/tutorme-app/src/app/api/tutor/reschedule-proposals/route.ts
@@ -10,7 +10,7 @@ import { NextResponse } from 'next/server'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { sessionRescheduleProposal, sessionRescheduleVote, liveSession } from '@/lib/db/schema'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, ne } from 'drizzle-orm'
 
 export const GET = withAuth(
   async (_req, session) => {
@@ -29,7 +29,9 @@ export const GET = withAuth(
       .where(
         and(
           eq(sessionRescheduleProposal.proposedBy, tutorId),
-          eq(sessionRescheduleProposal.status, 'PENDING')
+          eq(sessionRescheduleProposal.status, 'PENDING'),
+          // Hide proposals for a session that has since ended (it's moot).
+          ne(liveSession.status, 'ended')
         )
       )
 

--- a/tutorme-app/src/lib/group-session/expire-seats.ts
+++ b/tutorme-app/src/lib/group-session/expire-seats.ts
@@ -13,6 +13,7 @@ import { and, eq, inArray, isNull, lt } from 'drizzle-orm'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { groupSession, groupSessionParticipant } from '@/lib/db/schema'
 import { notifyWaitlistOfOpening } from '@/lib/one-on-one/waitlist'
+import { reconcileProposalsForSession } from '@/lib/schedule/reschedule-consent'
 
 /** How long a student has to complete checkout before their seat is released. */
 const RESERVATION_TTL_MS = 30 * 60 * 1000
@@ -35,6 +36,7 @@ export async function expireStaleGroupSeats(
     .select({
       participantId: groupSessionParticipant.participantId,
       groupSessionId: groupSessionParticipant.groupSessionId,
+      studentId: groupSessionParticipant.studentId,
     })
     .from(groupSessionParticipant)
     .where(and(...conditions))
@@ -52,13 +54,19 @@ export async function expireStaleGroupSeats(
     )
 
   // Re-open any session that was FULL, and let its waitlist know a seat opened.
+  const liveSessionByGs = new Map<string, string | null>()
   for (const gsId of new Set(stale.map(s => s.groupSessionId))) {
     const [gs] = await drizzleDb
-      .select({ status: groupSession.status, tutorId: groupSession.tutorId })
+      .select({
+        status: groupSession.status,
+        tutorId: groupSession.tutorId,
+        liveSessionId: groupSession.liveSessionId,
+      })
       .from(groupSession)
       .where(eq(groupSession.groupSessionId, gsId))
       .limit(1)
     if (!gs) continue
+    liveSessionByGs.set(gsId, gs.liveSessionId)
     if (gs.status === 'FULL') {
       await drizzleDb
         .update(groupSession)
@@ -66,6 +74,13 @@ export async function expireStaleGroupSeats(
         .where(eq(groupSession.groupSessionId, gsId))
     }
     if (gs.status !== 'CANCELLED') void notifyWaitlistOfOpening(gs.tutorId)
+  }
+
+  // A released seat drops the student from the reschedule roster — re-evaluate
+  // any pending proposal so their unanswered vote can't stall it.
+  for (const seat of stale) {
+    const liveSessionId = liveSessionByGs.get(seat.groupSessionId)
+    if (liveSessionId) await reconcileProposalsForSession(seat.studentId, liveSessionId)
   }
 
   return stale.length

--- a/tutorme-app/src/lib/schedule/reschedule-consent.ts
+++ b/tutorme-app/src/lib/schedule/reschedule-consent.ts
@@ -335,19 +335,48 @@ export async function reconcileProposalsAfterDeparture(
           inArray(sessionRescheduleProposal.courseId, familyIds)
         )
       )
-    for (const proposal of proposals) {
-      await drizzleDb
-        .delete(sessionRescheduleVote)
-        .where(
-          and(
-            eq(sessionRescheduleVote.proposalId, proposal.proposalId),
-            eq(sessionRescheduleVote.studentId, studentId)
-          )
-        )
-      await evaluatePendingProposal(proposal)
-    }
+    await dropVotesAndReevaluate(proposals, studentId)
   } catch (err) {
     console.warn('[reschedule] departure reconcile failed (non-critical):', err)
+  }
+}
+
+/**
+ * Same as above but keyed by session — for group-seat cancellations (an expired
+ * or withdrawn seat), where the session may have no course. Best-effort.
+ */
+export async function reconcileProposalsForSession(
+  studentId: string,
+  sessionId: string
+): Promise<void> {
+  try {
+    const proposals = await drizzleDb
+      .select()
+      .from(sessionRescheduleProposal)
+      .where(
+        and(
+          eq(sessionRescheduleProposal.status, 'PENDING'),
+          eq(sessionRescheduleProposal.sessionId, sessionId)
+        )
+      )
+    await dropVotesAndReevaluate(proposals, studentId)
+  } catch (err) {
+    console.warn('[reschedule] session reconcile failed (non-critical):', err)
+  }
+}
+
+/** Drop a departed student's votes from these proposals, then re-evaluate each. */
+async function dropVotesAndReevaluate(proposals: Proposal[], studentId: string): Promise<void> {
+  for (const proposal of proposals) {
+    await drizzleDb
+      .delete(sessionRescheduleVote)
+      .where(
+        and(
+          eq(sessionRescheduleVote.proposalId, proposal.proposalId),
+          eq(sessionRescheduleVote.studentId, studentId)
+        )
+      )
+    await evaluatePendingProposal(proposal)
   }
 }
 
@@ -462,6 +491,13 @@ export async function getOpenProposal(sessionId: string): Promise<{
     )
     .limit(1)
   if (!proposal) return null
+  // A proposal for a session that has since ended is moot — treat it as none.
+  const [sess] = await drizzleDb
+    .select({ status: liveSession.status })
+    .from(liveSession)
+    .where(eq(liveSession.sessionId, sessionId))
+    .limit(1)
+  if (!sess || sess.status === 'ended') return null
   const votes = await drizzleDb
     .select({ response: sessionRescheduleVote.response })
     .from(sessionRescheduleVote)


### PR DESCRIPTION
The two minor follow-ups flagged in #1082.

## 1. Read-side ended-session filter
The student & tutor reschedule-proposal lists and `getOpenProposal` now exclude proposals whose session has **ended**, so a stale banner/badge can't linger passively (it was only closed on next interaction before). `'ended'` is a valid `LiveSessionStatus`, so the `ne(status, 'ended')` filter is safe — unlike the `'cancelled'` literal fixed in #1080.

## 2. Group-seat expiry reconcile
`expireStaleGroupSeats` now calls a new `reconcileProposalsForSession(studentId, sessionId)` after cancelling a seat. A released **RESERVED** seat drops that student from the roster and re-evaluates the pending proposal, so their unanswered vote can't stall it. (The host-cancels-whole-session path already ends the `liveSession`, so it's covered by the ended-session handling.) Shared vote-drop + re-evaluate loop factored into `dropVotesAndReevaluate`.

## Verification (ephemeral Postgres, 9/9)
```
Item 1: proposal shown while scheduled → getOpenProposal null once ended ✔
Item 2: roster = PAID + RESERVED seats; seat1 agrees → pending;
        expire RESERVED seat2 → proposal APPLIED, session moved            ✔
```
Typecheck clean; lint 0.

With this, the reschedule consent gate's known edge cases are fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)