### PR TITLE
fix(test-mode): object-cover on chat avatar images

### DIFF
--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -107,7 +107,9 @@ export function ChatMessageBubble({
       {showAvatar && (
         <div className="flex flex-col items-center gap-1">
           <Avatar className="h-10 w-10 shrink-0 overflow-hidden">
-            {resolvedAvatar && <AvatarImage src={resolvedAvatar} alt={name} />}
+            {resolvedAvatar && (
+              <AvatarImage src={resolvedAvatar} alt={name} className="object-cover" />
+            )}
             <AvatarFallback
               className={cn(
                 'text-xs font-medium',


### PR DESCRIPTION
## Problem

In the test-mode chat view, the student avatar rendered distorted (vertically squished) and looked smaller than the tutor's circular profile image.

## Root cause

`ChatMessageBubble` renders both avatars at the same fixed `h-10 w-10` circle, but `AvatarImage` uses `aspect-square h-full w-full` with **no `object-fit`**. A non-square source photo (the student's portrait) gets force-stretched into the 40×40 box — distorting the image and, with a light/transparent background, visually shrinking it next to the tutor's full-bleed square headshot.

## Fix

One class: add `object-cover` to the `AvatarImage` in `chat-message-bubble.tsx`. The image now fills the 40×40 circle (cropping overflow instead of stretching), so the student avatar renders at exactly the same size and quality as the tutor's. Square source images (like the tutor's) are visually unaffected.

Same component is used by the real classroom chat, so production chat avatars get the same correction.

## Testing

- `npx prettier --write` — formatted
- `npm run typecheck` — clean