### PR TITLE
test(course-builder): lock in the two lesson-persistence guards (#1127, #1128)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DASHBOARD_THEMES, getThemeStyle } from '@/components/dashboard-theme'
+import { emptySaveDecision } from '@/lib/courses/course-builder-guards'
 import { saveCourse } from './save-course'
 import type {
   CourseBuilderRef,
@@ -172,8 +173,14 @@ export function useCourseBuilderContentModel({
     // lost. This MUST also cover autosave: the mount autosave fires on a 2s
     // debounce and can beat a slow load, sending an empty payload. Autosave is
     // silent; a manual save tells the tutor to wait.
-    if (!isDetached && lessons.length === 0 && loadedLessons === null) {
-      if (!options?.isAutoSave) {
+    const emptySave = emptySaveDecision({
+      isDetached,
+      lessonCount: lessons.length,
+      loadedLessonsIsNull: loadedLessons === null,
+      isAutoSave: !!options?.isAutoSave,
+    })
+    if (emptySave !== 'proceed') {
+      if (emptySave === 'block-warn') {
         toast.error('Lessons haven’t finished loading yet — reload the course before saving.')
       }
       return

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -212,6 +212,7 @@ import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
 import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
 import { nextDmiGate } from '@/lib/assessment/dmi-generate-gate'
 import { resolveDocPaneVisibility } from '@/lib/courses/doc-pane-visibility'
+import { shouldRehydrateBuilder } from '@/lib/courses/course-builder-guards'
 import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
@@ -4067,7 +4068,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       // initial key / course changes, at which point it reflects the latest edits.
       const courseChanged = lastHydratedCourseIdRef.current !== (courseId ?? null)
       lastHydratedCourseIdRef.current = courseId ?? null
-      if (!courseChanged && builderNodes.length > 0) return
+      if (!shouldRehydrateBuilder(courseChanged, builderNodes.length)) return
 
       const normalized = normalizeCourseBuilderNodesForAssessments(
         resolvedInitialCourseBuilderNodes

--- a/tutorme-app/src/lib/courses/course-builder-guards.test.ts
+++ b/tutorme-app/src/lib/courses/course-builder-guards.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { shouldRehydrateBuilder, emptySaveDecision } from './course-builder-guards'
+
+describe('shouldRehydrateBuilder (#1127 — late load must not clobber edits)', () => {
+  it('hydrates when the course changed (new mount / course switch), even with edits', () => {
+    expect(shouldRehydrateBuilder(true, 0)).toBe(true)
+    expect(shouldRehydrateBuilder(true, 3)).toBe(true)
+  })
+
+  it('hydrates the SAME course only while the builder is still empty', () => {
+    // Reopen: builder empty, load delivers → hydrate.
+    expect(shouldRehydrateBuilder(false, 0)).toBe(true)
+  })
+
+  it('does NOT re-hydrate the same course once the tutor has added lessons', () => {
+    // The regression: a late async load for the same course must not overwrite
+    // in-progress edits.
+    expect(shouldRehydrateBuilder(false, 1)).toBe(false)
+    expect(shouldRehydrateBuilder(false, 5)).toBe(false)
+  })
+})
+
+describe('emptySaveDecision (#1128 — no empty save before the load finishes)', () => {
+  const base = { isDetached: false, lessonCount: 2, loadedLessonsIsNull: false, isAutoSave: false }
+
+  it('proceeds for a normal save with content', () => {
+    expect(emptySaveDecision(base)).toBe('proceed')
+  })
+
+  it('blocks an empty save while the load is pending/failed (loadedLessons === null)', () => {
+    // Manual save → warn the tutor.
+    expect(
+      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: true, isAutoSave: false })
+    ).toBe('block-warn')
+    // Autosave → block silently (the regression: this used to be allowed and wiped lessons).
+    expect(
+      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: true, isAutoSave: true })
+    ).toBe('block-silent')
+  })
+
+  it('allows a genuinely-empty course once it has loaded (loadedLessons === [])', () => {
+    expect(
+      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: false, isAutoSave: true })
+    ).toBe('proceed')
+  })
+
+  it('allows deleting all lessons on a loaded course (user intent)', () => {
+    // loaded (not null) + now empty → proceed (deploy guard still protects deployed lessons).
+    expect(
+      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: false, isAutoSave: false })
+    ).toBe('proceed')
+  })
+
+  it('never blocks a detached draft (different flow)', () => {
+    expect(
+      emptySaveDecision({
+        isDetached: true,
+        lessonCount: 0,
+        loadedLessonsIsNull: true,
+        isAutoSave: true,
+      })
+    ).toBe('proceed')
+    expect(
+      emptySaveDecision({
+        isDetached: true,
+        lessonCount: 0,
+        loadedLessonsIsNull: true,
+        isAutoSave: false,
+      })
+    ).toBe('proceed')
+  })
+})

