### PR TITLE
fix(test-mode): classroom message alignment and reset persistence

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10623,6 +10623,40 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                       }))
                                                     }
                                                   }}
+                                                  onReset={() => {
+                                                    // Clear all test data for this extension
+                                                    // 1. Clear classroom messages
+                                                    setClassroomMessages(prev => {
+                                                      const next = { ...prev }
+                                                      delete next[extKey]
+                                                      try {
+                                                        localStorage.setItem(
+                                                          'tutor-classroom-messages-v1',
+                                                          JSON.stringify(next)
+                                                        )
+                                                      } catch {
+                                                        // ignore
+                                                      }
+                                                      return next
+                                                    })
+                                                    // 2. Clear all student tab stores for this extension
+                                                    ;['student1', 'student2'].forEach(st => {
+                                                      const sk = `${extKey}:${st}`
+                                                      delete testTaskChatStore.current[sk]
+                                                    })
+                                                    // 3. Clear classroom tab store
+                                                    delete testTaskChatStore.current[
+                                                      `${extKey}:classroom`
+                                                    ]
+                                                    try {
+                                                      localStorage.setItem(
+                                                        'tutor-test-chat-store-v1',
+                                                        JSON.stringify(testTaskChatStore.current)
+                                                      )
+                                                    } catch {
+                                                      // ignore
+                                                    }
+                                                  }}
                                                   mode={
                                                     isClassroomTab ? 'classroom' : 'test-student'
                                                   }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -64,6 +64,7 @@ export function TestTaskChat({
   initialState,
   onPersist,
   onBroadcast,
+  onReset,
   incomingMessages,
   mode = 'test-student',
   tutorAvatarUrl,
@@ -78,6 +79,8 @@ export function TestTaskChat({
   onPersist?: (state: TestTaskChatState) => void
   /** Called when a new message is sent from this tab so the parent can relay it to other tabs. */
   onBroadcast?: (msg: TestTaskChatMsg) => void
+  /** Called when the user clicks the reset/restart button. Parent should clear all persisted data. */
+  onReset?: () => void
   /** Messages injected from outside (e.g. from other tabs via the parent). Appended to the chat. */
   incomingMessages?: TestTaskChatMsg[]
   /** Which preview mode this is rendering in. */
@@ -155,7 +158,7 @@ export function TestTaskChat({
     const a = draft.trim()
     if (!a || busy) return
     const msg: ChatMsg = {
-      role: isClassroom ? 'tutor' : 'student',
+      role: 'student',
       content: a,
       timestamp: Date.now(),
     }
@@ -179,7 +182,7 @@ export function TestTaskChat({
     let nextMessages = messages
     if (pending) {
       const pendingMsg: ChatMsg = {
-        role: isClassroom ? 'tutor' : 'student',
+        role: 'student',
         content: pending,
         timestamp: Date.now(),
       }
@@ -271,6 +274,7 @@ export function TestTaskChat({
     setDraft('')
     setCompleted(false)
     onPersist?.(emptyState)
+    onReset?.()
   }
 
   const accentColor = isClassroom ? 'text-[#F17623]' : 'text-violet-600'


### PR DESCRIPTION
- Change message role from 'tutor' to 'student' in classroom mode so messages appear on the right side (simulating live session student position)
- Add onReset callback to TestTaskChat so reset button clears all persisted data: classroomMessages, testTaskChatStore entries, and localStorage keys
- Reset now properly deletes data across all tabs and resets the test session