### PR TITLE
feat(launcher): nudge students to pay for imminent unpaid bookings

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/live-now/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/live-now/route.ts
@@ -35,6 +35,12 @@ interface Candidate {
   studentId: string | null
   /** Group: the session title. */
   title: string | null
+  /** Student booked but hasn't paid — the launcher nudges "Pay to join". */
+  needsPayment?: boolean
+  /** 1-on-1 pending payment: the request to pay for. */
+  requestId?: string | null
+  /** Group pending payment: the reserved seat to resume checkout for. */
+  participantId?: string | null
 }
 
 export const GET = withAuth(async (_req: NextRequest, session) => {
@@ -116,10 +122,76 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
       )
     )
 
+  // Student-only: imminent bookings that are accepted/reserved but NOT yet paid.
+  // Surfaced so the launcher can nudge "Pay to join" before start — otherwise an
+  // unpaid booking gets no app-wide reminder and the student silently misses the
+  // session they booked. (Tutors can't act on an unpaid booking, so tutor-side is
+  // intentionally excluded.)
+  const unpaidOneOnOnes = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      tutorId: oneOnOneBookingRequest.tutorId,
+      studentId: oneOnOneBookingRequest.studentId,
+      requestId: oneOnOneBookingRequest.requestId,
+    })
+    .from(oneOnOneBookingRequest)
+    .innerJoin(calendarEvent, eq(calendarEvent.eventId, oneOnOneBookingRequest.calendarEventId))
+    .innerJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
+    .where(
+      and(
+        eq(oneOnOneBookingRequest.status, 'ACCEPTED'),
+        eq(oneOnOneBookingRequest.studentId, userId),
+        eq(calendarEvent.isCancelled, false),
+        gte(liveSession.scheduledAt, from),
+        lte(liveSession.scheduledAt, until)
+      )
+    )
+
+  const unpaidGroup = await drizzleDb
+    .select({
+      sessionId: liveSession.sessionId,
+      scheduledAt: liveSession.scheduledAt,
+      durationMinutes: liveSession.durationMinutes,
+      status: liveSession.status,
+      tutorId: groupSession.tutorId,
+      title: groupSession.title,
+      participantId: groupSessionParticipant.participantId,
+    })
+    .from(groupSessionParticipant)
+    .innerJoin(
+      groupSession,
+      eq(groupSession.groupSessionId, groupSessionParticipant.groupSessionId)
+    )
+    .innerJoin(liveSession, eq(liveSession.sessionId, groupSession.liveSessionId))
+    .where(
+      and(
+        eq(groupSessionParticipant.studentId, userId),
+        eq(groupSessionParticipant.status, 'RESERVED'),
+        inArray(groupSession.status, ['OPEN', 'FULL']),
+        gte(liveSession.scheduledAt, from),
+        lte(liveSession.scheduledAt, until)
+      )
+    )
+
   const candidates: Candidate[] = [
     ...oneOnOnes.map(r => ({ ...r, isGroup: false, title: null as string | null })),
     ...groupAsStudent.map(r => ({ ...r, isGroup: true, studentId: null as string | null })),
     ...groupAsTutor.map(r => ({ ...r, isGroup: true, studentId: null as string | null })),
+    ...unpaidOneOnOnes.map(r => ({
+      ...r,
+      isGroup: false,
+      title: null as string | null,
+      needsPayment: true,
+    })),
+    ...unpaidGroup.map(r => ({
+      ...r,
+      isGroup: true,
+      studentId: null as string | null,
+      needsPayment: true,
+    })),
   ]
     .filter(c => c.scheduledAt)
     .sort((a, b) => new Date(a.scheduledAt!).getTime() - new Date(b.scheduledAt!).getTime())
@@ -152,14 +224,21 @@ export const GET = withAuth(async (_req: NextRequest, session) => {
     title = `1-on-1 with ${other?.name || (viewerIsTutor ? 'your student' : 'your tutor')}`
   }
 
+  const needsPayment = !!pick.needsPayment
+
   return NextResponse.json({
     session: {
       sessionId: pick.sessionId,
       scheduledAt: new Date(pick.scheduledAt).toISOString(),
       title,
       viewerIsTutor,
-      joinable: pick.status === 'active' || now >= start - EARLY_ENTRY_MS,
-      live: pick.status === 'active',
+      // An unpaid booking can't be joined until checkout completes — the launcher
+      // shows "Pay to join" instead of Join and routes to the pay path below.
+      needsPayment,
+      joinable: !needsPayment && (pick.status === 'active' || now >= start - EARLY_ENTRY_MS),
+      live: !needsPayment && pick.status === 'active',
+      payRequestId: needsPayment ? (pick.requestId ?? null) : null,
+      payParticipantId: needsPayment ? (pick.participantId ?? null) : null,
     },
   })
 })

