### PR TITLE
test(classroom): regression guards — DMI drift, lesson correlation, answer decode

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/deployables/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/deployables/route.ts
@@ -22,6 +22,7 @@ import { builderTask, builderTaskDmi, course, courseLesson, courseVariant } from
 import { buildStudentDeployPayload, type RawDeployDmiItem } from '@/lib/assessment/deploy-safety'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import { formatCourseVariantName } from '@/lib/courses/variant-name'
+import { buildScopedLessonResolver } from '@/lib/courses/lesson-correlation'
 
 // The hidden system course that anchors course-less (ad-hoc) session deploys.
 // Tasks under it are prior live deploys, not authored course content — keep them
@@ -370,33 +371,7 @@ export const GET = withAuth(
         order: typeof l.order === 'number' ? l.order : 0,
       }))
 
-      // rootId → scoped lessonId (rootId = the template lesson id both a template
-      // lesson and its published copies share) and order → scoped lessonId fallback.
-      const scopedIds = new Set(lessonRows.map(l => l.lessonId))
-      const byRoot = new Map<string, string>()
-      const byOrder = new Map<number, string>()
-      // `order` has no unique constraint; only use it as a fallback for orders that
-      // identify exactly ONE lesson, so a duplicate order never mis-nests a task
-      // (an ambiguous one falls through to "Other tasks" instead of guessing).
-      const orderCount = new Map<number, number>()
-      for (const l of lessonRows) {
-        if (typeof l.order === 'number') orderCount.set(l.order, (orderCount.get(l.order) ?? 0) + 1)
-      }
-      for (const l of lessonRows) {
-        byRoot.set(l.sourceLessonId || l.lessonId, l.lessonId)
-        if (typeof l.order === 'number' && orderCount.get(l.order) === 1)
-          byOrder.set(l.order, l.lessonId)
-      }
-      resolveScopedLessonId = (lessonId, sourceId, order) => {
-        if (!lessonId) return null
-        if (scopedIds.has(lessonId)) return lessonId // already a scoped lesson
-        const root = sourceId || lessonId
-        return (
-          byRoot.get(root) ??
-          (typeof order === 'number' ? byOrder.get(order) : undefined) ??
-          lessonId // truly foreign — leave as-is (client shows it under "Other tasks")
-        )
-      }
+      resolveScopedLessonId = buildScopedLessonResolver(lessonRows)
       scopedCourse = {
         courseId: scopedCourseId,
         name: courseRows[0]?.name || 'Course',

--- a/tutorme-app/src/components/one-on-one/session-submissions-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-submissions-panel.tsx
@@ -15,7 +15,7 @@ import {
   Download,
   ExternalLink,
 } from 'lucide-react'
-import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
+import { decodeStudentAnswer } from '@/lib/assessment/decode-student-answer'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import type { AutoGradeQuestionResult } from '@/lib/grading/auto-grade'
 import type { SessionRoomTask, SessionStudentResponse } from './use-session-room-state'
@@ -497,7 +497,7 @@ function SubmissionDetail({
                   <span className="font-medium text-slate-500">
                     {q.questionLabel || q.questionNumber || i + 1}.
                   </span>{' '}
-                  <span className="text-slate-700">{decodeAnswer(q, value)}</span>
+                  <span className="text-slate-700">{decodeStudentAnswer(q, value)}</span>
                 </span>
               </li>
             ))}
@@ -632,44 +632,4 @@ function feedbackText(v: unknown): string | null {
     }
   }
   return null
