### PR TITLE
feat(group-sessions): let students resume payment for a held (reserved) seat

### DIFF
--- a/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/group-sessions/page.tsx
@@ -3,9 +3,18 @@
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { Users, Loader2, CalendarDays, ArrowUpRight, BookOpen, Video } from 'lucide-react'
+import {
+  Users,
+  Loader2,
+  CalendarDays,
+  ArrowUpRight,
+  BookOpen,
+  Video,
+  CreditCard,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { bookGroupSeat } from '@/lib/group-session/book-seat'
+import { resumeGroupSeatPayment } from '@/lib/group-session/resume-payment'
 import { formatEarnings } from '@/lib/format-currency'
 
 interface BrowseSession {
@@ -27,6 +36,7 @@ interface BrowseSession {
 }
 
 interface MySession {
+  participantId: string
   groupSessionId: string
   title: string
   liveSessionId: string | null
@@ -36,6 +46,8 @@ interface MySession {
   timezone: string
   tutorName?: string | null
   joinable: boolean
+  /** Seat held but not paid — render "Complete payment" instead of Join. */
+  needsPayment?: boolean
 }
 
 function formatDate(iso: string): string {
@@ -123,7 +135,28 @@ export default function StudentGroupSessionsPage() {
                     {s.tutorName ? <span className="capitalize">with {s.tutorName}</span> : null}
                   </div>
                 </div>
-                {s.liveSessionId ? (
+                {s.needsPayment ? (
+                  <button
+                    type="button"
+                    disabled={busyId === s.participantId}
+                    onClick={async () => {
+                      setBusyId(s.participantId)
+                      const result = await resumeGroupSeatPayment(s.participantId)
+                      // On 'redirecting' the page is navigating away; only clear
+                      // busy on failure so the button can be retried.
+                      if (result !== 'redirecting') setBusyId(null)
+                    }}
+                    className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-60"
+                    title="Complete payment to confirm your seat"
+                  >
+                    {busyId === s.participantId ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <CreditCard className="h-3.5 w-3.5" />
+                    )}
+                    Complete payment
+                  </button>
+                ) : s.liveSessionId ? (
                   <Link
                     href={s.joinable ? `/${locale}/call/${s.liveSessionId}` : '#'}
                     aria-disabled={!s.joinable}

--- a/tutorme-app/src/app/api/group-sessions/mine/route.ts
+++ b/tutorme-app/src/app/api/group-sessions/mine/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, asc, eq, gte } from 'drizzle-orm'
+import { and, asc, eq, gte, inArray } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { groupSession, groupSessionParticipant, liveSession, profile } from '@/lib/db/schema'
@@ -23,6 +23,8 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
 
   const rows = await drizzleDb
     .select({
+      participantId: groupSessionParticipant.participantId,
+      seatStatus: groupSessionParticipant.status,
       groupSessionId: groupSession.groupSessionId,
       title: groupSession.title,
       liveSessionId: groupSession.liveSessionId,
@@ -45,7 +47,10 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
     .where(
       and(
         eq(groupSessionParticipant.studentId, session.user.id),
-        eq(groupSessionParticipant.status, 'PAID'),
+        // PAID = confirmed seat (Join). RESERVED = seat held awaiting payment —
+        // included so the student can resume checkout instead of silently losing
+        // the seat when it expires (there is no other surface to pay from).
+        inArray(groupSessionParticipant.status, ['PAID', 'RESERVED']),
         gte(liveSession.scheduledAt, graceStart)
       )
     )
@@ -53,24 +58,34 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
     .limit(50)
 
   return NextResponse.json({
-    sessions: rows.map(r => ({
-      groupSessionId: r.groupSessionId,
-      title: r.title,
-      liveSessionId: r.liveSessionId,
-      requestedDate: r.requestedDate,
-      startTime: r.startTime,
-      endTime: r.endTime,
-      timezone: r.timezone,
-      tutorName: r.tutorName,
-      scheduledAt: r.scheduledAt,
-      // Joinable from 20 min before start UNTIL the session ends (start +
-      // duration) — otherwise a finished session kept showing an active "Join".
-      joinable: (() => {
-        if (!r.scheduledAt) return false
-        const startMs = r.scheduledAt.getTime()
-        const endMs = startMs + (r.durationMinutes ?? 120) * 60_000
-        return startMs - now.getTime() <= EARLY_ENTRY_MS && now.getTime() < endMs
-      })(),
-    })),
+    sessions: rows.map(r => {
+      const needsPayment = r.seatStatus === 'RESERVED'
+      return {
+        participantId: r.participantId,
+        groupSessionId: r.groupSessionId,
+        title: r.title,
+        liveSessionId: r.liveSessionId,
+        requestedDate: r.requestedDate,
+        startTime: r.startTime,
+        endTime: r.endTime,
+        timezone: r.timezone,
+        tutorName: r.tutorName,
+        scheduledAt: r.scheduledAt,
+        // A held (unpaid) seat can't be joined — the student must complete
+        // checkout first; the page renders a "Complete payment" action for it.
+        needsPayment,
+        // Joinable from 20 min before start UNTIL the session ends (start +
+        // duration) — otherwise a finished session kept showing an active "Join".
+        // A RESERVED seat is never joinable until paid.
+        joinable:
+          !needsPayment &&
+          (() => {
+            if (!r.scheduledAt) return false
+            const startMs = r.scheduledAt.getTime()
+            const endMs = startMs + (r.durationMinutes ?? 120) * 60_000
+            return startMs - now.getTime() <= EARLY_ENTRY_MS && now.getTime() < endMs
+          })(),
+      }
+    }),
   })
 })

--- a/tutorme-app/src/lib/group-session/resume-payment.ts
+++ b/tutorme-app/src/lib/group-session/resume-payment.ts
@@ -1,0 +1,35 @@
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
+import { toast } from 'sonner'
+
+export type ResumePaymentResult = 'redirecting' | 'error'
+
+/**
+ * Resume checkout for a group-session seat the student already RESERVED but
+ * never paid for (e.g. they closed the tab mid-checkout). The seat's
+ * participantId is enough — `/api/payments/create` reuses the existing pending
+ * checkout URL if one exists, or mints a fresh one, and rejects a seat that is
+ * already PAID or no longer RESERVED. Mirrors the checkout step in
+ * `bookGroupSeat`, minus the reserve call (the seat already exists).
+ */
+export async function resumeGroupSeatPayment(
+  groupSessionParticipantId: string
+): Promise<ResumePaymentResult> {
+  try {
+    const payRes = await fetchWithCsrf('/api/payments/create', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ groupSessionParticipantId }),
+    })
+    const payData = await payRes.json().catch(() => ({}))
+    if (payRes.ok && payData.checkoutUrl) {
+      window.location.href = payData.checkoutUrl
+      return 'redirecting'
+    }
+    toast.error(payData.error || 'Could not resume checkout')
+    return 'error'
+  } catch {
+    toast.error('Something went wrong — please try again')
+    return 'error'
+  }
+}


### PR DESCRIPTION
## Retrospective GAP 2 (HIGH) — a reserved group seat was invisible and unpayable

Group booking reserves a seat then redirects to checkout. If the student **abandons** the redirect (closed tab, declined card, back button), the seat sits **RESERVED** — but `/group-sessions/mine` was **PAID-only**, so the held seat was invisible on the sessions page and there was **no surface anywhere to pay for it**. It expired silently: a lost booking with no recovery.

**Fix — reuse the existing checkout endpoint, no new backend:**
- `/group-sessions/mine` now also returns **RESERVED** seats, each with its `participantId` and a `needsPayment` flag (a held seat is never `joinable` until paid).
- `resumeGroupSeatPayment(participantId)` re-hits `/api/payments/create`, which already **reuses the pending checkout URL** (or mints a fresh one) and rejects a seat that is already paid / no longer reserved.
- The group-sessions page renders a **"Complete payment"** action for held seats instead of a Join button.

This closes the loop from the calendar's "Awaiting payment" badge to a real pay path for group seats.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)