### PR TITLE
fix(course-builder): render text-only tasks in Test mode chat preview

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4553,7 +4553,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
       generatingTaskDocRef.current = true
       try {
-        const { blob, fileName } = generateTaskTextPDF(taskBuilder.title || 'Task', content)
+        const { blob, fileName } = await generateTaskTextPDF(taskBuilder.title || 'Task', content)
         const file = new File([blob], fileName, { type: 'application/pdf' })
         const formData = new FormData()
         formData.append('file', file)

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10681,20 +10681,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                           )
                                           const hasDmi = !!version
 
-                                          if (!hasDoc && !hasDmi) {
-                                            return (
-                                              <div className="h-full min-h-0 w-full overflow-y-auto p-4">
-                                                <p className="text-muted-foreground whitespace-pre-wrap text-sm">
-                                                  {testPciContent[tab.id] || ''}
-                                                </p>
-                                              </div>
-                                            )
-                                          }
-
                                           // Test-tab task preview: render the exact student chat flow
                                           // (the document collapses into the chat on the first sample
                                           // answer) filling this panel — instead of a separate PDF +
                                           // chat, so the tutor previews what students actually see.
+                                          // This branch runs first so text-only tasks with no document
+                                          // still get a functional chat preview.
                                           if (mainTab === 'test-pci' && testPciSource === 'task') {
                                             const previewExt = taskBuilder.activeExtensionId
                                               ? taskBuilder.extensions.find(
@@ -10837,6 +10829,18 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                         ]
                                                   }
                                                 />
+                                              </div>
+                                            )
+                                          }
+
+                                          // Nothing to render as a document or DMI — fall back to
+                                          // plain text (e.g. assessments/live with no source doc).
+                                          if (!hasDoc && !hasDmi) {
+                                            return (
+                                              <div className="h-full min-h-0 w-full overflow-y-auto p-4">
+                                                <p className="text-muted-foreground whitespace-pre-wrap text-sm">
+                                                  {testPciContent[tab.id] || ''}
+                                                </p>
                                               </div>
                                             )
                                           }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -347,6 +347,7 @@ import {
   AI_SUGGESTIONS,
   CONTENT_TEMPLATES,
   generateQuestionPaperPDF,
+  generateTaskTextPDF,
   resolveSelectedItem,
   stringToColor,
   formatDuration,
@@ -4527,6 +4528,105 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       return newAssessment
     }, [nodes, ensureFirstLessonContext])
 
+    // When a task has only manually-typed text (no uploaded PDF), generate a PDF
+    // from that text and upload it so the task behaves identically to a loaded
+    // document in Test mode and in live classrooms.
+    const generatingTaskDocRef = useRef(false)
+    const ensureTaskTextDocument = useCallback(async () => {
+      if (generatingTaskDocRef.current) return
+      if (!loadedTaskId) return
+
+      const isExtension = !!taskBuilder.activeExtensionId
+      const content = isExtension
+        ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.content || ''
+        : taskBuilder.taskContent
+      const trimmed = content.trim()
+      if (!trimmed) return
+
+      const existingDoc = isExtension
+        ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)?.sourceDocument
+        : taskBuilder.sourceDocument
+      // If a real uploaded document is present, never overwrite it.
+      if (existingDoc && !existingDoc.generatedFromText) return
+      // Already generated and content hasn't changed → nothing to do.
+      if (existingDoc?.generatedFromText && existingDoc.extractedText === content) return
+
+      generatingTaskDocRef.current = true
+      try {
+        const { blob, fileName } = generateTaskTextPDF(taskBuilder.title || 'Task', content)
+        const file = new File([blob], fileName, { type: 'application/pdf' })
+        const formData = new FormData()
+        formData.append('file', file)
+
+        const res = await fetchWithCsrf('/api/uploads/documents', {
+          method: 'POST',
+          body: formData,
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          toast.error(data.error || `Failed to upload ${fileName}`)
+          return
+        }
+        const data = await res.json()
+        const newDoc = {
+          fileName: data.name || fileName,
+          fileUrl: data.url || '',
+          fileKey: data.key || '',
+          mimeType: data.type || 'application/pdf',
+          uploadedAt: new Date().toISOString(),
+          extractedText: content,
+          generatedFromText: true,
+        }
+
+        if (isExtension) {
+          setTaskBuilder(prev => ({
+            ...prev,
+            extensions: prev.extensions.map(ext =>
+              ext.id === prev.activeExtensionId ? { ...ext, sourceDocument: newDoc } : ext
+            ),
+          }))
+        } else {
+          setTaskSourceDocument(newDoc)
+          setTaskUploadedFiles([{ id: 'source', name: newDoc.fileName }])
+          setTaskBuilder(prev => ({ ...prev, sourceDocument: newDoc }))
+        }
+
+        setCourseBuilderNodes(prev =>
+          prev.map(mod => ({
+            ...mod,
+            lessons: mod.lessons.map(lesson => ({
+              ...lesson,
+              tasks: lesson.tasks.map(task => {
+                if (task.id !== loadedTaskId) return task
+                if (isExtension) {
+                  return {
+                    ...task,
+                    extensions: (task.extensions || []).map(ext =>
+                      ext.id === taskBuilder.activeExtensionId
+                        ? { ...ext, sourceDocument: newDoc }
+                        : ext
+                    ),
+                  }
+                }
+                return { ...task, sourceDocument: newDoc, description: content }
+              }),
+            })),
+          }))
+        )
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Failed to convert text to PDF')
+      } finally {
+        generatingTaskDocRef.current = false
+      }
+    }, [
+      loadedTaskId,
+      taskBuilder.activeExtensionId,
+      taskBuilder.extensions,
+      taskBuilder.sourceDocument,
+      taskBuilder.taskContent,
+      taskBuilder.title,
+    ])
+
     const assetsLesson = nodes[0]?.lessons?.[0] ?? null
 
     const applyTemplate = useCallback(
@@ -8079,6 +8179,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             if (next === 'live') {
               handleSyncToLive()
               prevMainTabRef.current = 'live'
+            }
+            // If the active task only has typed text, generate its PDF document
+            // before switching to Test or Live so the preview/classroom sees a
+            // real, clickable sourceDocument just like an uploaded PDF.
+            if ((next === 'test-pci' || next === 'live') && mainBuilderTab === 'task') {
+              ensureTaskTextDocument()
             }
             // setMainTab notifies the parent route (and updates local state when
             // the component is used uncontrolled).
@@ -11714,6 +11820,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                   }))
                                                 }
                                               }}
