### PR TITLE
fix(course-builder): stop a late async load from wiping newly-added lessons

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -705,6 +705,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [resolvedInitialCourseBuilderNodes])
     const lastInitialCourseBuilderNodesKeyRef = useRef<string | null>(null)
+    // The course whose loaded data we last hydrated the builder from, so a late/
+    // async initial for the SAME course can't clobber in-progress edits.
+    const lastHydratedCourseIdRef = useRef<string | null>(null)
     const [builderNodes, setBuilderNodes] = useState<CourseBuilderNode[]>([])
     const [liveNodes, setLiveNodes] = useState<CourseBuilderNode[]>([])
 
@@ -4053,12 +4056,26 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     useEffect(() => {
       if (lastInitialCourseBuilderNodesKeyRef.current === initialCourseBuilderNodesKey) return
       lastInitialCourseBuilderNodesKeyRef.current = initialCourseBuilderNodesKey
+
+      // Only (re)hydrate the builder from the loaded course data when we switch to
+      // a DIFFERENT course, or while the builder is still empty. A late/async
+      // initial for the SAME course — e.g. the background course load finishing
+      // AFTER the tutor has begun adding lessons to a newly-created course — must
+      // NOT overwrite their in-memory lessons; autosave would then persist the
+      // clobbered state and the lessons would be lost on reload. builderNodes is
+      // read (not depended on) intentionally: the effect only re-runs when the
+      // initial key / course changes, at which point it reflects the latest edits.
+      const courseChanged = lastHydratedCourseIdRef.current !== (courseId ?? null)
+      lastHydratedCourseIdRef.current = courseId ?? null
+      if (!courseChanged && builderNodes.length > 0) return
+
       const normalized = normalizeCourseBuilderNodesForAssessments(
         resolvedInitialCourseBuilderNodes
       )
       setBuilderNodes(normalized)
       setLiveNodes(isStudentView || saveMode !== 'draft' ? cloneNodes(normalized) : [])
-    }, [initialCourseBuilderNodesKey, resolvedInitialCourseBuilderNodes])
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [courseId, initialCourseBuilderNodesKey, resolvedInitialCourseBuilderNodes])
 
     // Helper to get effective value based on difficulty mode and preview
     const getEffectiveValue = <T extends WithDifficultyVariants>(


### PR DESCRIPTION
**Bug:** creating a course with lessons + materials, then reopening it, showed the lessons **gone** — not persisted.

## Root cause (a state-hydration race, not save/load)
Save (`updateCourseBuilderData`) and load (`getCourseBuilderData`) both handle `builderData` correctly. The break is in **`CourseBuilder.tsx`**:

- The init effect re-applies the loaded course data (`initialLessons` → `resolvedInitialCourseBuilderNodes`) to local `builderNodes` **every time its JSON key changes**.
- The load hook (`use-course-builder-content-model`) delivers that data **asynchronously** (`loadedLessons: null → [default "Lesson 1"]`) *after* mount.
- So: tutor creates a course → redirected to the builder → **starts adding lessons before the background load finishes** → the load arrives → the effect re-runs and **overwrites their in-memory lessons** with the default single lesson → the now-enabled **autosave (#1110)** persists the clobbered state → lessons gone on reload.

## Fix (surgical — one ref + a guard)
Only (re)hydrate from the loaded data when we switch to a **different** course (tracked via a new `lastHydratedCourseIdRef`) or while the builder is **still empty**. A late/async initial for the **same** course no longer clobbers in-progress edits.

Traced correct for all flows:
- **New course, edits made during load** → skip clobber, keep edits → autosave persists → **survives reload** ✅
- **New course, no edits yet** → default lesson hydrates, then additions are kept ✅
- **Reopen a saved course** → builder is empty at that point → saved lessons hydrate ✅
- **Switch course A→B** → `courseId` changed → re-hydrate B ✅

The save already deletes lessons no longer present (`incomingLessonIds` → `idsToDelete`), so the default empty lesson doesn't orphan/reappear.

## Verification
`tsc --noEmit` clean (0 errors), prettier clean. Diff is +18/−1, confined to the one effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)