### PR TITLE
fix(video): recover from an expired join token on Retry

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -272,6 +272,7 @@ export default function OneOnOneCallPage() {
       twoWay={video.twoWay}
       courseId={video.courseId ?? null}
       courseName={video.courseName ?? null}
+      onRefreshToken={runJoin}
     />
   )
 }

--- a/tutorme-app/src/components/class/daily-video-frame.tsx
+++ b/tutorme-app/src/components/class/daily-video-frame.tsx
@@ -42,6 +42,11 @@ interface DailyVideoFrameProps {
    *  video for both roles (symmetric two-way) instead of the tutor→students
    *  broadcast layout, and let the student toggle their camera. */
   twoWay?: boolean
+  /** Optional: re-mint a fresh access token and re-enter. Wired to Retry so a
+   *  join that failed on an EXPIRED token (e.g. after a long idle) can recover —
+   *  a plain retry would just replay the same dead token. Falls back to a local
+   *  retry when not provided. */
+  onRefreshToken?: () => void | Promise<void>
 }
 
 export function DailyVideoFrame({
@@ -52,6 +57,7 @@ export function DailyVideoFrame({
   floating = false,
   isTutor = false,
   twoWay = false,
+  onRefreshToken,
 }: DailyVideoFrameProps) {
   const {
     call,
@@ -498,7 +504,10 @@ export function DailyVideoFrame({
               type="button"
               onClick={() => {
                 joinedRef.current = false
-                setJoinAttempt(v => v + 1)
+                // Prefer a fresh token (recovers from an expired one); fall back
+                // to a local retry when the parent can't re-mint.
+                if (onRefreshToken) void onRefreshToken()
+                else setJoinAttempt(v => v + 1)
               }}
               className="rounded-full bg-white/10 px-4 py-2 text-xs font-semibold text-white hover:bg-white/20"
             >

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -47,6 +47,8 @@ interface SessionClassroomProps {
    *  straight into the Course Builder to edit it (changes sync everywhere). */
   courseId?: string | null
   courseName?: string | null
+  /** Re-mint a fresh access token and re-enter (recovers from an expired token). */
+  onRefreshToken?: () => void | Promise<void>
 }
 
 export function SessionClassroom({
@@ -57,6 +59,7 @@ export function SessionClassroom({
   twoWay,
   courseId,
   courseName,
+  onRefreshToken,
 }: SessionClassroomProps) {
   const { data: session } = useSession()
   const [activePanel, setActivePanel] = useState<ActivePanel>(null)
@@ -98,6 +101,7 @@ export function SessionClassroom({
       token={token}
       isTutor={isTutor}
       twoWay={twoWay}
+      onRefreshToken={onRefreshToken}
       className="h-full w-full rounded-none border-0"
     />
   )


### PR DESCRIPTION
From the 1-on-1 video audit — the one genuinely-real lower-severity finding (the other two turned out to be non-issues).

## Bug
If a 1-on-1 join failed because the Daily access **token had expired** (long idle → return), the Retry button just replayed the **same dead token** → failed again with no recovery.

## Fix
Optional `onRefreshToken` prop on `DailyVideoFrame`; Retry prefers it to **re-mint a fresh token** and re-enter, falling back to the existing local retry when a parent can't re-mint. Threaded through `SessionClassroom`; the `/call` page wires it to its existing `runJoin` (mints a fresh token via `/api/class/rooms/[id]/join`). Additive + backward-compatible.

## Verified NON-issues (left alone)
- **Cleanup not calling `leave()`** — *by design.* The call is a global singleton that intentionally persists across navigation for the floating overlay; calling `leave()` on unmount would drop the call whenever you navigate.
- **Post-join permission-error not re-showing** — *already handled* at `daily-video-frame.tsx:131-134` (resets the dismissal on a new error).

## Verification
Typecheck confirms the prop threads end-to-end; the change is additive with a preserved fallback. Full behaviour (token actually expiring → Retry re-mints) needs the running app + Daily + a real expired token, so it's best confirmed on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)