### PR TITLE
fix(course-builder): enlarge task font-size pill and default to 18px

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1793,7 +1793,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       Record<string, number>
     >({})
     const activeItemId = mainBuilderTab === 'assessment' ? loadedAssessmentId : loadedTaskId
-    const extractedTextFontSize = activeItemId ? (extractedTextFontSizeMap[activeItemId] ?? 14) : 14
+    const extractedTextFontSize = activeItemId ? (extractedTextFontSizeMap[activeItemId] ?? 18) : 18
     const setExtractedTextFontSize = (val: number) => {
       if (activeItemId) setExtractedTextFontSizeMap(prev => ({ ...prev, [activeItemId]: val }))
     }
@@ -11589,7 +11589,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             />
                                             {/* Floating font size control */}
                                             <div
-                                              className="absolute bottom-6 right-6 z-20 flex items-center gap-1 rounded-md px-2 py-1 text-white"
+                                              className="absolute bottom-6 right-6 z-20 flex origin-bottom-right scale-150 items-center gap-1 rounded-md px-2 py-1 text-white"
                                               style={{
                                                 background: 'rgba(40,40,40,0.78)',
                                                 backdropFilter: 'blur(8px)',
@@ -12028,7 +12028,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             />
                                             {/* Floating font size control */}
                                             <div
-                                              className="absolute bottom-6 right-6 z-20 flex items-center gap-1 rounded-md px-2 py-1 text-white"
+                                              className="absolute bottom-6 right-6 z-20 flex origin-bottom-right scale-150 items-center gap-1 rounded-md px-2 py-1 text-white"
                                               style={{
                                                 background: 'rgba(40,40,40,0.78)',
                                                 backdropFilter: 'blur(8px)',


### PR DESCRIPTION
- Scales the floating font-size pill by 1.5x (origin-bottom-right) so it is 50% larger while staying anchored in the lower-right corner.\n- Changes the default extracted-text font size from 14px to 18px.\n- Updated both the Task Builder and Assessment Builder controls.