### PR TITLE
fix(student-calendar): route group sessions from the calendar grid to /call too

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard/components/DashboardCalendar.tsx
@@ -349,6 +349,7 @@ export function DashboardCalendar({
             ? 'completed'
             : 'scheduled'
       const isOneOnOne = (ev as any).type === 'one-on-one'
+      const isGroup = (ev as any).type === 'group'
       return {
         id: ev.id,
         title: ev.title,
@@ -360,10 +361,13 @@ export function DashboardCalendar({
         isOnline: true,
         // Carry the join keys through: without sessionId the Join button
         // always reported "not linked"; requestId lets a missing 1-on-1 session
-        // self-heal; maxStudents (2 for a 1-on-1) routes to the shared call room.
+        // self-heal; isDirectSession routes 1-on-1 AND group sessions to the
+        // shared /call room (the calendar-grid dialog otherwise sent group
+        // sessions to /student/feedback).
         sessionId: (ev as any).sessionId ?? undefined,
         requestId: (ev as any).requestId ?? undefined,
         pendingPayment: (ev as any).pendingPayment ?? undefined,
+        isDirectSession: isOneOnOne || isGroup,
         maxStudents: isOneOnOne ? 2 : ((ev as any).maxStudents ?? undefined),
         description:
           (ev as any).meetingUrl || (ev.tutorName ? `Tutor: ${ev.tutorName}` : undefined),


### PR DESCRIPTION
## Gap left open by #1153 — found in the retrospective review

#1153 fixed the **tutor** calendar's Join routing (1-on-1 + group → `/call`), but `InteractiveCalendar` is a **shared** component and the `isDirectSession` flag was only emitted by the *tutor* events route. On the student dashboard the grid is fed by the student `interactiveEvents` map, which set `maxStudents: 2` only for `type === 'one-on-one'` — so a **group** event fell back to the capacity heuristic (`undefined → 50 → not-direct`), and the calendar-grid detail-dialog **Join** sent the student to `/student/feedback` instead of the shared `/call` room.

**Failure:** student with a paid, live group seat → Calendar tab → clicks the group event → Join → lands on `/student/feedback` instead of the group call room.

**Fix (one line):** derive `isDirectSession = type === 'one-on-one' || type === 'group'` in the student `interactiveEvents` map (the type is already present per row) so both session kinds route to `/call` from the grid — matching the Bookings-list buttons and the tutor side. Course classes unaffected.

Adversarial review also confirmed **clean**: no row fanout from #1153's `GroupSession` join (unique index), no other tutor entry points mis-routing, and the #1154 course chip can't overlap/block anything.

## Verification
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)