### PR TITLE
fix(course-builder): scroll loaded PDF task row to top of Curriculum panel

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4194,7 +4194,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         ensureSectionExpanded(resolved.nodeId, type === 'task' ? 'task' : 'assessment')
         window.setTimeout(() => {
           const el = document.querySelector(`[data-curriculum-item="${type}:${id}"]`)
-          if (el) scrollElementIntoView(el, { margin: 16, block: 'nearest' })
+          if (el) scrollElementIntoView(el, { margin: 16, block: 'start' })
         }, 60)
       }, 50)
     }


### PR DESCRIPTION
## What it does

When a PDF is loaded into a task/assessment (OS drop or Assets-card drag), `revealCurriculumItem` already:
- selects the target task/assessment,
- expands the lesson node, and
- expands the Tasks/Assessment section.

This PR changes the final scroll from `block: 'nearest'` to `block: 'start'` so the task/assessment card that received the PDF is positioned at the **top** of the visible Curriculum/Directory panel.

## Scope

Single-line change in `CourseBuilder.tsx`. No logic or data flow changes.