### PR TITLE
feat(forms): inline red required-field errors — CreateClassDialog (tail)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateClassDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CreateClassDialog.tsx
@@ -68,6 +68,11 @@ export function CreateClassDialog({
   const router = useRouter()
   const [creating, setCreating] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<{
+    title?: string
+    date?: string
+    time?: string
+  }>({})
   const timeOptions = useTimeOptions()
 
   const [form, setForm] = useState({
@@ -104,18 +109,17 @@ export function CreateClassDialog({
   }, [open, initialDate])
 
   const handleSubmit = async () => {
-    if (!form.title.trim()) {
-      toast.error('Please enter a session title')
+    // Highlight every empty required field at once (red + inline) instead of a
+    // one-at-a-time toast.
+    const errs: { title?: string; date?: string; time?: string } = {}
+    if (!form.title.trim()) errs.title = 'Please enter a session title'
+    if (!form.date) errs.date = 'Please select a date'
+    if (!form.time) errs.time = 'Please select a time'
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs)
       return
     }
-    if (!form.date) {
-      toast.error('Please select a date')
-      return
-    }
-    if (!form.time) {
-      toast.error('Please select a time')
-      return
-    }
+    setFieldErrors({})
 
     setCreating(true)
     setApiError(null)
@@ -219,10 +223,13 @@ export function CreateClassDialog({
               <Label className="text-gray-900">Class Title *</Label>
               <Input
                 value={form.title}
-                onChange={e => setForm({ ...form, title: e.target.value })}
+                onChange={e => {
+                  setForm({ ...form, title: e.target.value })
+                  if (fieldErrors.title) setFieldErrors(prev => ({ ...prev, title: undefined }))
+                }}
                 placeholder="e.g., AP Calculus - Limits"
                 disabled={creating}
-                aria-invalid={!!apiError}
+                errorMessage={fieldErrors.title}
               />
             </div>
 
@@ -242,18 +249,28 @@ export function CreateClassDialog({
                 <Input
                   type="date"
                   value={form.date}
-                  onChange={e => setForm({ ...form, date: e.target.value })}
+                  onChange={e => {
+                    setForm({ ...form, date: e.target.value })
+                    if (fieldErrors.date) setFieldErrors(prev => ({ ...prev, date: undefined }))
+                  }}
                   disabled={creating}
+                  errorMessage={fieldErrors.date}
                 />
               </div>
               <div>
                 <Label className="text-gray-900">Time *</Label>
                 <Select
                   value={form.time}
-                  onValueChange={v => setForm({ ...form, time: v })}
+                  onValueChange={v => {
+                    setForm({ ...form, time: v })
+                    if (fieldErrors.time) setFieldErrors(prev => ({ ...prev, time: undefined }))
+                  }}
                   disabled={creating}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger
+                    aria-invalid={!!fieldErrors.time}
+                    className={fieldErrors.time ? 'border-destructive' : undefined}
+                  >
                     <SelectValue placeholder="Select time" />
                   </SelectTrigger>
                   <SelectContent>
@@ -264,6 +281,11 @@ export function CreateClassDialog({
                     ))}
                   </SelectContent>
                 </Select>
+                {fieldErrors.time && (
+                  <p className="text-destructive mt-1 text-xs" role="alert">
+                    {fieldErrors.time}
+                  </p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
Tail of the inline-red-validation rollout.

**CreateClassDialog** (a live tutor create dialog) — identical title/date/time pattern to `CreateSessionForm` (wave 1). It now highlights **all** empty required fields at once in **red inline** (title + date via the shared `Input.errorMessage`, time via a red `Select` trigger + message) and clears as you edit, instead of one-at-a-time toasts.

`tsc --noEmit` clean (0 errors), prettier clean. Toasts retained for API errors.

Note: `/tutor/resources` was checked and skipped for now — its only field check is "select a file", and the upload button is already `disabled` without one (marginal for red-highlighting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)