+                                              onBlur={() => ensureTaskTextDocument()}
                                             />
                                             {/* Floating font size control */}
                                             <div

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -337,6 +337,18 @@ export function TestTaskChat({
           />
         )}
 
+        {/* Text-only task: show the question text as the initial tutor message. */}
+        {!sourceDocument && questionText && (
+          <ChatMessageBubble
+            sender="tutor"
+            name="Tutor"
+            content={questionText}
+            avatarUrl={tutorAvatarUrl}
+            isClassroom={isClassroom}
+            studentOnRight
+          />
+        )}
+
         {/* PDF Popup — overlay within chat panel, no header, X on right */}
         {pdfPopupOpen && loadable && (
           <div className="absolute inset-0 z-10 flex flex-col bg-white">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -457,44 +457,80 @@ export function generateQuestionPaperPDF(
 /**
  * Generate a simple PDF from a task's typed title + content so that text-only
  * tasks can be previewed and deployed exactly like uploaded PDF documents.
+ *
+ * Uses html2canvas to rasterise the text as an image inside the PDF. This avoids
+ * font/encoding limitations and gives us full browser language support (CJK,
+ * Arabic, Devanagari, emojis, etc.) without bundling huge font files.
  */
-export function generateTaskTextPDF(
+export async function generateTaskTextPDF(
   title: string,
   content: string
-): { blob: Blob; fileName: string } {
-  // Dynamic import jsPDF to avoid SSR issues
-  const jsPDF = require('jspdf')
-  const doc = new jsPDF()
-
-  const pageWidth = doc.internal.pageSize.getWidth()
-  const margin = 15
-  const contentWidth = pageWidth - margin * 2
-  let y = 20
-
-  if (title.trim()) {
-    doc.setFontSize(16)
-    doc.setFont('helvetica', 'bold')
-    const titleLines = doc.splitTextToSize(title.trim(), contentWidth)
-    doc.text(titleLines, margin, y)
-    y += titleLines.length * 8 + 12
+): Promise<{ blob: Blob; fileName: string }> {
+  if (typeof document === 'undefined') {
+    throw new Error('generateTaskTextPDF must be called in a browser')
   }
 
-  if (content.trim()) {
-    doc.setFontSize(11)
-    doc.setFont('helvetica', 'normal')
-    const lines = doc.splitTextToSize(content.trim(), contentWidth)
-    for (const line of lines) {
-      if (y > 270) {
-        doc.addPage()
-        y = 20
-      }
-      doc.text(line, margin, y)
-      y += 6
+  const jsPDF = require('jspdf')
+  const html2canvas = (await import('html2canvas')).default
+
+  const container = document.createElement('div')
+  container.style.position = 'fixed'
+  container.style.left = '-9999px'
+  container.style.top = '-9999px'
+  container.style.width = '794px' // A4 width at 96dpi
+  container.style.padding = '48px'
+  container.style.background = '#ffffff'
+  container.style.color = '#1f2937'
+  container.style.fontFamily =
+    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans", "Helvetica Neue", Arial, sans-serif'
+  container.style.fontSize = '16px'
+  container.style.lineHeight = '1.6'
+  container.style.whiteSpace = 'pre-wrap'
+  container.style.wordBreak = 'break-word'
+
+  const titleEl = document.createElement('h1')
+  titleEl.style.fontSize = '24px'
+  titleEl.style.fontWeight = '700'
+  titleEl.style.margin = '0 0 24px 0'
+  titleEl.style.lineHeight = '1.3'
+  titleEl.style.color = '#111827'
+  titleEl.textContent = title.trim()
+  container.appendChild(titleEl)
+
+  const contentEl = document.createElement('div')
+  contentEl.style.whiteSpace = 'pre-wrap'
+  contentEl.style.wordBreak = 'break-word'
+  contentEl.textContent = content.trim()
+  contentEl.setAttribute('dir', 'auto')
+  container.appendChild(contentEl)
+
+  document.body.appendChild(container)
+
+  try {
+    const canvas = await html2canvas(container, {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: '#ffffff',
+      logging: false,
+    })
+
+    const cssWidth = container.scrollWidth
+    const cssHeight = container.scrollHeight
+    // 1 CSS px = 0.75 pt (72 pt / 96 dpi)
+    const ptWidth = cssWidth * 0.75
+    const ptHeight = cssHeight * 0.75
+
+    const doc = new jsPDF({ unit: 'pt', format: [ptWidth, ptHeight] })
+    const imgData = canvas.toDataURL('image/png')
+    doc.addImage(imgData, 'PNG', 0, 0, ptWidth, ptHeight)
+
+    const safeTitle = title.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'Task'
+    return { blob: doc.output('blob'), fileName: `${safeTitle}.pdf` }
+  } finally {
+    if (container.parentNode) {
+      document.body.removeChild(container)
     }
   }
-
-  const safeTitle = title.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'Task'
-  return { blob: doc.output('blob'), fileName: `${safeTitle}.pdf` }
 }
 
 export function resolveSelectedItem(

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -454,6 +454,49 @@ export function generateQuestionPaperPDF(
   return { blob: pdfBlob, url: pdfUrl, fileName }
 }
 
+/**
+ * Generate a simple PDF from a task's typed title + content so that text-only
+ * tasks can be previewed and deployed exactly like uploaded PDF documents.
+ */
+export function generateTaskTextPDF(
+  title: string,
+  content: string
+): { blob: Blob; fileName: string } {
+  // Dynamic import jsPDF to avoid SSR issues
+  const jsPDF = require('jspdf')
+  const doc = new jsPDF()
+
+  const pageWidth = doc.internal.pageSize.getWidth()
+  const margin = 15
+  const contentWidth = pageWidth - margin * 2
+  let y = 20
+
+  if (title.trim()) {
+    doc.setFontSize(16)
+    doc.setFont('helvetica', 'bold')
+    const titleLines = doc.splitTextToSize(title.trim(), contentWidth)
+    doc.text(titleLines, margin, y)
+    y += titleLines.length * 8 + 12
+  }
+
+  if (content.trim()) {
+    doc.setFontSize(11)
+    doc.setFont('helvetica', 'normal')
+    const lines = doc.splitTextToSize(content.trim(), contentWidth)
+    for (const line of lines) {
+      if (y > 270) {
+        doc.addPage()
+        y = 20
+      }
+      doc.text(line, margin, y)
+      y += 6
+    }
+  }
+
+  const safeTitle = title.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'Task'
+  return { blob: doc.output('blob'), fileName: `${safeTitle}.pdf` }
+}
+
 export function resolveSelectedItem(
   selectedItem: { type: string; id: string } | null,
   nodes: CourseBuilderNode[]


### PR DESCRIPTION
## Problem
A task created with only manually typed text and no PDF/DMI was falling through to the no-document fallback in Test mode, so:
- No chat input pill / "Task complete" button appeared.
- The task text was not shown as a tutor message to the simulated student.
- "Test Student" displays appeared blank for text-only tasks.

## Changes
- Move the Test-tab task preview branch ahead of the no-doc/DMI fallback so text-only tasks still render `TestTaskChat` with a working input area.
- Render the task `questionText` as the initial tutor message in `TestTaskChat` when no source document is present.
- Auto-convert typed task text into a real PDF document:
  - New `generateTaskTextPDF()` helper in `builder-utils.ts` uses `html2canvas` + jsPDF.
  - The browser renders the title/content with system/Noto fonts, then rasterises it into the PDF — so Latin, CJK, Arabic, Devanagari, emoji, etc. are all supported without bundling font files.
  - When a task has typed text but no uploaded PDF, the builder generates the PDF client-side and uploads it through `/api/uploads/documents`.
  - The resulting `sourceDocument` is stored with a `generatedFromText` flag, so the task behaves identically to an uploaded PDF in Test mode and in live classrooms.
  - Generation triggers on content blur and when switching to Test/Live, with guards to avoid overwriting real uploaded documents or duplicate uploads.

## Verification
- `npm run typecheck` passes.
- `npm run test -- --run` passes (108 files, 680 tests).
- Targeted ESLint on the changed files passes (only pre-existing warnings).
