### PR TITLE
fix(sessions): refresh the deploy panel after an in-session course edit

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -367,6 +367,22 @@ function TutorInsightsPageInner() {
         setIndependent,
       })
 
+      // When running inside the in-session Edit-course modal (iframe), tell the
+      // parent classroom a save landed so it can refetch its deploy panel — which
+      // otherwise keeps serving the pre-edit task content. Fires on autosave too
+      // (before the early return below), since the modal auto-saves silently.
+      if (
+        embedded &&
+        result?.success &&
+        typeof window !== 'undefined' &&
+        window.parent !== window
+      ) {
+        window.parent.postMessage(
+          { type: 'tutorme:course-saved', courseId },
+          window.location.origin
+        )
+      }
+
       if (options?.isAutoSave) return
 
       if (result.success) {

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -12,7 +12,7 @@
  * task deployment) are intentionally absent — a course-less session has none.
  */
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
 import { Send, FolderOpen, Users, Pencil, PenTool, LayoutGrid } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
@@ -70,7 +70,21 @@ export function SessionClassroom({
   const [boardTarget, setBoardTarget] = useState<BoardTarget | null>(null)
   const [showBoardsPicker, setShowBoardsPicker] = useState(false)
   const [showCourseEditor, setShowCourseEditor] = useState(false)
+  // Bumped when the Edit-course modal (iframe) reports a save, so the deploy
+  // panel refetches instead of serving pre-edit task content.
+  const [deployRefreshKey, setDeployRefreshKey] = useState(0)
   const myId = session?.user?.id ?? ''
+
+  // Listen for the embedded course-editor's save postMessage and refresh the
+  // deploy panel's task list. Same-origin check guards against foreign frames.
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.origin !== window.location.origin) return
+      if (e.data?.type === 'tutorme:course-saved') setDeployRefreshKey(k => k + 1)
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
   const ownBoardOpened = useOwnBoardOpened(boardTarget?.mine === true)
 
   // useSocket keys its effect on the option fields (not object identity), so an
@@ -233,6 +247,7 @@ export function SessionClassroom({
                 sessionId={sessionId}
                 socket={socket}
                 courseId={courseId}
+                refreshKey={deployRefreshKey}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -58,6 +58,7 @@ export function SessionDeployPanel({
   sessionId,
   socket,
   courseId,
+  refreshKey,
   onClose,
 }: {
   sessionId: string
@@ -65,6 +66,9 @@ export function SessionDeployPanel({
   /** When the session is built around a course, only that course's tasks are
    *  deployable; null/undefined offers all the tutor's published tasks. */
   courseId?: string | null
+  /** Bumped by the parent when the linked course is edited in the in-session
+   *  modal, so the task list refetches instead of serving stale content. */
+  refreshKey?: number
   onClose: () => void
 }) {
   const [items, setItems] = useState<Deployable[]>([])
@@ -88,7 +92,7 @@ export function SessionDeployPanel({
     return () => {
       active = false
     }
-  }, [courseId])
+  }, [courseId, refreshKey])
 
   // Group the flat task list into course → lesson → tasks, filtered by the
   // search query (matches task title, course name or lesson title).


### PR DESCRIPTION
## Retrospective finding A2 (MEDIUM)

The Edit-course modal (iframe) auto-saves to the DB (#1110), but the deploy panel only fetched its task list on **mount / courseId change**. So a tutor who edited a task in the modal, closed it, then deployed "the same task" from an **already-open** panel sent students the **pre-edit** content. The "edits sync everywhere" claim wasn't true for the live room in the same tab.

**Fix — a small same-origin postMessage bridge:**
- On a successful save, the embedded insights page posts `{ type: 'tutorme:course-saved' }` to its parent (fires on autosave too, before the autosave early-return).
- The classroom listens (origin-checked) and bumps a `refreshKey`.
- `SessionDeployPanel` takes `refreshKey` and includes it in its fetch effect deps → refetches.

Editing the linked course now reflects in the deploy panel without reopening it. No-op when not embedded (normal insights page never posts).

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)