### PR TITLE
fix(tutor): eliminate remaining white focus flash on course/category dropdowns

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1133,13 +1133,19 @@ function CourseBuilderInsightsRouteInner({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="live">
+                      <SelectItem
+                        value="live"
+                        className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                      >
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-green-500" />
                           Live
                         </div>
                       </SelectItem>
-                      <SelectItem value="draft">
+                      <SelectItem
+                        value="draft"
+                        className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                      >
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-amber-500" />
                           Editing
@@ -1606,7 +1612,11 @@ function CourseBuilderInsightsRouteInner({
                           <SelectContent>
                             {['USD', 'SGD', 'EUR', 'GBP', 'KRW', 'JPY', 'HKD', 'CNY', 'INR'].map(
                               c => (
-                                <SelectItem key={c} value={c}>
+                                <SelectItem
+                                  key={c}
+                                  value={c}
+                                  className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                                >
                                   {c}
                                 </SelectItem>
                               )

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
@@ -316,7 +316,7 @@ export function CourseCategoryPicker({
               <SelectItem
                 key={region.id}
                 value={region.id}
-                className="mx-1.5 rounded-md text-white hover:bg-white/20"
+                className="mx-1.5 rounded-md text-white hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
               >
                 {region.name}
               </SelectItem>
@@ -359,7 +359,7 @@ export function CourseCategoryPicker({
                 <button
                   key={country.code}
                   onClick={() => setSelectedCountryCode(country.code)}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/20"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-black/10"
                 >
                   <div
                     className={cn(


### PR DESCRIPTION
## Summary

Follow-up to #1147 (course selector flash fix, deployed). The same Jul 9 regression (#833, "restore focus rings") left identical white hover/focus styles on four other dropdowns in the same tutor flows. Because Radix Select moves real DOM focus onto hovered items, the `focus-visible` white background + ring fires while simply sweeping the mouse — the flash reported by the tutor.

## Changes (same pattern as #1147)

- **Region dropdown** (Edit Category / Choose a Category panel, `CourseCategoryPicker.tsx`): items were `hover:bg-white/20` + inherited white `focus-visible` bg/ring → now `hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0`
- **Country dropdown** (same panel): `hover:bg-white/20` → `hover:bg-black/10`
- **Live/Editing save-mode selector** (header, next to course selector): items inherited base white styles → same black/10 + no-ring treatment
- **Currency selector** (reschedule dialog): same treatment

Shared `select.tsx` intentionally untouched (app-wide primitive); overrides are per-instance as before.

## Verification

- twMerge simulation against the app's real `tailwind-merge`: base white classes dropped, fix classes win for both new instance shapes ✓
- Prettier: both files clean ✓

Class-string-only change; no logic touched.