### PR TITLE
fix(courses): expand to variant family in reads that missed template/published data

### DIFF
--- a/tutorme-app/src/app/api/student/lesson-replays/route.ts
+++ b/tutorme-app/src/app/api/student/lesson-replays/route.ts
@@ -11,6 +11,7 @@ import {
   courseLesson,
 } from '@/lib/db/schema'
 import { eq, and, inArray, desc } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 
 export async function GET(_req: NextRequest) {
   const session = await getServerSession(authOptions, _req)
@@ -79,11 +80,12 @@ export async function GET(_req: NextRequest) {
 
         // Lessons now directly reference courses (no modules)
         if (liveSessionRow.courseId) {
+          const lessonFamily = await expandToCourseFamily([liveSessionRow.courseId])
           const lessonIds = (
             await drizzleDb
               .select({ lessonId: courseLesson.lessonId })
               .from(courseLesson)
-              .where(eq(courseLesson.courseId, liveSessionRow.courseId))
+              .where(inArray(courseLesson.courseId, lessonFamily))
           ).map(l => l.lessonId)
 
           if (lessonIds.length > 0) {

--- a/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/submissions-tree/route.ts
@@ -14,6 +14,7 @@ import {
   taskSubmission,
 } from '@/lib/db/schema'
 import { and, eq, inArray, isNull, asc } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 
 export const dynamic = 'force-dynamic'
 
@@ -43,6 +44,10 @@ export const GET = withAuth(async (request, session, context) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
   }
 
+  // Content (lessons/sessions/enrollments/materials/reports) can sit under either
+  // the template or the published variant id, so scope them to the whole family.
+  const courseFamily = await expandToCourseFamily([courseId])
+
   const lessons = await drizzleDb
     .select({
       id: courseLesson.lessonId,
@@ -50,7 +55,7 @@ export const GET = withAuth(async (request, session, context) => {
       order: courseLesson.order,
     })
     .from(courseLesson)
-    .where(and(eq(courseLesson.courseId, courseId), isNull(courseLesson.deletedAt)))
+    .where(and(inArray(courseLesson.courseId, courseFamily), isNull(courseLesson.deletedAt)))
     .orderBy(asc(courseLesson.order))
 
   const sessions = await drizzleDb
@@ -61,7 +66,7 @@ export const GET = withAuth(async (request, session, context) => {
       status: liveSession.status,
     })
     .from(liveSession)
-    .where(and(eq(liveSession.courseId, courseId), eq(liveSession.tutorId, tutorId)))
+    .where(and(inArray(liveSession.courseId, courseFamily), eq(liveSession.tutorId, tutorId)))
     .orderBy(asc(liveSession.scheduledAt))
 
   const sessionIds = sessions.map(s => s.id).filter(Boolean)
@@ -85,7 +90,7 @@ export const GET = withAuth(async (request, session, context) => {
     })
     .from(courseEnrollment)
     .leftJoin(profile, eq(courseEnrollment.studentId, profile.userId))
-    .where(eq(courseEnrollment.courseId, courseId))
+    .where(inArray(courseEnrollment.courseId, courseFamily))
 
   const deployed =
     sessionIds.length === 0
@@ -105,7 +110,7 @@ export const GET = withAuth(async (request, session, context) => {
           .from(deployedMaterial)
           .where(
             and(
-              eq(deployedMaterial.courseId, courseId),
+              inArray(deployedMaterial.courseId, courseFamily),
               inArray(deployedMaterial.sessionId, sessionIds)
             )
           )
@@ -174,7 +179,7 @@ export const GET = withAuth(async (request, session, context) => {
           .where(
             and(
               eq(studentTaskReport.tutorId, tutorId),
-              eq(studentTaskReport.courseId, courseId),
+              inArray(studentTaskReport.courseId, courseFamily),
               inArray(studentTaskReport.studentId, studentIds)
             )
           )

--- a/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/comprehension/route.ts
+++ b/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/comprehension/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { and, eq, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
@@ -49,11 +50,14 @@ export const GET = withAuth(
       .select({ itemId: deployedMaterial.itemId, type: deployedMaterial.type })
       .from(deployedMaterial)
       .where(eq(deployedMaterial.sessionId, sessionId))
-    const courseTasks = sess.courseId
+    // Expand to the variant family so legacy course tasks under the sibling
+    // (template vs published) course id are still counted.
+    const taskCourseFamily = sess.courseId ? await expandToCourseFamily([sess.courseId]) : []
+    const courseTasks = taskCourseFamily.length
       ? await drizzleDb
           .select({ taskId: builderTask.taskId })
           .from(builderTask)
-          .where(eq(builderTask.courseId, sess.courseId))
+          .where(inArray(builderTask.courseId, taskCourseFamily))
       : []
     const taskIds = Array.from(
       new Set([

--- a/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/submissions/route.ts
+++ b/tutorme-app/src/app/api/tutor/live-sessions/[sessionId]/submissions/route.ts
@@ -13,6 +13,7 @@ import {
   taskSubmission,
 } from '@/lib/db/schema'
 import { and, asc, eq, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 
 export const dynamic = 'force-dynamic'
 
@@ -49,6 +50,9 @@ export const GET = withAuth(async (req, session, context) => {
   // in-memory courseId drifted from the DB row) may not. Don't hard-fail —
   // submissions are anchored to the session, so we can still surface them.
   const courseId = sessionRow.courseId || ''
+  // The session's courseId may be the template while enrollments/reports live
+  // under the published variant (or vice versa) — match the whole family.
+  const courseFamily = courseId ? await expandToCourseFamily([courseId]) : []
 
   const [courseRow] = courseId
     ? await drizzleDb
@@ -75,7 +79,7 @@ export const GET = withAuth(async (req, session, context) => {
         })
         .from(courseEnrollment)
         .leftJoin(profile, eq(courseEnrollment.studentId, profile.userId))
-        .where(eq(courseEnrollment.courseId, courseId))
+        .where(inArray(courseEnrollment.courseId, courseFamily))
     : []
 
   // Anchor deployed materials to the SESSION only — not also to the session's
@@ -160,7 +164,7 @@ export const GET = withAuth(async (req, session, context) => {
           .where(
             and(
               eq(studentTaskReport.tutorId, tutorId),
-              eq(studentTaskReport.courseId, courseId),
+              inArray(studentTaskReport.courseId, courseFamily),
               inArray(studentTaskReport.studentId, studentIds)
             )
           )

--- a/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
+++ b/tutorme-app/src/lib/notifications/session-reminder-scheduler.ts
@@ -28,6 +28,7 @@ import {
   groupSession,
   groupSessionParticipant,
 } from '@/lib/db/schema'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { notify, notifyMany } from './notify'
 
 /** How far ahead of a session's start to send the reminder. */
@@ -130,10 +131,14 @@ export async function runSessionReminderScan(): Promise<void> {
     // case they're also enrolled, so they don't get two reminders.
     if (s.courseId) {
       try {
+        // Expand to the variant family: a session's courseId can be the template
+        // while students enrol under the published variant, so a raw match would
+        // find nobody and silently skip everyone's reminder.
+        const familyIds = await expandToCourseFamily([s.courseId])
         const enrolled = await drizzleDb
           .select({ studentId: courseEnrollment.studentId })
           .from(courseEnrollment)
-          .where(eq(courseEnrollment.courseId, s.courseId))
+          .where(inArray(courseEnrollment.courseId, familyIds))
         const studentIds = Array.from(
           new Set(enrolled.map(e => e.studentId).filter(id => id && id !== s.tutorId))
         )


### PR DESCRIPTION
Audit sweep for the recurring **template-vs-published course-id landmine** (the class behind #992/#997/#1000 and the reschedule-notify fix): a raw `courseId` filter with no `expandToCourseFamily` silently misses the sibling variant's data. Six confirmed holdouts fixed.

## Fixed
- **HIGH — `session-reminder-scheduler`**: enrolled students silently got **no session reminder** when the session's `courseId` was the template while they enrolled under the published variant. Now family-expanded.
- **`tutor/live-sessions/[id]/submissions`**: enrolled-student roster + grading reports.
- **`tutor/courses/[id]/submissions-tree`**: lessons, sessions, enrollments, deployed materials, reports (all five content filters).
- **`tutor/live-sessions/[id]/comprehension`**: legacy course-tasks fallback (the deployed-material path was already immune; this makes the union fully robust).
- **`student/lesson-replays`**: per-replay lesson/task count.

## Inspected, NOT a gap
- `tutor/classes/start-ad-hoc` — its enrollment notify is guarded by `if (isPublished)`, so `courseId` is already the published id. Left unchanged.

## Verification
Drove the **real `runSessionReminderScan`** on ephemeral Postgres: session under the **template** id + student enrolled under the **published** variant →
```
OLD raw lookup by template id → 0 enrollments (bug reproduced)
fixed scan → student receives "Upcoming session — Algebra starts in about 30 minutes"; reminderSentAt claimed
```
The other four are the same mechanical `expandToCourseFamily` + `inArray` change. Typecheck clean; lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)