### PR TITLE
fix(create-course): remove translucent wrapper to match Edit Category…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1349,13 +1349,11 @@ function CourseBuilderInsightsRouteInner({
                   </div>
                 </div>
               ) : (
-                <div className="rounded-xl border border-white/30 bg-white/35 p-4 shadow-sm backdrop-blur-xl">
-                  <CourseCategoryPicker
-                    value={newCourseCategories ?? []}
-                    onChange={v => setNewCourseCategories?.(v)}
-                    storageUserId={createStorageUserId}
-                  />
-                </div>
+                <CourseCategoryPicker
+                  value={newCourseCategories ?? []}
+                  onChange={v => setNewCourseCategories?.(v)}
+                  storageUserId={createStorageUserId}
+                />
               )}
             </div>
 


### PR DESCRIPTION
… styling

Remove bg-white/35 wrapper around CourseCategoryPicker in Create Course dialog so it renders directly on dark background, matching Edit Category dialog. The wrapper was added in 43d8c6085 and caused visual divergence.

- Remove rounded-xl border border-white/30 bg-white/35 p-4 shadow-sm wrapper
- CourseCategoryPicker now renders directly on dark dialog background