### PR TITLE
fix(ui): apply focus-flash suppression to all dropdown/select panels

### DIFF
--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -721,6 +721,20 @@
     z-index: 1000;
   }
 
+  /* Suppress the white focus-ring flash on Radix dropdown/select panels and items.
+     Keyboard users still get the hover/focus-visible pill from the component classes. */
+  [data-radix-dropdown-menu-content],
+  [data-radix-dropdown-menu-sub-content],
+  [data-radix-select-content] {
+    outline: none !important;
+  }
+  [data-radix-dropdown-menu-content] [data-highlighted],
+  [data-radix-dropdown-menu-sub-content] [data-highlighted],
+  [data-radix-select-content] [data-highlighted] {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+
   /* Typography Hierarchy - Fira Code for headings */
   h1,
   h2,

--- a/tutorme-app/src/components/ui/dropdown-menu.tsx
+++ b/tutorme-app/src/components/ui/dropdown-menu.tsx
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'focus-visible:bg-accent focus-visible:ring-primary/50 data-[state=open]:bg-accent flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-offset-0',
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-all hover:bg-white/20 focus:outline-none focus-visible:bg-white/20 focus-visible:ring-0 data-[state=open]:bg-white/20',
       inset && 'pl-8',
       className
     )}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover min-w-[8rem] overflow-hidden rounded-[14px] border border-white/[0.08] py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.25)]',
-        'bg-[rgba(31,41,55,0.50)] text-white backdrop-blur-[18px]',
+        'bg-[rgba(31,41,55,0.50)] text-white backdrop-blur-[18px] focus-visible:outline-none focus-visible:ring-0',
         className
       )}
       {...props}

--- a/tutorme-app/src/components/ui/select.tsx
+++ b/tutorme-app/src/components/ui/select.tsx
@@ -20,7 +20,7 @@ const SelectTrigger = React.forwardRef<
     ref={ref}
     style={{ outline: 'none' }}
     className={cn(
-      'border-input bg-background placeholder:text-muted-foreground focus-visible:ring-primary/50 flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'border-input bg-background placeholder:text-muted-foreground flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className
     )}
     {...props}
