### PR TITLE
fix(classroom): restore panel and display-area outlines without colored corner border

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10150,7 +10150,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border-0 bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                     )}
                   >
                     <div
@@ -10627,7 +10627,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                       </div>
                                     ) : null
                                   ) : (
-                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border-0 bg-white p-0">
+                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0">
                                       <PanelErrorBoundary
                                         label="this view"
                                         resetKeys={[


### PR DESCRIPTION
## Summary
The previous Classroom/Test panel edit changed both the outer panel Card and the inner display area from `border` to `border-0` to remove the faint colored corner lines (`border-orange-300` / `border-violet-300`). That also removed the main panel outline and the display-area outline entirely.

## Fix
Restore a neutral `border` on both containers while keeping the colored conditional border classes removed, so the panel and display area outlines return without the second colored corner outline.

- `CourseBuilder` center panel Card: `border-0` → `border`
- `CourseBuilder` display area div: `border-0` → `border`

## Verification
- `npm run typecheck` ✅
- `npm run format:check` ✅
- `npm run test` ✅ — 109 test files, 690 tests passed
