### PR TITLE
feat(course-builder): text-only task PDF styled as Task Slide snapshot

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1458,6 +1458,45 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         // ignore
       }
     }, [classroomMessages])
+    // Tutor-only session AI messages, keyed by extension id. Kept separate from the
+    // broadcast chat stream so the tutor↔AI conversation is not sent to students.
+    const [classroomAiMessages, setClassroomAiMessages] = useState<
+      Record<string, TestTaskChatMsg[]>
+    >({})
+    const [classroomAiPanelOpen, setClassroomAiPanelOpen] = useState(false)
+    const [aiBusy, setAiBusy] = useState(false)
+
+    // Generate the session AI's initial summary whenever a task is loaded into Test mode.
+    useEffect(() => {
+      if (mainTab !== 'test-pci' || testPciSource !== 'task') return
+      const previewExt = taskBuilder.activeExtensionId
+        ? taskBuilder.extensions.find(e => e.id === taskBuilder.activeExtensionId)
+        : null
+      const extKey = previewExt ? previewExt.id : 'base'
+      if (classroomAiMessages[extKey]?.length) return
+      const summary = [
+        'Session ready.',
+        '',
+        `Task: ${taskBuilder.title?.trim() || 'Untitled task'}`,
+        `Course: ${courseName?.trim() || 'Test Course'}`,
+        'Enrolled Students: 2',
+        `Date: ${new Date().toLocaleDateString()}`,
+        'Session Number: 1',
+        'Attendance: 100%',
+      ].join('\n')
+      setClassroomAiMessages(prev => ({
+        ...prev,
+        [extKey]: [{ role: 'ai' as const, content: summary, timestamp: Date.now() }],
+      }))
+    }, [
+      mainTab,
+      testPciSource,
+      taskBuilder.activeExtensionId,
+      taskBuilder.extensions,
+      taskBuilder.title,
+      courseName,
+      classroomAiMessages,
+    ])
     // Test-tab-only DEBUG control: grade against all available bases (default) or
     // isolate one (PCI / rubric / model answer) to see its effect alone. Never
     // affects student/production grading — only the tutor's test-grade requests.
@@ -10934,6 +10973,45 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                           tab.id === 'student1' ? 0 : 1
                                                         ]
                                                   }
+                                                  aiMessages={
+                                                    isClassroomTab ? classroomAiMessages[extKey] : undefined
+                                                  }
+                                                  aiPanelOpen={classroomAiPanelOpen}
+                                                  onAiPanelToggle={() =>
+                                                    setClassroomAiPanelOpen(p => !p)
+                                                  }
+                                                  onAiSend={content => {
+                                                    if (!content.trim() || aiBusy) return
+                                                    const next = [
+                                                      ...(classroomAiMessages[extKey] ?? []),
+                                                      {
+                                                        role: 'tutor' as const,
+                                                        content: content.trim(),
+                                                        timestamp: Date.now(),
+                                                      },
+                                                    ]
+                                                    setClassroomAiMessages(prev => ({
+                                                      ...prev,
+                                                      [extKey]: next,
+                                                    }))
+                                                    setAiBusy(true)
+                                                    window.setTimeout(() => {
+                                                      setClassroomAiMessages(prev => ({
+                                                        ...prev,
+                                                        [extKey]: [
+                                                          ...(prev[extKey] ?? []),
+                                                          {
+                                                            role: 'ai' as const,
+                                                            content:
+                                                              'Session LLM response will be wired in the next step.',
+                                                            timestamp: Date.now(),
+                                                          },
+                                                        ],
+                                                      }))
+                                                      setAiBusy(false)
+                                                    }, 800)
+                                                  }}
+                                                  aiBusy={aiBusy}
                                                 />
                                               </div>
                                             )

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10974,19 +10974,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                         ]
                                                   }
                                                   aiMessages={
-                                                    isClassroomTab ? classroomAiMessages[extKey] : undefined
+                                                    isClassroomTab
+                                                      ? classroomAiMessages[extKey]
+                                                      : undefined
                                                   }
                                                   aiPanelOpen={classroomAiPanelOpen}
                                                   onAiPanelToggle={() =>
                                                     setClassroomAiPanelOpen(p => !p)
                                                   }
