### PR TITLE
fix(whiteboard): replay existing strokes when joining a private board

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1082,6 +1082,42 @@ export async function initEnhancedSocketServer(server: NetServer) {
       await (effectiveRole === 'student'
         ? addStudentToRoom(socket, room)
         : addTutorToRoom(socket, room))
+
+      // Private board sub-room: replay the strokes already drawn to the joining
+      // socket, so a tutor opening a student's board (or anyone rejoining) sees
+      // the existing drawing instead of a blank board. EnhancedWhiteboard only
+      // applies live deltas, so without this the board appears empty. Sent to the
+      // joiner alone; attributed to the board owner (board rooms aren't filtered).
+      const replayBoardIdx = roomId.indexOf(':board:')
+      if (replayBoardIdx >= 0 && room.whiteboardData) {
+        const ownerId = roomId.slice(replayBoardIdx + ':board:'.length)
+        const wb = room.whiteboardData as {
+          strokes?: Array<{ pageIndex?: number }>
+          shapes?: Array<{ pageIndex?: number }>
+          texts?: Array<{ pageIndex?: number }>
+        }
+        for (const stroke of wb.strokes ?? []) {
+          socket.emit('whiteboard:stroke:added', {
+            userId: ownerId,
+            stroke,
+            pageIndex: stroke.pageIndex ?? 0,
+          })
+        }
+        for (const shape of wb.shapes ?? []) {
+          socket.emit('whiteboard:shape:added', {
+            userId: ownerId,
+            shape,
+            pageIndex: shape.pageIndex ?? 0,
+          })
+        }
+        for (const text of wb.texts ?? []) {
+          socket.emit('whiteboard:text:added', {
+            userId: ownerId,
+            text,
+            pageIndex: text.pageIndex ?? 0,
+          })
+        }
+      }
     })
 
     // Activity ping keeps room and student alive during quiet sessions


### PR DESCRIPTION
## Review finding on #1078 — tutor opens a student board → blank

`EnhancedWhiteboard` only applies **live** `whiteboard:stroke:added` deltas and never requests state, so a tutor opening a student's board (or anyone rejoining after a page reload) saw a **blank** board and only caught strokes drawn from that moment on — the "watch what they've drawn" promise was half-broken.

**Fix (server-side, no client change):** on `join_class` for a `<sessionId>:board:<owner>` sub-room, the server replays the stored `strokes`/`shapes`/`texts` from `room.whiteboardData` to the **joining socket alone** (attributed to the board owner — board rooms aren't user-filtered), so the existing drawing renders immediately. Scoped to `:board:` rooms to avoid changing the course classroom's per-user filtering.

## Verification
- `tsc` clean · `eslint` 0 errors · socket-server unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)