### PR TITLE
fix(db): enforce 1:1 calendarEventId with a unique index (booking + group session)

### DIFF
--- a/tutorme-app/src/lib/db/schema/tables/calendar.ts
+++ b/tutorme-app/src/lib/db/schema/tables/calendar.ts
@@ -273,6 +273,12 @@ export const oneOnOneBookingRequest = pgTable(
     OneOnOneBookingRequest_seriesId_idx: index('OneOnOneBookingRequest_seriesId_idx').on(
       table.seriesId
     ),
+    // A CalendarEvent belongs to exactly one booking (accept/heal always mints a
+    // fresh event and repoints this column at it). Enforce that 1:1 so reads that
+    // join on it can't fan out. NULLs are allowed to repeat (unpaid/legacy rows).
+    OneOnOneBookingRequest_calendarEventId_key: uniqueIndex(
+      'OneOnOneBookingRequest_calendarEventId_key'
+    ).on(table.calendarEventId),
   })
 )
 
@@ -380,6 +386,11 @@ export const groupSession = pgTable(
     GroupSession_tutorId_idx: index('GroupSession_tutorId_idx').on(table.tutorId),
     GroupSession_status_idx: index('GroupSession_status_idx').on(table.status),
     GroupSession_requestedDate_idx: index('GroupSession_requestedDate_idx').on(table.requestedDate),
+    // A CalendarEvent belongs to exactly one group session — same 1:1 invariant
+    // as the 1-on-1 booking above. NULLs may repeat.
+    GroupSession_calendarEventId_key: uniqueIndex('GroupSession_calendarEventId_key').on(
+      table.calendarEventId
+    ),
   })
 )
 

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -414,6 +414,37 @@ CREATE UNIQUE INDEX IF NOT EXISTS "SessionRescheduleVote_proposal_student_key"
   ON "SessionRescheduleVote" ("proposalId", "studentId");
 CREATE INDEX IF NOT EXISTS "SessionRescheduleVote_proposalId_idx"
   ON "SessionRescheduleVote" ("proposalId");
+
+-- Enforce the 1:1 booking↔CalendarEvent and groupSession↔CalendarEvent invariants
+-- so a join on calendarEventId can't fan out (accept/heal always mints a fresh
+-- event and repoints the column). Guarded: if a stray duplicate exists in prod,
+-- skip + RAISE WARNING rather than throw — this whole block runs as one implicit
+-- transaction, so a failing CREATE would roll back every table-ensure above.
+-- NULL calendarEventId rows (unpaid/legacy) are allowed to repeat.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM "OneOnOneBookingRequest"
+    WHERE "calendarEventId" IS NOT NULL
+    GROUP BY "calendarEventId" HAVING count(*) > 1
+  ) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS "OneOnOneBookingRequest_calendarEventId_key"
+      ON "OneOnOneBookingRequest" ("calendarEventId");
+  ELSE
+    RAISE WARNING 'Skipped OneOnOneBookingRequest_calendarEventId_key: duplicate calendarEventId values present — clean them up, then restart to enforce.';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM "GroupSession"
+    WHERE "calendarEventId" IS NOT NULL
+    GROUP BY "calendarEventId" HAVING count(*) > 1
+  ) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS "GroupSession_calendarEventId_key"
+      ON "GroupSession" ("calendarEventId");
+  ELSE
+    RAISE WARNING 'Skipped GroupSession_calendarEventId_key: duplicate calendarEventId values present — clean them up, then restart to enforce.';
+  END IF;
+END $$;
 `)
 
 export async function applyStartupSchemaFixes(): Promise<void> {


### PR DESCRIPTION
## Follow-up to the retrospective — the latent finding from #1114's review

`OneOnOneBookingRequest.calendarEventId` and `GroupSession.calendarEventId` are each a **1:1** link to a `CalendarEvent` (accept/heal always mints a fresh event and repoints the column), but **neither had a unique constraint** — the invariant held only by convention. The #1114 tutor-calendar `leftJoin` on `calendarEventId` is safe *only* because of that; a stray duplicate would silently fan out calendar rows.

**Fix:**
- **Drizzle schema:** `uniqueIndex` on both columns (source of truth + fresh DBs / integration `drizzle-push`).
- **`startup-schema-fix.ts`** (migration journal is frozen, so prod DDL lives here): create the unique indexes, **guarded by a dup-check `DO` block** — if a duplicate somehow exists it `RAISE WARNING`s and skips instead of throwing. This is deliberate: `ENSURE_TABLES_SQL` runs as one implicit transaction, so a failing `CREATE` would roll back *every* table-ensure in the batch. NULL `calendarEventId` rows (unpaid/legacy) are allowed to repeat.

No insert path creates a second reference to one event (verified: `respond`, `ensure-session`, `reschedule` all keep it 1:1), so the constraint won't break normal flow — it just turns a would-be silent bug into a loud one.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)