### PR TITLE
test(integration): regression suites for this session's fixes

### DIFF
--- a/tutorme-app/src/__tests__/integration/refund-clamp.test.ts
+++ b/tutorme-app/src/__tests__/integration/refund-clamp.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test: refund over-refund clamp + reservation (PR #1105).
+ *
+ * Drives the REAL POST /api/payments/refund handler (auth/CSRF middleware made
+ * pass-through; the payment GATEWAY is mocked so no money moves). Verifies the
+ * cumulative cap: partial refunds are allowed up to the exact paid amount, and
+ * anything beyond the refundable balance is rejected before the gateway is
+ * called. A regression that drops the clamp would let this over-refund.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray, sql, and } from 'drizzle-orm'
+
+// Middleware: keep the real error classes, make the wrappers pass-through with a
+// fixed ADMIN session (ADMIN skips the per-course ownership check).
+vi.mock('@/lib/api/middleware', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    withCsrf: (h: unknown) => h,
+    withAuth: (h: (req: unknown, session: unknown) => unknown) => (req: unknown) =>
+      h(req, { user: { id: 'refund-admin', role: 'ADMIN' } }),
+  }
+})
+
+// Gateway: succeed without moving money.
+vi.mock('@/lib/payments', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    getPaymentGateway: () => ({
+      refundPayment: async () => ({ refundId: `gw_${Date.now()}`, status: 'succeeded' }),
+    }),
+  }
+})
+
+import { NextRequest } from 'next/server'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, course, payment, refund } from '@/lib/db/schema'
+import { POST } from '@/app/api/payments/refund/route'
+
+const stamp = Date.now()
+const adminId = 'refund-admin'
+const studentId = crypto.randomUUID()
+const COURSE = `rf_course_${stamp}`
+const PAY = `rf_pay_${stamp}`
+
+function refundReq(amount: number) {
+  const req = new NextRequest('http://localhost/api/payments/refund', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ paymentId: PAY, amount, reason: 'test' }),
+  })
+  return POST(req as unknown as NextRequest)
+}
+const refundedTotal = () =>
+  drizzleDb
+    .select({ t: sql<number>`COALESCE(SUM(${refund.amount}),0)` })
+    .from(refund)
+    .where(
+      and(eq(refund.paymentId, PAY), inArray(refund.status, ['COMPLETED', 'PENDING', 'PROCESSING']))
+    )
+    .then(r => Number(r[0]?.t ?? 0))
+
+describe('refund over-refund clamp', () => {
+  beforeAll(async () => {
+    await drizzleDb.insert(user).values([
+      {
+        userId: adminId,
+        email: `rf-admin-${stamp}@ex.com`,
+        role: 'ADMIN',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: studentId,
+        email: `rf-stu-${stamp}@ex.com`,
+        role: 'STUDENT',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ] as never)
+    await drizzleDb
+      .insert(course)
+      .values({ courseId: COURSE, name: 'RF', isPublished: true, creatorId: adminId } as never)
+    await drizzleDb.insert(payment).values({
+      paymentId: PAY,
+      studentId,
+      amount: 100,
+      currency: 'USD',
+      status: 'COMPLETED',
+      gateway: 'HITPAY',
+      metadata: { courseId: COURSE },
+    } as never)
+  })
+
+  afterAll(async () => {
+    await drizzleDb.delete(refund).where(eq(refund.paymentId, PAY))
+    await drizzleDb.delete(payment).where(eq(payment.paymentId, PAY))
+    await drizzleDb.delete(course).where(eq(course.courseId, COURSE))
+    await drizzleDb.delete(user).where(inArray(user.userId, [adminId, studentId]))
+    vi.restoreAllMocks()
+  })
+
+  it('allows partial refunds up to the paid amount, then rejects over-refund', async () => {
+    // First partial: 60 of 100 → OK
+    expect((await refundReq(60)).status).toBe(200)
+    expect(await refundedTotal()).toBe(60)
+
+    // Would exceed: 60 already + 50 > 100 → rejected, no new refund row
+    const over = await refundReq(50)
+    expect(over.status).toBe(400)
+    expect(await refundedTotal()).toBe(60) // unchanged
+
+    // Exact remaining balance: 60 + 40 = 100 → OK
+    expect((await refundReq(40)).status).toBe(200)
+    expect(await refundedTotal()).toBe(100)
+
+    // Nothing left: any further refund rejected
+    expect((await refundReq(1)).status).toBe(400)
+    expect(await refundedTotal()).toBe(100)
+  })
+
+  it('rejects a single refund larger than the payment', async () => {
+    // (fresh payment via a second describe would be cleaner, but the previous
+    //  test already exhausted PAY; a 200 here would be a real over-refund bug)
+    expect((await refundReq(200)).status).toBe(400)
+  })
+})

--- a/tutorme-app/src/__tests__/integration/reschedule-consent.test.ts
+++ b/tutorme-app/src/__tests__/integration/reschedule-consent.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration test: reschedule consent gate (see [[tutorme-reschedule-consent]]).
+ *
+ * Locks in the state machine the feature depends on:
+ *  - propose keeps the session at its OLD time (a PENDING proposal);
+ *  - it only moves once EVERY rostered student agrees;
+ *  - a single disagree rejects it (session keeps its time);
+ *  - a student who leaves without voting can't stall it (departure reconcile).
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { and, eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import {
+  user,
+  profile,
+  course,
+  courseEnrollment,
+  liveSession,
+  calendarEvent,
+  sessionRescheduleProposal,
+} from '@/lib/db/schema'
+import {
+  proposeReschedule,
+  respondToProposal,
+  reconcileProposalsAfterDeparture,
+} from '@/lib/schedule/reschedule-consent'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const s1 = crypto.randomUUID()
+const s2 = crypto.randomUUID()
+const s3 = crypto.randomUUID()
+const userIds = [tutorId, s1, s2, s3]
+const COURSE = `rc_course_${stamp}`
+const T0 = new Date('2027-03-01T14:00:00.000Z')
+// Distinct proposed time per session so the tutor-level conflict check never collides.
+const proposedFor = (n: number) => new Date(Date.UTC(2027, 3, n, 16, 0, 0))
+
+let sc = 0
+async function makeSession(): Promise<string> {
+  const id = `rc_sess_${stamp}_${++sc}`
+  await drizzleDb.insert(liveSession).values({
+    sessionId: id,
+    tutorId,
+    courseId: COURSE,
+    title: 'Session',
+    category: 'General',
+    status: 'scheduled',
+    scheduledAt: T0,
+    durationMinutes: 60,
+  } as never)
+  await drizzleDb.insert(calendarEvent).values({
+    eventId: `rc_ce_${id}`,
+    tutorId,
+    title: 'Session',
+    type: 'LESSON',
+    status: 'CONFIRMED',
+    startTime: T0,
+    endTime: new Date(T0.getTime() + 3_600_000),
+    timezone: 'UTC',
+    isAllDay: false,
+    isRecurring: false,
+    isVirtual: true,
+    maxAttendees: 50,
+    createdBy: tutorId,
+    externalId: id,
+    courseId: COURSE,
+    isCancelled: false,
+  } as never)
+  return id
+}
+const sessionTime = (id: string) =>
+  drizzleDb
+    .select({ at: liveSession.scheduledAt })
+    .from(liveSession)
+    .where(eq(liveSession.sessionId, id))
+    .then(r => r[0]?.at?.toISOString())
+const propStatus = (pid: string) =>
+  drizzleDb
+    .select({ s: sessionRescheduleProposal.status })
+    .from(sessionRescheduleProposal)
+    .where(eq(sessionRescheduleProposal.proposalId, pid))
+    .then(r => r[0]?.s)
+
+async function propose(sessionId: string, at: Date) {
+  const r = await proposeReschedule({
+    session: { sessionId, courseId: COURSE, tutorId, title: 'Session' },
+    currentStart: T0,
+    currentEnd: new Date(T0.getTime() + 3_600_000),
+    proposedStart: at,
+    proposedEnd: new Date(at.getTime() + 3_600_000),
+  })
+  return r.kind === 'proposed' ? r.proposalId : ''
+}
+
+describe('reschedule consent gate', () => {
+  beforeAll(async () => {
+    await drizzleDb.insert(user).values(
+      userIds.map((id, i) => ({
+        userId: id,
+        email: `rc-${i}-${stamp}@ex.com`,
+        role: i === 0 ? ('TUTOR' as const) : ('STUDENT' as const),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })) as never
+    )
+    await drizzleDb
+      .insert(profile)
+      .values(
+        [s1, s2, s3].map(id => ({ profileId: `rc_p_${id}`, userId: id, timezone: 'UTC' })) as never
+      )
+    await drizzleDb
+      .insert(course)
+      .values({ courseId: COURSE, name: 'RC', isPublished: true, creatorId: tutorId } as never)
+    await drizzleDb.insert(courseEnrollment).values(
+      [s1, s2, s3].map(id => ({
+        enrollmentId: `rc_e_${id}`,
+        studentId: id,
+        courseId: COURSE,
+      })) as never
+    )
+  })
+
+  afterAll(async () => {
+    const sessions = (
+      await drizzleDb
+        .select({ id: liveSession.sessionId })
+        .from(liveSession)
+        .where(eq(liveSession.tutorId, tutorId))
+    ).map(r => r.id)
+    if (sessions.length) {
+      // proposals cascade to votes on delete
+      await drizzleDb
+        .delete(sessionRescheduleProposal)
+        .where(inArray(sessionRescheduleProposal.sessionId, sessions))
+      await drizzleDb.delete(calendarEvent).where(inArray(calendarEvent.externalId, sessions))
+      await drizzleDb.delete(liveSession).where(inArray(liveSession.sessionId, sessions))
+    }
+    await drizzleDb.delete(courseEnrollment).where(eq(courseEnrollment.courseId, COURSE))
+    await drizzleDb.delete(course).where(eq(course.courseId, COURSE))
+    await drizzleDb.delete(profile).where(inArray(profile.userId, [s1, s2, s3]))
+    await drizzleDb.delete(user).where(inArray(user.userId, userIds))
+  })
+
+  it('propose keeps the old time; unanimous agreement applies the move', async () => {
+    const sess = await makeSession()
+    const at = proposedFor(5)
+    const pid = await propose(sess, at)
+    expect(pid).toBeTruthy()
+    expect(await sessionTime(sess)).toBe(T0.toISOString()) // still old while pending
+
+    expect(
+      (await respondToProposal({ proposalId: pid, studentId: s1, response: 'AGREE' })).status
+    ).toBe('PENDING')
+    await respondToProposal({ proposalId: pid, studentId: s2, response: 'AGREE' })
+    expect(await sessionTime(sess)).toBe(T0.toISOString()) // still old at 2/3
+
+    expect(
+      (await respondToProposal({ proposalId: pid, studentId: s3, response: 'AGREE' })).status
+    ).toBe('APPLIED')
+    expect(await sessionTime(sess)).toBe(at.toISOString()) // moved
+    expect(await propStatus(pid)).toBe('APPLIED')
+  })
+
+  it('a single disagree rejects it; the session keeps its time', async () => {
+    const sess = await makeSession()
+    const pid = await propose(sess, proposedFor(7))
+    await respondToProposal({ proposalId: pid, studentId: s1, response: 'AGREE' })
+    expect(
+      (await respondToProposal({ proposalId: pid, studentId: s2, response: 'DISAGREE' })).status
+    ).toBe('REJECTED')
+    expect(await sessionTime(sess)).toBe(T0.toISOString())
+    expect(await propStatus(pid)).toBe('REJECTED')
+    // A closed proposal rejects further votes.
+    expect(
+      (await respondToProposal({ proposalId: pid, studentId: s3, response: 'AGREE' })).status
+    ).toBe('ERROR')
+  })
+
+  it("a departed non-voter can't stall it — a later agree reconciles and applies", async () => {
+    const sess = await makeSession()
+    const at = proposedFor(9)
+    const pid = await propose(sess, at) // roster s1,s2,s3
+    await respondToProposal({ proposalId: pid, studentId: s1, response: 'AGREE' })
+    // s2 leaves without voting; a raw all-agreed check would count its PENDING vote forever.
+    await drizzleDb
+      .delete(courseEnrollment)
+      .where(and(eq(courseEnrollment.studentId, s2), eq(courseEnrollment.courseId, COURSE)))
+    const r = await respondToProposal({ proposalId: pid, studentId: s3, response: 'AGREE' })
+    expect(r.status).toBe('APPLIED') // s2's stale vote ignored (roster-reconciled)
+    expect(await sessionTime(sess)).toBe(at.toISOString())
+    // restore s2 for other tests / cleanup symmetry
+    await drizzleDb
+      .insert(courseEnrollment)
+      .values({ enrollmentId: `rc_e2_${s2}`, studentId: s2, courseId: COURSE } as never)
+  })
+
+  it('reconcileProposalsAfterDeparture applies a proposal everyone-remaining already agreed to', async () => {
+    const sess = await makeSession()
+    const at = proposedFor(11)
+    const pid = await propose(sess, at)
+    await respondToProposal({ proposalId: pid, studentId: s1, response: 'AGREE' })
+    await respondToProposal({ proposalId: pid, studentId: s3, response: 'AGREE' }) // s2 still pending
+    expect(await propStatus(pid)).toBe('PENDING')
+    await drizzleDb
+      .delete(courseEnrollment)
+      .where(and(eq(courseEnrollment.studentId, s2), eq(courseEnrollment.courseId, COURSE)))
+    await reconcileProposalsAfterDeparture(s2, COURSE)
+    expect(await propStatus(pid)).toBe('APPLIED')
+    expect(await sessionTime(sess)).toBe(at.toISOString())
+  })
+})

--- a/tutorme-app/src/__tests__/integration/seat-oversell.test.ts
+++ b/tutorme-app/src/__tests__/integration/seat-oversell.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration test: group-seat oversell protection (PR #1104).
+ *
+ * Two students racing for the LAST seat must not both succeed. Drives the REAL
+ * POST /api/group-sessions/[id]/join handler concurrently (auth mocked per
+ * request via a header) so the payment-row-lock is actually exercised — a
+ * regression that drops the transaction/lock would let this oversell.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { and, eq, inArray } from 'drizzle-orm'
+
+vi.mock('@/lib/auth', () => ({
+  authOptions: {},
+  // Return whichever student the request names — lets us fire concurrent joins
+  // as different users through the real handler.
+  getServerSession: vi.fn(async (_opts: unknown, req: Request) => ({
+    user: { id: req.headers.get('x-test-user'), role: 'STUDENT' },
+  })),
+}))
+
+import { NextRequest } from 'next/server'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, groupSession, groupSessionParticipant } from '@/lib/db/schema'
+import { countActiveSeats } from '@/lib/group-session/seats'
+import { POST } from '@/app/api/group-sessions/[id]/join/route'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const s1 = crypto.randomUUID()
+const s2 = crypto.randomUUID()
+const userIds = [tutorId, s1, s2]
+const GS = `oversell_gs_${stamp}`
+
+function joinReq(studentId: string) {
+  const req = new NextRequest(`http://localhost/api/group-sessions/${GS}/join`, {
+    method: 'POST',
+    headers: { 'x-test-user': studentId, 'content-type': 'application/json' },
+  })
+  return POST(req, { params: Promise.resolve({ id: GS }) })
+}
+
+describe('group-seat oversell protection', () => {
+  beforeAll(async () => {
+    await drizzleDb.insert(user).values(
+      userIds.map((id, i) => ({
+        userId: id,
+        email: `os-${i}-${stamp}@ex.com`,
+        role: i === 0 ? ('TUTOR' as const) : ('STUDENT' as const),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })) as never
+    )
+    await drizzleDb.insert(groupSession).values({
+      groupSessionId: GS,
+      tutorId,
+      title: 'Last-seat race',
+      requestedDate: new Date('2027-09-01T00:00:00.000Z'),
+      startTime: '15:00',
+      endTime: '16:00',
+      timezone: 'UTC',
+      capacity: 1, // exactly one seat
+      pricePerSeat: 20, // paid → POST reserves (no immediate admit)
+      currency: 'USD',
+      status: 'OPEN',
+    } as never)
+  })
+
+  afterAll(async () => {
+    await drizzleDb
+      .delete(groupSessionParticipant)
+      .where(eq(groupSessionParticipant.groupSessionId, GS))
+    await drizzleDb.delete(groupSession).where(eq(groupSession.groupSessionId, GS))
+    await drizzleDb.delete(user).where(inArray(user.userId, userIds))
+    vi.restoreAllMocks()
+  })
+
+  it('two concurrent joins for a capacity-1 session grant exactly one seat', async () => {
+    const [r1, r2] = await Promise.all([joinReq(s1), joinReq(s2)])
+    const statuses = [r1.status, r2.status].sort()
+    // one 200 (reserved), one 409 (full)
+    expect(statuses).toEqual([200, 409])
+
+    const active = await countActiveSeats(GS)
+    expect(active).toBe(1) // NOT 2 — no oversell
+
+    const reserved = await drizzleDb
+      .select({ id: groupSessionParticipant.participantId })
+      .from(groupSessionParticipant)
+      .where(
+        and(
+          eq(groupSessionParticipant.groupSessionId, GS),
+          inArray(groupSessionParticipant.status, ['RESERVED', 'PAID'])
+        )
+      )
+    expect(reserved.length).toBe(1)
+  })
+})

--- a/tutorme-app/src/__tests__/integration/variant-family.test.ts
+++ b/tutorme-app/src/__tests__/integration/variant-family.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration test: course variant-family expansion.
+ *
+ * Locks in the asymmetry the whole "template vs published" landmine depends on
+ * (see [[tutorme-template-vs-published-course-ids]]):
+ *  - a PUBLISHED id expands to {itself, its template} only — NOT sibling variants
+ *    (so reads scoped by a published id never leak/admit other variants);
+ *  - a TEMPLATE id fans out to {itself, ALL its published variants};
+ *  - a standalone (non-variant) id resolves to just itself.
+ * A regression here silently re-introduces the "wrongly excluded / wrongly
+ * included" class the prevention guard (#1098) and the sweeps (#1089) fixed.
+ *
+ * Requires DATABASE_URL + a running, migrated Postgres (see setup.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, course, courseVariant } from '@/lib/db/schema'
+import { expandToCourseFamily, expandFamilyWithMap } from '@/lib/courses/variant-family'
+
+const stamp = Date.now()
+const tutorId = crypto.randomUUID()
+const T = `vf_tmpl_${stamp}`
+const P1 = `vf_pub1_${stamp}`
+const P2 = `vf_pub2_${stamp}`
+const STANDALONE = `vf_solo_${stamp}`
+const courseIds = [T, P1, P2, STANDALONE]
+const variantIds = [`vf_v1_${stamp}`, `vf_v2_${stamp}`]
+
+const sorted = (a: string[]) => [...a].sort()
+
+describe('variant-family expansion', () => {
+  beforeAll(async () => {
+    await drizzleDb.insert(user).values({
+      userId: tutorId,
+      email: `vf-${stamp}@ex.com`,
+      role: 'TUTOR',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never)
+    await drizzleDb.insert(course).values([
+      { courseId: T, name: 'Template', isPublished: false, creatorId: tutorId },
+      { courseId: P1, name: 'US variant', isPublished: true, creatorId: tutorId },
+      { courseId: P2, name: 'UK variant', isPublished: true, creatorId: tutorId },
+      { courseId: STANDALONE, name: 'Solo', isPublished: true, creatorId: tutorId },
+    ] as never)
+    // One template T with TWO published variants (P1, P2). STANDALONE has none.
+    await drizzleDb.insert(courseVariant).values([
+      {
+        variantId: variantIds[0],
+        templateCourseId: T,
+        publishedCourseId: P1,
+        nationality: 'US',
+        category: `vf-cat-${stamp}`,
+      },
+      {
+        variantId: variantIds[1],
+        templateCourseId: T,
+        publishedCourseId: P2,
+        nationality: 'UK',
+        category: `vf-cat-${stamp}`,
+      },
+    ] as never)
+  })
+
+  afterAll(async () => {
+    await drizzleDb.delete(courseVariant).where(inArray(courseVariant.variantId, variantIds))
+    await drizzleDb.delete(course).where(inArray(course.courseId, courseIds))
+    await drizzleDb.delete(user).where(inArray(user.userId, [tutorId]))
+  })
+
+  it('a PUBLISHED id expands to {itself, template} only — never a sibling variant', async () => {
+    expect(sorted(await expandToCourseFamily([P1]))).toEqual(sorted([P1, T]))
+    expect(sorted(await expandToCourseFamily([P2]))).toEqual(sorted([P2, T]))
+    // The safety property: P1's family must NOT contain the sibling P2.
+    expect(await expandToCourseFamily([P1])).not.toContain(P2)
+  })
+
+  it('a TEMPLATE id fans out to {itself, ALL published variants}', async () => {
+    expect(sorted(await expandToCourseFamily([T]))).toEqual(sorted([T, P1, P2]))
+  })
+
+  it('a standalone (non-variant) id resolves to just itself', async () => {
+    expect(await expandToCourseFamily([STANDALONE])).toEqual([STANDALONE])
+  })
+
+  it('empty input yields empty output', async () => {
+    expect(await expandToCourseFamily([])).toEqual([])
+  })
+
+  it('expandFamilyWithMap maps each family id back to the queried (enrolled) id', async () => {
+    // Querying by the published P1: family {P1, T} both map back to P1.
+    const { ids, toEnrolled } = await expandFamilyWithMap([P1])
+    expect(sorted(ids)).toEqual(sorted([P1, T]))
+    expect(toEnrolled.get(P1)).toBe(P1)
+    expect(toEnrolled.get(T)).toBe(P1)
+  })
+})


### PR DESCRIPTION
Follow-up to the retrospective: the fixes shipped this session were verified with **throwaway** ephemeral-Postgres harnesses that were deleted. Nothing permanent guards them — a future refactor could silently break them and green CI wouldn't notice. These four integration suites close that gap (the **Integration tests** CI check runs them).

## Suites (12 tests)
- **variant-family** — the expansion asymmetry the whole template/published class depends on: a **published** id → `{itself, template}` only (never a sibling variant), a **template** id → all published variants. This is the exact property I empirically verified in the retrospective; locking it in prevents the "wrongly excluded / wrongly included" class from resurfacing.
- **reschedule-consent** — the state machine: propose keeps the old time → unanimous applies → a single disagree rejects → a departed non-voter can't stall it (reconcile).
- **seat-oversell** — drives the **real** `POST /group-sessions/[id]/join` handler **concurrently** (auth mocked per-request); two students racing for a capacity-1 seat get **exactly one**. A regression that drops the row lock would oversell here.
- **refund-clamp** — drives the **real** `POST /payments/refund` handler (middleware pass-through, **gateway mocked so no money moves**); partial refunds allowed up to the paid amount, over-refund rejected **before** the gateway.

Test-only — no production code touched. Typecheck clean, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)