### PR TITLE
fix(course-builder): stop delete-missing save from wiping lessons loaded after edits begin

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/save-course.ts
@@ -40,7 +40,7 @@ function getDefaultStorageKey(courseId: string | null): string {
   return `insights-course-builder:${courseId ?? 'default'}`
 }
 
-function isDraftCourseId(courseId: string | null): boolean {
+export function isDraftCourseId(courseId: string | null): boolean {
   return !courseId || DRAFT_SENTINELS.has(courseId)
 }
 

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
@@ -4,7 +4,8 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DASHBOARD_THEMES, getThemeStyle } from '@/components/dashboard-theme'
-import { emptySaveDecision } from '@/lib/courses/course-builder-guards'
+import { preSaveDecision } from '@/lib/courses/course-builder-guards'
+import { isDraftCourseId } from './save-course'
 import { saveCourse } from './save-course'
 import type {
   CourseBuilderRef,
@@ -165,22 +166,24 @@ export function useCourseBuilderContentModel({
   ) => {
     const isDetached = dataMode === 'detached'
 
-    // Guard against wiping the course when its content never loaded. On a
-    // DB-backed course, loadedLessons stays null only while the load is still
-    // pending or has failed (a successfully-empty course loads as []). Saving an
-    // empty tree in that state would soft-delete every lesson server-side — and
-    // the server floor only spares DEPLOYED lessons, so un-deployed ones would be
-    // lost. This MUST also cover autosave: the mount autosave fires on a 2s
-    // debounce and can beat a slow load, sending an empty payload. Autosave is
-    // silent; a manual save tells the tutor to wait.
-    const emptySave = emptySaveDecision({
+    // Never save while the initial load is incomplete. On a DB-backed course,
+    // loadedLessons stays null only while the load is still pending or has failed
+    // (a successfully-empty course loads as []). In that state builderNodes does
+    // NOT yet reflect the DB, so the delete-missing save would soft-delete every
+    // not-yet-loaded lesson — the "lessons disappear on create/reopen" bug. This
+    // MUST cover BOTH the empty case (the 2s mount autosave beating a slow load)
+    // and a non-empty payload (the tutor adds lessons during the load window). It
+    // MUST also cover autosave, silently; a manual save tells the tutor to wait.
+    // Once the load lands, the hydration effect merges it in, so later saves carry
+    // the full lesson set and this gate opens (loadedLessons is [] or populated).
+    const gate = preSaveDecision({
       isDetached,
-      lessonCount: lessons.length,
+      isDraftCourse: isDraftCourseId(courseId),
       loadedLessonsIsNull: loadedLessons === null,
       isAutoSave: !!options?.isAutoSave,
     })
-    if (emptySave !== 'proceed') {
-      if (emptySave === 'block-warn') {
+    if (gate !== 'proceed') {
+      if (gate === 'block-warn') {
         toast.error('Lessons haven’t finished loading yet — reload the course before saving.')
       }
       return

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -212,7 +212,10 @@ import { revealPolicyToDeployMode } from '@/lib/assessment/reveal-policy'
 import { dmiOptionLetter, dmiSelectedOptionLetters } from '@/lib/assessment/mcq-answer'
 import { nextDmiGate } from '@/lib/assessment/dmi-generate-gate'
 import { resolveDocPaneVisibility } from '@/lib/courses/doc-pane-visibility'
-import { shouldRehydrateBuilder } from '@/lib/courses/course-builder-guards'
+import {
+  shouldRehydrateBuilder,
+  mergeLoadedWithPendingEdits,
+} from '@/lib/courses/course-builder-guards'
 import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
@@ -709,6 +712,11 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // The course whose loaded data we last hydrated the builder from, so a late/
     // async initial for the SAME course can't clobber in-progress edits.
     const lastHydratedCourseIdRef = useRef<string | null>(null)
+    // The course for which we've already absorbed the FIRST real (non-empty) load.
+    // Until this is set, the builder's lessons don't yet reflect the DB, so the
+    // first real load is MERGED in (not skipped) to preserve any lessons the tutor
+    // added during the load window while still capturing the full DB baseline.
+    const mergedRealLoadCourseIdRef = useRef<string | null>(null)
     const [builderNodes, setBuilderNodes] = useState<CourseBuilderNode[]>([])
     const [liveNodes, setLiveNodes] = useState<CourseBuilderNode[]>([])
 
@@ -4058,23 +4066,44 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       if (lastInitialCourseBuilderNodesKeyRef.current === initialCourseBuilderNodesKey) return
       lastInitialCourseBuilderNodesKeyRef.current = initialCourseBuilderNodesKey
 
-      // Only (re)hydrate the builder from the loaded course data when we switch to
-      // a DIFFERENT course, or while the builder is still empty. A late/async
-      // initial for the SAME course — e.g. the background course load finishing
-      // AFTER the tutor has begun adding lessons to a newly-created course — must
-      // NOT overwrite their in-memory lessons; autosave would then persist the
-      // clobbered state and the lessons would be lost on reload. builderNodes is
-      // read (not depended on) intentionally: the effect only re-runs when the
-      // initial key / course changes, at which point it reflects the latest edits.
       const courseChanged = lastHydratedCourseIdRef.current !== (courseId ?? null)
       lastHydratedCourseIdRef.current = courseId ?? null
-      if (!shouldRehydrateBuilder(courseChanged, builderNodes.length)) return
 
       const normalized = normalizeCourseBuilderNodesForAssessments(
         resolvedInitialCourseBuilderNodes
       )
+      const hydrateLive = (nodes: CourseBuilderNode[]) =>
+        setLiveNodes(isStudentView || saveMode !== 'draft' ? cloneNodes(nodes) : [])
+
+      if (courseChanged) {
+        // Switched to a different course (or first mount): replace wholesale.
+        // Don't merge — builderNodes still holds the previous course's lessons.
+        mergedRealLoadCourseIdRef.current = normalized.length > 0 ? (courseId ?? null) : null
+        setBuilderNodes(normalized)
+        hydrateLive(normalized)
+        return
+      }
+
+      // Same course. The FIRST time real (non-empty) loaded data lands — the
+      // background load finishing AFTER the builder opened empty — MERGE it with
+      // any lessons the tutor added during the load window. Skipping it (as #1127
+      // did) would leave builderNodes without the DB lessons, and the next
+      // delete-missing save would soft-delete them (the "lessons disappear" bug).
+      if (normalized.length > 0 && mergedRealLoadCourseIdRef.current !== (courseId ?? null)) {
+        mergedRealLoadCourseIdRef.current = courseId ?? null
+        const merged = mergeLoadedWithPendingEdits(normalized, builderNodes)
+        setBuilderNodes(merged)
+        hydrateLive(merged)
+        return
+      }
+
+      // A later re-fetch for the same course must NOT clobber in-progress edits;
+      // only re-hydrate while the builder is still empty. builderNodes is read
+      // (not depended on) intentionally: the effect only re-runs on key/course
+      // change, at which point it reflects the latest edits.
+      if (!shouldRehydrateBuilder(courseChanged, builderNodes.length)) return
       setBuilderNodes(normalized)
-      setLiveNodes(isStudentView || saveMode !== 'draft' ? cloneNodes(normalized) : [])
+      hydrateLive(normalized)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [courseId, initialCourseBuilderNodesKey, resolvedInitialCourseBuilderNodes])
 

--- a/tutorme-app/src/lib/courses/course-builder-guards.test.ts
+++ b/tutorme-app/src/lib/courses/course-builder-guards.test.ts
@@ -1,72 +1,122 @@
 import { describe, it, expect } from 'vitest'
-import { shouldRehydrateBuilder, emptySaveDecision } from './course-builder-guards'
+import {
+  shouldRehydrateBuilder,
+  preSaveDecision,
+  mergeLoadedWithPendingEdits,
+} from './course-builder-guards'
 
-describe('shouldRehydrateBuilder (#1127 — late load must not clobber edits)', () => {
+describe('shouldRehydrateBuilder (#1127 — late re-fetch must not clobber edits)', () => {
   it('hydrates when the course changed (new mount / course switch), even with edits', () => {
     expect(shouldRehydrateBuilder(true, 0)).toBe(true)
     expect(shouldRehydrateBuilder(true, 3)).toBe(true)
   })
 
   it('hydrates the SAME course only while the builder is still empty', () => {
-    // Reopen: builder empty, load delivers → hydrate.
     expect(shouldRehydrateBuilder(false, 0)).toBe(true)
   })
 
   it('does NOT re-hydrate the same course once the tutor has added lessons', () => {
-    // The regression: a late async load for the same course must not overwrite
-    // in-progress edits.
     expect(shouldRehydrateBuilder(false, 1)).toBe(false)
     expect(shouldRehydrateBuilder(false, 5)).toBe(false)
   })
 })
 
-describe('emptySaveDecision (#1128 — no empty save before the load finishes)', () => {
-  const base = { isDetached: false, lessonCount: 2, loadedLessonsIsNull: false, isAutoSave: false }
+describe('preSaveDecision (no save while the initial load is incomplete)', () => {
+  const base = {
+    isDetached: false,
+    isDraftCourse: false,
+    loadedLessonsIsNull: false,
+    isAutoSave: false,
+  }
 
-  it('proceeds for a normal save with content', () => {
-    expect(emptySaveDecision(base)).toBe('proceed')
+  it('proceeds for a normal save once the course has loaded', () => {
+    expect(preSaveDecision(base)).toBe('proceed')
+    expect(preSaveDecision({ ...base, isAutoSave: true })).toBe('proceed')
   })
 
-  it('blocks an empty save while the load is pending/failed (loadedLessons === null)', () => {
-    // Manual save → warn the tutor.
-    expect(
-      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: true, isAutoSave: false })
-    ).toBe('block-warn')
-    // Autosave → block silently (the regression: this used to be allowed and wiped lessons).
-    expect(
-      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: true, isAutoSave: true })
-    ).toBe('block-silent')
+  it('blocks ANY save while the load is pending/failed (loadedLessons === null)', () => {
+    // Manual save -> warn the tutor.
+    expect(preSaveDecision({ ...base, loadedLessonsIsNull: true, isAutoSave: false })).toBe(
+      'block-warn'
+    )
+    // Autosave -> block silently. This is the core fix: a non-empty payload built
+    // during the load window used to delete every not-yet-loaded lesson.
+    expect(preSaveDecision({ ...base, loadedLessonsIsNull: true, isAutoSave: true })).toBe(
+      'block-silent'
+    )
   })
 
-  it('allows a genuinely-empty course once it has loaded (loadedLessons === [])', () => {
+  it('allows a course whose load completed, even when empty (loadedLessons === [])', () => {
+    // loadedLessonsIsNull === false models a completed load (empty or populated).
+    expect(preSaveDecision({ ...base, loadedLessonsIsNull: false })).toBe('proceed')
+  })
+
+  it('never blocks a detached draft (no DB load)', () => {
+    expect(preSaveDecision({ ...base, isDetached: true, loadedLessonsIsNull: true })).toBe(
+      'proceed'
+    )
     expect(
-      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: false, isAutoSave: true })
+      preSaveDecision({ ...base, isDetached: true, loadedLessonsIsNull: true, isAutoSave: true })
     ).toBe('proceed')
   })
 
-  it('allows deleting all lessons on a loaded course (user intent)', () => {
-    // loaded (not null) + now empty → proceed (deploy guard still protects deployed lessons).
+  it('never blocks a draft-sentinel course whose "save" is a create (insights/builder-draft)', () => {
+    // Its load 404s so loadedLessons stays null; blocking would break creation.
+    expect(preSaveDecision({ ...base, isDraftCourse: true, loadedLessonsIsNull: true })).toBe(
+      'proceed'
+    )
     expect(
-      emptySaveDecision({ ...base, lessonCount: 0, loadedLessonsIsNull: false, isAutoSave: false })
+      preSaveDecision({ ...base, isDraftCourse: true, loadedLessonsIsNull: true, isAutoSave: true })
     ).toBe('proceed')
   })
+})
 
-  it('never blocks a detached draft (different flow)', () => {
-    expect(
-      emptySaveDecision({
-        isDetached: true,
-        lessonCount: 0,
-        loadedLessonsIsNull: true,
-        isAutoSave: true,
-      })
-    ).toBe('proceed')
-    expect(
-      emptySaveDecision({
-        isDetached: true,
-        lessonCount: 0,
-        loadedLessonsIsNull: true,
-        isAutoSave: false,
-      })
-    ).toBe('proceed')
+describe('mergeLoadedWithPendingEdits (first real load keeps DB baseline + in-progress adds)', () => {
+  const node = (nodeId: string, lessonId: string) => ({
+    id: nodeId,
+    lessons: [{ id: lessonId }],
+  })
+
+  it('returns the loaded set unchanged when nothing was added during the load', () => {
+    const loaded = [node('node-a', 'a'), node('node-b', 'b')]
+    expect(mergeLoadedWithPendingEdits(loaded, [])).toEqual(loaded)
+  })
+
+  it('appends lessons added during the load window after the loaded (DB) lessons', () => {
+    // Reopen [A,B,C]; tutor added D before the load landed. Merge must keep A,B,C
+    // AND D so the next save carries all four (no wrongful delete of A,B,C).
+    const loaded = [node('node-a', 'a'), node('node-b', 'b'), node('node-c', 'c')]
+    const pending = [node('node-d', 'd')]
+    const merged = mergeLoadedWithPendingEdits(loaded, pending)
+    expect(merged.map(n => n.lessons[0].id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('keeps the default lesson plus a lesson added on a newly-created course', () => {
+    // Create -> default Lesson 1 (L1) in DB; tutor added Lesson 2 during the load.
+    const loaded = [node('node-L1', 'L1')]
+    const pending = [node('node-new', 'new2')]
+    expect(mergeLoadedWithPendingEdits(loaded, pending).map(n => n.lessons[0].id)).toEqual([
+      'L1',
+      'new2',
+    ])
+  })
+
+  it('drops a pending node that collides with a loaded lesson (same lesson id)', () => {
+    const loaded = [node('node-a', 'a')]
+    const pending = [node('node-a', 'a'), node('node-x', 'x')]
+    expect(mergeLoadedWithPendingEdits(loaded, pending).map(n => n.lessons[0].id)).toEqual([
+      'a',
+      'x',
+    ])
+  })
+
+  it('dedupes by node id even when a pending node has no lesson id yet', () => {
+    const loaded = [{ id: 'node-a', lessons: [{ id: 'a' }] }]
+    const pending = [
+      { id: 'node-a', lessons: [] },
+      { id: 'node-fresh', lessons: [] },
+    ]
+    const merged = mergeLoadedWithPendingEdits(loaded, pending)
+    expect(merged.map(n => n.id)).toEqual(['node-a', 'node-fresh'])
   })
 })

--- a/tutorme-app/src/lib/courses/course-builder-guards.ts
+++ b/tutorme-app/src/lib/courses/course-builder-guards.ts
@@ -1,38 +1,91 @@
 /**
- * Pure decisions for the two Course Builder persistence guards. Both protect
- * against silent lesson data-loss, so they're extracted here and unit-tested —
- * a future refactor of the (untestable) React effect / save closure can't
+ * Pure decisions for the Course Builder lesson-persistence guards. They protect
+ * against silent lesson data-loss, so they're extracted here and unit-tested — a
+ * future refactor of the (untestable) React effect / save closure can't
  * reintroduce the loss without failing a test. See course-builder-guards.test.ts.
+ *
+ * The save (`updateCourseBuilderData`) is delete-missing: it soft-deletes every
+ * DB lesson whose id is NOT in the incoming payload. That is only safe if the
+ * payload was built from a `builderNodes` state that already contains every
+ * lesson currently in the DB. The builder opens EMPTY and cannot tell "still
+ * loading" (`loadedLessons === null`) from "genuinely empty" (`[]`), so a tutor
+ * who starts adding lessons before the initial load lands would otherwise build a
+ * payload missing the not-yet-loaded lessons — and the save would delete them.
+ * Two rules close that: (1) never save while the load is incomplete, and (2) when
+ * the load lands, MERGE it with any lessons added during the load window.
  */
 
 /**
- * Whether the builder should (re)hydrate its local node state from the loaded
- * course data. Only when switching to a DIFFERENT course, or while the builder is
- * still empty — otherwise a late/async initial for the SAME course would clobber
- * the tutor's in-progress edits (which autosave then persists). See #1127.
+ * Whether the builder should (re)hydrate its local node state from a SUBSEQUENT
+ * (non-first) delivery of loaded course data — i.e. a re-fetch for the same
+ * course. Only when switching to a DIFFERENT course, or while the builder is
+ * still empty; otherwise a late/async re-fetch for the SAME course would clobber
+ * the tutor's in-progress edits (which autosave then persists). See #1127. The
+ * FIRST real load is handled separately by a merge (see mergeLoadedWithPendingEdits).
  */
 export function shouldRehydrateBuilder(courseChanged: boolean, currentNodeCount: number): boolean {
   return courseChanged || currentNodeCount === 0
 }
 
-export type EmptySaveDecision = 'proceed' | 'block-silent' | 'block-warn'
+export type SaveGateDecision = 'proceed' | 'block-silent' | 'block-warn'
 
 /**
- * Whether a save carrying an EMPTY lesson set must be blocked because the course
- * content hasn't finished loading (`loadedLessons === null` → load pending or
- * failed). Saving empty then would soft-delete every un-deployed lesson. Blocks
- * autosave silently and a manual save with a warning; a genuinely-empty course
- * (loaded as []) or a detached draft proceeds. See #1128.
+ * Whether a save must be blocked because the course content hasn't finished
+ * loading. For a DB-backed course, `loadedLessons === null` means the initial
+ * load is still pending or has failed — the builder's lesson set does NOT yet
+ * reflect the DB, so a delete-missing save would soft-delete every not-yet-loaded
+ * lesson (the create/reopen "lessons disappear" bug). Block ANY save in that
+ * state — autosave silently, a manual save with a warning. Bypassed when there
+ * are no persisted lessons to protect: a detached draft, or a draft-sentinel
+ * course (insights-draft / builder-draft) whose "save" is really a create — its
+ * load 404s so loadedLessons stays null, and blocking would break creation. A
+ * course whose load has completed (`loadedLessons` is `[]` or populated)
+ * proceeds. Supersedes the narrower empty-only guard from #1128.
  */
-export function emptySaveDecision(params: {
+export function preSaveDecision(params: {
   isDetached: boolean
-  lessonCount: number
+  isDraftCourse: boolean
   loadedLessonsIsNull: boolean
   isAutoSave: boolean
-}): EmptySaveDecision {
-  const { isDetached, lessonCount, loadedLessonsIsNull, isAutoSave } = params
-  if (!isDetached && lessonCount === 0 && loadedLessonsIsNull) {
+}): SaveGateDecision {
+  const { isDetached, isDraftCourse, loadedLessonsIsNull, isAutoSave } = params
+  if (isDetached || isDraftCourse) return 'proceed'
+  if (loadedLessonsIsNull) {
     return isAutoSave ? 'block-silent' : 'block-warn'
   }
   return 'proceed'
+}
+
+type MergeableNode = { id?: string; lessons?: Array<{ id?: string } | null | undefined> }
+
+/**
+ * Merge the just-loaded course nodes with any nodes the tutor added while the
+ * initial load was still in flight, so builderNodes ends up containing BOTH the
+ * full DB baseline AND the in-progress additions. Loaded nodes come first (they
+ * are the authoritative DB order); a pending node is appended only if it isn't
+ * already represented in the loaded set — matched by its lesson id, else its node
+ * id. During the load window the builder is empty, so the tutor can only ADD new
+ * lessons (never edit a not-yet-loaded one); a pending node that collides with a
+ * loaded lesson is therefore the same lesson and is dropped in favour of the
+ * loaded copy. This lets a save carry every DB lesson (no wrongful delete) while
+ * keeping the tutor's new lessons.
+ */
+export function mergeLoadedWithPendingEdits<T extends MergeableNode>(
+  loaded: T[],
+  pending: T[]
+): T[] {
+  const loadedLessonIds = new Set<string>()
+  const loadedNodeIds = new Set<string>()
+  for (const node of loaded) {
+    if (node.id) loadedNodeIds.add(node.id)
+    const lessonId = node.lessons?.[0]?.id
+    if (lessonId) loadedLessonIds.add(lessonId)
+  }
+  const extras = pending.filter(node => {
+    const lessonId = node.lessons?.[0]?.id
+    if (lessonId && loadedLessonIds.has(lessonId)) return false
+    if (node.id && loadedNodeIds.has(node.id)) return false
+    return true
+  })
+  return [...loaded, ...extras]
 }


### PR DESCRIPTION
The **real** root cause behind *"lessons disappear when I create a course, save, exit, and return"* — the one #1127/#1128 only partially closed.

## Root cause
- The server save (`updateCourseBuilderData`) is **delete-missing**: it soft-deletes every DB lesson whose id is absent from the payload (payload = `builderNodes` → lessons).
- Course creation inserts a default **Lesson 1** row.
- The builder opens with `builderNodes=[]` and **can't distinguish "still loading" (`loadedLessons === null`) from "genuinely empty" (`[]`)** — inside CourseBuilder `const lessons = initialLessons || []`.
- So when the tutor starts adding lessons **before the initial load lands**, the save runs against a `builderNodes` that's **missing the not-yet-loaded lessons** → the server deletes them (the default Lesson 1, or **all** prior lessons when reopening an existing course).
- My earlier #1127 guard made it worse by **skipping** re-hydration once editing began, so the loaded lessons never came back into `builderNodes`.

## Fix (two parts, both with pure unit tests)
1. **`preSaveDecision`** — block **any** save (autosave silently, manual with a warning) while `loadedLessons === null` for a real DB-backed course, not just empty payloads. Bypassed for detached drafts **and** draft-sentinel courses (`insights-draft` / `builder-draft`) whose "save" is really a *create* (their load 404s, so blocking would break creation).
2. **`mergeLoadedWithPendingEdits`** — on the **first real load**, merge the loaded lessons with any the tutor added during the load window (loaded first; append pending nodes whose lesson/node id isn't already loaded) instead of skipping. So `builderNodes` always holds the full DB baseline before a save is possible, while in-progress edits survive. Course switches still **replace wholesale** (no cross-course contamination), tracked via `mergedRealLoadCourseIdRef`.

## Verification
Traced end-to-end and independently adversarially reviewed across: new-course & reopen × edit-before/after-load, course-switch, same-course re-fetch, load-failure, genuinely-empty course. **No scenario loses lessons.** The reviewer confirmed no data-loss hole and flagged the `builder-draft` create-flow regression, which part 1's draft-sentinel bypass closes.

13 unit tests, `tsc --noEmit` clean, prettier clean.

Note: on a **persistent load failure** saves stay blocked (toast: reload the course) — deliberately safer than deleting unloaded lessons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)