### PR TITLE
feat(session-classroom): show the linked course as a chip in the live room

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -14,7 +14,7 @@
 
 import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
-import { Send, FolderOpen, Users, Pencil, PenTool, LayoutGrid } from 'lucide-react'
+import { Send, FolderOpen, Users, Pencil, PenTool, LayoutGrid, BookOpen } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
@@ -137,6 +137,16 @@ export function SessionClassroom({
           videoComponent={video}
         />
       </FallbackBoundary>
+
+      {/* Linked-course chip — so everyone in the room can see which course this
+          session is built around (the tutor's deploy/edit affordances are scoped
+          to it). Absent for a course-less session. */}
+      {courseName ? (
+        <div className="pointer-events-none absolute left-3 top-3 z-40 inline-flex max-w-[45vw] items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur">
+          <BookOpen className="h-3.5 w-3.5 shrink-0 text-blue-600" />
+          <span className="truncate">{courseName}</span>
+        </div>
+      ) : null}
 
       {/* Classroom toolbar: deploy + responses (tutor) + materials (everyone). */}
       <div className="pointer-events-none absolute right-3 top-3 z-40 flex gap-2">


### PR DESCRIPTION
## Bug 2 — a group session's linked course "doesn't appear anywhere" live

The data is wired correctly (create writes `liveSession.courseId`, the join route returns it, the `/call` page passes it to `SessionClassroom`), but the classroom had **no visible course indicator** — the only cue was the tutor's small "Edit course" button, and students saw nothing at all. So a group session created "with a course" looked course-less once live.

**Fix:** add a **course chip** (top-left of the room) showing the course name to *everyone* in the session whenever it's course-linked. The tutor's Edit/deploy affordances were already scoped to the course; this makes the linkage visible. Course-less sessions render nothing (gated on `courseName`).

Pairs with #1153 (which makes the tutor actually land on `/call` for group sessions instead of the course builder).

> Note: if a **pre-existing** group session still shows no course after both PRs, its `liveSession.courseId` predates the linkage feature (created before it shipped) — that's data, not code, and would need a one-off backfill. New sessions are correct.

## Verification
- `tsc` clean · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)