### PR TITLE
feat(deploy): deploy a task's attached PDF; harden task materialization

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -15,7 +15,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { and, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNull, ne, or } from 'drizzle-orm'
 import { withAuth } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { builderTask, builderTaskDmi, course, courseLesson, courseVariant } from '@/lib/db/schema'
@@ -93,7 +93,22 @@ async function resolveCourseFamily(scopedId: string): Promise<string[]> {
  * Idempotent: upserts keyed on the authored item id and refreshed from
  * builderData (the source of truth), so re-opening the panel just no-ops/refreshes.
  */
-async function materializeCourseFamilyTasks(tutorId: string, familyIds: string[]): Promise<void> {
+/** The attachable document a task was built from (e.g. a question-paper PDF).
+ *  Shaped like the socket's LiveTaskSourceDocument; the durable `fileKey` is what
+ *  matters — the socket re-signs the url from it on deploy. */
+interface SourceDocLite {
+  fileName: string
+  fileUrl: string
+  fileKey: string
+  mimeType: string
+}
+
+const MATERIALIZE_CAP = 500
+
+async function materializeCourseFamilyTasks(
+  tutorId: string,
+  familyIds: string[]
+): Promise<Map<string, SourceDocLite>> {
   const lessons = await drizzleDb
     .select({
       lessonId: courseLesson.lessonId,
@@ -112,6 +127,10 @@ async function materializeCourseFamilyTasks(tutorId: string, familyIds: string[]
   const taskRows: (typeof builderTask.$inferInsert)[] = []
   const dmiRows: (typeof builderTaskDmi.$inferInsert)[] = []
   const seen = new Set<string>()
+  // Read fresh from builderData every call (not stored on BuilderTask), so a
+  // task's attached PDF flows to the deploy panel even for already-materialized
+  // rows, and picks up a re-linked document without a stale copy.
+  const sourceDocByTask = new Map<string, SourceDocLite>()
 
   for (const l of lessons) {
     const bd = (l.builderData ?? {}) as Record<string, unknown>
@@ -119,8 +138,29 @@ async function materializeCourseFamilyTasks(tutorId: string, familyIds: string[]
       const arr = Array.isArray(bd[key]) ? (bd[key] as Record<string, unknown>[]) : []
       for (const item of arr) {
         const id = typeof item?.id === 'string' ? item.id : null
-        if (!id || seen.has(id) || taskRows.length >= 500) continue
+        if (!id || seen.has(id)) continue
         seen.add(id)
+
+        // A task's source document (question-paper PDF etc.) — carry the durable
+        // fileKey so the deploy path can show it in the live Materials panel.
+        const sd = item.sourceDocument as Record<string, unknown> | undefined
+        if (sd && typeof sd.fileKey === 'string' && sd.fileKey) {
+          const fk = sd.fileKey
+          sourceDocByTask.set(id, {
+            fileKey: fk,
+            fileUrl: typeof sd.fileUrl === 'string' ? sd.fileUrl : '',
+            fileName:
+              typeof sd.fileName === 'string' ? sd.fileName : fk.split('/').pop() || 'document',
+            mimeType:
+              typeof sd.mimeType === 'string'
+                ? sd.mimeType
+                : fk.toLowerCase().endsWith('.pdf')
+                  ? 'application/pdf'
+                  : 'application/octet-stream',
+          })
+        }
+
+        if (taskRows.length >= MATERIALIZE_CAP) continue
         const title = (typeof item.title === 'string' && item.title.trim()) || 'Untitled task'
         const content =
           (typeof item.content === 'string' && item.content) ||
@@ -155,38 +195,28 @@ async function materializeCourseFamilyTasks(tutorId: string, familyIds: string[]
     }
   }
 
-  if (taskRows.length === 0) return
-
-  await drizzleDb
-    .insert(builderTask)
-    .values(taskRows)
-    .onConflictDoUpdate({
-      target: builderTask.taskId,
-      set: {
-        title: sql`excluded."title"`,
-        content: sql`excluded."content"`,
-        type: sql`excluded."type"`,
-        courseId: sql`excluded."courseId"`,
-        lessonId: sql`excluded."lessonId"`,
-        status: sql`excluded."status"`,
-        publishedAt: sql`excluded."publishedAt"`,
-        updatedAt: sql`excluded."updatedAt"`,
-      },
-    })
-
-  if (dmiRows.length > 0) {
-    await drizzleDb
-      .insert(builderTaskDmi)
-      .values(dmiRows)
-      .onConflictDoUpdate({
-        target: builderTaskDmi.dmiId,
-        set: {
-          items: sql`excluded."items"`,
-          type: sql`excluded."type"`,
-          updatedAt: sql`excluded."updatedAt"`,
-        },
-      })
+  if (seen.size > MATERIALIZE_CAP) {
+    console.warn(
+      `[deployables] course family has ${seen.size} authored tasks; materializing only the first ${MATERIALIZE_CAP}.`
+    )
   }
+
+  if (taskRows.length > 0) {
+    // Insert new tasks only. Do NOT overwrite an existing row: an in-session
+    // inline edit (tasks/[taskId] PATCH) writes title/content straight to
+    // BuilderTask, and re-opening the panel must not stomp it back to the
+    // builderData snapshot. Also avoids re-writing unchanged rows on every open.
+    await drizzleDb.insert(builderTask).values(taskRows).onConflictDoNothing({
+      target: builderTask.taskId,
+    })
+  }
+  if (dmiRows.length > 0) {
+    await drizzleDb.insert(builderTaskDmi).values(dmiRows).onConflictDoNothing({
+      target: builderTaskDmi.dmiId,
+    })
+  }
+
+  return sourceDocByTask
 }
 
 export const GET = withAuth(
@@ -202,9 +232,10 @@ export const GET = withAuth(
     // Ensure the course's authored lesson tasks exist as deployable BuilderTask
     // rows before we read them (see materializeCourseFamilyTasks). Only for a
     // course-scoped session; non-critical, so a failure never blocks the panel.
+    let sourceDocByTask = new Map<string, SourceDocLite>()
     if (scopedFamily) {
       try {
-        await materializeCourseFamilyTasks(session.user.id, scopedFamily)
+        sourceDocByTask = await materializeCourseFamilyTasks(session.user.id, scopedFamily)
       } catch (err) {
         console.warn('[deployables] task materialization failed (non-critical):', err)
       }
@@ -277,6 +308,10 @@ export const GET = withAuth(
         lessonTitle: r.lessonTitle || null,
         lessonOrder: typeof r.lessonOrder === 'number' ? r.lessonOrder : null,
         dmiItems: safeItemsByTask.get(r.taskId) ?? [],
+        // The task's attached document (e.g. question-paper PDF), so deploying it
+        // shows the PDF in the live Materials panel. Durable fileKey; the socket
+        // re-signs the url on deploy. Null when the task has no document.
+        sourceDocument: sourceDocByTask.get(r.taskId) ?? null,
       })),
     })
   },

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -29,6 +29,14 @@ interface Deployable {
   lessonOrder: number | null
   /** Student-safe questions (answers already stripped server-side). */
   dmiItems: StudentDmiItem[]
+  /** The document the task was built from (e.g. a question-paper PDF), shown in
+   *  the live Materials panel when deployed. Null when the task has none. */
+  sourceDocument: {
+    fileName: string
+    fileUrl: string
+    fileKey: string
+    mimeType: string
+  } | null
 }
 
 interface LessonGroup {
@@ -169,6 +177,9 @@ export function SessionDeployPanel({
         source: t.type,
         lessonId: t.lessonId ?? undefined,
         dmiItems: t.dmiItems,
+        // Attached PDF (if any) — the server re-signs its url from the durable
+        // fileKey on deploy and shows it in the Materials panel for everyone.
+        sourceDocument: t.sourceDocument ?? undefined,
         deployedAt: Date.now(),
         polls: [],
         questions: [],
@@ -281,6 +292,11 @@ export function SessionDeployPanel({
                                         <span className="lowercase text-blue-500">
                                           · {t.dmiItems.length} q
                                           {t.dmiItems.length === 1 ? '' : 's'}
+                                        </span>
+                                      ) : null}
+                                      {t.sourceDocument ? (
+                                        <span className="inline-flex items-center gap-0.5 lowercase text-rose-500">
+                                          · <FileText className="h-3 w-3" /> pdf
                                         </span>
                                       ) : null}
                                     </p>


### PR DESCRIPTION
Follow-up to #1171 — adds the materials/PDF deployability you asked for, and fixes two gaps the #1171 adversarial review found (same code path).

## 1. Materials/PDFs deployable
A course task built from a document (e.g. the imported **question-paper PDF** on your "Assessment 1") stores it as `builderData.sourceDocument {fileKey,…}`. Now:
- the deployables route reads the **fresh** `sourceDocument` per task (durable `fileKey`) and returns it,
- the deploy panel sends it on `task:deploy`,
- the socket already re-signs the url via `ensureViewableSourceDocument` and shows it in the live **Materials panel** for everyone.

A small **"pdf"** cue marks such tasks in the panel. The doc is read fresh from `builderData` each call (not copied onto `BuilderTask`), so it can't go stale and re-linking a document just works.

## 2. Hardening (from the #1171 review)
- **Inline-edit clobber (regression fix):** materialization now uses `onConflictDoNothing` instead of overwriting `title`/`content` from `builderData`. An in-session inline edit (`tasks/[taskId]` PATCH writes straight to `BuilderTask`) is no longer stomped back to the builder snapshot on the next panel open. This also removes the per-open write-amplification the review flagged.
- **Silent 500-cap:** now logs a warning instead of silently dropping overflow tasks on a huge course.

## Answer-key isolation — re-verified
Raw `dmiItems` (with `answer`) live only in `BuilderTaskDmi`; the query still strips them via `buildStudentDeployPayload` → `toStudentDmiItem` (allowlist) before anything reaches a client. Unchanged.

## Known follow-up (not in this PR)
The other #1171 finding — a task *deleted* in the builder can linger as a materialized "ghost" — is left as a deliberate follow-up (safe reconciliation needs a way to distinguish materialized rows from deploy-created ones; noted, not silently ignored).

## Verification
- `tsc` clean · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)