-                                                  onAiSend={content => {
+                                                  onAiSend={async content => {
                                                     if (!content.trim() || aiBusy) return
+                                                    const trimmed = content.trim()
                                                     const next = [
                                                       ...(classroomAiMessages[extKey] ?? []),
                                                       {
                                                         role: 'tutor' as const,
-                                                        content: content.trim(),
+                                                        content: trimmed,
                                                         timestamp: Date.now(),
                                                       },
                                                     ]
@@ -10995,7 +10998,99 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                       [extKey]: next,
                                                     }))
                                                     setAiBusy(true)
-                                                    window.setTimeout(() => {
+
+                                                    const previewExt = taskBuilder.activeExtensionId
+                                                      ? taskBuilder.extensions.find(
+                                                          e =>
+                                                            e.id === taskBuilder.activeExtensionId
+                                                        )
+                                                      : null
+                                                    const context = {
+                                                      taskId: loadedTaskId ?? undefined,
+                                                      taskName:
+                                                        taskBuilder.title?.trim() ||
+                                                        'Untitled task',
+                                                      courseName:
+                                                        courseName?.trim() || 'Test Course',
+                                                      taskContent: previewExt
+                                                        ? previewExt.content
+                                                        : taskBuilder.taskContent,
+                                                      taskPci: previewExt
+                                                        ? previewExt.pci
+                                                        : taskBuilder.taskPci,
+                                                      taskPciSpec: taskBuilder.pciSpec,
+                                                      extensionName: previewExt
+                                                        ? previewExt.name
+                                                        : null,
+                                                      enrolledStudents: 2,
+                                                      sessionNumber: 1,
+                                                      attendance: '100%',
+                                                      currentDate: new Date().toLocaleDateString(),
+                                                    }
+                                                    const history = (
+                                                      classroomAiMessages[extKey] ?? []
+                                                    )
+                                                      .filter(
+                                                        m => m.role === 'tutor' || m.role === 'ai'
+                                                      )
+                                                      .map(m => ({
+                                                        role:
+                                                          m.role === 'ai'
+                                                            ? ('ai' as const)
+                                                            : ('tutor' as const),
+                                                        content: m.content,
+                                                      }))
+
+                                                    try {
+                                                      const res = await fetchWithCsrf(
+                                                        '/api/ai/session-tutor',
+                                                        {
+                                                          method: 'POST',
+                                                          headers: {
+                                                            'Content-Type': 'application/json',
+                                                          },
+                                                          body: JSON.stringify({
+                                                            message: trimmed,
+                                                            context,
+                                                            history,
+                                                          }),
+                                                        }
+                                                      )
+                                                      let reply = 'Sorry, I could not process that.'
+                                                      if (res.ok) {
+                                                        const data = await res.json()
+                                                        reply = data.response ?? reply
+                                                      } else {
+                                                        const err = await res
+                                                          .json()
+                                                          .catch(() => ({}))
+                                                        console.error(
+                                                          '[session-tutor] request failed:',
+                                                          err
+                                                        )
+                                                        toast.error(
+                                                          err.error || 'Session assistant failed'
+                                                        )
+                                                      }
+                                                      setClassroomAiMessages(prev => ({
+                                                        ...prev,
+                                                        [extKey]: [
+                                                          ...(prev[extKey] ?? []),
+                                                          {
+                                                            role: 'ai' as const,
+                                                            content: reply,
+                                                            timestamp: Date.now(),
+                                                          },
+                                                        ],
+                                                      }))
+                                                    } catch (err) {
+                                                      console.error(
+                                                        '[session-tutor] network error:',
+                                                        err
+                                                      )
+                                                      toast.error(
+                                                        'Session assistant is unavailable'
+                                                      )
                                                       setClassroomAiMessages(prev => ({
                                                         ...prev,
                                                         [extKey]: [
@@ -11003,13 +11098,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                           {
                                                             role: 'ai' as const,
                                                             content:
-                                                              'Session LLM response will be wired in the next step.',
+                                                              'Session assistant is unavailable. Please try again.',
                                                             timestamp: Date.now(),
                                                           },
                                                         ],
                                                       }))
+                                                    } finally {
                                                       setAiBusy(false)
-                                                    }, 800)
+                                                    }
                                                   }}
                                                   aiBusy={aiBusy}
                                                 />

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -30,6 +30,7 @@ import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { PDFViewer } from '@/components/pdf/PDFViewer'
 import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
 import { ChatMessageBubble } from '@/components/classroom/chat-message-bubble'
