### PR TITLE
feat(classroom): live Monitor panel (roster + comprehension + DM)

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -23,6 +23,7 @@ import {
   LayoutGrid,
   BookOpen,
   MessageSquare,
+  Users,
 } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
@@ -37,10 +38,12 @@ import {
 } from '@/components/one-on-one/session-boards'
 import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
 import { SessionChatPanel } from '@/components/one-on-one/session-chat-panel'
+import { SessionMonitorPanel } from '@/components/one-on-one/session-monitor-panel'
+import { toast } from 'sonner'
 import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 
-type ActivePanel = 'deploy' | 'materials' | 'responses' | 'chat' | null
+type ActivePanel = 'deploy' | 'materials' | 'responses' | 'chat' | 'monitor' | null
 interface BoardTarget {
   ownerId: string
   ownerName: string
@@ -111,6 +114,45 @@ export function SessionClassroom({
       : undefined
 
   const { socket } = useSocket(socketOptions)
+
+  // Students emit a light engagement signal (tab focus + recent interaction) every
+  // ~15s so the tutor's Monitor shows live status. Cheap heuristic — no tracking
+  // beyond "is this tab focused and did they interact recently".
+  useEffect(() => {
+    if (!socket || isTutor || !sessionId) return
+    let lastInteraction = Date.now()
+    const bump = () => {
+      lastInteraction = Date.now()
+    }
+    const events = ['pointerdown', 'keydown', 'pointermove', 'wheel'] as const
+    events.forEach(e => window.addEventListener(e, bump, { passive: true }))
+    const tick = () => {
+      const focused = typeof document !== 'undefined' && document.visibilityState === 'visible'
+      const idleMs = Date.now() - lastInteraction
+      const engagement = !focused ? 20 : idleMs < 30_000 ? 100 : idleMs < 90_000 ? 55 : 35
+      socket.emit('activity_ping', { roomId: sessionId, engagement, activity: 'classroom' })
+    }
+    tick()
+    const iv = setInterval(tick, 15_000)
+    return () => {
+      clearInterval(iv)
+      events.forEach(e => window.removeEventListener(e, bump))
+    }
+  }, [socket, isTutor, sessionId])
+
+  // Student receives a private nudge from the tutor (tutor:direct_message) → toast.
+  useEffect(() => {
+    if (!socket || isTutor) return
+    const onDm = (data: { targetStudentId?: string; message?: string }) => {
+      if (data?.targetStudentId && data.targetStudentId === myId && data.message) {
+        toast(data.message, { icon: '👋', duration: 8000 })
+      }
+    }
+    socket.on('student:direct_message', onDm)
+    return () => {
+      socket.off('student:direct_message', onDm)
+    }
+  }, [socket, isTutor, myId])
 
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
@@ -197,6 +239,14 @@ export function SessionClassroom({
             >
               <ListChecks className="h-3.5 w-3.5" />
               Submissions
+            </button>
+            <button
+              type="button"
+              onClick={() => toggle('monitor')}
+              className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+            >
+              <Users className="h-3.5 w-3.5" />
+              Monitor
             </button>
             {courseId ? (
               <button
@@ -305,6 +355,16 @@ export function SessionClassroom({
                 tasks={tasks}
                 responsesByTask={responsesByTask}
                 students={students}
+                onClose={() => setActivePanel(null)}
+              />
+            ) : null}
+            {activePanel === 'monitor' && isTutor ? (
+              <SessionMonitorPanel
+                sessionId={sessionId}
+                socket={socket}
+                students={students}
+                tasks={tasks}
+                responsesByTask={responsesByTask}
                 onClose={() => setActivePanel(null)}
               />
             ) : null}

--- a/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { toast } from 'sonner'
+import { X, RefreshCw, MessageSquare, Send, Loader2, Users } from 'lucide-react'
+import type {
+  SessionRosterStudent,
+  SessionRoomTask,
+  SessionStudentResponse,
+} from './use-session-room-state'
+
+/**
+ * Tutor-only live Monitor for the session — the in-session counterpart of the
+ * course-builder classroom's monitoring panel, scoped to this room's roster. Per
+ * student it shows: presence, live engagement + a status badge (from the socket
+ * `student_state_update` signal), real **understanding %** (from
+ * `/api/tutor/live-sessions/[sessionId]/comprehension`, derived from graded
+ * submissions), and tasks-done this session. The tutor can send a private nudge
+ * (`tutor:direct_message`) that surfaces as a toast on that student's screen.
+ */
+export function SessionMonitorPanel({
+  sessionId,
+  socket,
+  students,
+  tasks,
+  responsesByTask,
+  onClose,
+}: {
+  sessionId: string
+  socket: Socket | null
+  students: SessionRosterStudent[]
+  tasks: SessionRoomTask[]
+  responsesByTask: Record<string, Record<string, SessionStudentResponse>>
+  onClose: () => void
+}) {
+  const [comprehension, setComprehension] = useState<
+    Record<string, { understanding: number | null; needsReview: number }>
+  >({})
+  const [loading, setLoading] = useState(true)
+  const [dmFor, setDmFor] = useState<string | null>(null)
+  const [dmText, setDmText] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/tutor/live-sessions/${sessionId}/comprehension`, {
+        credentials: 'include',
+      })
+      if (res.ok) {
+        const d = await res.json()
+        setComprehension(d?.comprehension ?? {})
+      }
+    } catch {
+      // non-fatal — the roster (presence/engagement) still renders without it
+    } finally {
+      setLoading(false)
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const answerable = useMemo(() => tasks.filter(t => (t.dmiItems?.length ?? 0) > 0), [tasks])
+  const doneByStudent = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const t of answerable)
+      for (const sid of Object.keys(responsesByTask[t.id] ?? {})) m.set(sid, (m.get(sid) ?? 0) + 1)
+    return m
+  }, [answerable, responsesByTask])
+
+  const roster = useMemo(
+    () => [...students].sort((a, b) => a.name.localeCompare(b.name)),
+    [students]
+  )
+
+  const sendDm = (studentId: string) => {
+    const msg = dmText.trim()
+    if (!msg || !socket) return
+    socket.emit('tutor:direct_message', { roomId: sessionId, studentId, message: msg })
+    setDmText('')
+    setDmFor(null)
+    toast.success('Message sent')
+  }
+
+  return (
+    <div className="pointer-events-auto flex h-full w-[26rem] max-w-[92vw] flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+          <Users className="h-4 w-4 text-blue-600" />
+          Monitor
+          <span className="text-xs font-normal text-slate-400">· {roster.length}</span>
+        </h3>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={load}
+            aria-label="Refresh"
+            title="Refresh understanding"
+            className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {roster.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-xs text-slate-500">
+            {loading ? (
+              <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+            ) : (
+              'No students have joined this session yet.'
+            )}
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {roster.map(s => {
+              const badge = statusBadge(s.status, s.engagement)
+              const understanding =
+                comprehension[s.userId]?.understanding ?? s.understanding ?? null
+              const needsReview = comprehension[s.userId]?.needsReview ?? 0
+              const done = doneByStudent.get(s.userId) ?? 0
+              return (
+                <li key={s.userId} className="rounded-xl border border-slate-200 p-3">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2 w-2 shrink-0 rounded-full ${badge.dot}`} />
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900">
+                      {s.name}
+                    </span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${badge.className}`}
+                    >
+                      {badge.label}
+                    </span>
+                    <button
+                      onClick={() => {
+                        setDmFor(cur => (cur === s.userId ? null : s.userId))
+                        setDmText('')
+                      }}
+                      title={`Send ${s.name} a private message`}
+                      aria-label={`Message ${s.name}`}
+                      className="shrink-0 rounded-lg border border-slate-200 p-1 text-slate-500 hover:bg-slate-50"
+                    >
+                      <MessageSquare className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+
+                  {/* Signals */}
+                  <div className="mt-2 grid grid-cols-3 gap-2 text-center">
+                    <Metric label="Engagement" value={pct(s.engagement)} />
+                    <Metric
+                      label="Understanding"
+                      value={understanding == null ? '—' : `${understanding}%`}
+                      hint={needsReview > 0 ? `${needsReview} to review` : undefined}
+                    />
+                    <Metric
+                      label="Tasks done"
+                      value={answerable.length > 0 ? `${done}/${answerable.length}` : String(done)}
+                    />
+                  </div>
+
+                  {dmFor === s.userId ? (
+                    <div className="mt-2 flex items-center gap-2">
+                      <input
+                        autoFocus
+                        value={dmText}
+                        onChange={e => setDmText(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') sendDm(s.userId)
+                          if (e.key === 'Escape') setDmFor(null)
+                        }}
+                        placeholder={`Private message to ${s.name}…`}
+                        className="min-w-0 flex-1 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none"
+                      />
+                      <button
+                        onClick={() => sendDm(s.userId)}
+                        disabled={!socket || dmText.trim().length === 0}
+                        aria-label="Send message"
+                        className="inline-flex shrink-0 items-center justify-center rounded-lg bg-blue-600 p-1.5 text-white hover:bg-blue-500 disabled:opacity-40"
+                      >
+                        <Send className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-lg bg-slate-50 py-1.5">
+      <div className="text-sm font-semibold text-slate-800">{value}</div>
+      <div className="text-[9px] font-medium uppercase tracking-wide text-slate-400">{label}</div>
+      {hint ? <div className="text-[9px] text-amber-600">{hint}</div> : null}
+    </div>
+  )
+}
+
+function pct(v: number | undefined): string {
+  return typeof v === 'number' ? `${Math.round(v)}%` : '—'
+}
+
+function statusBadge(
+  status: string | undefined,
+  engagement: number | undefined
+): { label: string; className: string; dot: string } {
+  const s = (status || '').toLowerCase()
+  const eng = typeof engagement === 'number' ? engagement : null
+  if (s === 'idle' || (eng != null && eng < 30))
+    return { label: 'Idle', className: 'bg-slate-100 text-slate-500', dot: 'bg-slate-300' }
+  if (s === 'needs_help' || (eng != null && eng < 60))
+    return { label: 'Needs a nudge', className: 'bg-amber-100 text-amber-700', dot: 'bg-amber-400' }
+  return { label: 'On track', className: 'bg-emerald-100 text-emerald-700', dot: 'bg-emerald-500' }
+}

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -53,8 +53,32 @@ export interface SessionChatMessage {
   isAI?: boolean
 }
 
+/** A roster student as the tutor's Monitor sees them — identity plus the live
+ *  engagement/understanding/status signals the socket server tracks. */
+export interface SessionRosterStudent {
+  userId: string
+  name: string
+  engagement?: number
+  understanding?: number | null
+  status?: string
+  currentActivity?: string
+  lastActivity?: number
+  joinedAt?: number
+}
+
+interface StudentStateUpdate {
+  userId: string
+  state?: {
+    engagement?: number
+    understanding?: number | null
+    status?: string
+    currentActivity?: string
+    lastActivity?: number
+  }
+}
+
 interface RoomStatePayload {
-  students?: Array<{ userId: string; name?: string }>
+  students?: Array<Partial<SessionRosterStudent> & { userId: string }>
   tasks?: Array<SessionRoomTask & { responses?: Record<string, Record<string, string>> }>
   chatHistory?: SessionChatMessage[]
 }
@@ -93,8 +117,9 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
   const [responsesByTask, setResponsesByTask] = useState<
     Record<string, Record<string, SessionStudentResponse>>
   >({})
-  // The student roster (for the tutor's board viewer), from room_state + joins.
-  const [students, setStudents] = useState<Array<{ userId: string; name: string }>>([])
+  // The student roster (for the tutor's board viewer + Monitor), from room_state +
+  // joins, enriched by live `student_state_update` events.
+  const [students, setStudents] = useState<SessionRosterStudent[]>([])
   // Room chat — hydrated from room_state on join, appended live. Held here (in the
   // always-mounted classroom) so the chat panel shows history even when opened late.
   const [chatMessages, setChatMessages] = useState<SessionChatMessage[]>([])
@@ -102,14 +127,27 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
   useEffect(() => {
     if (!socket) return
 
-    const mergeStudents = (incoming: Array<{ userId: string; name?: string }>) =>
+    const mergeStudents = (incoming: Array<Partial<SessionRosterStudent> & { userId: string }>) =>
       setStudents(prev => {
         const byId = new Map(prev.map(s => [s.userId, s]))
         for (const s of incoming) {
-          if (s?.userId) byId.set(s.userId, { userId: s.userId, name: s.name || 'Student' })
+          if (!s?.userId) continue
+          const existing = byId.get(s.userId)
+          byId.set(s.userId, {
+            ...existing,
+            ...s,
+            userId: s.userId,
+            name: s.name || existing?.name || 'Student',
+          })
         }
         return Array.from(byId.values())
       })
+
+    // Live engagement/understanding/status changes (the tutor's Monitor).
+    const onStudentState = (u: StudentStateUpdate) => {
+      if (!u?.userId || !u.state) return
+      mergeStudents([{ userId: u.userId, ...u.state }])
+    }
 
     const upsertTask = (t: SessionRoomTask) => {
       if (!t?.id) return
@@ -231,6 +269,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     socket.on('task:graded', onGraded)
     socket.on('student_joined', onStudentJoined)
     socket.on('chat_message', onChatMessage)
+    socket.on('student_state_update', onStudentState)
     return () => {
       socket.off('room_state', onRoomState)
       socket.off('task:deployed', onDeployed)
@@ -239,6 +278,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       socket.off('task:graded', onGraded)
       socket.off('student_joined', onStudentJoined)
       socket.off('chat_message', onChatMessage)
+      socket.off('student_state_update', onStudentState)
     }
   }, [socket])
 

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -2616,8 +2616,13 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (socket.data.role !== 'tutor') return
         const { roomId, studentId, message } = data
         if (!roomId || !studentId || !message) return
-        // Send message specifically tagged for that student
-        io.to(roomId).emit('student:direct_message', {
+        // Deliver ONLY to the target student's own `user:` room — not the whole
+        // class. Broadcasting to the room (with client-side filtering) leaked the
+        // message text to every peer's socket; `emitToUser` keeps a "private" nudge
+        // actually private. Payload shape unchanged, so existing listeners (the
+        // 1-on-1 classroom + the course-builder feedback page) still match on
+        // `targetStudentId`.
+        emitToUser(studentId, 'student:direct_message', {
           targetStudentId: studentId,
           message,
         })


### PR DESCRIPTION
Third classroom feature-parity item: bring the course-builder classroom's **live Monitor** to the 1-on-1/group room (tutor-only). Highest-value for group sessions — the tutor previously had no way to see who's lost.

## What
- **Roster enrichment** — `useSessionRoomState` now keeps each student's live `engagement` / `understanding` / `status` / `currentActivity` (from `room_state.students` and the socket `student_state_update` event), instead of dropping them to `{userId,name}`.
- **Student engagement emitter** — students emit a light `activity_ping` every ~15s derived from tab focus + recent interaction (pointer/key/wheel). No tracking beyond "focused & interacted recently"; the server recomputes status (on-track / needs-a-nudge / idle).
- **Monitor panel (tutor)** — per-student card: presence dot, **engagement %** + status badge, real **understanding %** (from `/api/tutor/live-sessions/[sessionId]/comprehension`, derived from graded submissions, with a "to review" count), and **tasks-done/total** this session.
- **Private nudge (DM)** — each card sends `tutor:direct_message`; the student receives it as a toast (`student:direct_message`). This is the DM deferred from the chat PR.

All the socket events + the comprehension API already existed server-side — this is client wiring + the panel + the student ping.

## Verification
- `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)