### PR TITLE
feat(sessions): scope live deploy to the session's linked course

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -28,7 +28,12 @@ import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 const ADHOC_ANCHOR_COURSE_ID = '__system_adhoc_course__'
 
 export const GET = withAuth(
-  async (_req: NextRequest, session) => {
+  async (req: NextRequest, session) => {
+    // When a live session is built around a course, the classroom passes its
+    // courseId so ONLY that course's tasks are deployable; with no course, all
+    // of the tutor's published tasks are offered.
+    const scopedCourseId = new URL(req.url).searchParams.get('courseId')?.trim() || null
+
     const rows = await drizzleDb
       .select({
         taskId: builderTask.taskId,
@@ -50,7 +55,8 @@ export const GET = withAuth(
           eq(builderTask.tutorId, session.user.id),
           eq(builderTask.status, 'published'),
           isNull(builderTask.deletedAt),
-          ne(builderTask.courseId, ADHOC_ANCHOR_COURSE_ID)
+          ne(builderTask.courseId, ADHOC_ANCHOR_COURSE_ID),
+          ...(scopedCourseId ? [eq(builderTask.courseId, scopedCourseId)] : [])
         )
       )
       .orderBy(desc(builderTask.updatedAt))

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -227,6 +227,7 @@ export function SessionClassroom({
               <SessionDeployPanel
                 sessionId={sessionId}
                 socket={socket}
+                courseId={courseId}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -57,10 +57,14 @@ interface CourseGroup {
 export function SessionDeployPanel({
   sessionId,
   socket,
+  courseId,
   onClose,
 }: {
   sessionId: string
   socket: Socket | null
+  /** When the session is built around a course, only that course's tasks are
+   *  deployable; null/undefined offers all the tutor's published tasks. */
+  courseId?: string | null
   onClose: () => void
 }) {
   const [items, setItems] = useState<Deployable[]>([])
@@ -71,7 +75,10 @@ export function SessionDeployPanel({
 
   useEffect(() => {
     let active = true
-    fetch('/api/one-on-one/deployables', { credentials: 'include' })
+    const url = courseId
+      ? `/api/one-on-one/deployables?courseId=${encodeURIComponent(courseId)}`
+      : '/api/one-on-one/deployables'
+    fetch(url, { credentials: 'include' })
       .then(r => (r.ok ? r.json() : { tasks: [] }))
       .then(d => {
         if (active) setItems(Array.isArray(d.tasks) ? d.tasks : [])
@@ -81,7 +88,7 @@ export function SessionDeployPanel({
     return () => {
       active = false
     }
-  }, [])
+  }, [courseId])
 
   // Group the flat task list into course → lesson → tasks, filtered by the
   // search query (matches task title, course name or lesson title).


### PR DESCRIPTION
## P2 — selected course didn't scope the live session

A group/1-on-1 session built around a course still showed **all** the tutor's tasks in the Deploy panel. Now:
- `SessionClassroom` passes its `courseId` to `SessionDeployPanel`.
- The panel requests `/api/one-on-one/deployables?courseId=…`.
- The endpoint filters to that course when the param is present; **with no linked course, all the tutor's published tasks remain available** (unchanged behavior).

Requested behavior exactly: course selected → only that course; none → all courses.

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)