### PR TITLE
feat(sessions): make the in-session Edit-course modal auto-save to the DB

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7800,10 +7800,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [leftPanelResizing])
 
-    // Auto-save course edits (debounced) — disabled in live mode
+    // Auto-save course edits (debounced). Off in insights mode UNLESS the caller
+    // opts in via insightsProps.autoSave (the in-session Edit-course modal), so
+    // edits persist without a manual Save. Gated on a stable boolean — NOT the
+    // insightsProps object — so a new-object-every-render doesn't reset the timer.
+    const autoSaveEnabled = !insightsProps || !!insightsProps.autoSave
     useEffect(() => {
       if (!canEdit) return
-      if (insightsProps) return
+      if (!autoSaveEnabled) return
       if (!onSave) return
 
       const timeoutId = setTimeout(() => {
@@ -7828,7 +7832,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       coursePropsModal.description,
       courseName,
       onSave,
-      insightsProps,
+      autoSaveEnabled,
     ])
 
     const filteredCourseBuilderNodes = useMemo(() => {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -372,6 +372,9 @@ export interface InsightsSessionOption {
 
 export interface CourseBuilderInsightsProps {
   courseId?: string | null
+  /** Enable the debounced course auto-save even in insights mode (used by the
+   *  in-session Edit-course modal so edits persist without a Save click). */
+  autoSave?: boolean
   courses?: Array<{ id: string; name: string; categories?: string[]; isPublished?: boolean }>
   /** Local drafts (not yet published). Carries the category chosen at creation
    *  so the builder can resolve Board/Subject before the course is published. */

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -115,8 +115,11 @@ function TutorInsightsPageInner() {
   } | null>(null)
   // When opened from Dashboard sidebar or My Page Create Course, start in draft mode
   const startInEditMode = searchParams.get('mode') === 'edit'
+  // Embedded in the in-session Edit-course modal: edit UI, but persist straight
+  // to the DB (live) and auto-save — so "changes sync everywhere" holds.
+  const embedded = searchParams.get('embed') === '1'
   const [saveMode, setSaveMode] = useState<'live' | 'draft'>(
-    searchParams.get('sessionId') ? 'live' : startInEditMode ? 'draft' : 'live'
+    searchParams.get('sessionId') || embedded ? 'live' : startInEditMode ? 'draft' : 'live'
   )
   const [draftCourses, setDraftCourses] = useState<CourseSummary[]>([])
 
@@ -130,8 +133,8 @@ function TutorInsightsPageInner() {
   // BUT respect explicit mode=edit query param (set by Create Course / Course Builder nav)
   useEffect(() => {
     if (!courseId || courseId === 'insights-draft') return
-    // If a sessionId is in the URL, force live mode
-    if (searchParams.get('sessionId')) {
+    // A sessionId or the embedded Edit-course modal force live (DB) persistence.
+    if (searchParams.get('sessionId') || searchParams.get('embed') === '1') {
       setSaveMode('live')
       return
     }
@@ -1343,6 +1346,7 @@ function TutorInsightsPageInner() {
           detachedCourseName={dataMode === 'detached' ? detachedCourseName : undefined}
           insightsProps={{
             courseId,
+            autoSave: embedded,
             courses: courses.map(course => ({
               id: course.id,
               name: course.name,

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -262,7 +262,7 @@ export function SessionClassroom({
         <Dialog open={showCourseEditor} onOpenChange={setShowCourseEditor}>
           <DialogContent size="full" className="h-[95vh] overflow-hidden p-0">
             <iframe
-              src={`/tutor/insights?tab=builder&courseId=${encodeURIComponent(courseId)}&mode=edit`}
+              src={`/tutor/insights?tab=builder&courseId=${encodeURIComponent(courseId)}&mode=edit&embed=1`}
               title={courseName ? `Edit ${courseName}` : 'Edit course'}
               className="h-full w-full rounded-lg border-0"
             />


### PR DESCRIPTION
## Option 1 — properly fix the edit-modal auto-save (B2/B3)

The review found the Edit-course modal (#1095) inherited the insights builder's behaviour:
- **B2:** course-level **auto-save disabled** whenever `insightsProps` is present.
- **B3:** `mode=edit` forced a **non-variant** course to persist to **localStorage only** — so "changes sync everywhere" was false for that case.

**Fix — scoped to the modal via a new `embed=1` param so the normal insights page is untouched:**
1. The modal iframe now loads `…&embed=1`.
2. `embed` forces `saveMode='live'` (initial value **and** the auto-detect effect), so `executeSave`'s `persistMode` is `'live'` → `saveCourse` writes to the **DB**.
3. `insightsProps.autoSave=true` enables the debounced course auto-save in insights mode. The gate reads a **stable boolean** (not the `insightsProps` object) so a new-object-every-render can't reset the 2s timer. Auto-save flows `handleSave → executeSave` (which skips the propagation dialog for `isAutoSave`).

Result: editing the linked course in the in-session modal **auto-saves to the DB** — no Save click, reflects everywhere the course is used. The normal `/tutor/insights` page is unaffected (no `embed`).

## Verification
- `tsc` clean · `eslint` 0 errors · `next build` success (exit 0)

⚠️ Deep change to the shared `CourseBuilder`/insights save path — worth a live check that a normal insights-page edit still behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)