### PR TITLE
fix(course-builder): remove top divider line in category dialogs

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1315,7 +1315,7 @@ function CourseBuilderInsightsRouteInner({
         >
           <div className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-br from-slate-900/5 via-slate-900/10 to-slate-900/20" />
           <div className="relative z-10 flex flex-col overflow-hidden">
-            <DialogHeader className="shrink-0 border-white/20 pb-4 pt-4 text-center">
+            <DialogHeader className="shrink-0 border-b-0 pb-4 pt-4 text-center">
               <DialogTitle className="mx-auto text-center text-white">
                 {createStep === 'category' ? 'Choose a Category' : 'Create New Course'}
               </DialogTitle>
@@ -1409,7 +1409,7 @@ function CourseBuilderInsightsRouteInner({
         >
           <div className="pointer-events-none absolute inset-0 z-0 bg-gradient-to-br from-slate-900/5 via-slate-900/10 to-slate-900/20" />
           <div className="relative z-10 flex flex-col overflow-hidden">
-            <DialogHeader className="shrink-0 border-white/20 pb-4 pt-4 text-center">
+            <DialogHeader className="shrink-0 border-b-0 pb-4 pt-4 text-center">
               <DialogTitle className="mx-auto text-center text-white">Edit Category</DialogTitle>
             </DialogHeader>
 


### PR DESCRIPTION
## Change

Removes the horizontal white line directly below the title in:

- **Edit Category** dialog
- **Create Course** dialog — both steps ("Create New Course" name step and "Choose a Category" share one shell/header, so the line disappears from the whole dialog; confirmed with user)

## How

The line is the metallic theme's `DialogHeader` `border-b` (`dialog.tsx:224`), brightened to `border-white/20` in #1148. Both headers now override with `border-b-0` via the className passthrough — twMerge drops the base `border-b` width, so **no** header line renders at all (neither the 20% line nor the original faint 6% one). One-class change per dialog, no JSX/layout changes.

## Unchanged

- Footer divider above Cancel/Save and Back/Create (`border-white/20`) — stays, per user
- Solid `border-slate-200` panel edge — stays
- `CourseCategoryPicker` tab-row divider — untouched
- `dialog.tsx` theme defaults — untouched; other metallic dialogs unaffected

## Testing

- twMerge simulation of the exact runtime class composition: `border-b-0` wins, `border-b` dropped
- `npx prettier --check` — clean
- `npm run typecheck` — clean