### PR TITLE
fix(calendar/join): suppress dead-end joins for pending + ended sessions

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -251,6 +251,7 @@ export function DashboardCalendar({
         // self-heal; maxStudents (2 for a 1-on-1) routes to the shared call room.
         sessionId: (ev as any).sessionId ?? undefined,
         requestId: (ev as any).requestId ?? undefined,
+        pendingPayment: (ev as any).pendingPayment ?? undefined,
         maxStudents: isOneOnOne ? 2 : ((ev as any).maxStudents ?? undefined),
         description:
           (ev as any).meetingUrl || (ev.tutorName ? `Tutor: ${ev.tutorName}` : undefined),

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -88,6 +88,8 @@ interface CalendarEvent {
   sessionId?: string
   /** 1-on-1 booking request id — used to self-heal a missing session link. */
   requestId?: string
+  /** Tutor accepted but the student hasn't paid — can't join yet. */
+  pendingPayment?: boolean
   studentCount?: number
   maxStudents?: number
   subject?: string
@@ -1483,8 +1485,13 @@ export function InteractiveCalendar({
                   </Button>
                   <Button
                     variant="modal-primary-dark"
-                    disabled={selectedEvent.status === 'cancelled' || joiningSession}
+                    disabled={
+                      selectedEvent.status === 'cancelled' ||
+                      joiningSession ||
+                      selectedEvent.pendingPayment
+                    }
                     onClick={async () => {
+                      if (selectedEvent.pendingPayment) return
                       const isOneOnOne = (selectedEvent.maxStudents ?? 50) <= 2
                       // 1-on-1 (capacity ≤ 2) → the shared two-way call room, which
                       // works for both roles (course classrooms are role-specific and
@@ -1540,17 +1547,19 @@ export function InteractiveCalendar({
                     }}
                   >
                     <Video className="mr-2 h-4 w-4" />
-                    {selectedEvent.status === 'cancelled'
-                      ? 'Cancelled'
-                      : selectedEvent.status === 'completed'
-                        ? isStudent
-                          ? 'View Feedback'
-                          : 'View Session'
-                        : selectedEvent.status === 'live'
-                          ? 'Join Session'
-                          : isStudent
-                            ? 'View Session'
-                            : 'Start Session'}
+                    {selectedEvent.pendingPayment
+                      ? 'Awaiting payment'
+                      : selectedEvent.status === 'cancelled'
+                        ? 'Cancelled'
+                        : selectedEvent.status === 'completed'
+                          ? isStudent
+                            ? 'View Feedback'
+                            : 'View Session'
+                          : selectedEvent.status === 'live'
+                            ? 'Join Session'
+                            : isStudent
+                              ? 'View Session'
+                              : 'Start Session'}
                   </Button>
                 </DialogFooter>
               </>

--- a/tutorme-app/src/app/api/group-sessions/mine/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/mine/route.ts
@@ -32,6 +32,7 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
       timezone: groupSession.timezone,
       status: groupSession.status,
       scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
       tutorName: profile.name,
     })
     .from(groupSessionParticipant)
@@ -62,8 +63,14 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
       timezone: r.timezone,
       tutorName: r.tutorName,
       scheduledAt: r.scheduledAt,
-      // The room is joinable from 20 min before the scheduled start.
-      joinable: !!r.scheduledAt && r.scheduledAt.getTime() - now.getTime() <= EARLY_ENTRY_MS,
+      // Joinable from 20 min before start UNTIL the session ends (start +
+      // duration) — otherwise a finished session kept showing an active "Join".
+      joinable: (() => {
+        if (!r.scheduledAt) return false
+        const startMs = r.scheduledAt.getTime()
+        const endMs = startMs + (r.durationMinutes ?? 120) * 60_000
+        return startMs - now.getTime() <= EARLY_ENTRY_MS && now.getTime() < endMs
+      })(),
     })),
   })
 })


### PR DESCRIPTION
Two adversarial-review findings about dead-end Join buttons:

**D2 (HIGH)** — #1102 only badged awaiting-payment bookings on the **Bookings-tab lists**; the **Calendar tab**'s `InteractiveCalendar` detail dialog still offered a live "Join Session" for an **ACCEPTED-unpaid** 1-on-1 / **RESERVED** group seat (dead-ends — the room requires PAID). `pendingPayment` is now threaded through `interactiveEvents` → the dialog disables the button and labels it **"Awaiting payment"**.

**C1 (MED)** — `/api/group-sessions/mine` marked a session `joinable` from 20 min before start with **no upper bound**, so a session that ended up to ~3h ago still showed an active green **Join**. Now gated to **before the session's end** (start + duration).

## Verification
- `tsc` clean · `eslint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)