### PR TITLE
fix(calendar): show a student's booking as soon as it's placed (not only once paid)

### DIFF
--- a/tutorme-app/src/app/api/student/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/student/calendar/events/route.ts
@@ -126,7 +126,10 @@ export const GET = withAuth(
     // finishes (COMPLETED) so the past session stays on the calendar to review. ---
     const oneOnOneFilters = [
       eq(calendarEvent.studentId, studentId),
-      inArray(oneOnOneBookingRequest.status, ['PAID', 'COMPLETED']),
+      // ACCEPTED = the tutor confirmed the slot and it's awaiting the student's
+      // payment; show it (flagged pending) so a booking is visible right after
+      // acceptance, not only once paid. EXPIRED/CANCELLED naturally drop out.
+      inArray(oneOnOneBookingRequest.status, ['ACCEPTED', 'PAID', 'COMPLETED']),
       eq(calendarEvent.isCancelled, false),
       isNull(calendarEvent.deletedAt),
     ]
@@ -148,6 +151,7 @@ export const GET = withAuth(
         externalId: calendarEvent.externalId,
         sessionStatus: liveSession.status,
         requestId: oneOnOneBookingRequest.requestId,
+        bookingStatus: oneOnOneBookingRequest.status,
       })
       .from(calendarEvent)
       .innerJoin(
@@ -162,7 +166,9 @@ export const GET = withAuth(
     // Surfaced so the student can find and join the shared room after booking.
     const groupFilters = [
       eq(groupSessionParticipant.studentId, studentId),
-      eq(groupSessionParticipant.status, 'PAID'),
+      // RESERVED = seat held awaiting payment; PAID = confirmed. Show both so a
+      // just-booked seat appears (flagged pending until paid).
+      inArray(groupSessionParticipant.status, ['RESERVED', 'PAID']),
       ne(groupSession.status, 'CANCELLED'),
     ]
     if (startParam) groupFilters.push(gte(liveSession.scheduledAt, startDate))
@@ -177,6 +183,7 @@ export const GET = withAuth(
         durationMinutes: liveSession.durationMinutes,
         meetingUrl: liveSession.roomUrl,
         sessionStatus: liveSession.status,
+        seatStatus: groupSessionParticipant.status,
       })
       .from(groupSessionParticipant)
       .innerJoin(
@@ -251,6 +258,9 @@ export const GET = withAuth(
         location: e.location,
         isVirtual: e.isVirtual,
         status: e.sessionStatus || e.status || 'scheduled',
+        // True when the tutor accepted but the student hasn't paid — the UI can
+        // badge it "awaiting payment" instead of showing a confirmed session.
+        pendingPayment: e.bookingStatus === 'ACCEPTED',
         courseId: null as string | null,
       })),
       ...groupEvents.map(e => {
@@ -272,6 +282,7 @@ export const GET = withAuth(
           location: 'Online',
           isVirtual: true,
           status: e.sessionStatus || 'scheduled',
+          pendingPayment: e.seatStatus === 'RESERVED',
           courseId: null as string | null,
         }
       }),


### PR DESCRIPTION
## The calendar/reminder investigation — precise findings

Traced the full booking→surface lifecycle. Everything is **PAID-gated by design**:
- **Student calendar** showed 1-on-1s only in `PAID`/`COMPLETED` (keyed by `calendarEvent.studentId`) and group seats only in `PAID`.
- **`/api/one-on-one/live-now`** (which the mounted `SessionLauncher` reminder polls) also filters to `PAID`, within a `now-4h … now+LOOKAHEAD` window — and it **does** include group sessions.

So the real gap: a booking is **invisible on the calendar between being placed and being paid** — which reads as "my booking doesn't show."

## Fix
The student calendar now also surfaces:
- **ACCEPTED** 1-on-1s (tutor confirmed the slot, awaiting the student's payment)
- **RESERVED** group seats (held, awaiting payment)

Each carries a **`pendingPayment`** flag so the UI can badge it "awaiting payment" rather than implying it's confirmed. Expired/cancelled bookings fall out naturally.

## Intentionally unchanged (flagging for your call)
- **Join + the live-now reminder still require PAID** — you can't enter an unpaid room, so reminding to join an unpaid session would be misleading. (If you want a "pay to confirm" nudge banner for accepted-unpaid sessions, that's a separate, easy add — say the word.)
- A **PENDING** request the tutor hasn't accepted shows in the student's **requests panel**, not as a calendar slot.

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)