### PR TITLE
fix(tutor-calendar): join 1-on-1/group sessions in the /call room, not the builder

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/InteractiveCalendar.tsx
@@ -90,6 +90,9 @@ interface CalendarEvent {
   requestId?: string
   /** Tutor accepted but the student hasn't paid — can't join yet. */
   pendingPayment?: boolean
+  /** A 1-on-1 or group session — joins the shared /call room, not the
+   *  course-builder classroom. (Course classes are false/undefined.) */
+  isDirectSession?: boolean
   studentCount?: number
   maxStudents?: number
   subject?: string
@@ -602,6 +605,8 @@ export function InteractiveCalendar({
             // An accepted-but-unpaid 1-on-1 has a live session row but no student
             // can enter yet — disables the "Start Session" button (see detail dialog).
             pendingPayment: e.pendingPayment,
+            // 1-on-1 / group → shared /call room; course classes → builder classroom.
+            isDirectSession: e.isDirectSession,
             color:
               e.status === 'live'
                 ? 'bg-emerald-500'
@@ -1496,13 +1501,16 @@ export function InteractiveCalendar({
                     onClick={async () => {
                       if (selectedEvent.pendingPayment) return
                       const isOneOnOne = (selectedEvent.maxStudents ?? 50) <= 2
-                      // 1-on-1 (capacity ≤ 2) → the shared two-way call room, which
-                      // works for both roles (course classrooms are role-specific and
-                      // can't host a course-less 1-on-1).
+                      // A direct (1-on-1 OR group) session lives in the shared
+                      // two-way /call room, which works for both roles. Course
+                      // classes open the role-specific course-builder classroom.
+                      // Prefer the server flag; fall back to the 1-on-1 heuristic so
+                      // old events (no flag) still route a 1-on-1 correctly.
+                      const isDirect = selectedEvent.isDirectSession ?? isOneOnOne
                       const routeToSession = (sessionId: string) => {
                         router.push(
                           withLocalePath(
-                            isOneOnOne
+                            isDirect
                               ? `/call/${sessionId}`
                               : isStudent
                                 ? `/student/feedback?sessionId=${sessionId}`

--- a/tutorme-app/src/app/api/tutor/calendar/events/route.ts
+++ b/tutorme-app/src/app/api/tutor/calendar/events/route.ts
@@ -15,6 +15,7 @@ import {
   sessionParticipant,
   courseVariant,
   oneOnOneBookingRequest,
+  groupSession,
 } from '@/lib/db/schema'
 import { eq, and, gte, lte, inArray, isNull, isNotNull, sql } from 'drizzle-orm'
 
@@ -66,6 +67,10 @@ export const GET = withAuth(
         // unpaid session doesn't offer a "Start Session" into a room the student
         // can't enter. Non-1-on-1 events have no booking row → null → not pending.
         bookingStatus: oneOnOneBookingRequest.status,
+        // A group session links its own CalendarEvent. A booking (1-on-1) OR a
+        // group session means this is a "direct" session that lives in the shared
+        // /call room — NOT a course class (which opens the course-builder classroom).
+        groupSessionId: groupSession.groupSessionId,
       })
       .from(calendarEvent)
       .leftJoin(liveSession, eq(liveSession.sessionId, calendarEvent.externalId))
@@ -73,6 +78,7 @@ export const GET = withAuth(
         oneOnOneBookingRequest,
         eq(oneOnOneBookingRequest.calendarEventId, calendarEvent.eventId)
       )
+      .leftJoin(groupSession, eq(groupSession.calendarEventId, calendarEvent.eventId))
       .where(and(...calFilters))
       .orderBy(calendarEvent.startTime)
 
@@ -130,6 +136,8 @@ export const GET = withAuth(
         isVirtual: e.isVirtual,
         sessionId: e.sessionId || e.externalId,
         pendingPayment: e.bookingStatus === 'ACCEPTED',
+        // 1-on-1 or group → the shared /call room, not the course-builder classroom.
+        isDirectSession: !!e.bookingStatus || !!e.groupSessionId,
       })),
       ...liveSessions
         .filter(ls => !coveredSessionIds.has(ls.sessionId))
@@ -146,6 +154,8 @@ export const GET = withAuth(
           isVirtual: true,
           sessionId: ls.sessionId,
           pendingPayment: false,
+          // Fallback rows are course sessions (they require a non-null courseId).
+          isDirectSession: false,
         })),
     ]
 


### PR DESCRIPTION
## Bug 1 — tutor Join from the sessions/calendar opens the course builder

Clicking Join/Start on a **1-on-1 or group** session from the tutor calendar opened the course-builder classroom (`/tutor/classroom` → `/tutor/insights`) instead of the shared two-way **`/call`** room. The floating session reminder worked because it always uses `/call`.

**Root cause:** the calendar detail dialog decided the destination with `isOneOnOne = (maxStudents ?? 50) <= 2`, but the tutor calendar-events route never sets `maxStudents` — so 1-on-1s (`undefined → 50`) *and* group sessions both fell through to the course-classroom branch.

**Fix — give the calendar a reliable signal instead of guessing from capacity:**
- The tutor calendar-events route left-joins `GroupSession` on `calendarEventId` and emits `isDirectSession = has-booking (1-on-1) || has-group-session`; course classes are `false`.
- The detail dialog routes on `isDirectSession` (falling back to the old 1-on-1 heuristic when the flag is absent, so nothing regresses). Direct sessions → `/call`; course classes still open the builder classroom.

This also explains **bug 2** partly: the tutor was never landing on `/call`, where a group session's linked-course affordances (Edit course / deploy) live. (A follow-up PR adds a visible course label there.)

## Verification
- `tsc` clean · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)