### PR TITLE
fix(classroom): right-align SAI in tutor test-mode Classroom and remove panel corner lines

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10134,8 +10134,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
-                      mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border-0 bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                     )}
                   >
                     <div
@@ -10612,14 +10611,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                       </div>
                                     ) : null
                                   ) : (
-                                    <div
-                                      className={cn(
-                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0',
-                                        mainTab === 'live'
-                                          ? 'border-orange-300'
-                                          : 'border-violet-300'
-                                      )}
-                                    >
+                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border-0 bg-white p-0">
                                       <PanelErrorBoundary
                                         label="this view"
                                         resetKeys={[

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -348,6 +348,7 @@ export function TestTaskChat({
                 timestamp={m.timestamp ? new Date(m.timestamp) : undefined}
                 isClassroom={isClassroom}
                 studentOnRight
+                aiOnRight={isClassroom}
               />
             )
           })}

--- a/tutorme-app/src/components/classroom/chat-message-bubble.tsx
+++ b/tutorme-app/src/components/classroom/chat-message-bubble.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { resolvePublicUrl } from '@/lib/utils'
-import { FileText, ImageIcon } from 'lucide-react'
+import { Bot, FileText, ImageIcon } from 'lucide-react'
 import { PDFThumbnail } from '@/components/pdf/PDFThumbnail'
 import { resolveDocDisplayUrl, isDocDisplayable } from '@/lib/storage/doc-url'
 import { cn } from '@/lib/utils'
@@ -27,6 +27,8 @@ export interface ChatMessageBubbleProps {
   isClassroom?: boolean
   /** When true, student messages appear on the right (tutor/AI on left). */
   studentOnRight?: boolean
+  /** When true, AI/SAI messages appear on the right (used in the tutor classroom view). */
+  aiOnRight?: boolean
 }
 
 export function ChatMessageBubble({
@@ -41,10 +43,16 @@ export function ChatMessageBubble({
   re,
   isClassroom = false,
   studentOnRight = false,
+  aiOnRight = false,
 }: ChatMessageBubbleProps) {
+  // When aiOnRight is true, AI/SAI messages are on the right (tutor classroom view).
   // When studentOnRight is true, student messages are on the right (tutor/AI on left).
   // Otherwise the legacy behavior: tutor/AI on right, student on left.
-  const isRight = studentOnRight ? sender === 'student' : sender === 'tutor' || sender === 'ai'
+  const isRight = aiOnRight
+    ? sender === 'ai'
+    : studentOnRight
+      ? sender === 'student'
+      : sender === 'tutor' || sender === 'ai'
   const isStudent = sender === 'student'
   const showAvatar = !!avatarUrl || !!name
 
@@ -115,12 +123,16 @@ export function ChatMessageBubble({
                 'text-xs font-medium',
                 isStudent
                   ? 'border border-slate-200 bg-white text-slate-600'
-                  : isClassroom
-                    ? 'bg-orange-100 text-orange-700'
-                    : 'bg-violet-100 text-violet-700'
+                  : sender === 'ai'
+                    ? isClassroom
+                      ? 'bg-orange-100 text-orange-700'
+                      : 'bg-violet-100 text-violet-700'
+                    : isClassroom
+                      ? 'bg-orange-100 text-orange-700'
+                      : 'bg-violet-100 text-violet-700'
               )}
             >
-              {initial}
+              {sender === 'ai' ? <Bot className="h-5 w-5" /> : initial}
             </AvatarFallback>
           </Avatar>
           {sender === 'ai' && <span className="text-[9px] font-medium text-gray-400">{name}</span>}


### PR DESCRIPTION
- Right-aligns SAI messages in the tutor's Test → Classroom tab (so they match student-message placement in the student classroom view).
- Uses the Bot icon from the Teaching Assistant AI panel as the SAI avatar.
- Removes the colored borders on the Test/Classroom panel containers that were producing faint purple/orange corner lines.

Verified: npm run typecheck and npm run format:check pass.