-}
-
-/**
- * Turn a stored answer back into something readable, matching how the student
- * field encoded it: mcq stores a letter, multiple_response a JSON array of
- * option texts, everything else the raw text.
- */
-function decodeAnswer(item: StudentDmiItem, value: unknown): string {
-  if (value == null) return '—'
-  // `answers` is jsonb — the submit route stores it verbatim, so a value can be a
-  // non-string (number, array, object). Normalise before the string logic below
-  // so an unexpected shape never crashes the row.
-  if (typeof value !== 'string') {
-    if (Array.isArray(value))
-      return value.map(v => (typeof v === 'string' ? v : JSON.stringify(v))).join(', ') || '—'
-    if (typeof value === 'object') {
-      try {
-        return JSON.stringify(value)
-      } catch {
-        return '—'
-      }
-    }
-    return String(value)
-  }
-  if (value.trim().length === 0) return '—'
-  const type = normalizeDmiQuestionType(item.questionType)
-  if (type === 'mcq' && item.options && item.options.length > 0) {
-    const idx = value.charCodeAt(0) - 65
-    const opt = idx >= 0 && idx < item.options.length ? item.options[idx] : null
-    return opt ? `${value}. ${opt}` : value
-  }
-  if (type === 'multiple_response') {
-    try {
-      const parsed = JSON.parse(value)
-      if (Array.isArray(parsed)) return parsed.filter(v => typeof v === 'string').join(', ') || '—'
-    } catch {
-      // fall through to raw
-    }
-  }
-  return value
 }

--- a/tutorme-app/src/lib/assessment/decode-student-answer.test.ts
+++ b/tutorme-app/src/lib/assessment/decode-student-answer.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { decodeStudentAnswer } from './decode-student-answer'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
+
+const mcq: StudentDmiItem = {
+  id: 'q1',
+  questionNumber: 1,
+  questionText: 'Pick one',
+  questionType: 'mcq',
+  options: ['Apple', 'Banana', 'Cherry'],
+}
+const text: StudentDmiItem = {
+  id: 'q2',
+  questionNumber: 2,
+  questionText: 'Explain',
+  questionType: 'short_answer',
+}
+
+describe('decodeStudentAnswer', () => {
+  it('decodes an mcq letter to its option', () => {
+    expect(decodeStudentAnswer(mcq, 'B')).toBe('B. Banana')
+  })
+
+  it('returns the raw letter when the option index is out of range', () => {
+    expect(decodeStudentAnswer(mcq, 'Z')).toBe('Z')
+  })
+
+  it('joins a multiple_response JSON array of option texts', () => {
+    const mr: StudentDmiItem = { ...mcq, questionType: 'multiple_response' }
+    expect(decodeStudentAnswer(mr, JSON.stringify(['Apple', 'Cherry']))).toBe('Apple, Cherry')
+  })
+
+  it('passes through plain text', () => {
+    expect(decodeStudentAnswer(text, 'because reasons')).toBe('because reasons')
+  })
+
+  it('shows a dash for empty / missing answers', () => {
+    expect(decodeStudentAnswer(text, '')).toBe('—')
+    expect(decodeStudentAnswer(text, '   ')).toBe('—')
+    expect(decodeStudentAnswer(text, undefined)).toBe('—')
+    expect(decodeStudentAnswer(text, null)).toBe('—')
+  })
+
+  it('never throws on non-string jsonb values (number / array / object)', () => {
+    expect(decodeStudentAnswer(text, 42)).toBe('42')
+    expect(decodeStudentAnswer(text, ['a', 'b'])).toBe('a, b')
+    expect(decodeStudentAnswer(text, { x: 1 })).toBe('{"x":1}')
+  })
+})

--- a/tutorme-app/src/lib/assessment/decode-student-answer.ts
+++ b/tutorme-app/src/lib/assessment/decode-student-answer.ts
@@ -1,0 +1,43 @@
+import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
+import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
+
+/**
+ * Turn a stored student answer back into something human-readable, matching how the
+ * answer field encoded it: an mcq stores the chosen letter, a multiple_response a
+ * JSON array of option texts, everything else the raw text.
+ *
+ * `answers` is a jsonb column the submit route persists verbatim, so a value can be
+ * a non-string (number, array, object) at runtime — those are normalised first so an
+ * unexpected shape never throws while rendering a submission.
+ */
+export function decodeStudentAnswer(item: StudentDmiItem, value: unknown): string {
+  if (value == null) return '—'
+  if (typeof value !== 'string') {
+    if (Array.isArray(value))
+      return value.map(v => (typeof v === 'string' ? v : JSON.stringify(v))).join(', ') || '—'
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value)
+      } catch {
+        return '—'
+      }
+    }
+    return String(value)
+  }
+  if (value.trim().length === 0) return '—'
+  const type = normalizeDmiQuestionType(item.questionType)
+  if (type === 'mcq' && item.options && item.options.length > 0) {
+    const idx = value.charCodeAt(0) - 65
+    const opt = idx >= 0 && idx < item.options.length ? item.options[idx] : null
+    return opt ? `${value}. ${opt}` : value
+  }
+  if (type === 'multiple_response') {
+    try {
+      const parsed = JSON.parse(value)
+      if (Array.isArray(parsed)) return parsed.filter(v => typeof v === 'string').join(', ') || '—'
+    } catch {
+      // fall through to raw
+    }
+  }
+  return value
+}

