### PR TITLE
fix: hide empty initial task tutor message in test mode when no task is loaded

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10872,11 +10872,17 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                   pciSpec={
                                                     previewExt ? undefined : taskBuilder.pciSpec
                                                   }
-                                                  questionText={`${taskBuilder.title}\n\n${previewExt ? previewExt.content : taskBuilder.taskContent}`}
+                                                  questionText={
+                                                    loadedTaskId
+                                                      ? `${taskBuilder.title}\n\n${previewExt ? previewExt.content : taskBuilder.taskContent}`
+                                                      : undefined
+                                                  }
                                                   sourceDocument={
-                                                    previewExt
-                                                      ? previewExt.sourceDocument
-                                                      : currentTaskDocument
+                                                    loadedTaskId
+                                                      ? previewExt
+                                                        ? previewExt.sourceDocument
+                                                        : currentTaskDocument
+                                                      : undefined
                                                   }
                                                   initialState={
                                                     isClassroomTab

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -376,7 +376,7 @@ export function TestTaskChat({
         )}
 
         {/* Text-only task: show the question text as the initial tutor message. */}
-        {!sourceDocument && questionText && (
+        {!sourceDocument && questionText?.trim() && (
           <ChatMessageBubble
             sender="tutor"
             name="Tutor"


### PR DESCRIPTION
When the tutor opens the Test mode without a task selected, the task preview was rendering an empty initial tutor message bubble (the question text was just whitespace). This change skips the initial task document / question text message unless a task is actually loaded, while keeping the SAI input and session-ready message visible.