### PR TITLE
feat(group-sessions): let students join their booked sessions

### DIFF
--- a/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { Users, Loader2, CalendarDays, ArrowUpRight, BookOpen } from 'lucide-react'
+import { Users, Loader2, CalendarDays, ArrowUpRight, BookOpen, Video } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { bookGroupSeat } from '@/lib/group-session/book-seat'
 import { formatEarnings } from '@/lib/format-currency'
@@ -26,6 +26,18 @@ interface BrowseSession {
   courseName?: string | null
 }
 
+interface MySession {
+  groupSessionId: string
+  title: string
+  liveSessionId: string | null
+  requestedDate: string
+  startTime: string
+  endTime: string
+  timezone: string
+  tutorName?: string | null
+  joinable: boolean
+}
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
     weekday: 'short',
@@ -39,16 +51,23 @@ export default function StudentGroupSessionsPage() {
   const params = useParams()
   const locale = (params?.locale as string) || 'en'
   const [sessions, setSessions] = useState<BrowseSession[]>([])
+  const [mine, setMine] = useState<MySession[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch('/api/group-sessions/browse', { credentials: 'include' })
-      const data = res.ok ? await res.json() : { sessions: [] }
-      setSessions(Array.isArray(data.sessions) ? data.sessions : [])
+      const [browseRes, mineRes] = await Promise.all([
+        fetch('/api/group-sessions/browse', { credentials: 'include' }),
+        fetch('/api/group-sessions/mine', { credentials: 'include' }),
+      ])
+      const browse = browseRes.ok ? await browseRes.json() : { sessions: [] }
+      const mineData = mineRes.ok ? await mineRes.json() : { sessions: [] }
+      setSessions(Array.isArray(browse.sessions) ? browse.sessions : [])
+      setMine(Array.isArray(mineData.sessions) ? mineData.sessions : [])
     } catch {
       setSessions([])
+      setMine([])
     } finally {
       setLoading(false)
     }
@@ -83,6 +102,51 @@ export default function StudentGroupSessionsPage() {
           </div>
         </div>
       </section>
+
+      {/* Your booked sessions — with a Join button once the room opens. */}
+      {mine.length > 0 ? (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50/50 p-4">
+          <h2 className="mb-2 text-sm font-semibold text-emerald-900">Your booked sessions</h2>
+          <ul className="flex flex-col gap-2">
+            {mine.map(s => (
+              <li
+                key={s.groupSessionId}
+                className="flex flex-col gap-2 rounded-xl border border-emerald-200 bg-white p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold text-slate-900">{s.title}</div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-3 text-xs text-slate-500">
+                    <span className="inline-flex items-center gap-1">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {formatDate(s.requestedDate)} · {s.startTime}–{s.endTime} ({s.timezone})
+                    </span>
+                    {s.tutorName ? <span className="capitalize">with {s.tutorName}</span> : null}
+                  </div>
+                </div>
+                {s.liveSessionId ? (
+                  <Link
+                    href={s.joinable ? `/${locale}/call/${s.liveSessionId}` : '#'}
+                    aria-disabled={!s.joinable}
+                    onClick={e => {
+                      if (!s.joinable) e.preventDefault()
+                    }}
+                    className={
+                      'inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold ' +
+                      (s.joinable
+                        ? 'bg-emerald-600 text-white hover:bg-emerald-500'
+                        : 'cursor-not-allowed bg-slate-100 text-slate-400')
+                    }
+                    title={s.joinable ? 'Join the session' : 'Opens 20 minutes before it starts'}
+                  >
+                    <Video className="h-3.5 w-3.5" />
+                    {s.joinable ? 'Join' : 'Not yet open'}
+                  </Link>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
 
       {loading ? (
         <div className="flex justify-center py-16">

--- a/tutorme-app/src/app/api/group-sessions/mine/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/mine/route.ts
@@ -1,0 +1,69 @@
+/**
+ * GET /api/group-sessions/mine  (student)
+ *
+ * The group sessions the signed-in student holds a PAID seat in and that haven't
+ * finished yet — so the student page can show them with a Join button (the
+ * browse feed only lists OPEN sessions with seats left, never the ones you've
+ * already booked). `joinable` is true once the room opens (20 min before start).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { and, asc, eq, gte } from 'drizzle-orm'
+import { withAuth } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { groupSession, groupSessionParticipant, liveSession, profile } from '@/lib/db/schema'
+
+const EARLY_ENTRY_MS = 20 * 60 * 1000
+
+export const GET = withAuth(async (_req: NextRequest, session) => {
+  const now = new Date()
+  // Keep sessions that are within their window or upcoming (grace: started up to
+  // 3h ago still count as "now").
+  const graceStart = new Date(now.getTime() - 3 * 60 * 60 * 1000)
+
+  const rows = await drizzleDb
+    .select({
+      groupSessionId: groupSession.groupSessionId,
+      title: groupSession.title,
+      liveSessionId: groupSession.liveSessionId,
+      requestedDate: groupSession.requestedDate,
+      startTime: groupSession.startTime,
+      endTime: groupSession.endTime,
+      timezone: groupSession.timezone,
+      status: groupSession.status,
+      scheduledAt: liveSession.scheduledAt,
+      tutorName: profile.name,
+    })
+    .from(groupSessionParticipant)
+    .innerJoin(
+      groupSession,
+      eq(groupSession.groupSessionId, groupSessionParticipant.groupSessionId)
+    )
+    .innerJoin(liveSession, eq(liveSession.sessionId, groupSession.liveSessionId))
+    .leftJoin(profile, eq(profile.userId, groupSession.tutorId))
+    .where(
+      and(
+        eq(groupSessionParticipant.studentId, session.user.id),
+        eq(groupSessionParticipant.status, 'PAID'),
+        gte(liveSession.scheduledAt, graceStart)
+      )
+    )
+    .orderBy(asc(liveSession.scheduledAt))
+    .limit(50)
+
+  return NextResponse.json({
+    sessions: rows.map(r => ({
+      groupSessionId: r.groupSessionId,
+      title: r.title,
+      liveSessionId: r.liveSessionId,
+      requestedDate: r.requestedDate,
+      startTime: r.startTime,
+      endTime: r.endTime,
+      timezone: r.timezone,
+      tutorName: r.tutorName,
+      scheduledAt: r.scheduledAt,
+      // The room is joinable from 20 min before the scheduled start.
+      joinable: !!r.scheduledAt && r.scheduledAt.getTime() - now.getTime() <= EARLY_ENTRY_MS,
+    })),
+  })
+})


### PR DESCRIPTION
## P1 (join) — students couldn't join their booked group sessions

The student Group Sessions page only listed **OPEN sessions to book**; a student who'd already booked + paid had **no Join affordance** there (the browse feed even hides FULL sessions).

**Added:** a **"Your booked sessions"** section backed by a new `GET /api/group-sessions/mine` (the student's **PAID** seats, upcoming, with the live room id + timing). Each has a **Join** button that lights up **20 min before start** and routes to `/call/[liveSessionId]`.

## On the calendar + reminder halves of the report
Deep investigation (agent) found these are **already wired** — the student calendar surfaces group sessions via the same PAID `groupSessionParticipant` join, and the app-wide `SessionLauncher` (mounted in the layout) polls `/api/one-on-one/live-now`, which **does** include group sessions. So a booked session that still doesn't show/remind is most likely **not in PAID state yet** (a payment-completion data path), rather than a wiring bug. I'd want a concrete repro (which session + its payment status) to fix that precisely instead of guessing.

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)