--- a/tutorme-app/src/lib/courses/lesson-correlation.test.ts
+++ b/tutorme-app/src/lib/courses/lesson-correlation.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { buildScopedLessonResolver } from './lesson-correlation'
+
+describe('buildScopedLessonResolver', () => {
+  // A published-variant course: two lessons copied from template (t-l1, t-l2) plus
+  // one authored directly on the variant.
+  const lessons = [
+    { lessonId: 'k-l1', order: 0, sourceLessonId: 't-l1' },
+    { lessonId: 'k-l2', order: 1, sourceLessonId: 't-l2' },
+    { lessonId: 'k-l3', order: 2, sourceLessonId: null },
+  ]
+  const resolve = buildScopedLessonResolver(lessons)
+
+  it('keeps a task already on one of the scoped lessons', () => {
+    expect(resolve('k-l3', null, 2)).toBe('k-l3')
+  })
+
+  it('maps a template-authored task onto the scoped lesson via sourceLessonId', () => {
+    // task lessonId is the template lesson t-l2 → scoped lesson k-l2 (root t-l2)
+    expect(resolve('t-l2', null, 1)).toBe('k-l2')
+  })
+
+  it('maps a sibling-variant task that shares the same template root', () => {
+    // another variant's lesson s-l1 whose sourceLessonId is t-l1 → k-l1
+    expect(resolve('s-l1', 't-l1', 0)).toBe('k-l1')
+  })
+
+  it('falls back to a unique order when there is no root match', () => {
+    expect(resolve('foreign', null, 1)).toBe('k-l2')
+  })
+
+  it('does NOT use the order fallback when the order is ambiguous', () => {
+    const dup = buildScopedLessonResolver([
+      { lessonId: 'a', order: 0, sourceLessonId: null },
+      { lessonId: 'b', order: 0, sourceLessonId: null }, // duplicate order 0
+    ])
+    // ambiguous order → left unchanged (surfaces under "Other tasks"), never guessed
+    expect(dup('foreign', null, 0)).toBe('foreign')
+  })
+
+  it('returns the input unchanged when nothing correlates', () => {
+    expect(resolve('foreign', null, 99)).toBe('foreign')
+  })
+
+  it('returns null for a null lessonId', () => {
+    expect(resolve(null, null, 0)).toBeNull()
+  })
+})

