### PR TITLE
feat(group-sessions): analytics-style mode selector + collapsible panels

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,12 +24,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Install the latest gitleaks linux binary from GitHub Releases.
-          url=$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | grep -oE '"browser_download_url": *"[^"]*linux_(x64|amd64)\.tar\.gz"' \
-            | head -1 | sed -E 's/.*"(https[^"]+)".*/\1/')
-          echo "Downloading gitleaks: $url"
-          curl -fsSL "$url" | tar -xz gitleaks
+          # Install gitleaks via official install script (more reliable than GitHub API).
+          curl -fsSL https://raw.githubusercontent.com/gitleaks/gitleaks/master/scripts/install.sh | bash
           ./gitleaks version
 
           # Scan ONLY the commits introduced by this push/PR — not full history,

--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -19,6 +19,9 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { formatEarnings } from '@/lib/format-currency'
 import { CourseCombobox, type CourseOption } from '@/components/course/course-combobox'
+import { SessionCalendarPanel } from '@/components/session-calendar-panel'
+import { TabsContent } from '@/components/ui/tabs'
+import { CollapsibleCard } from '@/components/collapsible-card'
 
 interface GroupSessionItem {
   groupSessionId: string
@@ -68,6 +71,7 @@ export default function TutorGroupSessionsPage() {
   const [courses, setCourses] = useState<CourseOption[]>([])
   const [coursesLoading, setCoursesLoading] = useState(true)
   const [courseId, setCourseId] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState('create')
 
   useEffect(() => {
     let active = true
@@ -213,216 +217,239 @@ export default function TutorGroupSessionsPage() {
 
       {/* Create form + Sessions list */}
       <div className="flex min-h-0 flex-1 flex-col pb-0.5">
-        <div className="mb-4 rounded-[18px] border border-[rgba(0,0,0,0.05)] bg-[#FFFFFF] p-6 shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
-          <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-slate-900">
-            <Plus className="h-4 w-4" /> New group session
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="text-sm font-medium text-slate-700 sm:col-span-2">
-              Title
-              <input
-                className={field}
-                value={form.title}
-                maxLength={120}
-                placeholder="e.g. SAT Math crash session"
-                onChange={e => setForm({ ...form, title: e.target.value })}
-              />
-            </label>
-            <label className="text-sm font-medium text-slate-700 sm:col-span-2">
-              Description (optional)
-              <textarea
-                className={field}
-                value={form.description}
-                maxLength={1000}
-                rows={2}
-                onChange={e => setForm({ ...form, description: e.target.value })}
-              />
-            </label>
-            <div className="text-sm font-medium text-slate-700 sm:col-span-2">
-              Course (optional)
-              <div className="mt-1">
-                <CourseCombobox
-                  options={courses}
-                  value={courseId}
-                  onChange={setCourseId}
-                  loading={coursesLoading}
-                  placeholder="Build this session around a course…"
-                />
+        <SessionCalendarPanel
+          value={activeTab}
+          onValueChange={setActiveTab}
+          variant="charcoal"
+          tabs={[
+            { value: 'create', label: 'Create Session', icon: Plus },
+            { value: 'sessions', label: 'Your Sessions', icon: Users },
+          ]}
+        >
+          <TabsContent value="create" className="flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              title="Create Session"
+              icon={<Plus className="h-5 w-5 text-slate-900" />}
+              defaultOpen={true}
+              fillHeight={true}
+            >
+              <div className="grid gap-4 sm:grid-cols-2 p-6">
+                <label className="text-sm font-medium text-slate-700 sm:col-span-2">
+                  Title
+                  <input
+                    className={field}
+                    value={form.title}
+                    maxLength={120}
+                    placeholder="e.g. SAT Math crash session"
+                    onChange={e => setForm({ ...form, title: e.target.value })}
+                  />
+                </label>
+                <label className="text-sm font-medium text-slate-700 sm:col-span-2">
+                  Description (optional)
+                  <textarea
+                    className={field}
+                    value={form.description}
+                    maxLength={1000}
+                    rows={2}
+                    onChange={e => setForm({ ...form, description: e.target.value })}
+                  />
+                </label>
+                <div className="text-sm font-medium text-slate-700 sm:col-span-2">
+                  Course (optional)
+                  <div className="mt-1">
+                    <CourseCombobox
+                      options={courses}
+                      value={courseId}
+                      onChange={setCourseId}
+                      loading={coursesLoading}
+                      placeholder="Build this session around a course…"
+                    />
+                  </div>
+                  <p className="mt-1 text-xs font-normal text-slate-400">
+                    Linking a course lets you deploy its lessons, tasks and assessments live in the
+                    room. Published and draft courses are both available.
+                  </p>
+                </div>
+                <label className="text-sm font-medium text-slate-700">
+                  Date
+                  <input
+                    type="date"
+                    className={field}
+                    value={form.date}
+                    onChange={e => setForm({ ...form, date: e.target.value })}
+                  />
+                </label>
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="text-sm font-medium text-slate-700">
+                    Start
+                    <input
+                      type="time"
+                      className={field}
+                      value={form.startTime}
+                      onChange={e => setForm({ ...form, startTime: e.target.value })}
+                    />
+                  </label>
+                  <label className="text-sm font-medium text-slate-700">
+                    End
+                    <input
+                      type="time"
+                      className={field}
+                      value={form.endTime}
+                      onChange={e => setForm({ ...form, endTime: e.target.value })}
+                    />
+                  </label>
+                </div>
+                <label className="text-sm font-medium text-slate-700">
+                  Seats
+                  <input
+                    type="number"
+                    min={1}
+                    max={50}
+                    className={field}
+                    value={form.capacity}
+                    onChange={e => setForm({ ...form, capacity: e.target.value })}
+                  />
+                  <span className="mt-1 block text-xs font-normal text-slate-400">
+                    Set 1 seat for a private 1-on-1.
+                  </span>
+                </label>
+                <label className="text-sm font-medium text-slate-700">
+                  Price per seat
+                  <input
+                    type="number"
+                    min={0}
+                    disabled={form.free}
+                    className={`${field} disabled:bg-slate-100 disabled:text-slate-400`}
+                    value={form.free ? '0' : form.pricePerSeat}
+                    onChange={e => setForm({ ...form, pricePerSeat: e.target.value })}
+                  />
+                </label>
+                <label className="flex items-center gap-2 self-end pb-2 text-sm font-medium text-slate-700 sm:col-span-2">
+                  <input
+                    type="checkbox"
+                    checked={form.free}
+                    onChange={e => setForm({ ...form, free: e.target.checked })}
+                    className="h-4 w-4"
+                  />
+                  Free session — students book a seat with no payment (great for testing or free
+                  workshops)
+                </label>
               </div>
-              <p className="mt-1 text-xs font-normal text-slate-400">
-                Linking a course lets you deploy its lessons, tasks and assessments live in the
-                room. Published and draft courses are both available.
-              </p>
-            </div>
-            <label className="text-sm font-medium text-slate-700">
-              Date
-              <input
-                type="date"
-                className={field}
-                value={form.date}
-                onChange={e => setForm({ ...form, date: e.target.value })}
-              />
-            </label>
-            <div className="grid grid-cols-2 gap-3">
-              <label className="text-sm font-medium text-slate-700">
-                Start
-                <input
-                  type="time"
-                  className={field}
-                  value={form.startTime}
-                  onChange={e => setForm({ ...form, startTime: e.target.value })}
-                />
-              </label>
-              <label className="text-sm font-medium text-slate-700">
-                End
-                <input
-                  type="time"
-                  className={field}
-                  value={form.endTime}
-                  onChange={e => setForm({ ...form, endTime: e.target.value })}
-                />
-              </label>
-            </div>
-            <label className="text-sm font-medium text-slate-700">
-              Seats
-              <input
-                type="number"
-                min={1}
-                max={50}
-                className={field}
-                value={form.capacity}
-                onChange={e => setForm({ ...form, capacity: e.target.value })}
-              />
-              <span className="mt-1 block text-xs font-normal text-slate-400">
-                Set 1 seat for a private 1-on-1.
-              </span>
-            </label>
-            <label className="text-sm font-medium text-slate-700">
-              Price per seat
-              <input
-                type="number"
-                min={0}
-                disabled={form.free}
-                className={`${field} disabled:bg-slate-100 disabled:text-slate-400`}
-                value={form.free ? '0' : form.pricePerSeat}
-                onChange={e => setForm({ ...form, pricePerSeat: e.target.value })}
-              />
-            </label>
-            <label className="flex items-center gap-2 self-end pb-2 text-sm font-medium text-slate-700 sm:col-span-2">
-              <input
-                type="checkbox"
-                checked={form.free}
-                onChange={e => setForm({ ...form, free: e.target.checked })}
-                className="h-4 w-4"
-              />
-              Free session — students book a seat with no payment (great for testing or free
-              workshops)
-            </label>
-          </div>
-          <div className="mt-4">
-            <Button variant="solocorn-book" onClick={create} disabled={creating}>
-              {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Create session
-            </Button>
-          </div>
-        </div>
+              <div className="px-6 pb-6">
+                <Button variant="solocorn-book" onClick={create} disabled={creating}>
+                  {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Create session
+                </Button>
+              </div>
+            </CollapsibleCard>
+          </TabsContent>
 
-        {/* Sessions list panel */}
-        <div className="mb-4 rounded-[18px] border border-[rgba(0,0,0,0.05)] bg-[#FFFFFF] p-6 shadow-[0_14px_45px_rgba(0,0,0,0.14)]">
-          <h2 className="mb-4 text-base font-semibold text-slate-900">Your sessions</h2>
-          {loading ? (
-            <div className="flex items-center gap-2 text-slate-500">
-              <Loader2 className="h-4 w-4 animate-spin" /> Loading…
-            </div>
-          ) : sessions.length === 0 ? (
-            <div className="py-16 text-center">
-              <CalendarDays className="mx-auto mb-4 h-12 w-12 text-gray-300" />
-              <h3 className="text-lg font-medium text-gray-700">No group sessions yet.</h3>
-              <p className="mt-1 text-sm text-gray-500">
-                Create your first session above to get started.
-              </p>
-            </div>
-          ) : (
-            <ul className="flex flex-col gap-3">
-              {sessions.map(gs => {
-                const cancelled = gs.status === 'CANCELLED'
-                return (
-                  <li
-                    key={gs.groupSessionId}
-                    className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate font-medium text-slate-900">{gs.title}</span>
-                        <span
-                          className={
-                            'rounded-full px-2 py-0.5 text-xs font-medium ' +
-                            (cancelled
-                              ? 'bg-slate-100 text-slate-500'
-                              : gs.status === 'FULL'
-                                ? 'bg-amber-100 text-amber-700'
-                                : 'bg-emerald-100 text-emerald-700')
-                          }
-                        >
-                          {gs.status}
-                        </span>
-                      </div>
-                      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600">
-                        <span className="inline-flex items-center gap-1">
-                          <CalendarDays className="h-3.5 w-3.5" />
-                          {formatDate(gs.requestedDate)} · {gs.startTime}–{gs.endTime}
-                        </span>
-                        <span>
-                          {gs.pricePerSeat > 0
-                            ? `${formatEarnings(gs.pricePerSeat, gs.currency || 'USD')}/seat`
-                            : 'Free'}
-                        </span>
-                        <span>
-                          {gs.capacity - gs.seatsLeft}/{gs.capacity} booked
-                        </span>
-                        {gs.courseName ? (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
-                            <BookOpen className="h-3 w-3" />
-                            {gs.courseName}
-                            {gs.coursePublished === false ? (
-                              <span className="text-blue-400">· draft</span>
-                            ) : null}
-                          </span>
-                        ) : null}
-                      </div>
-                    </div>
-                    {!cancelled ? (
-                      <div className="flex shrink-0 items-center gap-2">
-                        {gs.liveSessionId ? (
-                          <Button
-                            variant="solocorn-book"
-                            onClick={() => router.push(`/call/${gs.liveSessionId}`)}
+          <TabsContent value="sessions" className="flex h-full flex-col gap-4 pb-4">
+            <CollapsibleCard
+              title="Your Sessions"
+              icon={<Users className="h-5 w-5 text-slate-900" />}
+              defaultOpen={true}
+              fillHeight={true}
+            >
+              <div className="flex h-full flex-col p-6">
+                {loading ? (
+                  <div className="flex items-center gap-2 text-slate-500">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                  </div>
+                ) : sessions.length === 0 ? (
+                  <div className="py-16 text-center">
+                    <CalendarDays className="mx-auto mb-4 h-12 w-12 text-gray-300" />
+                    <h3 className="text-lg font-medium text-gray-700">No group sessions yet.</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                      Create your first session above to get started.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="min-h-0 flex-1 overflow-y-auto">
+                    <ul className="flex flex-col gap-3">
+                      {sessions.map(gs => {
+                        const cancelled = gs.status === 'CANCELLED'
+                        return (
+                          <li
+                            key={gs.groupSessionId}
+                            className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
                           >
-                            <Video className="mr-2 h-4 w-4" />
-                            Join room
-                          </Button>
-                        ) : null}
-                        <Button
-                          variant="outline"
-                          className="text-red-600 hover:bg-red-50"
-                          disabled={cancelId === gs.groupSessionId}
-                          onClick={() => cancel(gs.groupSessionId)}
-                        >
-                          {cancelId === gs.groupSessionId ? (
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          ) : (
-                            <Trash2 className="mr-2 h-4 w-4" />
-                          )}
-                          Cancel &amp; refund
-                        </Button>
-                      </div>
-                    ) : null}
-                  </li>
-                )
-              })}
-            </ul>
-          )}
-        </div>
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2">
+                                <span className="truncate font-medium text-slate-900">{gs.title}</span>
+                                <span
+                                  className={
+                                    'rounded-full px-2 py-0.5 text-xs font-medium ' +
+                                    (cancelled
+                                      ? 'bg-slate-100 text-slate-500'
+                                      : gs.status === 'FULL'
+                                        ? 'bg-amber-100 text-amber-700'
+                                        : 'bg-emerald-100 text-emerald-700')
+                                  }
+                                >
+                                  {gs.status}
+                                </span>
+                              </div>
+                              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-600">
+                                <span className="inline-flex items-center gap-1">
+                                  <CalendarDays className="h-3.5 w-3.5" />
+                                  {formatDate(gs.requestedDate)} · {gs.startTime}–{gs.endTime}
+                                </span>
+                                <span>
+                                  {gs.pricePerSeat > 0
+                                    ? `${formatEarnings(gs.pricePerSeat, gs.currency || 'USD')}/seat`
+                                    : 'Free'}
+                                </span>
+                                <span>
+                                  {gs.capacity - gs.seatsLeft}/{gs.capacity} booked
+                                </span>
+                                {gs.courseName ? (
+                                  <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                                    <BookOpen className="h-3 w-3" />
+                                    {gs.courseName}
+                                    {gs.coursePublished === false ? (
+                                      <span className="text-blue-400">· draft</span>
+                                    ) : null}
+                                  </span>
+                                ) : null}
+                              </div>
+                            </div>
+                            {!cancelled ? (
+                              <div className="flex shrink-0 items-center gap-2">
+                                {gs.liveSessionId ? (
+                                  <Button
+                                    variant="solocorn-book"
+                                    onClick={() => router.push(`/call/${gs.liveSessionId}`)}
+                                  >
+                                    <Video className="mr-2 h-4 w-4" />
+                                    Join room
+                                  </Button>
+                                ) : null}
+                                <Button
+                                  variant="outline"
+                                  className="text-red-600 hover:bg-red-50"
+                                  disabled={cancelId === gs.groupSessionId}
+                                  onClick={() => cancel(gs.groupSessionId)}
+                                >
+                                  {cancelId === gs.groupSessionId ? (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <Trash2 className="mr-2 h-4 w-4" />
+                                  )}
+                                  Cancel &amp; refund
+                                </Button>
+                              </div>
+                            ) : null}
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </CollapsibleCard>
+          </TabsContent>
+        </SessionCalendarPanel>
       </div>
     </div>
   )

--- a/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/group-sessions/page.tsx
@@ -233,7 +233,7 @@ export default function TutorGroupSessionsPage() {
               defaultOpen={true}
               fillHeight={true}
             >
-              <div className="grid gap-4 sm:grid-cols-2 p-6">
+              <div className="grid gap-4 p-6 sm:grid-cols-2">
                 <label className="text-sm font-medium text-slate-700 sm:col-span-2">
                   Title
                   <input
@@ -376,7 +376,9 @@ export default function TutorGroupSessionsPage() {
                           >
                             <div className="min-w-0">
                               <div className="flex items-center gap-2">
-                                <span className="truncate font-medium text-slate-900">{gs.title}</span>
+                                <span className="truncate font-medium text-slate-900">
+                                  {gs.title}
+                                </span>
                                 <span
                                   className={
                                     'rounded-full px-2 py-0.5 text-xs font-medium ' +


### PR DESCRIPTION
## Summary

Transforms the Group Sessions page from a long scrolling layout into an Analytics-style two-panel mode selector system.

### Changes

- **Mode selector tabs** — Added  (charcoal variant) with two tabs:
  -  — form to create new group sessions
  -  — list of existing sessions with status, booking info, and actions

- **Collapsible panels** — Each tab content wrapped in  with:
  - Dark metallic header ()
  - Expand/collapse chevron
  - Floating shadow effect matching Analytics page

- **No page scrolling** — Layout uses  with internal scrolling only in the sessions list panel

- **Hero unchanged** — Blue gradient hero with Active/Total pills remains as-is

### Reused Components

-  (from Analytics/Reports pages)
-  (from Analytics/Reports pages)
-  (from Radix UI)

### Screenshots

N/A — UI matches existing Analytics page pattern.

### Testing

-  ✅ clean
-  ✅ successful
- Verified existing form logic, API calls, and session list rendering unchanged
