### PR TITLE
fix(course-builder): orange circular hover highlight on hero back button

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -939,7 +939,10 @@ function CourseBuilderInsightsRouteInner({
         <div className="flex w-full flex-col gap-4">
           <div className="flex min-h-[72px] w-full flex-col gap-4 rounded-2xl border border-[#E5E7EB] bg-white px-4 py-3 shadow-[0_8px_20px_rgba(0,0,0,0.08)] sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
-              <BackButton href="/tutor/dashboard" />
+              <BackButton
+                href="/tutor/dashboard"
+                className="rounded-full hover:bg-[#F17623] hover:text-white"
+              />
 
               <div className="flex flex-col justify-center">
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

The back arrow in the Course Builder hero panel never showed the requested hover highlight. Investigation confirmed the hover mechanism itself works (classes merge correctly via twMerge, CSS rules exist in the built stylesheet) — but the shipped default (`hover:bg-slate-300` gray on `rounded-lg` square) did not match the requested design: an **orange circular highlight**.

## Fix

Override the shared `BackButton`'s defaults through its existing `className` passthrough at the Course Builder hero instance only:

- `rounded-full` — circular (overrides `rounded-lg`)
- `hover:bg-[#F17623]` — classroom orange fill on hover (overrides `hover:bg-slate-300` and ghost variant's `hover:bg-accent/50`)
- `hover:text-white` — white arrow on the orange circle (overrides ghost's `hover:text-accent-foreground`)
- `hover:scale-105` retained

Verified the final merged class string with the real `cva` + `tailwind-merge` from `node_modules`: all overrides win as expected.

Scope is limited to the Course Builder hero; other `BackButton` usages across the app are unchanged.

## Testing

- `npx prettier --check` — clean
- `npm run typecheck` — clean
- twMerge/cva simulation of the exact runtime class composition — all target classes present, all conflicting classes dropped