### PR TITLE
fix(course-builder): reveal curriculum task after loading PDF

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -4270,7 +4270,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         // Expand the item's node/section first (no-op if already expanded).
         const resolved = resolveSelectedItem({ type, id }, nodesRef.current)
         if (resolved) {
-          ensureSectionExpanded(resolved.nodeId, type === 'task' ? 'task' : 'assessment')
+          let section: 'task' | 'assessment' | 'homework' = type === 'task' ? 'task' : 'assessment'
+          if (
+            type === 'homework' &&
+            'category' in resolved.item &&
+            (resolved.item as any).category === 'homework'
+          ) {
+            section = 'homework'
+          }
+          ensureSectionExpanded(resolved.nodeId, section)
         }
 
         // Wait for the DOM to reflect the expansion, then scroll with retries.
@@ -6371,6 +6379,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setMainBuilderTab('assessment')
       setSelectedItem({ type: 'assessment', id: targetAssess.id })
       loadAssessmentIntoBuilder(targetAssess)
+      revealCurriculumItem('homework', targetAssess.id)
 
       // Show PDF by default, hide text
       setAssessmentPdfVisibleMap(prev => ({ ...prev, [targetAssess.id]: true }))
@@ -6887,12 +6896,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                           const taskId = updatedExistingTask.id
                           setSelectedItem({ type: 'task', id: updatedExistingTask.id })
                           loadTaskIntoBuilder(updatedExistingTask)
+                          revealCurriculumItem('task', taskId)
                           setTaskPdfVisibleMap(prev => ({ ...prev, [taskId]: true }))
                           setTaskTextVisibleMap(prev => ({ ...prev, [taskId]: false }))
                         } else if (newTasks.length > 0) {
                           const firstNew = newTasks[0]
                           setSelectedItem({ type: 'task', id: firstNew.id })
                           loadTaskIntoBuilder(firstNew)
+                          revealCurriculumItem('task', firstNew.id)
 
                           setTaskPdfVisibleMap(prev => ({ ...prev, [firstNew.id]: true }))
                           setTaskTextVisibleMap(prev => ({ ...prev, [firstNew.id]: false }))
@@ -7107,6 +7118,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                         setMainBuilderTab('task')
                         setSelectedItem({ type: 'task', id: newTask.id })
                         loadTaskIntoBuilder(newTask)
+                        revealCurriculumItem('task', newTask.id)
 
                         // Show PDF by default, hide text
                         setTaskPdfVisibleMap(prev => ({ ...prev, [newTask.id]: true }))


### PR DESCRIPTION
After loading a PDF via the "Load as Tasks" / "Task + Extensions" modals (or the assessment load path), the Curriculum panel now expands the correct lesson/task section and scrolls to the loaded item, instead of leaving the panel at the top lesson.