### PR TITLE
fix(test-mode): student messages on right in Test Student tabs

### DIFF
--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -102,12 +102,7 @@ export function ChatMessageBubble({
   })()
 
   return (
-    <div
-      className={cn(
-        'flex gap-2',
-        isRight ? 'flex-row justify-end' : 'flex-row justify-start'
-      )}
-    >
+    <div className={cn('flex gap-2', isRight ? 'flex-row justify-end' : 'flex-row justify-start')}>
       {/* Avatar */}
       {showAvatar && (
         <div className="flex flex-col items-center gap-1">

--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -105,7 +105,7 @@ export function ChatMessageBubble({
     <div
       className={cn(
         'flex gap-2',
-        isRight ? 'flex-row-reverse justify-end' : 'flex-row justify-start'
+        isRight ? 'flex-row justify-end' : 'flex-row justify-start'
       )}
     >
       {/* Avatar */}


### PR DESCRIPTION
## Problem\nIn the Test Student tabs (Test Student 1, Test Student 2), student messages were appearing on the left side instead of the right side.\n\n## Root Cause\nThe `ChatMessageBubble` component used `flex-row-reverse` for right-aligned messages. This reversed the DOM order, putting the avatar on the far right and the bubble on the left — which looked like a left-aligned message.\n\n## Fix\nChanged `flex-row-reverse` → `flex-row` for right-aligned messages. Now the avatar appears first (left) and the bubble second (right), both pushed to the right edge with `justify-end`. This matches standard chat app layout.\n\n## Files Changed\n- `tutorme-app/src/components/classroom/chat-message-bubble.tsx` (1 line)\n\n## Testing\n- Type check passes\n- No new lint warnings