### PR TITLE
fix(sessions): explain the course-scoped empty state in the deploy panel

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -207,8 +207,10 @@ export function SessionDeployPanel({
             <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
           </div>
         ) : items.length === 0 ? (
-          <div className="rounded-lg border border-dashed py-10 text-center text-xs text-slate-500">
-            No saved tasks to deploy yet. Create tasks in the course builder first.
+          <div className="rounded-lg border border-dashed px-4 py-10 text-center text-xs text-slate-500">
+            {courseId
+              ? 'This session is scoped to its course, and that course has no saved tasks yet. Add tasks to it in the course builder to deploy them here.'
+              : 'No saved tasks to deploy yet. Create tasks in the course builder first.'}
           </div>
         ) : courses.length === 0 ? (
           <div className="rounded-lg border border-dashed py-10 text-center text-xs text-slate-500">


### PR DESCRIPTION
## Follow-up to P2 — "leave strict"

You chose to keep the deploy panel **strictly scoped** to the session's course (no fallback-to-all-courses). The only remaining rough edge: when that course has no saved tasks, the panel showed *"Create tasks in the course builder first"*, which reads like the whole builder is empty even though the tutor has plenty of tasks under other courses.

**Fix:** make the empty message course-aware — a legitimately-scoped-but-empty list now explains *why* it's empty and what to do:

> This session is scoped to its course, and that course has no saved tasks yet. Add tasks to it in the course builder to deploy them here.

Course-less sessions keep the original message. No behaviour change — copy only.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)