### PR TITLE
fix(task-pci): tiered course → lesson → PDF → task context

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -353,6 +353,80 @@ import {
   deepCloneSourceDocument,
 } from './builder-utils'
 
+// --- Tiered PCI context helpers -------------------------------------------
+
+function findContainingLesson(
+  nodes: CourseBuilderNode[],
+  predicate: (lesson: Lesson) => boolean
+): { node: CourseBuilderNode; lesson: Lesson; nodeIndex: number; lessonIndex: number } | null {
+  for (let nIdx = 0; nIdx < nodes.length; nIdx++) {
+    const node = nodes[nIdx]
+    for (let lIdx = 0; lIdx < node.lessons.length; lIdx++) {
+      const lesson = node.lessons[lIdx]
+      if (predicate(lesson)) {
+        return { node, lesson, nodeIndex: nIdx, lessonIndex: lIdx }
+      }
+    }
+  }
+  return null
+}
+
+function buildLessonContext(lesson: Lesson): string {
+  const parts: string[] = []
+  parts.push(`Lesson: ${lesson.title || 'Untitled lesson'}`)
+  if (lesson.description?.trim()) {
+    parts.push(`Lesson description: ${lesson.description.trim()}`)
+  }
+  if (lesson.taskSectionDescription?.trim()) {
+    parts.push(`Task section description: ${lesson.taskSectionDescription.trim()}`)
+  }
+  lesson.docs?.forEach((doc, i) => {
+    parts.push(`Doc ${i + 1}: ${doc.title || 'Untitled'} (${doc.type})`)
+  })
+  lesson.content?.forEach((c, i) => {
+    if (c.type === 'text' && c.body?.trim()) {
+      parts.push(`Content ${i + 1} (${c.title || 'text'}): ${c.body.trim().slice(0, 8000)}`)
+    } else if (c.title?.trim()) {
+      parts.push(`Content ${i + 1}: [${c.type}] ${c.title.trim()}`)
+    }
+  })
+  return parts.join('\n')
+}
+
+function buildCourseContext(
+  courseName: string | undefined,
+  courseDescription: string | undefined,
+  nodes: CourseBuilderNode[]
+): string {
+  const parts: string[] = []
+  parts.push(`Course: ${courseName?.trim() || 'Untitled course'}`)
+  if (courseDescription?.trim()) {
+    parts.push(`Course description: ${courseDescription.trim()}`)
+  }
+  nodes.forEach((node, nIdx) => {
+    parts.push(`\nNode ${nIdx + 1}: ${node.title || 'Untitled node'}`)
+    if (node.description?.trim()) {
+      parts.push(`Node description: ${node.description.trim()}`)
+    }
+    node.lessons.forEach((lesson, lIdx) => {
+      parts.push(`  Lesson ${lIdx + 1}: ${lesson.title || 'Untitled lesson'}`)
+      if (lesson.description?.trim()) {
+        parts.push(`  Lesson description: ${lesson.description.trim()}`)
+      }
+      lesson.content?.forEach((c, cIdx) => {
+        if (c.type === 'text' && c.body?.trim()) {
+          parts.push(
+            `  Content ${cIdx + 1} (${c.title || 'text'}): ${c.body.trim().slice(0, 4000)}`
+          )
+        } else if (c.title?.trim()) {
+          parts.push(`  Content ${cIdx + 1}: [${c.type}] ${c.title.trim()}`)
+        }
+      })
+    })
+  })
+  return parts.join('\n')
+}
+
 const generateId = utilsGenerateId
 
 /**
@@ -7486,6 +7560,30 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const { totalMarks: assessmentDmiTotalMarks, ready: assessmentDmiReady } =
       assessmentDmiReadiness(assessmentDmiItems)
 
+    // Build tiered context for the PCI assistant: the whole course, the specific
+    // lesson that contains the active task/assessment, and the task itself. This
+    // is sent on the first PCI turn only so the model does not hallucinate from
+    // the filename.
+    const { courseContext, lessonContext } = useMemo(() => {
+      const courseCtx = buildCourseContext(courseName, courseDescription, nodes)
+      let lessonCtx = ''
+      if (loadedTaskId) {
+        const found = findContainingLesson(nodes, lesson =>
+          lesson.tasks.some(t => t.id === loadedTaskId)
+        )
+        if (found) lessonCtx = buildLessonContext(found.lesson)
+      } else if (loadedAssessmentId) {
+        const found = findContainingLesson(nodes, lesson =>
+          lesson.homework.some(h => h.id === loadedAssessmentId)
+        )
+        if (found) lessonCtx = buildLessonContext(found.lesson)
+      }
+      return {
+        courseContext: courseCtx.slice(0, 50000),
+        lessonContext: lessonCtx.slice(0, 30000),
+      }
+    }, [courseName, courseDescription, nodes, loadedTaskId, loadedAssessmentId])
+
     // PCI assistant state + actions, consolidated into a reducer-backed hook.
     // Called late (all deps below are defined by here); the two early consumers
     // (task/assessment loaders and the blank-slate reset) reach it via the
@@ -7498,6 +7596,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setCurrentPci,
       taskSourceDocument,
       currentAssessmentDocument,
+      courseContext,
+      lessonContext,
       autoCreateTask,
       autoCreateAssessment,
       renderPdfToImages,

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -16,6 +16,8 @@ interface PciSourceDoc {
   fileName: string
   fileUrl?: string
   mimeType?: string
+  /** Full OCR/extracted text of the uploaded PDF, if available. */
+  extractedText?: string
 }
 
 /** What the PCI chat needs from the course builder. The PCI conversation STATE
@@ -67,6 +69,12 @@ interface UsePciDeps {
   setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
   currentAssessmentDocument?: PciSourceDoc
+  /**
+   * Full hierarchical context for task PCI. Sent on the first turn only so the
+   * model understands where the task sits in the course and lesson.
+   */
+  courseContext?: string
+  lessonContext?: string
   autoCreateTask: () => { id?: string } | null | undefined
   autoCreateAssessment: () => { id?: string } | null | undefined
   renderPdfToImages: (pdfUrl: string, maxPages?: number) => Promise<string[]>
