### PR TITLE
feat(lint): guard against variant-family enrollment bug + fix 4 more instances

### DIFF
--- a/tutorme-app/eslint.config.mjs
+++ b/tutorme-app/eslint.config.mjs
@@ -74,6 +74,20 @@ const config = [
       'no-with': 'error',
       'no-caller': 'error',
       'no-unsafe-finally': 'error',
+      // Variant-family guard: reading enrollments by a session's courseId
+      // (eq(courseEnrollment.courseId, someSession.courseId)) silently misses
+      // students enrolled under the sibling course variant (template vs
+      // published). Use expandToCourseFamily(...) + inArray(...). The `course`
+      // join and single-id/cast forms are intentionally not matched.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.name='eq'][arguments.0.object.name='courseEnrollment'][arguments.0.property.name='courseId'][arguments.1.type='MemberExpression'][arguments.1.property.name='courseId']:not([arguments.1.object.name='course'])",
+          message:
+            "Filtering courseEnrollment by a session's courseId misses students under the sibling course variant. Use `inArray(courseEnrollment.courseId, await expandToCourseFamily([<id>]))`. See variant-family.ts.",
+        },
+      ],
     },
   },
   {

--- a/tutorme-app/src/app/api/class/payment-alert/route.ts
+++ b/tutorme-app/src/app/api/class/payment-alert/route.ts
@@ -18,6 +18,7 @@ import {
   familyNotification,
 } from '@/lib/db/schema'
 import { eq, and, inArray, sql } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { logAudit, AUDIT_ACTIONS } from '@/lib/security/audit'
 import crypto from 'crypto'
 
@@ -101,7 +102,7 @@ export async function POST(request: NextRequest) {
       .from(courseEnrollment)
       .where(
         and(
-          eq(courseEnrollment.courseId, body.courseId),
+          inArray(courseEnrollment.courseId, await expandToCourseFamily([body.courseId])),
           eq(courseEnrollment.studentId, session.user.id)
         )
       )

--- a/tutorme-app/src/app/api/student/subjects/enroll/route.ts
+++ b/tutorme-app/src/app/api/student/subjects/enroll/route.ts
@@ -94,6 +94,7 @@ export const POST = withCsrf(
           .where(
             and(
               eq(courseEnrollment.studentId, session.user.id),
+              // eslint-disable-next-line no-restricted-syntax -- exact match: dedup for THIS resolved course, not a session-derived id
               eq(courseEnrollment.courseId, courseByCategory.courseId)
             )
           )

--- a/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
+++ b/tutorme-app/src/app/api/student/subjects/unenroll/route.ts
@@ -35,6 +35,7 @@ export const POST = withCsrf(
         .where(
           and(
             eq(courseEnrollment.studentId, session.user.id),
+            // eslint-disable-next-line no-restricted-syntax -- exact match: unenroll targets THIS resolved course, not a session-derived id
             eq(courseEnrollment.courseId, courseRow.courseId)
           )
         )

--- a/tutorme-app/src/app/api/tutor/sessions/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/sessions/[id]/route.ts
@@ -4,7 +4,8 @@
  */
 
 import { NextResponse } from 'next/server'
-import { eq, and, isNull } from 'drizzle-orm'
+import { eq, and, isNull, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { withAuth } from '@/lib/api/middleware'
 import { getParamAsync } from '@/lib/api/params'
 import { drizzleDb } from '@/lib/db/drizzle'
@@ -100,7 +101,12 @@ export const PATCH = withAuth(
         const enrollments = await drizzleDb
           .select({ studentId: courseEnrollment.studentId })
           .from(courseEnrollment)
-          .where(eq(courseEnrollment.courseId, existingSession.courseId))
+          .where(
+            inArray(
+              courseEnrollment.courseId,
+              await expandToCourseFamily([existingSession.courseId])
+            )
+          )
 
         const studentIds = enrollments.map(e => e.studentId)
 

--- a/tutorme-app/src/app/api/webhooks/daily/route.ts
+++ b/tutorme-app/src/app/api/webhooks/daily/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession, courseEnrollment } from '@/lib/db/schema'
-import { eq, desc, and, isNotNull } from 'drizzle-orm'
+import { eq, desc, and, isNotNull, inArray } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { notify } from '@/lib/notifications/notify'
 import { getRecordingDownloadLink } from '@/lib/video/daily-webhook'
 
@@ -125,7 +126,9 @@ export async function POST(req: NextRequest) {
       const enrollments = await drizzleDb
         .select({ studentId: courseEnrollment.studentId })
         .from(courseEnrollment)
-        .where(eq(courseEnrollment.courseId, sessionRow.courseId))
+        .where(
+          inArray(courseEnrollment.courseId, await expandToCourseFamily([sessionRow.courseId]))
+        )
 
       await Promise.allSettled(
         enrollments.map(e =>

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -8,6 +8,7 @@ import { Server as SocketIOServer, Socket } from 'socket.io'
 import Redis from 'ioredis'
 import * as Sentry from '@sentry/nextjs'
 import { eq, and, inArray, desc } from 'drizzle-orm'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { drizzleDb } from '@/lib/db/drizzle'
 import {
   liveSession,
@@ -773,7 +774,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
                   const rows = await drizzleDb
                     .select({ studentId: courseEnrollment.studentId })
                     .from(courseEnrollment)
-                    .where(eq(courseEnrollment.courseId, s.courseId))
+                    .where(
+                      inArray(courseEnrollment.courseId, await expandToCourseFamily([s.courseId]))
+                    )
                   const studentIds = rows.map(r => r.studentId).filter(Boolean)
                   if (studentIds.length > 0) {
                     void notifyMany({
@@ -922,10 +925,14 @@ export async function initEnhancedSocketServer(server: NetServer) {
           where: eq(liveSession.sessionId, roomId),
         })
         if (liveSessionRow?.courseId) {
+          // Match the whole variant family: the session's courseId may be the
+          // template while the student enrolled under the published variant —
+          // a raw match would wrongly reject a legitimately enrolled student.
+          const enrolledFamily = await expandToCourseFamily([liveSessionRow.courseId])
           const enrolled = await drizzleDb.query.courseEnrollment.findFirst({
             where: and(
               eq(courseEnrollment.studentId, userId),
-              eq(courseEnrollment.courseId, liveSessionRow.courseId)
+              inArray(courseEnrollment.courseId, enrolledFamily)
             ),
           })
           if (!enrolled) {


### PR DESCRIPTION
The prevention guard for the recurring template/published variant landmine — plus the real bugs building it surfaced.

## The guard
An ESLint `no-restricted-syntax` rule (error-level) that flags exactly `eq(courseEnrollment.courseId, <x>.courseId)` — reading enrollments keyed by a session's courseId, which silently misses students under the sibling variant. It's deliberately narrow (excludes the `course` join and single-id/cast forms), so it's **near-zero false positive** and safe as an error.

A blanket rule was considered and rejected — it would fire ~79 times, almost all legitimate (joins/writes/single-course ops). This narrow shape is the actual bug signature.

## 4 more real bugs it surfaced (all fixed)
- **socket-server room JOIN GATE (HIGH):** a legitimately enrolled student was **wrongly blocked** ("You are not enrolled in this course") when the session sat under the template id. An access bug.
- socket-server "class starting soon" lobby reminder — reached nobody
- daily webhook "recording available" notification — reached nobody
- `tutor/sessions/[id]` update notification — reached nobody
- `class/payment-alert` enrollment check — expanded for robustness

Two genuine exact-match cases (`subjects/enroll` dedup, `subjects/unenroll` delete) are documented with `eslint-disable` + reason.

## Verification
- Rule **errors** on `eq(courseEnrollment.courseId, sess.courseId)`, **ignores** `eq(courseEnrollment.courseId, course.courseId)` (join); **0 rule hits across the entire repo** → error-level, CI-clean.
- Join-gate fix **DB-verified**: old gate finds nothing (blocks the student), family-expanded gate allows the legitimately enrolled student.
- Typecheck clean.

Now new instances of this class fail lint in review instead of shipping as silent bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)