### PR TITLE
fix(student-calendar): stop offering Join on ended group sessions

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -479,7 +479,14 @@ export function DashboardCalendar({
                                 {formatDate(s.start)} · {formatEventTime(s.start)}
                               </p>
                             </div>
-                            {s.pendingPayment ? (
+                            {new Date(s.end).getTime() < Date.now() ? (
+                              // Session already ended — suppress the dead-end Join
+                              // (the room is closed). Parity with the 1-on-1 list,
+                              // which flips a past session to its Rate/ended state.
+                              <span className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-semibold text-gray-500">
+                                Ended
+                              </span>
+                            ) : s.pendingPayment ? (
                               <span
                                 className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-amber-100 px-3 py-1.5 text-xs font-semibold text-amber-700"
                                 title="Seat held — complete payment to confirm and unlock the room."


### PR DESCRIPTION
## Retrospective finding B6 (MEDIUM)

The student group-session list gated its Join button on **seat status only** (pending vs paid), with **no end-time check** — unlike the 1-on-1 list, which flips a past session to its Rate/ended state via `end < now`. So a finished group session kept showing a live **"Join"** that routed into a closed room. (The dedicated `/group-sessions/mine` route does gate joinability by end time, but this calendar list doesn't use it.)

**Fix:** add the same end-gate — once `s.end` is in the past, show a muted **"Ended"** state instead of Join. Group seats have no per-student rating flow, so it's just an ended label (vs the 1-on-1 "Rate" action).

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)