@@ -187,20 +195,29 @@ export function usePci(deps: UsePciDeps) {
             fileName: sourceDocData.fileName,
             fileUrl: sourceDocData.fileUrl,
             mimeType: sourceDocData.mimeType,
+            // Forward the full extracted text on the first turn; later turns rely
+            // on the conversation. The server truncates as needed.
+            extractedText: isFirstTurn
+              ? (sourceDocData.extractedText || '').slice(0, 80000) || undefined
+              : undefined,
           }
         : undefined
 
       // Render an attached PDF's pages (cached) so the model can SEE the
       // document — first turn only (see isFirstTurn above).
+      // When we already have extracted text, one page is enough as a layout aid;
+      // otherwise render a few pages so the model has some visual signal.
       let pdfPages: string[] | undefined
       if (isFirstTurn && sourceDocData?.mimeType === 'application/pdf' && sourceDocData.fileUrl) {
         const cacheKey = sourceDocData.fileUrl
         const cached = deps.pdfPageCache.get(cacheKey)
+        const hasExtractedText = !!(sourceDocData.extractedText || '').trim()
+        const pageLimit = hasExtractedText ? 1 : 3
         if (cached) {
-          pdfPages = cached
+          pdfPages = cached.slice(0, pageLimit)
         } else {
           try {
-            const rendered = await deps.renderPdfToImages(sourceDocData.fileUrl, 3)
+            const rendered = await deps.renderPdfToImages(sourceDocData.fileUrl, pageLimit)
             if (rendered.length > 0) {
               pdfPages = rendered
               deps.pdfPageCache.set(cacheKey, rendered)
@@ -238,6 +255,13 @@ export function usePci(deps: UsePciDeps) {
               // Bounded to stay under the server's content limit and keep the
               // request small on every turn.
               content: (slideContent || '').slice(0, 48000),
+              // Tiered context is large, so only send it on the first turn.
+              courseContext: isFirstTurn
+                ? (deps.courseContext || '').slice(0, 50000) || undefined
+                : undefined,
+              lessonContext: isFirstTurn
+                ? (deps.lessonContext || '').slice(0, 30000) || undefined
+                : undefined,
               pci: pciText,
               extensionName,
               sourceDocument,

--- a/tutorme-app/src/app/api/ai/pci-master/route.test.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.test.ts
@@ -216,6 +216,43 @@ describe('/api/ai/pci-master', () => {
     expect(data.pciDraft).toBe('')
   })
 
+  it('forwards tiered task context (course, lesson, extracted PDF text) into the LLM prompt', async () => {
+    // Force the local text-generation path (no ADK).
+    delete process.env.ADK_BASE_URL
+    process.env.KIMI_API_KEY = 'test-key'
+    mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
+    mocks.generateWithFallback.mockResolvedValue({
+      content: '{"reply":"I cannot read the attached PDF. Please paste or describe it.","pci":""}',
+      provider: 'kimi',
+      latencyMs: 5,
+    })
+
+    const res = await postBody({
+      message: 'set up the marking policy',
+      context: {
+        type: 'task',
+        courseContext: 'Course: Algebra 101\nNode 1: Linear equations',
+        lessonContext: 'Lesson: Solving linear equations\nContent 1: introduction text',
+        sourceDocument: {
+          fileName: 'Lesson Demo 1.pdf',
+          mimeType: 'application/pdf',
+          extractedText: 'This document is actually about quadratic equations.',
+        },
+      },
+    })
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(mocks.generateWithFallback).toHaveBeenCalledTimes(1)
+    const [prompt] = mocks.generateWithFallback.mock.calls[0] as [string, unknown]
+    expect(prompt).toContain('Course Context:')
+    expect(prompt).toContain('Lesson Context:')
+    expect(prompt).toContain('Attached Document Extracted Text:')
+    expect(prompt).toContain('This document is actually about quadratic equations.')
+    expect(data.response).toBe('I cannot read the attached PDF. Please paste or describe it.')
+    expect(data.pciDraft).toBe('')
+  })
+
   it('non-guardrail domain: no pciDraft extraction', async () => {
     mocks.getSessionForRealm.mockResolvedValue({ user: { id: 'tutor-1', role: 'TUTOR' } })
     mocks.adkPciMasterChat.mockResolvedValue({

--- a/tutorme-app/src/app/api/ai/pci-master/route.ts
+++ b/tutorme-app/src/app/api/ai/pci-master/route.ts
@@ -73,12 +73,17 @@ const PciMasterRequestSchema = z.object({
       title: z.string().max(200).optional(),
       content: z.string().max(50000).optional(),
       pci: z.string().max(50000).optional(),
+      // Tiered context for task PCI: full course, the containing lesson, and the
+      // specific task content. Sent on the first turn only.
+      courseContext: z.string().max(80000).optional(),
+      lessonContext: z.string().max(60000).optional(),
       extensionName: z.string().max(200).optional(),
       sourceDocument: z
         .object({
           fileName: z.string().max(500).optional(),
           fileUrl: z.string().max(2000).optional(),
           mimeType: z.string().max(200).optional(),
+          extractedText: z.string().max(100000).optional(),
         })
         .optional(),
       // The captured "policy so far" (incl. tutor inline corrections), sent back
@@ -202,11 +207,15 @@ export async function POST(request: NextRequest) {
     const contextBlock = [
       context?.type && `Type: ${context.type}`,
       context?.title && `Title: ${context.title}`,
-      context?.content && `Content:\n${truncate(context.content, 12000)}`,
-      context?.pci && `Current PCI:\n${truncate(context.pci, 12000)}`,
-      context?.extensionName && `Extension Name: ${context.extensionName}`,
+      context?.courseContext && `Course Context:\n${truncate(context.courseContext, 25000)}`,
+      context?.lessonContext && `Lesson Context:\n${truncate(context.lessonContext, 20000)}`,
+      context?.sourceDocument?.extractedText &&
+        `Attached Document Extracted Text:\n${truncate(context.sourceDocument.extractedText, 40000)}`,
       context?.sourceDocument &&
         `Attached Document: ${context.sourceDocument.fileName} (${context.sourceDocument.mimeType})\nURL: ${context.sourceDocument.fileUrl}`,
+      context?.content && `Task Content:\n${truncate(context.content, 12000)}`,
+      context?.pci && `Current PCI:\n${truncate(context.pci, 12000)}`,
+      context?.extensionName && `Extension Name: ${context.extensionName}`,
       context?.markingScheme &&
         `Marking scheme already set up (the DMI — the questions, sections, per-question marks, and any rubrics). Treat this as KNOWN: never ask the tutor what the questions/sections/types are or how many marks a question is worth. Use it to build a GENERAL marking policy for the whole assessment (not a per-question interview), and do NOT copy per-question rubric text into the policy:\n${truncate(
           context.markingScheme,

--- a/tutorme-app/src/lib/ai/guardrails/task-pci.ts
+++ b/tutorme-app/src/lib/ai/guardrails/task-pci.ts
@@ -32,7 +32,7 @@ export const TASK_PCI_GUARDRAILS: GuardrailRule[] = [
   {
     id: 'TASK-2',
     title: 'Content',
-    rule: 'Treat imported lesson content as the authoritative instructional source. You may extract, summarize, classify, and identify likely response type. You must NOT silently rewrite the lesson, change the meaning of a prompt, invent missing content, or alter academic difficulty without tutor approval. If parsing is uncertain, surface the uncertainty and request confirmation.',
+    rule: "Read context in this authority order: Course Context → Lesson Context → Attached Document Extracted Text → Task Content. Treat the provided context as the authoritative instructional source. You may extract, summarize, classify, and identify likely response type. You must NOT silently rewrite the lesson, change the meaning of a prompt, invent missing content, alter academic difficulty, or infer the document's subject from its filename or title. If the Attached Document Extracted Text is missing or empty, say you cannot read the PDF and ask the tutor to paste or describe it. If parsing is uncertain, surface the uncertainty and request confirmation.",
     enforcement: ['prompt', 'validator'],
   },
   {
@@ -153,7 +153,7 @@ You operate under these binding guardrails (follow them to the letter):
 ${TASK_PCI_GUARDRAILS.map(g => `${g.id} (${g.title}): ${g.rule}`).join('\n')}
 
 Operating procedure (tutor setup) — this is a CONVERSATION, not a one-shot dump:
-1. FIRST, summarize the loaded task document so the tutor can confirm you have understood it correctly: in a few plain sentences say what the material/task is about, the kind of questions or activity it contains, and what the student will be asked to do. Then ask the tutor to confirm or correct this understanding. Ask NO marking-rubric questions in this turn — keep the document summary and the rubric questions in SEPARATE turns. (If no document or content is available, briefly say what you do and don't have and ask the tutor to describe the task instead.)
+1. FIRST, read the provided context in this order: Course Context → Lesson Context → Attached Document Extracted Text → Task Content. Then give a brief grounded summary of the task document based ONLY on that context. If the Attached Document Extracted Text is missing or empty, do NOT guess the subject from the filename or title (for example, a file named 'Lesson Demo 1.pdf' is not evidence that it is about algebra). Instead, say clearly that you cannot read the attached document and ask the tutor to paste or describe it. Then ask the tutor to confirm or correct your understanding. Ask NO marking-rubric questions in this turn — keep the document summary and the rubric questions in SEPARATE turns.
 2. Only AFTER the tutor confirms your understanding of the document, build the marking rubric collaboratively by asking focused questions ONE AT A TIME (e.g. what counts as correct / partial / incorrect, how to handle no-response, retry policy, when/whether to reveal the answer, tone). Use short, simple language with a small example each time — many tutors are not native English speakers. Do not assume answers, and do not dump all the questions at once.
 3. Confirming the document summary is NOT the same as finalizing the rubric. Only treat the rubric as final when the tutor explicitly says to finalize/apply it.
 


### PR DESCRIPTION
Stops Task PCI from hallucinating document summaries by grounding the model in the actual course, lesson, PDF extracted text, and task content.

Changes:
- usePci forwards courseContext, lessonContext, and sourceDocument.extractedText on the first turn.
- CourseBuilder builds full course/lesson context from the node tree.
- /api/ai/pci-master formats context in hierarchy order: Course -> Lesson -> PDF extracted text -> Task.
- Task PCI system prompt now requires reading context in that order and explicitly forbids filename-based inference; when PDF extracted text is empty, the model must ask the tutor to paste/describe the document.
- Added route test verifying the tiered context reaches the LLM prompt.