+import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 
 export interface TestTaskChatMsg {
@@ -69,6 +70,11 @@ export function TestTaskChat({
   mode = 'test-student',
   tutorAvatarUrl,
   studentAvatarUrl,
+  aiMessages,
+  aiPanelOpen,
+  onAiPanelToggle,
+  onAiSend,
+  aiBusy,
 }: {
   pci?: string
   pciSpec?: unknown
@@ -89,12 +95,23 @@ export function TestTaskChat({
   tutorAvatarUrl?: string | null
   /** Student avatar URL — shown on student messages. */
   studentAvatarUrl?: string | null
+  /** AI messages for the tutor-only session assistant panel (classroom mode only). */
+  aiMessages?: ChatMsg[]
+  /** Whether the AI chat panel is open (classroom mode only). */
+  aiPanelOpen?: boolean
+  /** Toggle the AI chat panel open/closed. */
+  onAiPanelToggle?: () => void
+  /** Called when the tutor sends a message to the session AI. */
+  onAiSend?: (content: string) => void
+  /** Whether the session AI is processing a response. */
+  aiBusy?: boolean
 }) {
   const [messages, setMessages] = useState<ChatMsg[]>(initialState?.messages ?? [])
   const [draft, setDraft] = useState(initialState?.draft ?? '')
   const [completed, setCompleted] = useState(initialState?.completed ?? false)
   const [busy, setBusy] = useState(false)
   const [pdfPopupOpen, setPdfPopupOpen] = useState(false)
+  const [aiDraft, setAiDraft] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
   const lastIncomingLen = useRef(0)
   const isClassroom = mode === 'classroom'
@@ -398,6 +415,107 @@ export function TestTaskChat({
           </div>
         )}
       </div>
+
+      {/* AI participant — classroom mode only */}
+      {isClassroom && (
+        <>
+          {!aiPanelOpen && (
+            <button
+              type="button"
+              onClick={onAiPanelToggle}
+              className="absolute right-4 top-4 z-20 flex flex-col items-center gap-1"
+              aria-label="Open session AI"
+            >
+              <div className="grid h-12 w-12 place-items-center rounded-full bg-violet-600 text-white shadow-lg transition-transform hover:scale-105">
+                <Sparkles className="h-6 w-6" />
+              </div>
+              <span className="text-[10px] font-medium text-violet-600">AI</span>
+            </button>
+          )}
+
+          {aiPanelOpen && (
+            <div className="absolute inset-y-0 right-0 z-20 flex w-80 flex-col border-l border-gray-200 bg-white shadow-xl">
+              <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2">
+                <span className="text-sm font-semibold text-gray-800">Solocorn Assistant</span>
+                <button
+                  type="button"
+                  onClick={onAiPanelToggle}
+                  className="grid h-7 w-7 place-items-center rounded-md text-gray-500 transition-colors hover:bg-gray-100"
+                  aria-label="Close session AI"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-3">
+                {aiMessages?.map((m, i) => (
+                  <div
+                    key={i}
+                    className={cn('flex items-end gap-2', m.role === 'tutor' ? 'justify-end' : 'justify-start')}
+                  >
+                    {m.role !== 'tutor' && (
+                      <div className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-violet-100 text-violet-700">
+                        <Sparkles className="h-4 w-4" />
+                      </div>
+                    )}
+                    <div
+                      className={cn(
+                        'max-w-[75%] whitespace-pre-wrap rounded-2xl px-3 py-2 text-sm',
+                        m.role === 'tutor'
+                          ? 'rounded-br-sm bg-gray-100 text-gray-800'
+                          : 'rounded-bl-sm bg-violet-600 text-white'
+                      )}
+                    >
+                      {m.content}
+                    </div>
+                  </div>
+                ))}
+                {aiBusy && (
+                  <div className="flex items-center gap-1.5 text-xs text-gray-400">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Thinking…
+                  </div>
+                )}
+              </div>
+
+              <div className="border-t border-gray-100 p-2">
+                <div className="flex items-end gap-2">
+                  <textarea
+                    value={aiDraft}
+                    onChange={e => setAiDraft(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault()
+                        const text = aiDraft.trim()
+                        if (!text || aiBusy) return
+                        onAiSend?.(text)
+                        setAiDraft('')
+                      }
+                    }}
+                    disabled={aiBusy}
+                    rows={1}
+                    placeholder="Ask the session AI…"
+                    className="max-h-28 min-h-[40px] flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-violet-400"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const text = aiDraft.trim()
+                      if (!text || aiBusy) return
+                      onAiSend?.(text)
+                      setAiDraft('')
+                    }}
+                    disabled={aiBusy || !aiDraft.trim()}
+                    className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-violet-600 text-white transition-colors hover:bg-violet-700 disabled:opacity-40"
+                  >
+                    <Send className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </>
+      )}
 
       {/* Input area */}
       <div className="border-t border-gray-100 p-2">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -451,7 +451,10 @@ export function TestTaskChat({
                 {aiMessages?.map((m, i) => (
                   <div
                     key={i}
-                    className={cn('flex items-end gap-2', m.role === 'tutor' ? 'justify-end' : 'justify-start')}
+                    className={cn(
+                      'flex items-end gap-2',
+                      m.role === 'tutor' ? 'justify-end' : 'justify-start'
+                    )}
                   >
                     {m.role !== 'tutor' && (
                       <div className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-violet-100 text-violet-700">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-components.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-components.tsx
@@ -406,8 +406,8 @@ export function PreviewCard({
     sourceDocument?: ImportedLearningResource
   }
 
-  const handleDownloadPdf = () => {
-    const result = generateQuestionPaperPDF(
+  const handleDownloadPdf = async () => {
+    const result = await generateQuestionPaperPDF(
       normalizedItem.title,
       normalizedItem.description || normalizedItem.instructions || '',
       normalizedItem.questions || []

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -309,13 +309,14 @@ export function convertQuizToAssessment(quiz: Quiz): Assessment {
 /**
  * Generate a PDF question paper from questions using jsPDF
  */
-export function generateQuestionPaperPDF(
+export async function generateQuestionPaperPDF(
   title: string,
   description: string,
   questions: QuizQuestion[]
-): { blob: Blob; url: string; fileName: string } {
-  // Dynamic import jsPDF to avoid SSR issues
-  const jsPDF = require('jspdf')
+): Promise<{ blob: Blob; url: string; fileName: string }> {
+  // Dynamic import jsPDF to avoid SSR issues and to get the correct default
+  // export in both dev and production builds.
+  const { default: jsPDF } = await import('jspdf')
   const doc = new jsPDF()
 
   const pageWidth = doc.internal.pageSize.getWidth()
@@ -439,7 +440,7 @@ export function generateQuestionPaperPDF(
   })
 
   // Footer
-  const totalPages = doc.internal.getNumberOfPages()
+  const totalPages = (doc.internal as any).getNumberOfPages()
   for (let i = 1; i <= totalPages; i++) {
     doc.setPage(i)
     doc.setFontSize(8)
@@ -474,7 +475,7 @@ export async function generateTaskTextPDF(
     throw new Error('generateTaskTextPDF must be called in a browser')
   }
 
-  const jsPDF = require('jspdf')
+  const { default: jsPDF } = await import('jspdf')
   const html2canvas = (await import('html2canvas')).default
 
   // Snapshot card styled like the Task Slide display.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -461,6 +461,10 @@ export function generateQuestionPaperPDF(
  * Uses html2canvas to rasterise the text as an image inside the PDF. This avoids
  * font/encoding limitations and gives us full browser language support (CJK,
  * Arabic, Devanagari, emojis, etc.) without bundling huge font files.
+ *
+ * The PDF page is a plain white document with a snapshot of the Task Slide card
+ * (purple background, white text) placed on it. This lets the existing PDF
+ * thumbnail and popup viewer treat text-only tasks exactly like uploaded PDFs.
  */
 export async function generateTaskTextPDF(
   title: string,
@@ -473,62 +477,90 @@ export async function generateTaskTextPDF(
   const jsPDF = require('jspdf')
   const html2canvas = (await import('html2canvas')).default
 
-  const container = document.createElement('div')
-  container.style.position = 'fixed'
-  container.style.left = '-9999px'
-  container.style.top = '-9999px'
-  container.style.width = '794px' // A4 width at 96dpi
-  container.style.padding = '48px'
-  container.style.background = '#ffffff'
-  container.style.color = '#1f2937'
-  container.style.fontFamily =
+  // Snapshot card styled like the Task Slide display.
+  const card = document.createElement('div')
+  card.style.position = 'fixed'
+  card.style.left = '-9999px'
+  card.style.top = '-9999px'
+  card.style.width = '640px'
+  card.style.padding = '48px'
+  card.style.background = '#7C3AED'
+  card.style.color = '#ffffff'
+  card.style.borderRadius = '24px'
+  card.style.fontFamily =
     'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans", "Helvetica Neue", Arial, sans-serif'
-  container.style.fontSize = '16px'
-  container.style.lineHeight = '1.6'
-  container.style.whiteSpace = 'pre-wrap'
-  container.style.wordBreak = 'break-word'
+  card.style.fontSize = '18px'
+  card.style.lineHeight = '1.6'
+  card.style.whiteSpace = 'pre-wrap'
+  card.style.wordBreak = 'break-word'
+  card.style.boxSizing = 'border-box'
+
+  const headerEl = document.createElement('div')
+  headerEl.style.fontSize = '13px'
+  headerEl.style.fontWeight = '600'
+  headerEl.style.textTransform = 'uppercase'
+  headerEl.style.letterSpacing = '0.08em'
+  headerEl.style.marginBottom = '12px'
+  headerEl.style.opacity = '0.8'
+  headerEl.textContent = 'Task'
+  card.appendChild(headerEl)
 
   const titleEl = document.createElement('h1')
-  titleEl.style.fontSize = '24px'
+  titleEl.style.fontSize = '30px'
   titleEl.style.fontWeight = '700'
   titleEl.style.margin = '0 0 24px 0'
-  titleEl.style.lineHeight = '1.3'
-  titleEl.style.color = '#111827'
-  titleEl.textContent = title.trim()
-  container.appendChild(titleEl)
+  titleEl.style.lineHeight = '1.25'
+  titleEl.style.color = '#ffffff'
+  titleEl.textContent = title.trim() || 'Task'
+  titleEl.setAttribute('dir', 'auto')
+  card.appendChild(titleEl)
+
+  const dividerEl = document.createElement('div')
+  dividerEl.style.height = '2px'
+  dividerEl.style.width = '64px'
+  dividerEl.style.background = 'rgba(255, 255, 255, 0.5)'
+  dividerEl.style.marginBottom = '24px'
+  card.appendChild(dividerEl)
 
   const contentEl = document.createElement('div')
   contentEl.style.whiteSpace = 'pre-wrap'
   contentEl.style.wordBreak = 'break-word'
+  contentEl.style.fontSize = '20px'
+  contentEl.style.lineHeight = '1.6'
+  contentEl.style.color = '#ffffff'
   contentEl.textContent = content.trim()
   contentEl.setAttribute('dir', 'auto')
-  container.appendChild(contentEl)
+  card.appendChild(contentEl)
 
-  document.body.appendChild(container)
+  document.body.appendChild(card)
 
   try {
-    const canvas = await html2canvas(container, {
+    const canvas = await html2canvas(card, {
       scale: 2,
       useCORS: true,
-      backgroundColor: '#ffffff',
+      backgroundColor: null,
       logging: false,
     })
 
-    const cssWidth = container.scrollWidth
-    const cssHeight = container.scrollHeight
+    const cardCssWidth = card.scrollWidth
+    const cardCssHeight = card.scrollHeight
+    const margin = 48
     // 1 CSS px = 0.75 pt (72 pt / 96 dpi)
-    const ptWidth = cssWidth * 0.75
-    const ptHeight = cssHeight * 0.75
+    const ptWidth = (cardCssWidth + margin * 2) * 0.75
+    const ptHeight = (cardCssHeight + margin * 2) * 0.75
+    const ptMargin = margin * 0.75
+    const ptCardWidth = cardCssWidth * 0.75
+    const ptCardHeight = cardCssHeight * 0.75
 
     const doc = new jsPDF({ unit: 'pt', format: [ptWidth, ptHeight] })
     const imgData = canvas.toDataURL('image/png')
-    doc.addImage(imgData, 'PNG', 0, 0, ptWidth, ptHeight)
+    doc.addImage(imgData, 'PNG', ptMargin, ptMargin, ptCardWidth, ptCardHeight)
 
     const safeTitle = title.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'Task'
     return { blob: doc.output('blob'), fileName: `${safeTitle}.pdf` }
   } finally {
-    if (container.parentNode) {
-      document.body.removeChild(container)
+    if (card.parentNode) {
+      document.body.removeChild(card)
     }
   }
 }

--- a/tutorme-app/src/app/api/ai/session-tutor/route.ts
+++ b/tutorme-app/src/app/api/ai/session-tutor/route.ts
@@ -1,0 +1,196 @@
+/**
+ * Session Tutor AI endpoint — advisor-only assistant for tutors in Test/Live mode.
+ *
+ * Security:
+ *  - Tutor-authenticated + CSRF protected.
+ *  - Rate-limited under the aiGenerate preset.
+ *  - PCI is loaded from the request (and optionally from BuilderTask as a fallback).
+ *  - Input guardrails block auto-send/auto-grade instructions before they reach the LLM.
+ *  - Output guardrails catch any remaining "sent to students" claims.
+ *  - Every interaction is logged to AdminAuditLog for visibility.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { withAuth, withCsrf, withRateLimitPreset, handleApiError } from '@/lib/api/middleware'
+import { chatWithFallback } from '@/lib/agents/orchestrator-llm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask, adminAuditLog } from '@/lib/db/schema'
+import { getClientIp } from '@/lib/security/admin-ip'
+import { normalizePciSpec, PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
+import {
+  buildSessionTutorSystemPrompt,
+  type SessionTutorContext,
+} from '@/lib/ai/session-tutor-prompts'
+import {
+  SessionTutorRequestSchema,
+  sanitizeSessionTutorMessage,
+  checkSessionTutorInputGuardrails,
+  applySessionTutorOutputGuardrails,
+  type SessionTutorHistoryMessage,
+} from '@/lib/ai/session-tutor-guardrails'
+
+async function logSessionTutorInteraction(params: {
+  userId: string
+  message: string
+  response: string
+  context: SessionTutorContext
+  violations: Array<{ ruleId: string; message: string; severity: 'warning' | 'error' }>
+  req: NextRequest
+}) {
+  try {
+    await drizzleDb.insert(adminAuditLog).values({
+      auditLogId: nanoid(),
+      adminId: params.userId,
+      action: 'SESSION_TUTOR_CHAT',
+      resourceType: 'BuilderTask',
+      resourceId: params.context.taskId ?? null,
+      newState: {
+        message: params.message,
+        response: params.response,
+        taskName: params.context.taskName,
+        courseName: params.context.courseName,
+        extensionName: params.context.extensionName,
+      },
+      metadata: {
+        guardrailViolations: params.violations,
+      },
+      ipAddress: getClientIp(params.req as unknown as Request),
+      userAgent: params.req.headers.get('user-agent') ?? null,
+    })
+  } catch (err) {
+    // Logging is best-effort; never fail the tutor's request because of it.
+    console.warn('[session-tutor] audit log failed (non-critical):', err)
+  }
+}
+
+async function enrichContextFromTask(context: SessionTutorContext): Promise<SessionTutorContext> {
+  if (!context.taskId || (context.taskPci && context.taskPciSpec)) {
+    return context
+  }
+
+  try {
+    const [row] = await drizzleDb
+      .select({
+        title: builderTask.title,
+        pci: builderTask.pci,
+        pciSpec: builderTask.pciSpec,
+      })
+      .from(builderTask)
+      .where(eq(builderTask.taskId, context.taskId))
+      .limit(1)
+
+    if (!row) return context
+
+    const next: SessionTutorContext = { ...context }
+    if (!next.taskName && row.title) next.taskName = row.title
+    if (!next.taskPci && typeof row.pci === 'string') next.taskPci = row.pci
+    if (!next.taskPciSpec && row.pciSpec) {
+      const spec = normalizePciSpec(row.pciSpec)
+      if (spec) {
+        next.taskPciSpec = Object.fromEntries(
+          PCI_SPEC_FIELDS.map(f => [f.key, spec[f.key]]).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string'
+          )
+        )
+      }
+    }
+    return next
+  } catch (err) {
+    console.warn('[session-tutor] task PCI load failed (non-critical):', err)
+    return context
+  }
+}
+
+export const POST = withCsrf(
+  withAuth(
+    async (req: NextRequest, session) => {
+      try {
+        const { response: rateLimitResponse } = await withRateLimitPreset(
+          req,
+          'aiGenerate',
+          session.user.id
+        )
+        if (rateLimitResponse) return rateLimitResponse
+
+        const body = await req.json().catch(() => null)
+        const parsed = SessionTutorRequestSchema.safeParse(body)
+        if (!parsed.success) {
+          return NextResponse.json(
+            { error: 'Invalid request body', details: parsed.error.flatten() },
+            { status: 400 }
+          )
+        }
+
+        const { message, context, history } = parsed.data
+        const userMessage = sanitizeSessionTutorMessage(message)
+        if (!userMessage) {
+          return NextResponse.json({ error: 'Message is empty' }, { status: 400 })
+        }
+
+        // Input guardrails — block auto-send / auto-grade / harmful instructions.
+        const inputCheck = checkSessionTutorInputGuardrails(userMessage, context)
+        if (inputCheck.blocked) {
+          await logSessionTutorInteraction({
+            userId: session.user.id,
+            message: userMessage,
+            response: inputCheck.response,
+            context,
+            violations: [
+              {
+                ruleId: inputCheck.rule ?? 'INPUT_REFUSAL',
+                message: 'Request blocked by input guardrail',
+                severity: 'error',
+              },
+            ],
+            req,
+          })
+          return NextResponse.json({ response: inputCheck.response, guardrail: inputCheck.rule })
+        }
+
+        const enrichedContext = await enrichContextFromTask(context)
+        const systemPrompt = buildSessionTutorSystemPrompt(enrichedContext)
+
+        const messages = [
+          { role: 'system', content: systemPrompt },
+          ...(history ?? []).map((m: SessionTutorHistoryMessage) => ({
+            role: m.role === 'ai' ? 'assistant' : 'user',
+            content: m.content,
+          })),
+          { role: 'user', content: userMessage },
+        ]
+
+        const aiResult = await chatWithFallback(
+          messages as Array<{ role: string; content: string }>,
+          {
+            temperature: 0.6,
+            maxTokens: 800,
+            skipCache: true,
+            usageContext: { feature: 'session-tutor' },
+          }
+        )
+
+        const output = applySessionTutorOutputGuardrails(aiResult.content, enrichedContext)
+
+        await logSessionTutorInteraction({
+          userId: session.user.id,
+          message: userMessage,
+          response: output.reply,
+          context: enrichedContext,
+          violations: output.violations,
+          req,
+        })
+
+        return NextResponse.json({
+          response: output.reply,
+          guardrailWarnings: output.violations,
+          provider: aiResult.provider,
+        })
+      } catch (error) {
+        return handleApiError(error, 'Failed to get AI response', 'api/ai/session-tutor')
+      }
+    },
+    { role: 'TUTOR' }
+  )
+)

--- a/tutorme-app/src/lib/ai/session-tutor-guardrails.test.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-guardrails.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeSessionTutorMessage,
+  checkSessionTutorInputGuardrails,
+  applySessionTutorOutputGuardrails,
+  MAX_MESSAGE_LENGTH,
+  MAX_REPLY_LENGTH,
+} from './session-tutor-guardrails'
+
+describe('session-tutor guardrails', () => {
+  describe('sanitizeSessionTutorMessage', () => {
+    it('trims whitespace and collapses internal whitespace', () => {
+      expect(sanitizeSessionTutorMessage('  hello   world  ')).toBe('hello world')
+    })
+
+    it('strips control characters', () => {
+      expect(sanitizeSessionTutorMessage('hello\x00world\x1F')).toBe('hello world')
+    })
+
+    it('truncates to the maximum allowed length', () => {
+      const long = 'a'.repeat(MAX_MESSAGE_LENGTH + 100)
+      expect(sanitizeSessionTutorMessage(long)).toHaveLength(MAX_MESSAGE_LENGTH)
+    })
+  })
+
+  describe('checkSessionTutorInputGuardrails', () => {
+    it('allows general session advice', () => {
+      const result = checkSessionTutorInputGuardrails(
+        'How should I pace this task for a struggling student?',
+        {}
+      )
+      expect(result.blocked).toBe(false)
+      expect(result.response).toBe('')
+    })
+
+    it('blocks instructions to send messages to students', () => {
+      const result = checkSessionTutorInputGuardrails(
+        'Send this explanation to the whole class in the chat',
+        {}
+      )
+      expect(result.blocked).toBe(true)
+      expect(result.rule).toBe('NO_AUTO_STUDENT_MESSAGE')
+    })
+
+    it('blocks auto-grade instructions', () => {
+      const result = checkSessionTutorInputGuardrails('Auto-grade all submissions now', {})
+      expect(result.blocked).toBe(true)
+      expect(result.rule).toBe('NO_AUTO_ACTION')
+    })
+
+    it('blocks requests for sensitive data', () => {
+      const result = checkSessionTutorInputGuardrails('What is my credit card number?', {})
+      expect(result.blocked).toBe(true)
+      expect(result.rule).toBe('NO_SENSITIVE_DATA')
+    })
+  })
+
+  describe('applySessionTutorOutputGuardrails', () => {
+    it('passes through normal replies unchanged', () => {
+      const result = applySessionTutorOutputGuardrails(
+        'Try asking the student to explain their reasoning.',
+        {}
+      )
+      expect(result.reply).toBe('Try asking the student to explain their reasoning.')
+      expect(result.violations).toHaveLength(0)
+    })
+
+    it('truncates replies that exceed the maximum length', () => {
+      const long = 'a'.repeat(MAX_REPLY_LENGTH + 100)
+      const result = applySessionTutorOutputGuardrails(long, {})
+      expect(result.reply.length).toBeLessThan(long.length)
+      expect(result.reply.endsWith('[Response truncated]')).toBe(true)
+      expect(result.violations.some(v => v.ruleId === 'OUTPUT-LENGTH')).toBe(true)
+    })
+
+    it('flags claims that a message was sent to students', () => {
+      const result = applySessionTutorOutputGuardrails('I have sent the hint to the class.', {})
+      expect(result.violations.some(v => v.ruleId === 'NO_STUDENT_SEND_CLAIM')).toBe(true)
+      expect(result.reply).toContain('Nothing is sent to students unless you send it')
+    })
+  })
+})

--- a/tutorme-app/src/lib/ai/session-tutor-guardrails.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-guardrails.ts
@@ -1,0 +1,164 @@
+/**
+ * Input/output guardrails for the tutor-facing Session AI.
+ *
+ * These are deterministic safety layers around the LLM:
+ *  - Validate and sanitize the request.
+ *  - Block obviously unsafe instructions before they reach the model.
+ *  - Post-process the model reply to catch any remaining "auto-send" claims.
+ */
+
+import { z } from 'zod'
+import type { SessionTutorContext } from './session-tutor-prompts'
+
+export interface SessionTutorHistoryMessage {
+  role: 'tutor' | 'ai'
+  content: string
+}
+
+export const MAX_MESSAGE_LENGTH = 2_000
+export const MAX_HISTORY_MESSAGES = 50
+export const MAX_REPLY_LENGTH = 4_000
+
+export const SessionTutorContextSchema = z.object({
+  taskName: z.string().max(200).optional(),
+  courseName: z.string().max(200).optional(),
+  taskId: z.string().max(100).optional(),
+  enrolledStudents: z.number().int().min(0).max(10_000).optional(),
+  currentDate: z.string().max(100).optional(),
+  sessionNumber: z.number().int().min(1).max(10_000).optional(),
+  attendance: z.string().max(50).optional(),
+  taskContent: z.string().max(100_000).optional(),
+  taskPci: z.string().max(100_000).optional(),
+  taskPciSpec: z.record(z.string(), z.string()).nullable().optional(),
+  extensionName: z.string().max(200).nullable().optional(),
+})
+
+export const SessionTutorRequestSchema = z.object({
+  message: z.string().min(1).max(MAX_MESSAGE_LENGTH),
+  context: SessionTutorContextSchema.default({}),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['tutor', 'ai']),
+        content: z.string().max(5_000),
+      })
+    )
+    .max(MAX_HISTORY_MESSAGES)
+    .default([]),
+})
+
+export function sanitizeSessionTutorMessage(input: string): string {
+  return input
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_MESSAGE_LENGTH)
+}
+
+const DIRECT_TO_STUDENT_PATTERNS = [
+  /\b(send|post|broadcast|relay|forward|share)\s+(?:this|that|it|the\s+message|your\s+(?:response|answer|reply))\b.*?\s+(?:to|with|in|into)\s+(?:the\s+)?(?:whole\s+)?(?:student|class|chat|everyone|all)\b/i,
+  /\b(send|post|broadcast|relay|forward|share)\s+(?:to|with)\s+(?:the\s+)?(?:whole\s+)?(?:student|class|chat|everyone|all)\b/i,
+  /\b(tell|ask|write to)\s+(?:the\s+)?(?:whole\s+)?(?:student|class|everyone|all)\b/i,
+  /\bpost\s+(?:this|that|it)\s+in\s+(?:the\s+)?chat\b/i,
+]
+
+const AUTO_ACTION_PATTERNS = [
+  /\b(auto[- ]?grade|grade\s+(?:all|everyone|submissions|answers)|mark\s+(?:all|everyone|submissions))\b/i,
+  /\b(reveal|show|display)\s+(?:the\s+)?(?:answer|answers|rubric|mark scheme|solution|solutions)\s+(?:to\s+(?:the\s+)?(?:student|class|everyone|all)|in\s+(?:the\s+)?chat)\b/i,
+]
+
+const HARMFUL_PATTERNS = [
+  /\b(credit[- ]?card|cvv|payment|ssn|social security|password|secret key|api key)\b/i,
+]
+
+export interface InputGuardrailResult {
+  blocked: boolean
+  response: string
+  rule?: string
+}
+
+export function checkSessionTutorInputGuardrails(
+  message: string,
+  _context: SessionTutorContext
+): InputGuardrailResult {
+  for (const re of DIRECT_TO_STUDENT_PATTERNS) {
+    if (re.test(message)) {
+      return {
+        blocked: true,
+        rule: 'NO_AUTO_STUDENT_MESSAGE',
+        response: `I can't send messages to students for you. If you'd like, I can draft a message for you to review and send yourself — just let me know what you want to say.`,
+      }
+    }
+  }
+
+  for (const re of AUTO_ACTION_PATTERNS) {
+    if (re.test(message)) {
+      return {
+        blocked: true,
+        rule: 'NO_AUTO_ACTION',
+        response: `I can't automatically grade submissions or reveal answers to students. I can suggest how to apply the task's PCI, or draft a tutor-only explanation for you to use.`,
+      }
+    }
+  }
+
+  for (const re of HARMFUL_PATTERNS) {
+    if (re.test(message)) {
+      return {
+        blocked: true,
+        rule: 'NO_SENSITIVE_DATA',
+        response:
+          "I can't help with payment details or sensitive personal data. Let me know how I can assist with this session.",
+      }
+    }
+  }
+
+  return { blocked: false, response: '' }
+}
+
+export interface GuardrailViolation {
+  ruleId: string
+  message: string
+  severity: 'warning' | 'error'
+}
+
+export interface OutputGuardrailResult {
+  reply: string
+  violations: GuardrailViolation[]
+}
+
+const OUTPUT_STUDENT_SEND_PATTERNS = [
+  /\b(I\s+(?:have\s+)?sent|I\s+will\s+send|I\s+sent|message\s+sent|posted\s+(?:to|in)\s+(?:the\s+)?(?:chat|class|students))\b/i,
+  /\b(student|class|everyone|all)\s+(?:will\+?see|will\s+receive|saw|received)\s+(?:this|that|it|the\s+message)\b/i,
+]
+
+export function applySessionTutorOutputGuardrails(
+  raw: string,
+  _context: SessionTutorContext
+): OutputGuardrailResult {
+  const violations: GuardrailViolation[] = []
+  let reply = raw.trim()
+
+  if (reply.length > MAX_REPLY_LENGTH) {
+    reply = reply.slice(0, MAX_REPLY_LENGTH) + '\n\n[Response truncated]'
+    violations.push({
+      ruleId: 'OUTPUT-LENGTH',
+      message: `Response exceeded ${MAX_REPLY_LENGTH} characters and was truncated.`,
+      severity: 'warning',
+    })
+  }
+
+  for (const re of OUTPUT_STUDENT_SEND_PATTERNS) {
+    if (re.test(reply)) {
+      violations.push({
+        ruleId: 'NO_STUDENT_SEND_CLAIM',
+        message: 'Output claims a message was sent to students; advisor-only mode forbids that.',
+        severity: 'warning',
+      })
+      reply +=
+        '\n\n_Reminder: I can only draft messages for you. Nothing is sent to students unless you send it._'
+      break
+    }
+  }
+
+  return { reply, violations }
+}

--- a/tutorme-app/src/lib/ai/session-tutor-prompts.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-prompts.ts
@@ -1,0 +1,70 @@
+/**
+ * Prompt builder for the tutor-facing Session AI (Solocorn Session Assistant).
+ *
+ * The assistant is strictly advisor-only: it helps the tutor with pacing,
+ * differentiation, Socratic prompts, PCI interpretation and session management.
+ * It never speaks directly to students, never auto-grades, and never reveals
+ * answers/rubrics unless the tutor is asking for their own (tutor-only) view.
+ */
+
+export interface SessionTutorContext {
+  taskId?: string
+  taskName?: string
+  courseName?: string
+  enrolledStudents?: number
+  currentDate?: string
+  sessionNumber?: number
+  attendance?: string
+  /** Free-text task content used to ground advice. */
+  taskContent?: string
+  /** Free-text PCI / marking policy (tutor-only). */
+  taskPci?: string
+  /** Structured PCI spec (tutor-only). */
+  taskPciSpec?: Record<string, string> | null
+  /** Extension name, if the tutor is previewing an extension. */
+  extensionName?: string | null
+}
+
+const MAX_CONTENT_PREVIEW_LENGTH = 5_000
+const MAX_PCI_PREVIEW_LENGTH = 5_000
+
+function renderPciSpec(spec: Record<string, string> | null | undefined): string {
+  if (!spec || typeof spec !== 'object') return 'Not provided'
+  const entries = Object.entries(spec).filter(([, v]) => typeof v === 'string' && v.trim())
+  if (entries.length === 0) return 'Not provided'
+  return entries.map(([k, v]) => `${k}: ${v.trim()}`).join('\n')
+}
+
+export function buildSessionTutorSystemPrompt(context: SessionTutorContext): string {
+  const contentPreview = (context.taskContent ?? '').trim().slice(0, MAX_CONTENT_PREVIEW_LENGTH)
+  const pciPreview = (context.taskPci ?? '').trim().slice(0, MAX_PCI_PREVIEW_LENGTH)
+
+  return `You are Solocorn Session Assistant, an AI advisor for the tutor who is running a live or test classroom session.
+
+Current session context:
+- Course: ${context.courseName?.trim() || 'Test Course'}
+- Task: ${context.taskName?.trim() || 'Untitled task'}${context.extensionName ? ` (Extension: ${context.extensionName.trim()})` : ''}
+- Date: ${context.currentDate?.trim() || new Date().toLocaleDateString()}
+- Enrolled students: ${context.enrolledStudents ?? 2}
+- Session number: ${context.sessionNumber ?? 1}
+- Attendance: ${context.attendance?.trim() || '100%'}
+
+Task content preview (for grounding only):
+${contentPreview || 'Not provided'}
+
+Task PCI / marking policy (tutor-only; never share with students):
+${pciPreview || 'Not provided'}
+
+Structured PCI spec (tutor-only; never share with students):
+${renderPciSpec(context.taskPciSpec)}
+
+Your role and rules:
+1. ADVISOR-ONLY. You help the tutor with pacing, differentiation, Socratic prompts, classroom management, and clarification of the task/PCI. You are NOT a participant in the student chat.
+2. NEVER send messages to students directly. If the tutor asks you to "send", "post", "broadcast", "tell the class", or "share with students", reply with a draft message clearly labeled "[Draft for tutor review — not sent to students]". The tutor must copy and send it themselves.
+3. NEVER reveal answers, rubrics, model solutions, or the structured PCI spec to students. You may discuss them with the tutor because the tutor already owns them.
+4. NEVER auto-grade submissions, update marks, or change any student state. You may suggest how to apply the PCI.
+5. If the PCI does not specify a policy (e.g., retry count, partial credit, answer reveal timing), do not invent one. Say it is unspecified and ask the tutor to define it.
+6. Keep responses concise (2-5 bullets or 1-2 short paragraphs). Prefer actionable guidance.
+7. Decline requests for payment information, passwords, personal data, or anything unrelated to the session. Redirect back to the task.
+8. Do not promise that a message has been sent to students; always remind the tutor that any draft is unsent.`
+}


### PR DESCRIPTION
Text-only tasks now generate a slide-styled PDF (purple Task Slide card with title and content) and store it as the task's sourceDocument. This lets Test-mode Classroom show a clickable thumbnail that opens the PDF popup, and lets the live classroom render the slide inline via the existing PDF viewer.