--- a/tutorme-app/src/components/one-on-one/session-launcher.tsx
+++ b/tutorme-app/src/components/one-on-one/session-launcher.tsx
@@ -13,11 +13,12 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { Video, X } from 'lucide-react'
+import { Video, X, CreditCard } from 'lucide-react'
 import { useVideoOverlayStore } from '@/stores/video-overlay-store'
 import { formatCountdown } from '@/lib/one-on-one/format'
+import { resumeGroupSeatPayment } from '@/lib/group-session/resume-payment'
 
 interface LiveSession {
   sessionId: string
@@ -27,6 +28,12 @@ interface LiveSession {
   viewerIsTutor: boolean
   joinable: boolean
   live: boolean
+  /** Booked but unpaid — show "Pay to join" instead of Join. */
+  needsPayment?: boolean
+  /** 1-on-1 pending payment: navigate to the payment page for this request. */
+  payRequestId?: string | null
+  /** Group pending payment: resume checkout for this reserved seat. */
+  payParticipantId?: string | null
 }
 
 const EARLY_ENTRY_MS = 20 * 60 * 1000
@@ -35,6 +42,8 @@ const POLL_MS = 45_000
 export function SessionLauncher() {
   const { status } = useSession()
   const router = useRouter()
+  const params = useParams()
+  const locale = (params?.locale as string) || 'en'
   const overlayOpen = useVideoOverlayStore(s => s.open)
   const [live, setLive] = useState<LiveSession | null>(null)
   const [dismissed, setDismissed] = useState<Set<string>>(new Set())
@@ -77,11 +86,19 @@ export function SessionLauncher() {
   if (dismissed.has(live.sessionId)) return null
 
   const start = new Date(live.scheduledAt).getTime()
-  const joinable = live.live || now >= start - EARLY_ENTRY_MS
-  const isLive = live.live || now >= start
+  const needsPayment = !!live.needsPayment
+  const joinable = !needsPayment && (live.live || now >= start - EARLY_ENTRY_MS)
+  const isLive = !needsPayment && (live.live || now >= start)
   const opensAt = start - EARLY_ENTRY_MS
 
   const join = () => router.push(`/call/${live.sessionId}`)
+  const pay = () => {
+    if (live.payRequestId) {
+      router.push(`/${locale}/payment?requestId=${live.payRequestId}`)
+    } else if (live.payParticipantId) {
+      resumeGroupSeatPayment(live.payParticipantId)
+    }
+  }
 
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[9998] flex justify-center px-4 sm:inset-x-auto sm:right-4 sm:justify-end">
@@ -96,7 +113,11 @@ export function SessionLauncher() {
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold">{live.title}</p>
           <p className="truncate text-xs text-white/60">
-            {isLive ? (
+            {needsPayment ? (
+              <span className="font-medium text-amber-300">
+                Payment needed · starts in {formatCountdown(start, now)}
+              </span>
+            ) : isLive ? (
               <span className="font-medium text-emerald-400">● Live now</span>
             ) : joinable ? (
               <span className="font-medium text-blue-300">Ready to join</span>
@@ -106,7 +127,16 @@ export function SessionLauncher() {
           </p>
         </div>
 
-        {joinable ? (
+        {needsPayment ? (
+          <button
+            type="button"
+            onClick={pay}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-xl bg-amber-500 px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-400"
+          >
+            <CreditCard className="h-4 w-4" />
+            Pay to join
+          </button>
+        ) : joinable ? (
           <button
             type="button"
             onClick={join}


### PR DESCRIPTION
## Retrospective GAP 3 (MED-HIGH) — no pre-start reminder to pay

The app-wide session launcher only surfaced **PAID** sessions, so a student with an accepted-but-unpaid 1-on-1 or a reserved group seat got **no reminder** as the session approached — they'd simply miss the session they "booked". Combined with the (now-fixed) dead badge and invisible group seat, an unpaid booking was a silent cliff.

**Fix:**
- `live-now` now also returns imminent **ACCEPTED** 1-on-1s and **RESERVED** group seats (student side only — tutors can't act on an unpaid booking) with a `needsPayment` flag and the ids needed to pay.
- The launcher renders a **"Pay to join"** variant (amber, `Payment needed · starts in …`) that routes to the payment page (1-on-1, via `requestId`) or resumes group checkout (`resumeGroupSeatPayment`, the helper from #1118).

With #1118 (group resume-pay) and #1119 (actionable badge), this completes the payment-loop closure: the app now both **shows** you owe payment and gives you a **way to pay**, everywhere it matters.

## Verification
- `tsc` clean · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)