### PR TITLE
feat(course-builder): reveal loaded PDF in Curriculum tree for tasks and assessments

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -736,6 +736,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       [mainTab, liveNodes, builderNodes]
     )
 
+    // Always-current ref to `nodes` so deferred callbacks (e.g. reveal-after-load
+    // timeouts) don't read stale state captured before setCourseBuilderNodes ran.
+    const nodesRef = useRef(nodes)
+    useEffect(() => {
+      nodesRef.current = nodes
+    }, [nodes])
+
     const setCourseBuilderNodes = useCallback(
       (updater: React.SetStateAction<CourseBuilderNode[]>) => {
         if (mainTab === 'live') {
@@ -4176,6 +4183,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       })
     }
 
+    // Reveal an item in the Curriculum panel after a document load: select it,
+    // expand its node + section, then scroll its row into view. The short
+    // timeouts let React commit the new row/expansion before we measure.
+    const revealCurriculumItem = (type: 'task' | 'homework', id: string) => {
+      setSelectedItem({ type, id })
+      window.setTimeout(() => {
+        const resolved = resolveSelectedItem({ type, id }, nodesRef.current)
+        if (!resolved) return
+        ensureSectionExpanded(resolved.nodeId, type === 'task' ? 'task' : 'assessment')
+        window.setTimeout(() => {
+          const el = document.querySelector(`[data-curriculum-item="${type}:${id}"]`)
+          if (el) scrollElementIntoView(el, { margin: 16, block: 'nearest' })
+        }, 60)
+      }, 50)
+    }
+
     // Add handlers
     // Next lesson number = one past the HIGHEST existing "Lesson N" — not the
     // count. So after deleting Lesson 3 (leaving 1, 2, 4) a new lesson is "Lesson
@@ -5615,6 +5638,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 }
                 currentId = created.id
               }
+              revealCurriculumItem('homework', currentId)
 
               const extractedText = asset.content || `[Asset: ${asset.name}]`
               const newDoc = {
@@ -5669,6 +5693,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                 }
                 currentId = created.id
               }
+              revealCurriculumItem('task', currentId)
 
               const extractedText = asset.content || `[Asset: ${asset.name}]`
               const newDoc = {
@@ -5802,6 +5827,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             }
             currentId = created.id
           }
+          revealCurriculumItem('homework', currentId)
 
           const newDoc = {
             fileName: newAsset.name,
@@ -5921,7 +5947,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
               }
 
               if (currentId) {
-                setSelectedItem({ type: 'task', id: currentId })
+                revealCurriculumItem('task', currentId)
                 const newAsset = {
                   id: `asset-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`,
                   name: firstFile.name,
@@ -8252,6 +8278,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                     }
                                                   >
                                                     <div
+                                                      data-curriculum-item={`task:${task.id}`}
                                                       className={cn(
                                                         'group/item relative mb-1.5 ml-0 mr-0 flex min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl border px-3 py-2 shadow-sm transition-colors',
                                                         selectedItem?.type === 'task' &&
@@ -8753,6 +8780,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                         </DropdownMenu>
                                                       )}
                                                     </div>
+                                                    {task.sourceDocument?.fileName && (
+                                                      <div className="mb-1.5 ml-6 flex min-w-0 items-center gap-1.5 rounded-lg border border-[#E7ECF3] bg-white px-2.5 py-1 text-[11px] text-slate-600">
+                                                        <FileText className="h-3 w-3 shrink-0 text-red-600" />
+                                                        <span className="truncate">
+                                                          {task.sourceDocument.fileName}
+                                                        </span>
+                                                      </div>
+                                                    )}
                                                   </SortableTreeItem>
                                                   {loadedTaskId === task.id &&
                                                     taskBuilder.extensions.length > 0 && (
@@ -9026,6 +9061,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                   isLast={idx === assessments.length - 1}
                                                 >
                                                   <div
+                                                    data-curriculum-item={`homework:${hw.id}`}
                                                     className={cn(
                                                       'group/item relative mb-1.5 ml-0 mr-0 flex min-w-0 cursor-pointer items-center gap-1.5 overflow-hidden rounded-xl border px-3 py-2 shadow-sm transition-colors',
                                                       selectedItem?.type === 'homework' &&
@@ -9353,6 +9389,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                       </DropdownMenu>
                                                     )}
                                                   </div>
+                                                  {hw.sourceDocument?.fileName && (
+                                                    <div className="mb-1.5 ml-6 flex min-w-0 items-center gap-1.5 rounded-lg border border-[#E7ECF3] bg-white px-2.5 py-1 text-[11px] text-slate-600">
+                                                      <FileText className="h-3 w-3 shrink-0 text-red-600" />
+                                                      <span className="truncate">
+                                                        {hw.sourceDocument.fileName}
+                                                      </span>
+                                                    </div>
+                                                  )}
                                                 </SortableTreeItem>
                                               ))}
                                             </SortableContext>


### PR DESCRIPTION
## Problem

The earlier edit (#1134) to surface newly loaded PDFs in the Curriculum panel had no visible effect for most flows: it only called `setSelectedItem` in the OS-file-drop → task path. Loading from the **Assets card** (the primary flow) never highlighted anything, **assessments** were never covered, and expansion/scroll only fired for a lesson's first task. The tree rows also never showed the loaded document.

## Change (all in `CourseBuilder.tsx`, +45/−1)

**1. `revealCurriculumItem(type, id)` helper** — one place that:
- selects the item (blue highlight for tasks, violet for assessments)
- expands its node + section (via `resolveSelectedItem` → `ensureSectionExpanded`)
- scrolls the exact row into view (`data-curriculum-item` anchors + `scrollElementIntoView`, `block:'nearest'` for minimal movement)
- runs on short deferred timeouts reading `nodesRef` (new always-current ref) so the newly created row/expansion has rendered before measuring — no stale-closure misses

**2. Wired into all four load paths:**
| Path | Before | Now |
|---|---|---|
| OS drop → task | bare `setSelectedItem` (#1134) | `revealCurriculumItem('task', id)` |
| Assets-card drag → task | nothing | `revealCurriculumItem('task', id)` |
| OS drop → assessment | nothing | `revealCurriculumItem('homework', id)` |
| Assets-card drag → assessment | nothing | `revealCurriculumItem('homework', id)` |

**3. PDF listed in the tree:** a filename chip (FileText icon + truncated name) renders under any task/assessment row that has a `sourceDocument`.

## Known limitation (pre-existing)

The tree renders each node's FIRST lesson only (`primaryLesson`, line ~8033). Items in later lessons get selected/expanded but have no row to scroll to. All load paths here use the first-lesson context, so the feature covers them.

## Testing

- `npm run typecheck` — clean
- `npx prettier --write` — unchanged (compliant)

**Manual QA after deploy:**
1. Drag a PDF from the Assets card into the Task Builder → task highlights blue, panel scrolls to it, filename chip appears under the task
2. Same into the Assessment Builder → violet highlight + chip
3. Drop a PDF file from the OS into each builder → same reveal behavior