### PR TITLE
fix(test-mode): use student role for follow-up questions in classroom

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -224,7 +224,7 @@ export function TestTaskChat({
     const q = draft.trim()
     if (!q || busy) return
     const questionMsg: ChatMsg = {
-      role: isClassroom ? 'tutor' : 'student',
+      role: 'student',
       content: q,
       timestamp: Date.now(),
     }


### PR DESCRIPTION
The ask() function (follow-up questions after task completion) still used role: isClassroom ? 'tutor' : 'student', causing classroom messages to appear on the left side instead of right. Change to always use 'student' role so classroom messages appear on the right (matching live session student position).

Completes the fix started in PR #1138 which only updated addAnswer() and complete() but missed ask().