### PR TITLE
fix(tutor): kill white focus-ring flash on hero course selector

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -995,7 +995,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               value="__live-header__"
                               disabled
-                              className="text-xs font-semibold text-white focus-visible:ring-0"
+                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
                             >
                               Live Courses
                             </SelectItem>
@@ -1004,7 +1004,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               key={c.id}
                               value={c.id}
-                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                              className="transition-none hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
                             >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
@@ -1022,7 +1022,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               value="__draft-header__"
                               disabled
-                              className="text-xs font-semibold text-white focus-visible:ring-0"
+                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
                             >
                               Draft Courses
                             </SelectItem>
@@ -1031,7 +1031,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               key={c.id}
                               value={c.id}
-                              className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                              className="transition-none hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
                             >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## Root cause (proven, not guessed)

Reproduced with the **real Radix Select component + the production stylesheet** in Chrome, sampling computed styles mid-transition:

- Radix Select moves real DOM focus to hovered items while you sweep the mouse.
- Global CSS nukes `[tabindex]:focus-visible` with `outline: none !important` (style `none`, color = white `currentColor`); the item's own `outline-none` utility is `2px solid transparent`.
- The item's `transition-all` interpolates **outline-color white↔transparent** over 150ms while `outline-style` flips `none→solid` at the 50% mark.
- Result: for ~75ms the item losing focus paints a **solid white ring** (captured at 0.91 white opacity — screenshot in comments). Too fast to screenshot manually, fires on every item during a mouse sweep. Exactly the reported symptom, and why it looked like it was "everywhere".

Because the global nuke is a base-layer `!important`, no utility can override the focus outline — the only reliable per-panel fix is to remove the transition so there is nothing to interpolate.

## Change

Adds `transition-none` to the four `SelectItem`s in the Course Builder hero "Select a Course" dropdown (live/draft lists + section headers). Hover/focus backgrounds unchanged; the `active:scale` press effect simply snaps instead of animating.

## Verification

- Real-component Chrome repro, before: leaving item at t≈15ms = `outline: solid rgba(255,255,255,0.91)` (visible white ring, captured on frame) → after: `solid rgba(0,0,0,0)` (nothing painted). ✓
- twMerge check: `transition-none` wins over base `transition-all`. ✓

## Rollout plan

This PR is the single-panel verification the tutor asked for. The same artifact exists on every Radix Select (base `select.tsx` has `transition-all`); after visual confirmation on prod, follow-up applies the same fix app-wide (including the dropdowns in #1151).