### PR TITLE
feat(classroom): in-session room chat for 1-on-1/group sessions

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-chat-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-chat-panel.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { X, Send, MessageSquare } from 'lucide-react'
+import type { SessionChatMessage } from './use-session-room-state'
+
+/**
+ * Room chat for the live session — everyone in the room (tutor + students) can post
+ * and everyone sees it. Messages are owned by the classroom (`useSessionRoomState`,
+ * hydrated from `room_state.chatHistory` on join and appended on the live
+ * `chat_message` event) and passed in, so opening the panel late still shows the
+ * full history. Sending emits `chat_message`, which the server broadcasts + persists.
+ */
+export function SessionChatPanel({
+  sessionId,
+  socket,
+  messages,
+  myUserId,
+  onClose,
+}: {
+  sessionId: string
+  socket: Socket | null
+  messages: SessionChatMessage[]
+  myUserId: string | undefined
+  onClose: () => void
+}) {
+  const [text, setText] = useState('')
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  // Keep pinned to the newest message as chat grows / the panel opens.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages])
+
+  const send = () => {
+    const t = text.trim()
+    if (!t || !socket) return
+    socket.emit('chat_message', { text: t, roomId: sessionId })
+    setText('')
+  }
+
+  return (
+    <div className="pointer-events-auto flex h-full w-80 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+          <MessageSquare className="h-4 w-4 text-blue-600" />
+          Chat
+        </h3>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div ref={scrollRef} className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3">
+        {messages.length === 0 ? (
+          <p className="mt-6 text-center text-xs text-slate-400">
+            No messages yet. Say hello to the room.
+          </p>
+        ) : (
+          messages.map(m => {
+            const mine = !!myUserId && m.userId === myUserId
+            return (
+              <div
+                key={m.id}
+                className={mine ? 'flex flex-col items-end' : 'flex flex-col items-start'}
+              >
+                {!mine ? (
+                  <span className="mb-0.5 px-1 text-[10px] font-medium text-slate-400">
+                    {m.isAI ? 'AI' : m.name}
+                  </span>
+                ) : null}
+                <div
+                  className={
+                    'max-w-[85%] whitespace-pre-wrap break-words rounded-2xl px-3 py-1.5 text-sm ' +
+                    (mine
+                      ? 'rounded-br-sm bg-blue-600 text-white'
+                      : 'rounded-bl-sm bg-slate-100 text-slate-800')
+                  }
+                >
+                  {m.text}
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 border-t p-2">
+        <input
+          value={text}
+          onChange={e => setText(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              send()
+            }
+          }}
+          placeholder={socket ? 'Message the room…' : 'Connecting…'}
+          disabled={!socket}
+          className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none disabled:opacity-60"
+        />
+        <button
+          onClick={send}
+          disabled={!socket || text.trim().length === 0}
+          aria-label="Send"
+          className="inline-flex shrink-0 items-center justify-center rounded-lg bg-blue-600 p-2 text-white hover:bg-blue-500 disabled:opacity-40"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -14,7 +14,16 @@
 
 import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
-import { Send, FolderOpen, ListChecks, Pencil, PenTool, LayoutGrid, BookOpen } from 'lucide-react'
+import {
+  Send,
+  FolderOpen,
+  ListChecks,
+  Pencil,
+  PenTool,
+  LayoutGrid,
+  BookOpen,
+  MessageSquare,
+} from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
@@ -27,10 +36,11 @@ import {
   useOwnBoardOpened,
 } from '@/components/one-on-one/session-boards'
 import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
+import { SessionChatPanel } from '@/components/one-on-one/session-chat-panel'
 import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 
-type ActivePanel = 'deploy' | 'materials' | 'responses' | null
+type ActivePanel = 'deploy' | 'materials' | 'responses' | 'chat' | null
 interface BoardTarget {
   ownerId: string
   ownerName: string
@@ -105,7 +115,7 @@ export function SessionClassroom({
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
   // room_state replay instead of missing everything that happened before.
-  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students } =
+  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students, chatMessages } =
     useSessionRoomState(socket, session?.user?.id)
 
   // The call feed rides along as the whiteboard's draggable video overlay.
@@ -254,6 +264,14 @@ export function SessionClassroom({
           <FolderOpen className="h-3.5 w-3.5" />
           Materials
         </button>
+        <button
+          type="button"
+          onClick={() => toggle('chat')}
+          className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+        >
+          <MessageSquare className="h-3.5 w-3.5" />
+          Chat
+        </button>
       </div>
 
       {/* Private-board overlay — sits above the shared board (which stays mounted
@@ -287,6 +305,15 @@ export function SessionClassroom({
                 tasks={tasks}
                 responsesByTask={responsesByTask}
                 students={students}
+                onClose={() => setActivePanel(null)}
+              />
+            ) : null}
+            {activePanel === 'chat' ? (
+              <SessionChatPanel
+                sessionId={sessionId}
+                socket={socket}
+                messages={chatMessages}
+                myUserId={myId}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -43,9 +43,20 @@ export interface SessionStudentResponse {
   correctAnswers?: Record<string, string> | null
 }
 
+/** A room chat message (mirrors the socket server's ChatMessage). */
+export interface SessionChatMessage {
+  id: string
+  userId: string
+  name: string
+  text: string
+  timestamp: number
+  isAI?: boolean
+}
+
 interface RoomStatePayload {
   students?: Array<{ userId: string; name?: string }>
   tasks?: Array<SessionRoomTask & { responses?: Record<string, Record<string, string>> }>
+  chatHistory?: SessionChatMessage[]
 }
 
 interface TaskCompletedEvent {
@@ -84,6 +95,9 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
   >({})
   // The student roster (for the tutor's board viewer), from room_state + joins.
   const [students, setStudents] = useState<Array<{ userId: string; name: string }>>([])
+  // Room chat — hydrated from room_state on join, appended live. Held here (in the
+  // always-mounted classroom) so the chat panel shows history even when opened late.
+  const [chatMessages, setChatMessages] = useState<SessionChatMessage[]>([])
 
   useEffect(() => {
     if (!socket) return
@@ -108,8 +122,16 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
 
     // Join-time replay: hydrate both the deployed tasks and any submissions that
     // already happened (task.responses), naming students from the roster.
+    const mergeChat = (incoming: SessionChatMessage[]) =>
+      setChatMessages(prev => {
+        const byId = new Map(prev.map(m => [m.id, m]))
+        for (const m of incoming) if (m?.id) byId.set(m.id, m)
+        return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp)
+      })
+
     const onRoomState = (state: RoomStatePayload) => {
       if (Array.isArray(state?.students)) mergeStudents(state.students)
+      if (Array.isArray(state?.chatHistory)) mergeChat(state.chatHistory)
       if (!Array.isArray(state?.tasks)) return
       const nameById = new Map((state.students ?? []).map(s => [s.userId, s.name || 'Student']))
       setTasks(prev => {
@@ -198,12 +220,17 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       if (data?.userId) mergeStudents([data])
     }
 
+    const onChatMessage = (msg: SessionChatMessage) => {
+      if (msg?.id && typeof msg.text === 'string') mergeChat([msg])
+    }
+
     socket.on('room_state', onRoomState)
     socket.on('task:deployed', onDeployed)
     socket.on('task:updated', onUpdated)
     socket.on('task:completed', onCompleted)
     socket.on('task:graded', onGraded)
     socket.on('student_joined', onStudentJoined)
+    socket.on('chat_message', onChatMessage)
     return () => {
       socket.off('room_state', onRoomState)
       socket.off('task:deployed', onDeployed)
@@ -211,6 +238,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       socket.off('task:completed', onCompleted)
       socket.off('task:graded', onGraded)
       socket.off('student_joined', onStudentJoined)
+      socket.off('chat_message', onChatMessage)
     }
   }, [socket])
 
@@ -239,5 +267,5 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     return out
   }, [responsesByTask, myUserId])
 
-  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students }
+  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students, chatMessages }
 }


### PR DESCRIPTION
Second classroom feature-parity item: a **room chat** in the 1-on-1/group live classroom (the course-builder classroom has one; the 1-on-1 room had no text backchannel at all).

## What
- New **Chat** panel (toolbar button available to **both** tutor and students).
- The room-state hook (`useSessionRoomState`) now carries chat: hydrates from `room_state.chatHistory` on join (so opening late shows history) and appends the live `chat_message` event (deduped, time-sorted).
- Sending emits `chat_message` — the socket server already **broadcasts + persists** it (to the `message` table). No server change needed.
- Own vs others' bubbles, sender names, auto-scroll to newest, Enter-to-send.

## Scope note
Tutor→student **private DM** (`tutor:direct_message`, also already server-supported) is deferred to the monitoring-panel PR, where it pairs naturally with the per-student roster.

## Verification
- `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)