### PR TITLE
fix(whiteboard): dedup delta apply by id so reconnect replay can't duplicate

### DIFF
--- a/tutorme-app/src/components/class/enhanced-whiteboard.tsx
+++ b/tutorme-app/src/components/class/enhanced-whiteboard.tsx
@@ -1992,15 +1992,34 @@ export function EnhancedWhiteboard({
           const page = ensurePage(op.pageIndex)
           if (!page) continue
           if (op.type === 'stroke') {
-            page.strokes = [...page.strokes, op.stroke]
+            // Dedup by id: the join-time replay re-fires on every socket
+            // reconnect (use-socket re-emits join_class on 'connect'), and a
+            // private board stays mounted — so without this an already-applied
+            // item would be appended again on each reconnect and persisted back.
+            const id = (op.stroke as { id?: string })?.id
+            if (!id || !page.strokes.some(s => (s as { id?: string }).id === id)) {
+              page.strokes = [...page.strokes, op.stroke]
+            }
           } else if (op.type === 'shape') {
-            page.shapes = [...page.shapes, op.shape]
+            const id = (op.shape as { id?: string })?.id
+            if (!id || !page.shapes.some(s => (s as { id?: string }).id === id)) {
+              page.shapes = [...page.shapes, op.shape]
+            }
           } else if (op.type === 'text') {
-            page.texts = [...page.texts, op.text]
+            const id = (op.text as { id?: string })?.id
+            if (!id || !page.texts.some(t => (t as { id?: string }).id === id)) {
+              page.texts = [...page.texts, op.text]
+            }
           } else if (op.type === 'formula') {
-            page.formulas = [...page.formulas, op.formula]
+            const id = (op.formula as { id?: string })?.id
+            if (!id || !page.formulas.some(f => (f as { id?: string }).id === id)) {
+              page.formulas = [...page.formulas, op.formula]
+            }
           } else if (op.type === 'graph') {
-            page.graphs = [...page.graphs, op.graph]
+            const id = (op.graph as { id?: string })?.id
+            if (!id || !page.graphs.some(g => (g as { id?: string }).id === id)) {
+              page.graphs = [...page.graphs, op.graph]
+            }
           } else if (op.type === 'page:clear') {
             page.strokes = []
             page.texts = []


### PR DESCRIPTION
## Round-2 retrospective finding (HIGH) — regression surfaced by #1113

The adversarial re-review of the batch caught this. `use-socket` re-emits `join_class` on **every** `'connect'` (auto-reconnect on, 50 attempts), and the server replays a private board's stored strokes/shapes/texts/formulas/graphs on each join. A private board stays **mounted** (hidden) across a reconnect, and the delta-apply path (`enhanced-whiteboard.tsx` `enqueue`) appended every incoming item **with no id check**.

**Failure:** student draws 10 items → network blip → socket reconnects → replay re-appends all 10 → board shows each item twice; another blip → tripled. The doubled array is persisted back via `onUpdate → whiteboard:*:add`, corrupting **server state** and the tutor's read-only view. Strokes overdraw (subtle); text/shapes/formulas/graphs visibly stack.

#1113 (owner-replay) widened the blast radius (the owner now applies replay too), but the vector predates it — #1108's replay already hit the tutor's view on reconnect.

**Fix:** the apply loop skips an item whose `id` already exists on the page (id-less items keep the old append behaviour). This is also why the owner's own strokes stay correct — the replayed copy shares the id of the locally-drawn one, so it's a no-op instead of a duplicate.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)