### PR TITLE
fix(security): authorize private-board sub-room joins (owner or tutor only)

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -890,6 +890,36 @@ export async function initEnhancedSocketServer(server: NetServer) {
       socket.join(roomId)
       socket.data.roomId = roomId
 
+      // Private whiteboard sub-rooms are `<sessionId>:board:<ownerId>`. They have
+      // no LiveSession row, so the tutor/enrollment gates below are no-ops and
+      // would let ANY authenticated user in. Authorize explicitly: only the
+      // board's owner, or the base session's scheduled tutor, may join — otherwise
+      // a peer could read/draw on someone's "private" board.
+      const boardIdx = roomId.indexOf(':board:')
+      if (boardIdx >= 0) {
+        const baseSessionId = roomId.slice(0, boardIdx)
+        const ownerId = roomId.slice(boardIdx + ':board:'.length)
+        let allowed = userId === ownerId
+        if (!allowed && baseSessionId) {
+          try {
+            const [ls] = await drizzleDb
+              .select({ tutorId: liveSession.tutorId })
+              .from(liveSession)
+              .where(eq(liveSession.sessionId, baseSessionId))
+              .limit(1)
+            allowed = !!ls && ls.tutorId === userId
+          } catch {
+            allowed = false
+          }
+        }
+        if (!allowed) {
+          socket.leave(roomId)
+          socket.data.roomId = undefined
+          socket.emit('error', { message: 'Not authorized for this board' })
+          return
+        }
+      }
+
       // Get or create room from Redis first, then memory
       let room = activeRooms.get(roomId)
       if (!room && redisClient) {


### PR DESCRIPTION
## 🔴 Security — private boards had no server-side authorization

Found by an adversarial review of #1078. Private whiteboards run on socket sub-rooms `<sessionId>:board:<owner>`. These have **no LiveSession row**, so `join_class`'s tutor-verification and enrollment gates are **no-ops** — they downgrade role but never *reject*. Result: any authenticated user could `socket.emit('join_class', {roomId: '<sessionId>:board:<victimId>', ...})` and both **read** every stroke broadcast on that board **and draw on it** (student role is allowed to add strokes). The "private per-student" guarantee was by-obscurity only.

**Fix:** `join_class` now detects `:board:` room ids and authorizes explicitly — only the **board's owner** or the **base session's scheduled tutor** may join; anyone else is rejected and `socket.leave`'d.

## Verification
- `tsc` clean · `eslint` 0 errors · socket-server unit tests 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)