### PR TITLE
fix(booking): route 1-on-1 booking through the review step (course picker)

### DIFF
--- a/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
+++ b/tutorme-app/src/components/booking/calendar-booking-dialog.tsx
@@ -1036,7 +1036,16 @@ export function CalendarBookingDialog({
           </Button>
           <Button
             variant="modal-primary-dark"
-            onClick={handleSubmit}
+            // Two-step: from Schedule, advance to the Summary tab first (where the
+            // course picker + note live) so students don't submit before choosing a
+            // course. Only the Summary step actually sends the request.
+            onClick={() => {
+              if (activeTab === 'schedule') {
+                setActiveTab('summary')
+                return
+              }
+              handleSubmit()
+            }}
             disabled={!selectedSlot || submitting || loading}
             className="h-10"
           >
@@ -1045,6 +1054,8 @@ export function CalendarBookingDialog({
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Sending...
               </>
+            ) : activeTab === 'schedule' ? (
+              'Next: review & course'
             ) : (
               'Confirm Booking Request'
             )}


### PR DESCRIPTION
## P5 — Task 3's course picker never showed

Root cause: the `CourseCombobox` (from #1072) is on the booking dialog's **Summary** tab, but the "Confirm Booking Request" button is in the footer (outside the tabs) and called `handleSubmit` directly — so a student on the **Schedule** tab submitted **instantly**, never seeing the Summary tab or its course picker.

**Fix:** the primary button is now two-step — from Schedule it advances to the **Summary** tab (label "Next: review & course"); only the Summary step actually sends the request. Students now always pass through the course + note fields before confirming. (Data wiring was already intact — dialog → `courseId` → API → DB.)

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)