### PR TITLE
fix(builder): correct BuilderTaskDmi column drift so DMI + documents actually show before deploy

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -247,42 +247,56 @@ async function materializeCourseFamilyTasks(
     )
   }
 
-  if (taskRows.length > 0) {
-    // Insert new tasks only. Do NOT overwrite an existing row: an in-session
-    // inline edit (tasks/[taskId] PATCH) writes title/content straight to
-    // BuilderTask, and re-opening the panel must not stomp it back to the
-    // builderData snapshot. Also avoids re-writing unchanged rows on every open.
-    await drizzleDb.insert(builderTask).values(taskRows).onConflictDoNothing({
-      target: builderTask.taskId,
-    })
-  }
-  if (dmiRows.length > 0) {
-    await drizzleDb.insert(builderTaskDmi).values(dmiRows).onConflictDoNothing({
-      target: builderTaskDmi.dmiId,
-    })
-  }
+  // The mutations below are best-effort: they make authored tasks appear as
+  // deployable rows. Crucially they are wrapped so that a write failure (e.g.
+  // an unexpected constraint) can NEVER discard `sourceDocByTask`, which is a
+  // pure read from builderData and is what surfaces a task's document in the
+  // deploy preview / live Materials panel. Previously a throw here bubbled to
+  // the caller's catch, which reset the map to empty — silently dropping every
+  // task's document. Read-then-write separation keeps the document reliable.
+  try {
+    if (taskRows.length > 0) {
+      // Insert new tasks only. Do NOT overwrite an existing row: an in-session
+      // inline edit (tasks/[taskId] PATCH) writes title/content straight to
+      // BuilderTask, and re-opening the panel must not stomp it back to the
+      // builderData snapshot. Also avoids re-writing unchanged rows on every open.
+      await drizzleDb.insert(builderTask).values(taskRows).onConflictDoNothing({
+        target: builderTask.taskId,
+      })
+    }
+    if (dmiRows.length > 0) {
+      await drizzleDb.insert(builderTaskDmi).values(dmiRows).onConflictDoNothing({
+        target: builderTaskDmi.dmiId,
+      })
+    }
 
-  // Reconcile deletions: soft-delete family tasks that we materialized but that
-  // are no longer in builderData (the tutor deleted them in the builder) — so a
-  // deleted task stops showing as a deployable "ghost". Only touches rows that
-  // were NEVER deployed (no DeployedMaterial); a task that was actually deployed
-  // has live history and is kept even if later removed from the builder. `seen`
-  // holds every current authored id. This distinguisher works without a flag, so
-  // it also cleans up rows materialized by earlier versions.
-  const currentIds = [...seen]
-  await drizzleDb
-    .update(builderTask)
-    .set({ deletedAt: now })
-    .where(
-      and(
-        eq(builderTask.tutorId, tutorId),
-        inArray(builderTask.courseId, familyIds),
-        isNull(builderTask.deletedAt),
-        ne(builderTask.courseId, ADHOC_ANCHOR_COURSE_ID),
-        ...(currentIds.length > 0 ? [notInArray(builderTask.taskId, currentIds)] : []),
-        sql`NOT EXISTS (SELECT 1 FROM "DeployedMaterial" dm WHERE dm."itemId" = ${builderTask.taskId})`
+    // Reconcile deletions: soft-delete family tasks that we materialized but that
+    // are no longer in builderData (the tutor deleted them in the builder) — so a
+    // deleted task stops showing as a deployable "ghost". Only touches rows that
+    // were NEVER deployed (no DeployedMaterial); a task that was actually deployed
+    // has live history and is kept even if later removed from the builder. `seen`
+    // holds every current authored id. This distinguisher works without a flag, so
+    // it also cleans up rows materialized by earlier versions.
+    const currentIds = [...seen]
+    await drizzleDb
+      .update(builderTask)
+      .set({ deletedAt: now })
+      .where(
+        and(
+          eq(builderTask.tutorId, tutorId),
+          inArray(builderTask.courseId, familyIds),
+          isNull(builderTask.deletedAt),
+          ne(builderTask.courseId, ADHOC_ANCHOR_COURSE_ID),
+          ...(currentIds.length > 0 ? [notInArray(builderTask.taskId, currentIds)] : []),
+          sql`NOT EXISTS (SELECT 1 FROM "DeployedMaterial" dm WHERE dm."itemId" = ${builderTask.taskId})`
+        )
       )
+  } catch (err) {
+    console.warn(
+      '[deployables] materialization writes failed (non-critical); documents/tasks still surfaced from builderData:',
+      err
     )
+  }
 
   return sourceDocByTask
 }

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -459,7 +459,10 @@ function TaskPreviewOverlay({
   // extract text from an uploaded doc. It's noise, not authored content — show
   // the real content only, and never as the sole "preview" of a task.
   const contentText = task.content?.trim() ?? ''
-  const isImportPlaceholder = /^\[Imported .+\]$/.test(contentText)
+  // The importer emits "[Imported file.docx]" (single upload) or several such
+  // blocks separated by blank lines (multi-upload). Match either shape wholly —
+  // real authored content interleaved with a block breaks the match and is shown.
+  const isImportPlaceholder = /^(\[Imported .+\]\s*)+$/.test(contentText)
   const showContent = contentText.length > 0 && !isImportPlaceholder
   const hasAnyPreview = !!task.sourceDocument || showContent || task.dmiItems.length > 0
 

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -455,6 +455,14 @@ function TaskPreviewOverlay({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
+  // The importer stores "[Imported <file>]" as placeholder content when it can't
+  // extract text from an uploaded doc. It's noise, not authored content — show
+  // the real content only, and never as the sole "preview" of a task.
+  const contentText = task.content?.trim() ?? ''
+  const isImportPlaceholder = /^\[Imported .+\]$/.test(contentText)
+  const showContent = contentText.length > 0 && !isImportPlaceholder
+  const hasAnyPreview = !!task.sourceDocument || showContent || task.dmiItems.length > 0
+
   return (
     <div
       className="pointer-events-auto fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
@@ -490,7 +498,10 @@ function TaskPreviewOverlay({
             </div>
           ) : null}
 
-          {task.content ? (
+          {/* Hide the auto-generated "[Imported file.docx]" placeholder content —
+              it's noise once the actual document is shown above. Only real
+              authored content is rendered. */}
+          {showContent ? (
             <div
               className="prose prose-sm mb-4 max-w-none text-slate-700"
               dangerouslySetInnerHTML={{ __html: sanitizeHtml(task.content) }}
@@ -561,7 +572,7 @@ function TaskPreviewOverlay({
             </ol>
           ) : null}
 
-          {!task.sourceDocument && !task.content && task.dmiItems.length === 0 ? (
+          {!hasAnyPreview ? (
             <p className="text-sm text-slate-400">This item has no previewable content.</p>
           ) : null}
         </div>

--- a/tutorme-app/src/lib/db/schema/tables/builder.ts
+++ b/tutorme-app/src/lib/db/schema/tables/builder.ts
@@ -141,7 +141,13 @@ export const builderTaskVersion = pgTable(
 export const builderTaskDmi = pgTable(
   'BuilderTaskDmi',
   {
-    dmiId: text('id').primaryKey().notNull(),
+    // NOTE: the prod column is literally "dmiId" (see migration 0020), NOT the
+    // usual "id". Mapping it to text('id') was a latent drift bug: every
+    // INSERT/upsert drizzle generated referenced a non-existent "id" column and
+    // threw `column "id" does not exist`, so nothing ever persisted here (answer
+    // keys on deploy, materialized DMI, etc. all silently failed). Keep this
+    // aligned with the actual column name.
+    dmiId: text('dmiId').primaryKey().notNull(),
     taskId: text('taskId')
       .notNull()
       .references(() => builderTask.taskId, { onDelete: 'cascade' }),
@@ -165,7 +171,9 @@ export const builderTaskDmi = pgTable(
 export const builderTaskDmiVersion = pgTable(
   'BuilderTaskDmiVersion',
   {
-    versionId: text('id').primaryKey().notNull(),
+    // Same drift as BuilderTaskDmi above — the prod column is "versionId", not
+    // "id" (migration 0020). Map it correctly so inserts don't throw.
+    versionId: text('versionId').primaryKey().notNull(),
     taskId: text('taskId')
       .notNull()
       .references(() => builderTask.taskId, { onDelete: 'cascade' }),


### PR DESCRIPTION
## The report
Tutors couldn't view an assessment's content before deploying — the preview showed only a `[Imported ….docx]` placeholder, no document, no questions. (Screenshot: `DEPLOY.png`.)

## Root cause — a schema-drift bug that has been silently breaking DMI persistence
The drizzle schema mapped `BuilderTaskDmi`'s primary key as `text('id')`, but the **actual prod column** (migration `0020`) is **`dmiId`**. So every `INSERT` drizzle generated referenced a non-existent `"id"` column and threw `column "id" does not exist`. Confirmed against prod: **`BuilderTaskDmi` has 0 rows** — answer-key persistence on deploy, materialized DMI, and version rows have *all* been failing silently. `BuilderTaskDmiVersion` had the identical drift (`versionId`).

That failure cascaded into the deploy preview:
- `materializeCourseFamilyTasks` builds a per-task `sourceDocByTask` map (a pure read from `builderData`) but only **returns it after** writing `BuilderTask`/`BuilderTaskDmi` rows.
- The DMI insert threw → the caller's `catch` reset the map to **empty** → every task lost its `sourceDocument` → the attached PDF never reached the preview or the live Materials panel.

Confirmed via prod logs: `[deployables] task materialization failed (non-critical): … insert into "BuilderTaskDmi" …`.

## Fixes
1. **Map both PKs to their real columns** — `BuilderTaskDmi.dmiId → text('dmiId')`, `BuilderTaskDmiVersion.versionId → text('versionId')`. **No DDL** — prod already has these columns; this only aligns the ORM with reality. Verified the corrected insert **succeeds** against prod (in a rolled-back transaction). This restores answer-key persistence, auto-grading reads, materialized DMI, and student DMI reads — not just the preview.
2. **Harden `materializeCourseFamilyTasks`** — wrap the best-effort writes so a write failure can *never* discard `sourceDocByTask`. A task's document is surfaced from `builderData` regardless of whether the materialization writes succeed.
3. **Preview polish** — suppress the auto-generated `[Imported <file>]` placeholder when a real document is shown; base the empty-state on real content.

## Impact note
`BuilderTaskDmi` writes have never worked in prod. After this deploys, deploying a task will start **persisting its answer key**, and DMI auto-grading will begin functioning as designed. This is the intended behavior that the drift was suppressing.

## Verification
- `tsc` clean · unit tests pass · `npm run build` succeeds
- Corrected `dmiId` insert verified against prod (rolled back, wrote nothing)
- Confirmed the target assessment's `sourceDocument` (a valid PDF `fileKey`) is present in `builderData` and will now reach the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)