### PR TITLE
fix(course-builder): stop autosave from wiping lessons before a slow load finishes

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
@@ -165,12 +165,17 @@ export function useCourseBuilderContentModel({
     const isDetached = dataMode === 'detached'
 
     // Guard against wiping the course when its content never loaded. On a
-    // DB-backed course, loadedLessons stays null only when the load failed
-    // (a successfully-empty course loads as []). Saving an empty tree in that
-    // state would delete every lesson, so refuse it. (The server enforces the
-    // same floor; this just avoids firing the destructive request.)
-    if (!isDetached && !options?.isAutoSave && lessons.length === 0 && loadedLessons === null) {
-      toast.error('Lessons haven’t finished loading yet — reload the course before saving.')
+    // DB-backed course, loadedLessons stays null only while the load is still
+    // pending or has failed (a successfully-empty course loads as []). Saving an
+    // empty tree in that state would soft-delete every lesson server-side — and
+    // the server floor only spares DEPLOYED lessons, so un-deployed ones would be
+    // lost. This MUST also cover autosave: the mount autosave fires on a 2s
+    // debounce and can beat a slow load, sending an empty payload. Autosave is
+    // silent; a manual save tells the tutor to wait.
+    if (!isDetached && lessons.length === 0 && loadedLessons === null) {
+      if (!options?.isAutoSave) {
+        toast.error('Lessons haven’t finished loading yet — reload the course before saving.')
+      }
       return
     }
 


### PR DESCRIPTION
Companion data-loss fix to #1127, found while auditing the persistence path.

## The gap
The save has an empty-save guard: *"refuse to save an empty tree while `loadedLessons === null`"* (load pending/failed) — because that would delete every lesson. But it's **bypassed for autosave** (`!options?.isAutoSave`), on the comment's assumption that *"the server enforces the same floor."*

The server floor is **incomplete**: `updateCourseBuilderData` only blocks deleting lessons that have **deployments** (`hasDeployments`); **un-deployed** lessons are soft-deleted when the incoming payload is empty.

And the autosave effect arms a **2s debounced timer on mount** with `nodes=[]`. On a **slow course load (>2s)** that timer fires an **empty payload before hydration** → all un-deployed lessons of an existing course get soft-deleted (vanish from the builder). Distinct from the clobber #1127 fixed.

## Fix
Apply the *empty + load-not-complete* guard to **autosave** as well — return **silently** for autosave (it's a background save), keep the toast for a manual save.

Traced safe:
- Empty autosave while load pending/failed → **blocked** (no wipe) ✅
- Genuinely-empty course after load (`loadedLessons === []`) → allowed ✅
- User deletes all lessons on a loaded course → allowed (deploy guard still protects) ✅
- Detached mode → unchanged ✅

## Verification
`tsc --noEmit` clean (0 errors), prettier clean. +11/−6, one guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)