### PR TITLE
fix(whiteboard): hydrate the owner's own private board + gate board writes

### DIFF
--- a/tutorme-app/src/components/class/enhanced-whiteboard.tsx
+++ b/tutorme-app/src/components/class/enhanced-whiteboard.tsx
@@ -2019,8 +2019,9 @@ export function EnhancedWhiteboard({
       userId?: string
       stroke: Stroke & { points?: number[] | Point[] }
       pageIndex?: number
+      replay?: boolean
     }) => {
-      if (data.userId && userId && data.userId === userId) return // own echo: already applied locally
+      if (!data.replay && data.userId && userId && data.userId === userId) return // own echo: already applied locally (but replayed hydration must apply)
       if (filterByUserId && data.userId !== filterByUserId) return
       const stroke: Stroke = {
         ...data.stroke,
@@ -2040,8 +2041,9 @@ export function EnhancedWhiteboard({
       userId?: string
       shape: ShapeElement
       pageIndex?: number
+      replay?: boolean
     }) => {
-      if (data.userId && userId && data.userId === userId) return // own echo: already applied locally
+      if (!data.replay && data.userId && userId && data.userId === userId) return // own echo: already applied locally (but replayed hydration must apply)
       if (filterByUserId && data.userId !== filterByUserId) return
       const idx = safePageIndex(data.pageIndex, currentPageIndexRef.current)
       enqueue({ type: 'shape', pageIndex: idx, shape: data.shape })
@@ -2056,8 +2058,13 @@ export function EnhancedWhiteboard({
       }
     }
 
-    const handleTextAdded = (data: { userId?: string; text: TextElement; pageIndex?: number }) => {
-      if (data.userId && userId && data.userId === userId) return // own echo: already applied locally
+    const handleTextAdded = (data: {
+      userId?: string
+      text: TextElement
+      pageIndex?: number
+      replay?: boolean
+    }) => {
+      if (!data.replay && data.userId && userId && data.userId === userId) return // own echo: already applied locally (but replayed hydration must apply)
       if (filterByUserId && data.userId !== filterByUserId) return
       const idx = safePageIndex(data.pageIndex, currentPageIndexRef.current)
       enqueue({ type: 'text', pageIndex: idx, text: data.text })
@@ -2078,8 +2085,9 @@ export function EnhancedWhiteboard({
       userId?: string
       formula: FormulaElement
       pageIndex?: number
+      replay?: boolean
     }) => {
-      if (data.userId && userId && data.userId === userId) return // own echo: already applied locally
+      if (!data.replay && data.userId && userId && data.userId === userId) return // own echo: already applied locally (but replayed hydration must apply)
       if (filterByUserId && data.userId !== filterByUserId) return
       const idx = safePageIndex(data.pageIndex, currentPageIndexRef.current)
       enqueue({ type: 'formula', pageIndex: idx, formula: data.formula })
@@ -2089,8 +2097,9 @@ export function EnhancedWhiteboard({
       userId?: string
       graph: GraphElement
       pageIndex?: number
+      replay?: boolean
     }) => {
-      if (data.userId && userId && data.userId === userId) return // own echo: already applied locally
+      if (!data.replay && data.userId && userId && data.userId === userId) return // own echo: already applied locally (but replayed hydration must apply)
       if (filterByUserId && data.userId !== filterByUserId) return
       const idx = safePageIndex(data.pageIndex, currentPageIndexRef.current)
       enqueue({ type: 'graph', pageIndex: idx, graph: data.graph })

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1095,12 +1095,18 @@ export async function initEnhancedSocketServer(server: NetServer) {
           strokes?: Array<{ pageIndex?: number }>
           shapes?: Array<{ pageIndex?: number }>
           texts?: Array<{ pageIndex?: number }>
+          formulas?: Array<{ pageIndex?: number }>
+          graphs?: Array<{ pageIndex?: number }>
         }
+        // `replay: true` tells the client this is hydration, not a live echo —
+        // the board owner (viewerId === ownerId) would otherwise drop every one
+        // of these as its "own echo" and see a blank board on rejoin.
         for (const stroke of wb.strokes ?? []) {
           socket.emit('whiteboard:stroke:added', {
             userId: ownerId,
             stroke,
             pageIndex: stroke.pageIndex ?? 0,
+            replay: true,
           })
         }
         for (const shape of wb.shapes ?? []) {
@@ -1108,6 +1114,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
             userId: ownerId,
             shape,
             pageIndex: shape.pageIndex ?? 0,
+            replay: true,
           })
         }
         for (const text of wb.texts ?? []) {
@@ -1115,6 +1122,23 @@ export async function initEnhancedSocketServer(server: NetServer) {
             userId: ownerId,
             text,
             pageIndex: text.pageIndex ?? 0,
+            replay: true,
+          })
+        }
+        for (const formula of wb.formulas ?? []) {
+          socket.emit('whiteboard:formula:added', {
+            userId: ownerId,
+            formula,
+            pageIndex: formula.pageIndex ?? 0,
+            replay: true,
+          })
+        }
+        for (const graph of wb.graphs ?? []) {
+          socket.emit('whiteboard:graph:added', {
+            userId: ownerId,
+            graph,
+            pageIndex: graph.pageIndex ?? 0,
+            replay: true,
           })
         }
       }
@@ -2186,6 +2210,15 @@ export async function initEnhancedSocketServer(server: NetServer) {
       }
     )
 
+    // A socket may only mutate/broadcast into a private board sub-room it actually
+    // joined. `join_class` gates board membership to the owner + base-session
+    // tutor (and makes a rejected socket leave), but io.to(roomId).emit does NOT
+    // require the sender to be a member — so without this check a crafted
+    // `roomId = "<session>:board:<victim>"` could write to a board the sender was
+    // rejected from. Base (non-board) rooms keep their existing behaviour.
+    const canWriteRoom = (roomId: string): boolean =>
+      !roomId.includes(':board:') || socket.rooms.has(roomId)
+
     // Incremental whiteboard delta sync handlers
     socket.on(
       'whiteboard:stroke:add',
@@ -2193,6 +2226,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
         const { roomId, stroke, pageIndex } = data || ({} as any)
         if (!roomId || !stroke) return
+        if (!canWriteRoom(roomId)) return
 
         const room = activeRooms.get(roomId)
         if (!room) return
@@ -2218,6 +2252,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
         const { roomId, shape, pageIndex } = data || ({} as any)
         if (!roomId || !shape) return
+        if (!canWriteRoom(roomId)) return
 
         const room = activeRooms.get(roomId)
         if (!room) return
@@ -2243,6 +2278,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
         const { roomId, text, pageIndex } = data || ({} as any)
         if (!roomId || !text) return
+        if (!canWriteRoom(roomId)) return
 
         const room = activeRooms.get(roomId)
         if (!room) return
@@ -2277,6 +2313,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
         const { roomId, formula, pageIndex } = data || ({} as any)
         if (!roomId || !formula) return
+        if (!canWriteRoom(roomId)) return
 
         const room = activeRooms.get(roomId)
         if (!room) return
@@ -2305,6 +2342,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
         const { roomId, graph, pageIndex } = data || ({} as any)
         if (!roomId || !graph) return
+        if (!canWriteRoom(roomId)) return
 
         const room = activeRooms.get(roomId)
         if (!room) return
@@ -2328,6 +2366,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
       if (socket.data.role !== 'tutor' && socket.data.role !== 'student') return
       const { roomId, pageIndex } = data || ({} as any)
       if (!roomId || typeof pageIndex !== 'number') return
+      if (!canWriteRoom(roomId)) return
 
       const room = activeRooms.get(roomId)
       if (!room) return


### PR DESCRIPTION
## Two private-board issues from the retrospective review (#1103/#1108)

### A2 — HIGH: the owner's own board came back blank on rejoin
The join-time replay (#1108) re-emits stored strokes attributed to the board **owner**. But the client drops any event whose `userId` matches the local user as an "own echo". On the owner's **own** board `viewerId === ownerId`, so **every replayed item was discarded** — the owner drew, closed/reopened the board, and saw a blank canvas (work looked lost). The tutor viewing the same board saw it fine, which made it look intermittent.

**Fix:** replay now carries `replay: true`; the client applies replayed items even when they match the local user. Formulas + graphs are now replayed too (previously omitted, so they never rehydrated for anyone).

### A3 — MED-HIGH: board writes weren't authorized
`join_class` gates who may **join** a `:board:` sub-room (owner + base-session tutor), but the delta handlers (`stroke/shape/text/formula/graph/page:clear`) only checked `role`, then mutated and broadcast whatever `roomId` the client sent. Since `io.to(roomId).emit` doesn't require membership, a crafted emit with `roomId = "<session>:board:<victim>"` could **write to or clear a board the sender was rejected from joining**. Not reachable from the UI, but a real authorization hole on a "private" feature.

**Fix:** each handler requires `socket.rooms.has(roomId)` for `:board:` rooms; base (non-board) rooms are unchanged.

## Verification
- `tsc` clean · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)