@@ -42,7 +42,7 @@ const SelectContent = React.forwardRef<
       ref={ref}
       className={cn(
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-popover relative max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-white/[0.12] shadow-[0_18px_40px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.16)]',
-        'bg-[linear-gradient(135deg,rgba(32,28,24,0.50),rgba(82,82,82,0.50))] py-2 text-white saturate-[140%] backdrop-blur-[18px]',
+        'bg-[linear-gradient(135deg,rgba(32,28,24,0.50),rgba(82,82,82,0.50))] py-2 text-white saturate-[140%] backdrop-blur-[18px] focus-visible:outline-none focus-visible:ring-0',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className


### PR DESCRIPTION
## Summary
The Course Selector dropdown focus-flash fix from previous PRs only reliably covered that single component. This change extends the same suppression to every Radix dropdown menu, submenu, and select panel in the app.

## Changes
- Updated , , and  to drop  and rely on the existing  /  pill.
- Updated  and  similarly.
- Added global CSS rules in  for , ,  and their  children to prevent the Radix accessibility flash while keeping keyboard navigation visual feedback on items.

## Verification
- 
> solocorn-app@0.1.0 typecheck
> tsc --noEmit ✅
- 
> solocorn-app@0.1.0 format:check
> prettier --check "src/**/*.{ts,tsx}" "scripts/**/*.js" "**/*.js"

Checking formatting...
All matched files use Prettier code style! ✅
- 
> solocorn-app@0.1.0 test
> vitest run


[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90mC:/VSCODE/Tutor/tutorme-app[39m

 [32m✓[39m src/lib/security/client-encryption.test.ts [2m([22m[2m12 tests[22m[2m)[22m[33m 1017[2mms[22m[39m
 [32m✓[39m src/lib/ai/fetch-utils.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 121[2mms[22m[39m
 [32m✓[39m src/lib/one-on-one/time.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 56[2mms[22m[39m
 [32m✓[39m src/lib/time/tz.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 49[2mms[22m[39m
 [32m✓[39m src/components/class/__tests__/hooks.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 107[2mms[22m[39m
 [32m✓[39m src/__tests__/security/comprehensive-security.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 157[2mms[22m[39m
 [32m✓[39m src/app/[locale]/tutor/dashboard/components/hooks/use-pci.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 86[2mms[22m[39m
 [32m✓[39m src/lib/ai/memory-store.server.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 1885[2mms[22m[39m
     [33m[2m✓[22m[39m returns null when student profile cannot be built [33m 1882[2mms[22m[39m
[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mtask domain: extracts {reply,pci,spec} — reply, finalized rubric, and structured spec (on approval)
[22m[39m[pci-master] domain=task composition=- documentKind=-

[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mtask domain: offers the rubric but flags it unconfirmed until the tutor applies (TASK-5)
[22m[39m[pci-master] domain=task composition=- documentKind=-

[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mtask domain: empty pci until finalized (no draft surfaced)
[22m[39m[pci-master] domain=task composition=- documentKind=-

[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mtask domain: falls back gracefully when the model ignores the envelope
[22m[39m[pci-master] domain=task composition=- documentKind=-

[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mflag ON: routes local generation through the agent-kit runner, preserving skipCache/timeout/retries + guardrails
[22m[39m[pci-master] domain=task composition=- documentKind=-

[90mstdout[2m | src/app/api/ai/pci-master/route.test.ts[2m > [22m[2m/api/ai/pci-master[2m > [22m[2mforwards tiered task context (course, lesson, extracted PDF text) into the LLM prompt
[22m[39m[pci-master] domain=task composition=- documentKind=-

 [32m✓[39m src/app/api/ai/pci-master/route.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 76[2mms[22m[39m
 [32m✓[39m src/lib/assessment/marking-scheme.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 51[2mms[22m[39m
 [32m✓[39m src/app/api/tutor/test-grade/route.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 43[2mms[22m[39m
 [32m✓[39m src/app/api/ai/parse-marking-scheme/route.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m src/lib/math/expression.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 149[2mms[22m[39m
 [32m✓[39m src/app/api/ai/chat/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m src/lib/auth.test.ts [2m([22m[2m5 tests[22m[2m)[22m[33m 1862[2mms[22m[39m
       [33m[2m✓[22m[39m returns a non-empty string different from input [33m 632[2mms[22m[39m
       [33m[2m✓[22m[39m produces different hashes for same input (salt) [33m 1226[2mms[22m[39m
 [32m✓[39m src/lib/assessment/deploy-safety.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m src/app/api/admin/auth/login/route.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m src/lib/security/proxy-url.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m src/lib/assessment/student-dmi.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 33[2mms[22m[39m
 [32m✓[39m src/app/api/auth/register/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 35[2mms[22m[39m
 [32m✓[39m src/app/api/public/test-kimi/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/lib/data/category-country.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 24[2mms[22m[39m
 [32m✓[39m src/app/api/admin/geolocation/route.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m src/app/api/auth/register/admin/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m src/app/api/polls/[pollId]/route.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 27[2mms[22m[39m
 [32m✓[39m src/app/api/admin/api-keys/[id]/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/app/api/admin/llm/routing/route.behavior.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m src/lib/api/middleware.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m src/app/api/admin/llm/providers/route.behavior.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 26[2mms[22m[39m
 [32m✓[39m src/app/api/courses/list/route.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/app/api/health/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/app/api/admin/auth/bridge/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/app/api/csp-report/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m src/app/api/admin/llm/providers/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/app/api/admin/llm/routing/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/lib/security/upload-access.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/lib/ai/guardrails/variants.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/lib/grading/auto-grade.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/app/api/admin/api-keys/route.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 24[2mms[22m[39m
 [32m✓[39m src/lib/ai/guardrails/curriculum.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 20[2mms[22m[39m
[90mstdout[2m | src/lib/socket-server-enhanced.lifecycle.test.ts[2m > [22m[2msocket-server-enhanced lifecycle[2m > [22m[2minitializes without REDIS_URL and registers cleanup timers
[22m[39m[Socket] Initializing enhanced server...

 [32m✓[39m src/lib/socket-server-enhanced.lifecycle.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/lib/grading/pci-grader.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/lib/ai/session-tutor-guardrails.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/app/api/admin/webhook-events/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/app/api/conversations/[id]/messages/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/lib/ai/guardrails/guardrails.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/app/api/polls/[pollId]/vote/route.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/app/api/admin/feature-flags/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/lib/ai/orchestrator-provider.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/app/api/proxy-file/route.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/app/api/admin/settings/route.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/app/api/public/test-ping/route.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/lib/assessment/document-signals.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/lib/assessment/dmi-generate-gate.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/app/api/student/resources/route.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/lib/security/rate-limit.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/lib/security/safe-markdown.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/app/api/admin/analytics/topology/route.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/lib/assessment/scheme-response.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/lib/ai/fallback-provider.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/app/[locale]/tutor/courses/components/save-course.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/lib/assessment/assessment-gates.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/proxy.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/app/api/student/assignments/[taskId]/upload/route.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m src/lib/ai/json.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/lib/documents/split-sections.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/validation/parent-child-security.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/lib/documents/conversion-limiter.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/lib/security/payment-security.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/lib/courses/course-builder-guards.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/lib/courses/doc-pane-visibility.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/lib/ai/agent-kit/runner.tools.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/lib/security/sanitize.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/ai/agent-kit/runner.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/components/one-on-one/one-on-one-request-card.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/agents/course-materials-service.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/assessment/mcq-answer.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/ai/orchestrator.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/lib/api/middleware.validation.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/assessment/sections.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/assessment/task-pci-context.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/ai/agent-kit/agents/pci-master.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/adk-client.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/socket-server-enhanced.rate-limit.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/courses/lesson-usage.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/lib/middleware-edge/middleware-edge.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/assessment/dmi-readiness.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/one-on-one/enter-classroom.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/lib/assessment/pci-spec.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/grading/marking-basis.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/lib/assessment/confidence.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/assessment/reveal-policy.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/lib/agents/shared-data.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/assessment/pci.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/lib/classroom/lobby-sessions.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/payments/factory.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/lib/documents/ensure-viewable.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/ai/agent-kit/agents/tutor.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/__tests__/migrate-retry.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/lib/assessment/pci-finalize.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/lib/one-on-one/format.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/lib/security/rbac.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/lib/payments/hitpay.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/student-availability.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/lib/assessment/active-assessment.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/lib/agents/tutor-assist-service.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/lib/payments/refund-one-on-one.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/lib/socket-server-enhanced.presence.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m

[2m Test Files [22m [1m[32m109 passed[39m[22m[90m (109)[39m
[2m      Tests [22m [1m[32m690 passed[39m[22m[90m (690)[39m
[2m   Start at [22m 00:21:36
[2m   Duration [22m 43.57s[2m (transform 6.22s, setup 47.34s, import 114.52s, tests 7.26s, environment 228.20s)[22m ✅ 109 test files, 690 tests passed

## Related
Closes the active issue: dropdown focus flash still appears in non-course-selector panels.