### PR TITLE
fix: UI polish batch — back-button hover, dialog lines, avatar, selector flash

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -939,7 +939,10 @@ function CourseBuilderInsightsRouteInner({
         <div className="flex w-full flex-col gap-4">
           <div className="flex min-h-[72px] w-full flex-col gap-4 rounded-2xl border border-[#E5E7EB] bg-white px-4 py-3 shadow-[0_8px_20px_rgba(0,0,0,0.08)] sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
-              <BackButton href="/tutor/dashboard" />
+              <BackButton
+                href="/tutor/dashboard"
+                className="rounded-full hover:bg-[#F17623] hover:text-white"
+              />
 
               <div className="flex flex-col justify-center">
                 <div className="flex items-center gap-2">

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1297,8 +1297,8 @@ function CourseBuilderInsightsRouteInner({
         <DialogContent
           className={
             createStep === 'name'
-              ? 'max-w-md border border-white/25 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl'
-              : 'max-h-[90vh] w-full max-w-5xl overflow-hidden border border-white/25 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl'
+              ? 'max-w-md border border-slate-200 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl'
+              : 'max-h-[90vh] w-full max-w-5xl overflow-hidden border border-slate-200 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl'
           }
           aria-describedby={undefined}
         >
@@ -1393,7 +1393,7 @@ function CourseBuilderInsightsRouteInner({
       {/* Edit Category Dialog */}
       <Dialog open={isEditCourseOpen} onOpenChange={setIsEditCourseOpen}>
         <DialogContent
-          className="max-h-[90vh] w-full max-w-5xl overflow-hidden border border-white/25 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl"
+          className="max-h-[90vh] w-full max-w-5xl overflow-hidden border border-slate-200 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl"
           aria-describedby={undefined}
         >
           <div className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-br from-slate-900/5 via-slate-900/10 to-slate-900/20" />

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1304,7 +1304,7 @@ function CourseBuilderInsightsRouteInner({
         >
           <div className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-br from-slate-900/5 via-slate-900/10 to-slate-900/20" />
           <div className="relative z-10 flex flex-col overflow-hidden">
-            <DialogHeader className="shrink-0 pb-4 pt-4 text-center">
+            <DialogHeader className="shrink-0 border-white/20 pb-4 pt-4 text-center">
               <DialogTitle className="mx-auto text-center text-white">
                 {createStep === 'category' ? 'Choose a Category' : 'Create New Course'}
               </DialogTitle>
@@ -1357,7 +1357,7 @@ function CourseBuilderInsightsRouteInner({
               )}
             </div>
 
-            <DialogFooter className="shrink-0 gap-3 px-6 pb-4">
+            <DialogFooter className="shrink-0 gap-3 border-white/20 px-6 pb-4">
               {createStep === 'name' ? (
                 <>
                   <Button variant="modal-secondary-dark" onClick={closeCreateDialog}>
@@ -1398,7 +1398,7 @@ function CourseBuilderInsightsRouteInner({
         >
           <div className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-br from-slate-900/5 via-slate-900/10 to-slate-900/20" />
           <div className="relative z-10 flex flex-col overflow-hidden">
-            <DialogHeader className="shrink-0 pb-4 pt-4 text-center">
+            <DialogHeader className="shrink-0 border-white/20 pb-4 pt-4 text-center">
               <DialogTitle className="mx-auto text-center text-white">Edit Category</DialogTitle>
             </DialogHeader>
 
@@ -1410,7 +1410,7 @@ function CourseBuilderInsightsRouteInner({
               />
             </div>
 
-            <DialogFooter className="shrink-0 gap-3 px-6 pb-4">
+            <DialogFooter className="shrink-0 gap-3 border-white/20 px-6 pb-4">
               <Button variant="modal-secondary-dark" onClick={() => setIsEditCourseOpen(false)}>
                 Cancel
               </Button>

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -998,7 +998,11 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {courses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="focus-visible:ring-0">
+                            <SelectItem
+                              key={c.id}
+                              value={c.id}
+                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                            >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}
@@ -1021,7 +1025,11 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {draftCourses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="focus-visible:ring-0">
+                            <SelectItem
+                              key={c.id}
+                              value={c.id}
+                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                            >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}

--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -107,7 +107,9 @@ export function ChatMessageBubble({
       {showAvatar && (
         <div className="flex flex-col items-center gap-1">
           <Avatar className="h-10 w-10 shrink-0 overflow-hidden">
-            {resolvedAvatar && <AvatarImage src={resolvedAvatar} alt={name} />}
+            {resolvedAvatar && (
+              <AvatarImage src={resolvedAvatar} alt={name} className="object-cover" />
+            )}
             <AvatarFallback
               className={cn(
                 'text-xs font-medium',


### PR DESCRIPTION
Consolidates four approved fixes into one branch so a single merge ships everything in one deploy. Each change was individually CI-green on its own PR; merges applied cleanly with no conflicts.

## Included

**1. Orange circular hover on Course Builder back arrow** (was #1144)
`BackButton` instance override: `rounded-full hover:bg-[#F17623] hover:text-white`, keeping `hover:scale-105`. Previous gray-square hover never matched the requested design.

**2. White lines in Edit Category + Choose a Category dialogs** (was #1145)
- Header/footer dividers brightened `border-white/[0.06]` → `border-white/20` (they existed but were invisible on the translucent background)
- Panel edge border `border-white/25` → `border-slate-200`, matching Go Live's solid edge exactly

**3. Student avatar distortion in test-mode chat** (was #1146)
`object-cover` on `AvatarImage` — non-square portrait photos were force-stretched into the 40px circle. Now fills the circle like the tutor's image.

**4. Course Selector white hover flash** (was #1147)
The long-misdiagnosed 'focus ring': Radix moves real DOM focus to hovered items, firing the base `SelectItem`'s `hover:bg-white/10` / `focus-visible:bg-white/10` on every row swept (re-introduced by `971b8e581` after `2929d127d` had removed it). Overridden with `hover:bg-black/10 focus-visible:bg-black/10` on the course selector items.

## Verification

- twMerge simulations run against the exact runtime class compositions for every change (all overrides win, no white bg remains on any hover/focus path)
- All four source PRs passed full CI individually
- Merged file contents are byte-identical to the CI-green branch contents

## On merge

Closes the need for #1144, #1145, #1146, #1147 — those can be closed unmerged once this lands.