### PR TITLE
fix(ui): light hover pills for dropdown/select items

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1004,7 +1004,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               key={c.id}
                               value={c.id}
-                              className="transition-none hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                              className="transition-none"
                             >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
@@ -1031,7 +1031,7 @@ function CourseBuilderInsightsRouteInner({
                             <SelectItem
                               key={c.id}
                               value={c.id}
-                              className="transition-none hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                              className="transition-none"
                             >
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
@@ -1135,7 +1135,7 @@ function CourseBuilderInsightsRouteInner({
                     <SelectContent>
                       <SelectItem
                         value="live"
-                        className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                        className=""
                       >
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-green-500" />
@@ -1144,7 +1144,7 @@ function CourseBuilderInsightsRouteInner({
                       </SelectItem>
                       <SelectItem
                         value="draft"
-                        className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                        className=""
                       >
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-amber-500" />
@@ -1615,7 +1615,7 @@ function CourseBuilderInsightsRouteInner({
                                 <SelectItem
                                   key={c}
                                   value={c}
-                                  className="hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                                  className=""
                                 >
                                   {c}
                                 </SelectItem>

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -1001,11 +1001,7 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {courses?.map(c => (
-                            <SelectItem
-                              key={c.id}
-                              value={c.id}
-                              className="transition-none"
-                            >
+                            <SelectItem key={c.id} value={c.id} className="transition-none">
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}
@@ -1028,11 +1024,7 @@ function CourseBuilderInsightsRouteInner({
                             </SelectItem>
                           )}
                           {draftCourses?.map(c => (
-                            <SelectItem
-                              key={c.id}
-                              value={c.id}
-                              className="transition-none"
-                            >
+                            <SelectItem key={c.id} value={c.id} className="transition-none">
                               {c.nationality && c.nationality !== 'Global' ? (
                                 <span className="inline-flex items-center gap-1">
                                   {c.name} — {c.variantCategory || ''} —{' '}
@@ -1133,19 +1125,13 @@ function CourseBuilderInsightsRouteInner({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem
-                        value="live"
-                        className=""
-                      >
+                      <SelectItem value="live" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-green-500" />
                           Live
                         </div>
                       </SelectItem>
-                      <SelectItem
-                        value="draft"
-                        className=""
-                      >
+                      <SelectItem value="draft" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-amber-500" />
                           Editing
@@ -1612,11 +1598,7 @@ function CourseBuilderInsightsRouteInner({
                           <SelectContent>
                             {['USD', 'SGD', 'EUR', 'GBP', 'KRW', 'JPY', 'HKD', 'CNY', 'INR'].map(
                               c => (
-                                <SelectItem
-                                  key={c}
-                                  value={c}
-                                  className=""
-                                >
+                                <SelectItem key={c} value={c} className="">
                                   {c}
                                 </SelectItem>
                               )

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseCategoryPicker.tsx
@@ -316,7 +316,7 @@ export function CourseCategoryPicker({
               <SelectItem
                 key={region.id}
                 value={region.id}
-                className="mx-1.5 rounded-md text-white hover:bg-black/10 focus-visible:bg-black/10 focus-visible:ring-0"
+                className="mx-1.5 rounded-md text-white"
               >
                 {region.name}
               </SelectItem>
@@ -359,7 +359,7 @@ export function CourseCategoryPicker({
                 <button
                   key={country.code}
                   onClick={() => setSelectedCountryCode(country.code)}
-                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-black/10"
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white hover:bg-white/40"
                 >
                   <div
                     className={cn(

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'focus-visible:ring-primary/50 relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] focus-visible:ring-2 focus-visible:ring-offset-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center gap-3.5 rounded-lg px-3.5 py-2.5 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/20 focus:outline-none focus-visible:bg-white/20 focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className
     )}
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'focus-visible:ring-primary/50 relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] focus-visible:ring-2 focus-visible:ring-offset-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/20 focus:outline-none focus-visible:bg-white/20 focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'focus-visible:ring-primary/50 relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/[0.12] focus:outline-none focus-visible:bg-white/[0.12] focus-visible:ring-2 focus-visible:ring-offset-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-lg py-2.5 pl-10 pr-4 text-sm font-semibold text-white/[0.96] outline-none transition-all hover:bg-white/20 focus:outline-none focus-visible:bg-white/20 focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[state=checked]:border-l-[3px] data-[state=checked]:border-[#0057ff] data-[state=checked]:bg-white/[0.16] data-[disabled]:opacity-50',
       className
     )}
     {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'focus-visible:ring-primary/50 relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/10 focus:outline-none focus-visible:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-10 pr-4 text-[13px] font-semibold text-white/[0.94] outline-none transition-all hover:bg-white/20 focus:outline-none focus-visible:bg-white/20 focus-visible:outline-none focus-visible:ring-0 active:scale-[0.98] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION
Updates dropdown/select item hover highlights to a light colored pill (white/20) and keeps the focus ring removed to avoid the flashing hover ring. Also removes dark hover overrides in the course selector and category picker so the base styling applies consistently.