--- a/tutorme-app/src/lib/courses/lesson-correlation.ts
+++ b/tutorme-app/src/lib/courses/lesson-correlation.ts
@@ -1,0 +1,45 @@
+/**
+ * Correlate a (course-family) task's lesson onto a specific scoped course's lesson.
+ *
+ * The in-session deploy panel pulls the whole template↔published course family so
+ * tasks authored under any variant are found, but template and published-variant
+ * lessons don't share ids. A published lesson records the template lesson it was
+ * copied from in `sourceLessonId`, so a template lesson and its published copies all
+ * resolve to the same "root" (`sourceLessonId || id`). Order is a last-resort
+ * fallback — and only for orders that identify exactly one lesson, since
+ * `CourseLesson.order` has no unique constraint (a duplicate order would otherwise
+ * mis-nest a task). When nothing correlates, the input lessonId is returned
+ * unchanged (the client then shows it under "Other tasks").
+ */
+
+export interface ScopedLessonMeta {
+  lessonId: string
+  order: number | null
+  sourceLessonId: string | null
+}
+
+export function buildScopedLessonResolver(lessons: ScopedLessonMeta[]) {
+  const scopedIds = new Set(lessons.map(l => l.lessonId))
+  const byRoot = new Map<string, string>()
+  const byOrder = new Map<number, string>()
+  const orderCount = new Map<number, number>()
+  for (const l of lessons)
+    if (typeof l.order === 'number') orderCount.set(l.order, (orderCount.get(l.order) ?? 0) + 1)
+  for (const l of lessons) {
+    byRoot.set(l.sourceLessonId || l.lessonId, l.lessonId)
+    if (typeof l.order === 'number' && orderCount.get(l.order) === 1)
+      byOrder.set(l.order, l.lessonId)
+  }
+  return (
+    lessonId: string | null,
+    sourceId: string | null,
+    order: number | null
+  ): string | null => {
+    if (!lessonId) return null
+    if (scopedIds.has(lessonId)) return lessonId // already a scoped lesson
+    const root = sourceId || lessonId
+    return (
+      byRoot.get(root) ?? (typeof order === 'number' ? byOrder.get(order) : undefined) ?? lessonId // truly foreign — leave as-is (client shows it under "Other tasks")
+    )
+  }
+}

--- a/tutorme-app/src/lib/db/schema/builder-dmi-columns.test.ts
+++ b/tutorme-app/src/lib/db/schema/builder-dmi-columns.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { getTableConfig } from 'drizzle-orm/pg-core'
+import { builderTaskDmi, builderTaskDmiVersion } from '@/lib/db/schema'
+
+/**
+ * Regression guard for the BuilderTaskDmi / BuilderTaskDmiVersion column drift
+ * (PR #1186). The prod columns (migration 0020) are literally `dmiId` / `versionId`,
+ * but the schema had mapped both to `text('id')`, so every drizzle-generated INSERT
+ * referenced a non-existent `"id"` column and silently threw — answer-key
+ * persistence, DMI materialization and versioning were all broken with 0 rows.
+ *
+ * CI builds the test DB from the schema via `drizzle-kit push`, so it can't catch a
+ * schema-vs-prod-column drift; this asserts the mapping directly instead.
+ */
+describe('BuilderTaskDmi column mapping (guards the #1186 drift fix)', () => {
+  it('BuilderTaskDmi primary key maps to the prod column "dmiId", not "id"', () => {
+    const pk = getTableConfig(builderTaskDmi).columns.find(c => c.primary)
+    expect(pk?.name).toBe('dmiId')
+  })
+
+  it('BuilderTaskDmiVersion primary key maps to the prod column "versionId", not "id"', () => {
+    const pk = getTableConfig(builderTaskDmiVersion).columns.find(c => c.primary)
+    expect(pk?.name).toBe('versionId')
+  })
+})


### PR DESCRIPTION
Locks down the hard-won fixes from this batch with unit tests (#2), extracting two bits of logic into pure, testable libs along the way. No behaviour change.

## Guards
- **BuilderTaskDmi column drift (#1186)** — `builder-dmi-columns.test.ts` asserts (via `getTableConfig`) that the drizzle PKs map to the real prod columns **`dmiId` / `versionId`**, not `id`. CI builds the test DB from the schema via `drizzle-kit push`, so it *can't* catch a schema-vs-prod-column drift — this asserts the mapping directly. If someone reverts the mapping, this fails.
- **Lesson correlation (#1188)** — extracted the deploy-panel correlation into a pure `buildScopedLessonResolver` (`src/lib/courses/lesson-correlation.ts`) and covered it: exact-match, `sourceLessonId` root match, sibling-variant shared-root, unambiguous-order fallback, **ambiguous-order NOT guessed**, foreign-left-unchanged, null. The deployables route now calls the helper.
- **Answer decode** — extracted `decodeStudentAnswer` (`src/lib/assessment/decode-student-answer.ts`) and covered mcq/multiple_response decoding + the **non-string jsonb guard** (number/array/object never throw). The Submissions panel now imports it.

## Verification
- 15 new unit tests pass · `tsc` clean · `npm run build` passes · pure refactors (route + panel behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)