### PR TITLE
fix(insights): don't auto-propagate autosaves to sibling course variants

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -416,12 +416,14 @@ function TutorInsightsPageInner() {
 
   const handleSave = useCallback(
     async (lessons: any[], options?: any) => {
-      // For published variants, auto-propagate edits to sibling variants (those
-      // published with this course, NOT all tutor courses). This runs on autosave
-      // too — autosave is debounced (~2s after edits settle), so siblings stay in
-      // sync without the tutor needing a manual Save. Independent variants are
-      // still excluded server-side.
-      if (isPublishedVariant) {
+      // For published variants, propagate edits to sibling variants (those
+      // published with this course, NOT all tutor courses) — but ONLY on an
+      // explicit manual Save. Autosave is debounced and silent (no toast), so
+      // auto-propagating would rewrite every sibling variant on each edit burst
+      // with no confirmation. On autosave we fall through and persist just this
+      // variant (persistMode stays 'live' for a published variant, so the edit
+      // is still saved to the DB — it simply doesn't touch the siblings).
+      if (isPublishedVariant && !options?.isAutoSave) {
         await executeSave(lessons, options, true, false)
         return
       }


### PR DESCRIPTION
## Regression from #1110 — live in prod

The retrospective adversarial review caught this. #1110 enabled autosave in the in-session **Edit-course modal**. That modal loads the session's **published-variant** course, so `isPublishedVariant` is `true` and `handleSave` (`insights/page.tsx`) took the **propagate-to-all-variants** branch — on the *silent, debounced* autosave path.

**Effect:** editing one lesson in the modal silently rewrote the content of **every sibling variant** (each category/nationality published from that course), every ~2s, with no toast and no confirmation. Before #1110 autosave was disabled on the insights page, so this is a new blast radius.

**Fix:** propagate to siblings only on an **explicit manual Save**. On autosave we persist just the current variant — `persistMode` stays `'live'` for a published variant, so the edit is still saved to the DB; it just no longer clobbers the siblings.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)