### PR TITLE
fix(course-builder): scroll loaded PDF task row to top of curriculum viewport

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4184,8 +4184,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     }
 
     // Reveal an item in the Curriculum panel after a document load: select it,
-    // expand its node + section, then scroll its row into view. The short
-    // timeouts let React commit the new row/expansion before we measure.
+    // expand its node + section, then scroll its row to the top of the Curriculum
+    // panel. The timeouts let React commit the new row/expansion before we
+    // measure. We scroll the Radix ScrollArea viewport directly because nested
+    // scrollable ancestors can confuse a generic scroll-into-view helper.
     const revealCurriculumItem = (type: 'task' | 'homework', id: string) => {
       setSelectedItem({ type, id })
       window.setTimeout(() => {
@@ -4193,9 +4195,21 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         if (!resolved) return
         ensureSectionExpanded(resolved.nodeId, type === 'task' ? 'task' : 'assessment')
         window.setTimeout(() => {
-          const el = document.querySelector(`[data-curriculum-item="${type}:${id}"]`)
-          if (el) scrollElementIntoView(el, { margin: 16, block: 'start' })
-        }, 60)
+          const el = document.querySelector(
+            `[data-curriculum-item="${type}:${id}"]`
+          ) as HTMLElement | null
+          if (!el) return
+
+          const viewport = el.closest<HTMLElement>('[data-radix-scroll-area-viewport]')
+          if (viewport) {
+            const relativeTop =
+              el.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+            const targetScrollTop = Math.max(0, viewport.scrollTop + relativeTop - 16)
+            viewport.scrollTo({ top: targetScrollTop, behavior: 'smooth' })
+          } else {
+            scrollElementIntoView(el, { margin: 16, block: 'start' })
+          }
+        }, 100)
       }, 50)
     }
 


### PR DESCRIPTION
Follow-up to #1157. The generic scroll helper can select the wrong scrollable ancestor in the course builder layout, so the loaded task/assessment row still didn't reach the top of the Curriculum panel. This change scrolls the Radix ScrollArea viewport directly and falls back to the generic helper only if the viewport isn't found.