### PR TITLE
fix(course-selector): make width, outline, and focus-ring changes visible

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -963,7 +963,7 @@ function CourseBuilderInsightsRouteInner({
                             // theme, so use a hardcoded dark text colour — the theme
                             // token text-foreground flips to white under dark themes
                             // and made the course name unreadable here.
-                            'h-9 min-w-[170px] max-w-[330px] border border-gray-200/50 bg-transparent text-sm font-semibold text-[#1F2933] shadow-none transition-colors focus:ring-0',
+                            'h-9 min-w-[220px] max-w-[420px] border border-slate-300 bg-transparent text-sm font-semibold text-[#1F2933] shadow-none transition-colors focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0',
                             hasNoCourses ? 'cursor-not-allowed opacity-60' : 'hover:bg-slate-100'
                           )}
                         >
@@ -987,7 +987,7 @@ function CourseBuilderInsightsRouteInner({
                             })()}
                           </SelectValue>
                         </SelectTrigger>
-                        <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[330px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
+                        <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[420px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
                           {courses && courses.length > 0 && (
                             <SelectItem
                               value="__live-header__"


### PR DESCRIPTION
## Problem\nPR #1141 (course selector styling) deployed successfully but had no visible effect.\n\n## Root Cause\nAll three changes were imperceptible or mis-targeted:\n\n1. **Width +10px** (160→170, 320→330) — a ~5% change, too small to notice\n2. **Faint outline** `border-gray-200/50` — 50% opacity light grey on the **white** header card is essentially invisible\n3. **Focus ring removal** — `focus-visible:ring-0` was added to the dropdown **items**, but the visible ring flash actually comes from the **trigger**: the base `SelectTrigger` component has `focus-visible:ring-2 focus-visible:ring-offset-2` which fires when focus returns to the trigger after selecting an item. The trigger only had `focus:ring-0` (different variant, doesn't suppress focus-visible).\n\n## Fix\n- Trigger width: `min-w-[170px] max-w-[330px]` → `min-w-[220px] max-w-[420px]`\n- Dropdown: `max-w-[330px]` → `max-w-[420px]`\n- Border: `border-gray-200/50` → `border-slate-300` (visible but still subtle)\n- Trigger: added `focus-visible:ring-0 focus-visible:ring-offset-0` to kill the ring flash on focus return\n\n## Files Changed\n- `tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx` (2 lines)\n\n## Testing\n- Type check passes\n\nNote: dropdown items keep `focus-visible:bg-white/10` (highlight pill on keyboard focus), which PR #1141 intentionally preserved.