### PR TITLE
fix(classroom): sanitize + de-noise the deployed task content students see

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -18,6 +18,7 @@ import {
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 import { sanitizeHtml } from '@/lib/security/sanitize'
+import { isImportPlaceholder } from '@/lib/tasks/import-placeholder'
 
 interface Deployable {
   taskId: string
@@ -482,15 +483,10 @@ function TaskPreviewOverlay({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  // The importer stores "[Imported <file>]" as placeholder content when it can't
-  // extract text from an uploaded doc. It's noise, not authored content — show
-  // the real content only, and never as the sole "preview" of a task.
+  // Show only real authored content — hide the importer's "[Imported file.docx]"
+  // placeholder (the actual document is rendered separately). See isImportPlaceholder.
   const contentText = task.content?.trim() ?? ''
-  // The importer emits "[Imported file.docx]" (single upload) or several such
-  // blocks separated by blank lines (multi-upload). Match either shape wholly —
-  // real authored content interleaved with a block breaks the match and is shown.
-  const isImportPlaceholder = /^(\[Imported .+\]\s*)+$/.test(contentText)
-  const showContent = contentText.length > 0 && !isImportPlaceholder
+  const showContent = contentText.length > 0 && !isImportPlaceholder(contentText)
   // The right column holds the authored content + questions. When both a document
   // and a right column exist they sit side by side; either one alone fills the row.
   const hasRightColumn = showContent || task.dmiItems.length > 0

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -16,6 +16,8 @@ import {
 import { toast } from 'sonner'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
+import { sanitizeHtml } from '@/lib/security/sanitize'
+import { isImportPlaceholder } from '@/lib/tasks/import-placeholder'
 import { resolvePublicUrl } from '@/lib/utils'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import type {
@@ -270,11 +272,13 @@ function ActiveTaskBody({
           </button>
         ) : null}
       </div>
-      {task.content ? (
+      {/* Shown to everyone in the room (incl. students). Sanitize the tutor-authored
+          HTML, and hide the auto-generated "[Imported file.docx]" placeholder — the
+          attached document itself is rendered separately by TaskDocumentCard. */}
+      {task.content && !isImportPlaceholder(task.content) ? (
         <div
           className="prose prose-sm mb-4 max-w-none text-slate-700"
-          // Tutor-authored task content, shown to their own session.
-          dangerouslySetInnerHTML={{ __html: task.content }}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(task.content) }}
         />
       ) : null}
     </>

--- a/tutorme-app/src/lib/tasks/import-placeholder.test.ts
+++ b/tutorme-app/src/lib/tasks/import-placeholder.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { isImportPlaceholder } from './import-placeholder'
+
+describe('isImportPlaceholder', () => {
+  it('matches a single-file import placeholder', () => {
+    expect(isImportPlaceholder('[Imported file.docx]')).toBe(true)
+    expect(isImportPlaceholder('  [Imported 1. AGENT MARKETPLACE INTERFACE.docx]  ')).toBe(true)
+  })
+
+  it('matches a multi-file combined placeholder', () => {
+    expect(isImportPlaceholder('[Imported a.pdf]\n\n[Imported b.pdf]')).toBe(true)
+  })
+
+  it('does NOT match real authored content, even when it starts with a block', () => {
+    expect(isImportPlaceholder('[Imported a.pdf]\n\nSolve for x.')).toBe(false)
+    expect(isImportPlaceholder('Answer all questions.')).toBe(false)
+    expect(isImportPlaceholder('<p>Read the passage below.</p>')).toBe(false)
+  })
+
+  it('treats empty / nullish content as not a placeholder', () => {
+    expect(isImportPlaceholder('')).toBe(false)
+    expect(isImportPlaceholder('   ')).toBe(false)
+    expect(isImportPlaceholder(null)).toBe(false)
+    expect(isImportPlaceholder(undefined)).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/tasks/import-placeholder.ts
+++ b/tutorme-app/src/lib/tasks/import-placeholder.ts
@@ -1,0 +1,14 @@
+/**
+ * The document importer stores `[Imported file.docx]` as a task's content when it
+ * can't extract text from an uploaded file (and several such blocks, separated by
+ * blank lines, for a multi-file import). That string is noise, not authored
+ * content — hide it anywhere the real document / preview is already shown.
+ *
+ * Matches the whole (trimmed) string as one or more `[Imported …]` blocks, so
+ * real authored content interleaved with such a block breaks the match and is
+ * still shown.
+ */
+export function isImportPlaceholder(content: string | null | undefined): boolean {
+  const s = (content ?? '').trim()
+  return s.length > 0 && /^(\[Imported .+\]\s*)+$/.test(s)
+}


### PR DESCRIPTION
Follow-up gap from the deploy-preview work: the fix that hid the `[Imported …]` placeholder + sanitized content was only in the tutor **preview**. The live **Materials** view (`SessionDeployedPanel`) — which **students** also see — still rendered `task.content` via `dangerouslySetInnerHTML` **raw** and showed the `[Imported file.docx]` placeholder as content.

## Fix
- Sanitize the tutor-authored HTML before rendering (removes the latent XSS surface).
- Hide the `[Imported …]` import placeholder (the attached document is already rendered by `TaskDocumentCard`).
- Extract the placeholder check into a shared `isImportPlaceholder` helper (`src/lib/tasks/import-placeholder.ts`, with unit tests) and reuse it in the deploy-panel preview so both views stay consistent.

## Verification
- New unit tests pass (`import-placeholder.test.ts`) · `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)