### PR TITLE
feat(deploy-panel): nest tasks under their real lessons + foldable lessons

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -375,9 +375,17 @@ export const GET = withAuth(
       const scopedIds = new Set(lessonRows.map(l => l.lessonId))
       const byRoot = new Map<string, string>()
       const byOrder = new Map<number, string>()
+      // `order` has no unique constraint; only use it as a fallback for orders that
+      // identify exactly ONE lesson, so a duplicate order never mis-nests a task
+      // (an ambiguous one falls through to "Other tasks" instead of guessing).
+      const orderCount = new Map<number, number>()
+      for (const l of lessonRows) {
+        if (typeof l.order === 'number') orderCount.set(l.order, (orderCount.get(l.order) ?? 0) + 1)
+      }
       for (const l of lessonRows) {
         byRoot.set(l.sourceLessonId || l.lessonId, l.lessonId)
-        if (typeof l.order === 'number') byOrder.set(l.order, l.lessonId)
+        if (typeof l.order === 'number' && orderCount.get(l.order) === 1)
+          byOrder.set(l.order, l.lessonId)
       }
       resolveScopedLessonId = (lessonId, sourceId, order) => {
         if (!lessonId) return null

--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -329,6 +329,18 @@ export const GET = withAuth(
     // not just the tasks.
     let scopedLessons: { lessonId: string; title: string; order: number }[] = []
     let scopedCourse: { courseId: string; name: string; variantName: string } | null = null
+    // Correlate a family task's lesson to THIS scoped course's lesson. Template and
+    // published-variant lessons don't share ids, but a published lesson records the
+    // template lesson it was copied from in `sourceLessonId`, so both resolve to the
+    // same "root" (sourceLessonId || id). Falls back to matching by `order`. Without
+    // this, a task authored under the template (or a sibling variant) has a lessonId
+    // that isn't in the scoped course's lesson list and would fall into "Other tasks"
+    // instead of nesting under its real lesson.
+    let resolveScopedLessonId: (
+      lessonId: string | null,
+      sourceId: string | null,
+      order: number | null
+    ) => string | null = lessonId => lessonId
     if (scopedCourseId) {
       const [lessonRows, courseRows, variantRows] = await Promise.all([
         drizzleDb
@@ -336,6 +348,7 @@ export const GET = withAuth(
             lessonId: courseLesson.lessonId,
             title: courseLesson.title,
             order: courseLesson.order,
+            sourceLessonId: courseLesson.sourceLessonId,
           })
           .from(courseLesson)
           .where(and(eq(courseLesson.courseId, scopedCourseId), isNull(courseLesson.deletedAt)))
@@ -356,6 +369,26 @@ export const GET = withAuth(
         title: l.title || 'Untitled lesson',
         order: typeof l.order === 'number' ? l.order : 0,
       }))
+
+      // rootId → scoped lessonId (rootId = the template lesson id both a template
+      // lesson and its published copies share) and order → scoped lessonId fallback.
+      const scopedIds = new Set(lessonRows.map(l => l.lessonId))
+      const byRoot = new Map<string, string>()
+      const byOrder = new Map<number, string>()
+      for (const l of lessonRows) {
+        byRoot.set(l.sourceLessonId || l.lessonId, l.lessonId)
+        if (typeof l.order === 'number') byOrder.set(l.order, l.lessonId)
+      }
+      resolveScopedLessonId = (lessonId, sourceId, order) => {
+        if (!lessonId) return null
+        if (scopedIds.has(lessonId)) return lessonId // already a scoped lesson
+        const root = sourceId || lessonId
+        return (
+          byRoot.get(root) ??
+          (typeof order === 'number' ? byOrder.get(order) : undefined) ??
+          lessonId // truly foreign — leave as-is (client shows it under "Other tasks")
+        )
+      }
       scopedCourse = {
         courseId: scopedCourseId,
         name: courseRows[0]?.name || 'Course',
@@ -377,6 +410,7 @@ export const GET = withAuth(
         coursePublished: course.isPublished,
         lessonTitle: courseLesson.title,
         lessonOrder: courseLesson.order,
+        lessonSourceId: courseLesson.sourceLessonId,
       })
       .from(builderTask)
       .leftJoin(course, eq(builderTask.courseId, course.courseId))
@@ -419,24 +453,79 @@ export const GET = withAuth(
       }
     }
 
-    return NextResponse.json({
-      tasks: rows.map(r => ({
+    // Scoped-lesson metadata (title/order) keyed by the scoped lessonId, so a task
+    // remapped onto a scoped lesson also reports that lesson's title/order.
+    const scopedLessonById = new Map(scopedLessons.map(l => [l.lessonId, l]))
+
+    // Resolve each task onto a scoped-course lesson, then de-duplicate: a published
+    // variant often carries its own copy of a template task, so the family query can
+    // return both — they resolve to the same lesson and would show twice. Keep one
+    // per (resolved lesson + title + type), preferring the scoped course's OWN copy
+    // (and, failing that, the one that actually carries a document / questions).
+    const seenTaskKey = new Map<string, number>() // key → index into `deployTasks`
+    const deployTasks: Array<{
+      taskId: string
+      title: string
+      type: 'task' | 'assessment' | 'homework'
+      content: string
+      lessonId: string | null
+      courseId: string | null
+      courseName: string
+      coursePublished: boolean
+      lessonTitle: string | null
+      lessonOrder: number | null
+      dmiItems: StudentDmiItem[]
+      sourceDocument: SourceDocLite | null
+    }> = []
+    for (const r of rows) {
+      const resolvedLessonId = resolveScopedLessonId(r.lessonId, r.lessonSourceId, r.lessonOrder)
+      const scopedLesson = resolvedLessonId ? scopedLessonById.get(resolvedLessonId) : undefined
+      const dmiItems = safeItemsByTask.get(r.taskId) ?? []
+      const sourceDocument = sourceDocByTask.get(r.taskId) ?? null
+      const task = {
         taskId: r.taskId,
         title: r.title || 'Untitled task',
         type: (r.type as 'task' | 'assessment' | 'homework') || 'task',
         content: r.content || '',
-        lessonId: r.lessonId || null,
+        lessonId: resolvedLessonId || null,
         courseId: r.courseId || null,
         courseName: r.courseName || 'Uncategorized',
         coursePublished: r.coursePublished ?? false,
-        lessonTitle: r.lessonTitle || null,
-        lessonOrder: typeof r.lessonOrder === 'number' ? r.lessonOrder : null,
-        dmiItems: safeItemsByTask.get(r.taskId) ?? [],
+        // Prefer the scoped lesson's own title/order once remapped, so the label the
+        // client shows matches the lesson it's nested under.
+        lessonTitle: scopedLesson?.title ?? r.lessonTitle ?? null,
+        lessonOrder:
+          scopedLesson?.order ?? (typeof r.lessonOrder === 'number' ? r.lessonOrder : null),
+        dmiItems,
         // The task's attached document (e.g. question-paper PDF), so deploying it
         // shows the PDF in the live Materials panel. Durable fileKey; the socket
         // re-signs the url on deploy. Null when the task has no document.
-        sourceDocument: sourceDocByTask.get(r.taskId) ?? null,
-      })),
+        sourceDocument,
+      }
+      // De-dupe only within a scoped session (the family can surface variant copies).
+      if (!scopedCourseId) {
+        deployTasks.push(task)
+        continue
+      }
+      const key = `${task.lessonId ?? '∅'}|${task.type}|${task.title.trim().toLowerCase()}`
+      const existingIdx = seenTaskKey.get(key)
+      if (existingIdx === undefined) {
+        seenTaskKey.set(key, deployTasks.length)
+        deployTasks.push(task)
+        continue
+      }
+      // Duplicate: keep the better copy — scoped course's own wins, else the richer
+      // one (has a document or questions).
+      const existing = deployTasks[existingIdx]
+      const score = (t: typeof task) =>
+        (t.courseId === scopedCourseId ? 4 : 0) +
+        (t.sourceDocument ? 2 : 0) +
+        (t.dmiItems.length > 0 ? 1 : 0)
+      if (score(task) > score(existing)) deployTasks[existingIdx] = task
+    }
+
+    return NextResponse.json({
+      tasks: deployTasks,
       // Full structure for a course-scoped session (empty for all-courses mode):
       // the session course (with its variant name) + every lesson, so the panel
       // renders the whole course, not just the lessons that happen to have tasks.

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -339,72 +339,99 @@ export function SessionDeployPanel({
 
                     {!isCollapsed ? (
                       <div className="flex flex-col gap-2 p-2">
-                        {c.lessons.map(l => (
-                          <div key={l.lessonId}>
-                            <p className="mb-1 px-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
-                              {l.lessonTitle}
-                            </p>
-                            {l.tasks.length === 0 ? (
-                              <p className="px-1 pb-1 text-[11px] italic text-slate-300">
-                                No deployable tasks yet
-                              </p>
-                            ) : null}
-                            <ul className="flex flex-col gap-1.5">
-                              {l.tasks.map(t => (
-                                <li
-                                  key={t.taskId}
-                                  className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 p-2"
+                        {c.lessons.map(l => {
+                          const hasTasks = l.tasks.length > 0
+                          const lKey = `l:${l.lessonId}`
+                          const lessonCollapsed = collapsed.has(lKey)
+                          return (
+                            <div key={l.lessonId}>
+                              {hasTasks ? (
+                                <button
+                                  onClick={() => toggle(lKey)}
+                                  aria-expanded={!lessonCollapsed}
+                                  className="mb-1 flex w-full items-center gap-1 px-1 py-0.5 text-left"
                                 >
-                                  <div className="flex min-w-0 items-center gap-2">
-                                    {t.dmiItems.length > 0 ? (
-                                      <ListChecks className="h-4 w-4 shrink-0 text-blue-400" />
-                                    ) : (
-                                      <FileText className="h-4 w-4 shrink-0 text-slate-400" />
-                                    )}
-                                    <div className="min-w-0">
-                                      <p className="truncate text-sm font-medium text-slate-900">
-                                        {t.title}
-                                      </p>
-                                      <p className="flex items-center gap-1 text-[11px] capitalize text-slate-400">
-                                        {t.type}
+                                  {lessonCollapsed ? (
+                                    <ChevronRight className="h-3 w-3 shrink-0 text-slate-400" />
+                                  ) : (
+                                    <ChevronDown className="h-3 w-3 shrink-0 text-slate-400" />
+                                  )}
+                                  <span className="min-w-0 flex-1 truncate text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                                    {l.lessonTitle}
+                                  </span>
+                                  <span className="shrink-0 rounded-full bg-slate-100 px-1.5 text-[10px] font-semibold text-slate-500">
+                                    {l.tasks.length}
+                                  </span>
+                                </button>
+                              ) : (
+                                <div className="mb-1 flex items-center gap-1 px-1 py-0.5">
+                                  <span className="min-w-0 flex-1 truncate text-[10px] font-semibold uppercase tracking-wide text-slate-300">
+                                    {l.lessonTitle}
+                                  </span>
+                                  <span className="shrink-0 text-[10px] italic text-slate-300">
+                                    empty
+                                  </span>
+                                </div>
+                              )}
+                              {hasTasks && !lessonCollapsed ? (
+                                <ul className="flex flex-col gap-1.5">
+                                  {l.tasks.map(t => (
+                                    <li
+                                      key={t.taskId}
+                                      className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 p-2"
+                                    >
+                                      <div className="flex min-w-0 items-center gap-2">
                                         {t.dmiItems.length > 0 ? (
-                                          <span className="lowercase text-blue-500">
-                                            · {t.dmiItems.length} q
-                                            {t.dmiItems.length === 1 ? '' : 's'}
-                                          </span>
-                                        ) : null}
-                                        {t.sourceDocument ? (
-                                          <span className="inline-flex items-center gap-0.5 lowercase text-rose-500">
-                                            · <FileText className="h-3 w-3" /> pdf
-                                          </span>
-                                        ) : null}
-                                      </p>
-                                    </div>
-                                  </div>
-                                  <div className="flex shrink-0 items-center gap-1">
-                                    <button
-                                      onClick={() => setPreviewTask(t)}
-                                      title="Preview the full task before deploying"
-                                      aria-label={`Preview "${t.title}"`}
-                                      className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50"
-                                    >
-                                      <Eye className="h-3.5 w-3.5" />
-                                      View
-                                    </button>
-                                    <button
-                                      onClick={() => deploy(t)}
-                                      disabled={deployingId === t.taskId}
-                                      className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
-                                    >
-                                      <Send className="h-3 w-3" />
-                                      Deploy
-                                    </button>
-                                  </div>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        ))}
+                                          <ListChecks className="h-4 w-4 shrink-0 text-blue-400" />
+                                        ) : (
+                                          <FileText className="h-4 w-4 shrink-0 text-slate-400" />
+                                        )}
+                                        <div className="min-w-0">
+                                          <p className="truncate text-sm font-medium text-slate-900">
+                                            {t.title}
+                                          </p>
+                                          <p className="flex items-center gap-1 text-[11px] capitalize text-slate-400">
+                                            {t.type}
+                                            {t.dmiItems.length > 0 ? (
+                                              <span className="lowercase text-blue-500">
+                                                · {t.dmiItems.length} q
+                                                {t.dmiItems.length === 1 ? '' : 's'}
+                                              </span>
+                                            ) : null}
+                                            {t.sourceDocument ? (
+                                              <span className="inline-flex items-center gap-0.5 lowercase text-rose-500">
+                                                · <FileText className="h-3 w-3" /> pdf
+                                              </span>
+                                            ) : null}
+                                          </p>
+                                        </div>
+                                      </div>
+                                      <div className="flex shrink-0 items-center gap-1">
+                                        <button
+                                          onClick={() => setPreviewTask(t)}
+                                          title="Preview the full task before deploying"
+                                          aria-label={`Preview "${t.title}"`}
+                                          className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50"
+                                        >
+                                          <Eye className="h-3.5 w-3.5" />
+                                          View
+                                        </button>
+                                        <button
+                                          onClick={() => deploy(t)}
+                                          disabled={deployingId === t.taskId}
+                                          className="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-2.5 py-1.5 text-xs font-semibold text-white hover:bg-blue-500 disabled:opacity-60"
+                                        >
+                                          <Send className="h-3 w-3" />
+                                          Deploy
+                                        </button>
+                                      </div>
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : null}
+                            </div>
+                          )
+                        })}
                       </div>
                     ) : null}
                   </div>


### PR DESCRIPTION
Two fixes to the in-session deploy panel's course tree, per request ("tasks/assessments not truly organized under lessons" + "lessons should be foldable").

## 1. Tasks truly nest under their lessons (variant-aware)
The panel pulls the whole course **family** (template + published variants) so tasks authored under any id are found. But template and published lessons don't share ids — a published lesson records its origin in `sourceLessonId`. Tasks authored under the template (or a sibling variant) therefore had a `lessonId` not in the scoped course's lesson list and fell into a catch-all **"Other tasks"** bucket.

Now the endpoint resolves each task's lesson onto the scoped course's lesson by their shared **template-root id** (`sourceLessonId || id`), falling back to `order`. It also **de-duplicates** variant copies of the same task (same resolved lesson + title + type), preferring the scoped course's own copy (then the one carrying a document/questions).

Verified against prod (Korea session): a template-authored assessment now nests under the correct published-variant lesson, and **"Other tasks" is empty**:
```
Lesson 1 (order 0): (empty)
Lesson 1 (order 1): Assessment 1   ← template-authored, now correctly nested
Lesson 2 (order 2): Assessment 1   ← variant's own
Other tasks: (none)
```

## 2. Foldable lessons
Each lesson with tasks has a collapsible header (chevron + item count), so a course with many items stays scannable. Empty lessons render as a muted "empty" row.

## Verification
- `tsc` clean · `npm run build` passes
- Correlation + dedup replicated against prod data (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)