### PR TITLE
fix(one-on-one): confirm before rejecting a booking request

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -479,6 +479,16 @@ function TutorDashboardContent() {
 
   const handleOneOnOneResponse = useCallback(
     async (requestId: string, action: 'accept' | 'reject') => {
+      // Rejecting declines the student's request (and the whole series). Confirm
+      // first so an inadvertent click doesn't turn a student away.
+      if (
+        action === 'reject' &&
+        !window.confirm(
+          'Reject this booking request? The student will be notified that you declined.'
+        )
+      ) {
+        return
+      }
       setRespondingRequestId(requestId)
       try {
         const res = await fetch('/api/one-on-one/respond', {

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -126,6 +126,15 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
     requestId: string,
     action: 'accept' | 'reject'
   ) => {
+    // Confirm rejections so an accidental click doesn't decline a student.
+    if (
+      action === 'reject' &&
+      !window.confirm(
+        'Reject this booking request? The student will be notified that you declined.'
+      )
+    ) {
+      return
+    }
     setRespondingIds(prev => ({ ...prev, [notificationId]: action }))
     try {
       const res = await fetch('/api/one-on-one/respond', {


### PR DESCRIPTION
## P4b — confirm before rejecting

A single click rejected a student's 1-on-1 request (and the whole series) with no undo. Both reject surfaces now confirm first:
- **Tutor dashboard** (`handleOneOnOneResponse`)
- **Communications/notifications panel** (`respondToOneOnOne`)

Uses `window.confirm` — the same pattern the booking dialog already uses for cancels — so it's consistent and low-risk.

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)