### PR TITLE
fix(ci): repair the gitleaks install in the secret-scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,8 +24,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Install gitleaks via official install script (more reliable than GitHub API).
-          curl -fsSL https://raw.githubusercontent.com/gitleaks/gitleaks/master/scripts/install.sh | bash
+          # Install a pinned gitleaks release binary directly. Deterministic — no
+          # GitHub API 'latest' lookup (rate-limit flaky) and no install script
+          # (the gitleaks repo has no scripts/install.sh — it 404s). Bump the
+          # version deliberately.
+          GITLEAKS_VERSION=8.18.4
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
           ./gitleaks version
 
           # Scan ONLY the commits introduced by this push/PR — not full history,


### PR DESCRIPTION
## Secret Scan has been failing on `main` since #1100

#1100 bundled an unrelated change to `.github/workflows/secret-scan.yml` that swapped the gitleaks install to:
```
curl -fsSL https://raw.githubusercontent.com/gitleaks/gitleaks/master/scripts/install.sh | bash
```
That URL **404s** — the gitleaks repo has no `scripts/install.sh` — and `set -euo pipefail` turned it into `curl: (22) … error: 404 → exit code 22`. Secret Scan isn't one of the 4 required checks, so the broken workflow didn't block the merge (and I missed it — flagged since the PR touched a workflow file).

**Fix:** a **pinned release-binary download** (v8.18.4, verified `HTTP 200`), which is deterministic — no `releases/latest` API lookup (the rate-limit flakiness #1100 was trying to avoid) and no install script:
```
curl -fsSL ".../releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
```

Once merged, Secret Scan goes green on `main` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)