### PR TITLE
fix(tutor-calendar): suppress Start Session on unpaid (accepted) 1-on-1s

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -599,6 +599,9 @@ export function InteractiveCalendar({
             nationality: e.nationality,
             variantCategory: e.variantCategory,
             studentCount: e.enrolledCount ?? 0,
+            // An accepted-but-unpaid 1-on-1 has a live session row but no student
+            // can enter yet — disables the "Start Session" button (see detail dialog).
+            pendingPayment: e.pendingPayment,
             color:
               e.status === 'live'
                 ? 'bg-emerald-500'

--- a/tutorme-app/src/app/api/tutor/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/route.ts
@@ -14,6 +14,7 @@ import {
   course,
   sessionParticipant,
   courseVariant,
+  oneOnOneBookingRequest,
 } from '@/lib/db/schema'
 import { eq, and, gte, lte, inArray, isNull, isNotNull, sql } from 'drizzle-orm'
 
@@ -60,9 +61,18 @@ export const GET = withAuth(
         sessionStatus: liveSession.status,
         sessionId: liveSession.sessionId,
         externalId: calendarEvent.externalId,
+        // A 1-on-1 CalendarEvent + LiveSession is created the moment the tutor
+        // ACCEPTS, before the student pays. Surface the booking status so an
+        // unpaid session doesn't offer a "Start Session" into a room the student
+        // can't enter. Non-1-on-1 events have no booking row → null → not pending.
+        bookingStatus: oneOnOneBookingRequest.status,
       })
       .from(calendarEvent)
       .leftJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
+      .leftJoin(
+        oneOnOneBookingRequest,
+        eq(oneOnOneBookingRequest.calendarEventId, calendarEvent.eventId)
+      )
       .where(and(...calFilters))
       .orderBy(calendarEvent.startTime)
 
@@ -119,6 +129,7 @@ export const GET = withAuth(
         location: e.location,
         isVirtual: e.isVirtual,
         sessionId: e.sessionId || e.externalId,
+        pendingPayment: e.bookingStatus === 'ACCEPTED',
       })),
       ...liveSessions
         .filter(ls => !coveredSessionIds.has(ls.sessionId))
@@ -134,6 +145,7 @@ export const GET = withAuth(
           location: 'Online',
           isVirtual: true,
           sessionId: ls.sessionId,
+          pendingPayment: false,
         })),
     ]
 


### PR DESCRIPTION
## Retrospective finding B4 — the student dead-end, un-fixed on the tutor side

A 1-on-1 `CalendarEvent` + `LiveSession` is created the moment the tutor **ACCEPTS** a request — *before* the student pays (`respond/route.ts`). The tutor calendar route never joined `oneOnOneBookingRequest`, so it emitted **no `pendingPayment` flag**. The `InteractiveCalendar` detail dialog already disables "Start Session" when `pendingPayment` is true (added in #1107) — but it received `undefined` and left the button **enabled**. The tutor clicks Start Session → lands in a room the student can never enter (student side correctly shows "Awaiting payment"). This is the exact mirror of the student dead-end #1102 fixed.

**Fix:**
- API: `leftJoin(oneOnOneBookingRequest, calendarEventId)` and set `pendingPayment = bookingStatus === 'ACCEPTED'`. Course/group events have no booking row → `null` → not pending.
- Frontend: map `pendingPayment` through `InteractiveCalendar`'s API projection, which previously dropped the field.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)