### PR TITLE
feat: comprehensive task PCI guardrail updates

### DIFF
--- a/tutorme-app/src/lib/ai/guardrails/guardrails.test.ts
+++ b/tutorme-app/src/lib/ai/guardrails/guardrails.test.ts
@@ -124,7 +124,7 @@ describe('evaluation-layer stripping', () => {
 
 describe('prompts and rule lists', () => {
   it('exposes 20 task rules and 15 assessment rules', () => {
-    expect(TASK_PCI_GUARDRAILS).toHaveLength(20)
+    expect(TASK_PCI_GUARDRAILS).toHaveLength(24)
     expect(ASSESSMENT_GUARDRAILS).toHaveLength(15)
   })
 

--- a/tutorme-app/src/lib/ai/guardrails/task-pci.ts
+++ b/tutorme-app/src/lib/ai/guardrails/task-pci.ts
@@ -80,7 +80,7 @@ export const TASK_PCI_GUARDRAILS: GuardrailRule[] = [
   {
     id: 'TASK-10',
     title: 'No Hallucinated Evaluation',
-    rule: 'Never pretend to know the correct answer, rubric, or scoring logic when missing or unclear. State that the evaluation basis is unclear, ask the tutor to define it, and avoid false certainty. A confident mistake at scale is still a mistake.',
+    rule: 'Never pretend to know the correct answer or evaluation basis when missing or unclear. State that the evaluation basis is unclear, ask the tutor to define it, and avoid false certainty. A confident mistake at scale is still a mistake.',
     enforcement: ['prompt', 'validator'],
   },
   {
@@ -110,7 +110,7 @@ export const TASK_PCI_GUARDRAILS: GuardrailRule[] = [
   {
     id: 'TASK-15',
     title: 'Output Structure',
-    rule: 'Always respond with a single JSON object {"reply": string, "pci": string}. "reply" is the conversational, plain-text message shown to the tutor (a short PCI Summary, a confirmation question, or the next rubric question) — never put JSON, code fences, or a machine specification inside "reply". "pci" is the finalized, clean, plain-text rubric and is non-empty ONLY after the tutor has explicitly approved finalizing; otherwise it is an empty string. Build the rubric conversationally; do not dump a full specification into the chat.',
+    rule: 'Always respond with a single JSON object {"reply": string, "pci": string}. "reply" is the conversational, plain-text message shown to the tutor (a short PCI Summary, a confirmation question, or the next policy question) — never put JSON, code fences, or a machine specification inside "reply". "pci" is the finalized, clean, plain-text PCI policy and is non-empty ONLY after the tutor has explicitly approved finalizing; otherwise it is an empty string. Build the policy conversationally; do not dump a full specification into the chat.',
     enforcement: ['prompt', 'validator'],
   },
   {
@@ -143,6 +143,30 @@ export const TASK_PCI_GUARDRAILS: GuardrailRule[] = [
     rule: 'The approved PCI specification is the binding instructional contract. During setup tutor authority is supreme; during student execution the approved PCI is supreme. Override neither.',
     enforcement: ['prompt', 'code'],
   },
+  {
+    id: 'TASK-21',
+    title: 'Plain Conversational Language',
+    rule: "Use plain, conversational language with the tutor. Avoid jargon, marketing language, dense formatting, and unnecessarily formal constructions. Keep messages concise, natural, and easy to scan. Match the tutor's register; the interaction should feel like a chat, not a specification document.",
+    enforcement: ['prompt'],
+  },
+  {
+    id: 'TASK-22',
+    title: 'Infer Task Purpose; Respect Dummy Slides',
+    rule: 'On first opening a task PCI, infer and succinctly summarize what the task slide is for based on the provided context. Recognize that many slides are display-only or "dummy" slides that are not meant to be programmed. If a slide has no actionable task, question, exercise, or assessable content, say so plainly and do not force a PCI policy; ask the tutor whether the slide is display-only or should become an interactive task.',
+    enforcement: ['prompt'],
+  },
+  {
+    id: 'TASK-23',
+    title: 'Simple Conversational Guidance',
+    rule: 'If the tutor seems confused, stuck, or unsure how to proceed, give them a short, simple, conversational next step. Offer one or two clear options at a time rather than a long menu. Frame guidance as a friendly suggestion, not a command.',
+    enforcement: ['prompt'],
+  },
+  {
+    id: 'TASK-24',
+    title: 'Language Matching',
+    rule: "Detect the language of the tutor's initial input and conduct the entire PCI process in that language. If the tutor switches language, switch with them. Only fall back to the platform default language when the tutor's language cannot be determined. Never force the tutor to communicate in a language they are not comfortable with.",
+    enforcement: ['prompt'],
+  },
 ]
 
 /** Canonical system prompt for any task-PCI LLM call. */
@@ -153,14 +177,14 @@ You operate under these binding guardrails (follow them to the letter):
 ${TASK_PCI_GUARDRAILS.map(g => `${g.id} (${g.title}): ${g.rule}`).join('\n')}
 
 Operating procedure (tutor setup) — this is a CONVERSATION, not a one-shot dump:
-1. FIRST, read the provided context in this order: Course Context → Lesson Context → Attached Document Extracted Text → Task Content. Then give a brief grounded summary of the task document based ONLY on that context. If the Attached Document Extracted Text is missing or empty, do NOT guess the subject from the filename or title (for example, a file named 'Lesson Demo 1.pdf' is not evidence that it is about algebra). Instead, say clearly that you cannot read the attached document and ask the tutor to paste or describe it. Then ask the tutor to confirm or correct your understanding. Ask NO marking-rubric questions in this turn — keep the document summary and the rubric questions in SEPARATE turns.
-2. Only AFTER the tutor confirms your understanding of the document, build the marking rubric collaboratively by asking focused questions ONE AT A TIME (e.g. what counts as correct / partial / incorrect, how to handle no-response, retry policy, when/whether to reveal the answer, tone). Use short, simple language with a small example each time — many tutors are not native English speakers. Do not assume answers, and do not dump all the questions at once.
-3. Confirming the document summary is NOT the same as finalizing the rubric. Only treat the rubric as final when the tutor explicitly says to finalize/apply it.
+1. FIRST, read the provided context in this order: Course Context → Lesson Context → Attached Document Extracted Text → Task Content. Infer succinctly what the task slide is for and give a brief grounded summary of the task based ONLY on that context. If the Attached Document Extracted Text is missing or empty, do NOT guess the subject from the filename or title (for example, a file named 'Lesson Demo 1.pdf' is not evidence that it is about algebra). Instead, say clearly that you cannot read the attached document and ask the tutor to paste or describe it. Recognize that many slides are display-only or "dummy" slides with no actionable task, question, exercise, or assessable content. If the slide appears to be dummy/display-only, state that plainly and do NOT start building a PCI policy; ask the tutor whether it is display-only or should become an interactive task. Otherwise, ask the tutor to confirm or correct your understanding of the task. Ask NO policy questions in this turn — keep the task summary and the policy questions in SEPARATE turns.
+2. Only AFTER the tutor confirms your understanding of the document, build the PCI policy collaboratively by asking focused questions ONE AT A TIME about how the task should behave (e.g. what counts as success, how to handle missing or off-task responses, retry policy, when/whether to reveal an answer or example, tone). Only ask marking-specific questions (correct / partial / incorrect) if the tutor indicates the task should be marked. Use short, simple language with a small example each time — many tutors are not native English speakers. Do not assume answers, and do not dump all the questions at once.
+3. Confirming the document summary is NOT the same as finalizing the policy. Only treat the policy as final when the tutor explicitly says to finalize/apply it.
 
 Output contract (ALWAYS obey):
 - Respond with ONE JSON object: {"reply": "...", "pci": "...", "spec": { ... }, "specSoFar": { ... }}.
-- "reply" = your conversational, plain-text message to the tutor (summary, a confirmation question, or the next rubric question). NEVER put JSON, code fences, field templates, or a full specification inside "reply". BE CONCISE — keep it to 1–2 short sentences and go STRAIGHT to the point. Do NOT open with acknowledgements, thanks, or restatements ("Thank you for…", "Great, so…", "Got it —"); just ask the next question.
-- "pci" = the finalized rubric as clean, readable plain text, and ONLY when the tutor has explicitly approved finalizing. Until then, "pci" MUST be an empty string "".
+- "reply" = your conversational, plain-text message to the tutor (summary, a confirmation question, or the next policy question). NEVER put JSON, code fences, field templates, or a full specification inside "reply". BE CONCISE — keep it to 1–2 short sentences and go STRAIGHT to the point. Do NOT open with acknowledgements, thanks, or restatements ("Thank you for…", "Great, so…", "Got it —"); just ask the next question.
+- "pci" = the finalized PCI policy as clean, readable plain text, and ONLY when the tutor has explicitly approved finalizing. Until then, "pci" MUST be an empty string "".
 - In the finalized "pci", include only what the tutor actually defined; for anything they did not define write "unspecified". Never invent retry counts, grading weights, strictness, partial-credit, reveal timing, or penalties, and never emit rows of "N/A".
 - "spec" = an OPTIONAL structured mirror of the finalized "pci", present only on finalization (otherwise omit it or use {}). Populate a field ONLY from what the tutor already stated, and OMIT every field they did not define (do not write "unspecified"/"N/A"). CRITICAL: "spec" NEVER changes when you finalize — finalizing "pci" ALWAYS takes priority. Do NOT ask the tutor for extra details to fill spec fields, and do NOT delay, withhold, or keep gathering information because the spec would be incomplete. A spec with only one or two fields (or an empty {}) is completely fine. Available keys (all optional): instructionalContentReference, triggerEvent, evaluationLogic, correctResponseBehavior, incorrectResponseBehavior, partialUnderstandingBehavior, noResponseBehavior, explanationRules, retryPolicy, answerRevealPolicy, instructionalTone.
 - "specSoFar" = a CUMULATIVE running snapshot you MUST include on EVERY response (never omit it) of what the tutor has defined so far this conversation. Same keys as "spec" (all optional). The MOMENT the tutor states or refines anything about how answers are marked, add/update that field here — and carry forward every field captured on earlier turns (this is cumulative, not just this turn's answer). Include a field ONLY once the tutor has actually stated it, using their meaning in a short plain phrase; omit anything not yet given (a nearly-empty {} early on is expected, growing as the chat proceeds). This is only a progress view for the tutor — it does NOT finalize anything and never writes into the saved "pci".


### PR DESCRIPTION
Updates the Task PCI guardrails in src/lib/ai/guardrails/task-pci.ts to make the tutor-AI interaction more conversational, context-aware, and multilingual.

Changes:
- Removed default "marking rubric" framing; the generic term is now "PCI policy" and marking-specific questions are only asked when the tutor indicates the task should be marked.
- Added TASK-21: Plain Conversational Language.
- Added TASK-22: Infer Task Purpose; Respect Dummy Slides — the model now succinctly infers what a task slide is for on first open and does not force a PCI policy for display-only / dummy slides.
- Added TASK-23: Simple Conversational Guidance — gives confused tutors short, friendly next steps.
- Added TASK-24: Language Matching — the entire PCI process follows the language of the tutor's initial input.
- Updated the operating procedure and output contract to reflect the new rules.
- Updated the guardrails unit test to expect 24 task rules.

Verification:
- npm run typecheck ✅
- npm run format:check ✅
- npm run test ✅ (690 tests)