### PR TITLE
fix(course-selector): remove white hover flash from dropdown items

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -998,7 +998,11 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {courses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="focus-visible:ring-0">
+                            <SelectItem
+                              key={c.id}
+                              value={c.id}
+                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                            >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}
@@ -1021,7 +1025,11 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {draftCourses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="focus-visible:ring-0">
+                            <SelectItem
+                              key={c.id}
+                              value={c.id}
+                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                            >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}


### PR DESCRIPTION
## Problem

A white 'focus ring' kept appearing in the Course Selector dropdown despite a dozen+ fix attempts. The actual symptom: **it flashes white while moving the mouse from one option to another inside the open panel.**

## Root cause — what everyone (including me) was missing

Every previous attempt targeted the **trigger's focus ring**. That was the wrong element. The white flash is on the **dropdown items**, via this mechanism:

1. Radix Select moves **real DOM focus** to each item as the pointer hovers it — so `:focus`/`:focus-visible` styles fire while sweeping the mouse, not just on keyboard navigation.
2. The base `SelectItem` (`ui/select.tsx`) carries `hover:bg-white/10` and `focus-visible:bg-white/10` — every row the pointer crosses lights up white and fades (`transition-all`), producing the flash.
3. Git history confirms this exact bug was already fixed once on Jul 3 (`2929d127d`: *'remove white focus flash from dropdown and select items... The white flash when hovering between items was visually jarring'*) — but `971b8e581` (*'restore focus rings'*) later re-added `focus-visible:bg-white/10`, and `hover:bg-white/10` was never removed. That's when 'it started.'

The course selector's items only overrode `focus-visible:ring-0` — both white backgrounds were still active.

## Fix

On the course selector's `SelectItem`s only (both Live and Draft lists), override the two white backgrounds with a subtle dark shade that can never flash white:

`hover:bg-black/10 focus-visible:bg-black/10` (keeping `focus-visible:ring-0`)

Verified with the app's real `tailwind-merge` against the exact base+instance composition: `hover:bg-white/10`, `focus-visible:bg-white/10`, and `focus-visible:ring-2` are all eliminated — **no white background remains on any hover/focus path**. Mouse and keyboard still get a (dark, non-flashing) highlight.

Scope is limited to the Course Selector; the shared `select.tsx` base is untouched, so no other dropdown in the app changes behavior.

## Testing

- twMerge simulation of final item classes — all white bg/ring classes dropped
- `npx prettier --check` — clean
- `npm run typecheck` — clean