--- a/tutorme-app/src/lib/courses/course-builder-guards.ts
+++ b/tutorme-app/src/lib/courses/course-builder-guards.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure decisions for the two Course Builder persistence guards. Both protect
+ * against silent lesson data-loss, so they're extracted here and unit-tested —
+ * a future refactor of the (untestable) React effect / save closure can't
+ * reintroduce the loss without failing a test. See course-builder-guards.test.ts.
+ */
+
+/**
+ * Whether the builder should (re)hydrate its local node state from the loaded
+ * course data. Only when switching to a DIFFERENT course, or while the builder is
+ * still empty — otherwise a late/async initial for the SAME course would clobber
+ * the tutor's in-progress edits (which autosave then persists). See #1127.
+ */
+export function shouldRehydrateBuilder(courseChanged: boolean, currentNodeCount: number): boolean {
+  return courseChanged || currentNodeCount === 0
+}
+
+export type EmptySaveDecision = 'proceed' | 'block-silent' | 'block-warn'
+
+/**
+ * Whether a save carrying an EMPTY lesson set must be blocked because the course
+ * content hasn't finished loading (`loadedLessons === null` → load pending or
+ * failed). Saving empty then would soft-delete every un-deployed lesson. Blocks
+ * autosave silently and a manual save with a warning; a genuinely-empty course
+ * (loaded as []) or a detached draft proceeds. See #1128.
+ */
+export function emptySaveDecision(params: {
+  isDetached: boolean
+  lessonCount: number
+  loadedLessonsIsNull: boolean
+  isAutoSave: boolean
+}): EmptySaveDecision {
+  const { isDetached, lessonCount, loadedLessonsIsNull, isAutoSave } = params
+  if (!isDetached && lessonCount === 0 && loadedLessonsIsNull) {
+    return isAutoSave ? 'block-silent' : 'block-warn'
+  }
+  return 'proceed'
+}


### PR DESCRIPTION
Regression tests for the two lesson data-loss guards fixed in #1127 / #1128, which lived as inline conditions in an untestable React effect and a save closure.

## What
- New **`src/lib/courses/course-builder-guards.ts`** — pure decisions:
  - **`shouldRehydrateBuilder(courseChanged, currentNodeCount)`** — the #1127 rule (only hydrate on course switch or empty builder; never clobber same-course edits).
  - **`emptySaveDecision({ isDetached, lessonCount, loadedLessonsIsNull, isAutoSave })`** → `'proceed' | 'block-silent' | 'block-warn'` — the #1128 rule (block empty save while load pending/failed; autosave silent, manual warned; loaded-but-empty / delete-all / detached proceed).
- Both call sites (`CourseBuilder.tsx` effect, `use-course-builder-content-model.ts` save) now **delegate** to these — **behaviour-preserving** (identical logic).
- **8 unit tests** covering both, including the exact regression cases (same-course late-load clobber, empty autosave wipe) and the must-still-work cases (delete-all, loaded-empty, detached).

## Verification
`vitest` 8/8. `tsc --noEmit` clean (0 errors). Prettier clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)