### PR TITLE
feat(classroom): session countdown timer + tutor End Session

### DIFF
--- a/tutorme-app/src/app/api/one-on-one/session-status/route.ts
+++ b/tutorme-app/src/app/api/one-on-one/session-status/route.ts
@@ -135,6 +135,11 @@ export const GET = withAuth(async (req: NextRequest, session) => {
     withName,
     viewerIsTutor: isTutor,
     scheduledAt: Number.isFinite(start) ? new Date(start).toISOString() : null,
+    durationMinutes: ls.durationMinutes ?? 60,
+    // The persisted lifecycle status — lets the classroom show its "ended" overlay
+    // on reload / late-join after a manual early end (the time-based `ended` below
+    // only reflects the scheduled window, not an early end).
+    status: ls.status,
     opensAt: Number.isFinite(opensAt) ? new Date(opensAt).toISOString() : null,
     live,
     // The tutor may always enter; a student once the session is live or inside the

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -24,6 +24,7 @@ import {
   BookOpen,
   MessageSquare,
   Users,
+  Clock,
 } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
@@ -86,6 +87,10 @@ export function SessionClassroom({
   // Bumped when the Edit-course modal (iframe) reports a save, so the deploy
   // panel refetches instead of serving pre-edit task content.
   const [deployRefreshKey, setDeployRefreshKey] = useState(0)
+  // Session timing (for the countdown) + whether the room has been ended.
+  const [timing, setTiming] = useState<{ endTs: number } | null>(null)
+  const [nowTs, setNowTs] = useState(0)
+  const [ended, setEnded] = useState(false)
   const myId = session?.user?.id ?? ''
 
   // Listen for the embedded course-editor's save postMessage and refresh the
@@ -154,6 +159,56 @@ export function SessionClassroom({
     }
   }, [socket, isTutor, myId])
 
+  // Session countdown: fetch the scheduled end once, then tick a coarse clock.
+  useEffect(() => {
+    if (!sessionId) return
+    let active = true
+    fetch(`/api/one-on-one/session-status?sessionId=${encodeURIComponent(sessionId)}`, {
+      credentials: 'include',
+    })
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => {
+        if (!active || !d?.scheduledAt) return
+        const start = new Date(d.scheduledAt).getTime()
+        const mins = typeof d.durationMinutes === 'number' ? d.durationMinutes : 60
+        if (Number.isFinite(start)) setTiming({ endTs: start + mins * 60_000 })
+        if (d.status === 'ended') setEnded(true)
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [sessionId])
+  useEffect(() => {
+    setNowTs(Date.now())
+    const iv = setInterval(() => setNowTs(Date.now()), 20_000)
+    return () => clearInterval(iv)
+  }, [])
+
+  // Everyone leaves the room when it ends (tutor End, or the server's timeout end).
+  useEffect(() => {
+    if (!socket) return
+    const onEnded = () => setEnded(true)
+    socket.on('session:ended', onEnded)
+    return () => {
+      socket.off('session:ended', onEnded)
+    }
+  }, [socket])
+
+  const endSession = () => {
+    if (!socket) return
+    if (!window.confirm('End this session for everyone? This closes the room.')) return
+    socket.emit('tutor:end_session', { roomId: sessionId })
+  }
+
+  const remainingMs = timing && nowTs ? timing.endTs - nowTs : null
+  const timerLabel =
+    remainingMs == null
+      ? ''
+      : remainingMs > 0
+        ? `${Math.max(1, Math.ceil(remainingMs / 60_000))}m left`
+        : `Overdue ${Math.floor(-remainingMs / 60_000)}m`
+
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
   // room_state replay instead of missing everything that happened before.
@@ -189,6 +244,31 @@ export function SessionClassroom({
           videoComponent={video}
         />
       </FallbackBoundary>
+
+      {/* Session countdown (everyone) + tutor "End session". */}
+      {timing ? (
+        <div className="pointer-events-none absolute left-1/2 top-3 z-40 flex -translate-x-1/2 items-center gap-2">
+          <div className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur">
+            <Clock className="h-3.5 w-3.5 text-slate-500" />
+            <span
+              className={
+                remainingMs != null && remainingMs < 0 ? 'text-rose-600' : 'text-slate-800'
+              }
+            >
+              {timerLabel}
+            </span>
+          </div>
+          {isTutor ? (
+            <button
+              type="button"
+              onClick={endSession}
+              className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-rose-600/90 px-3 py-2 text-xs font-semibold text-white shadow-lg backdrop-blur hover:bg-rose-600"
+            >
+              End
+            </button>
+          ) : null}
+        </div>
+      ) : null}
 
       {/* Linked-course chip — so everyone in the room can see which course this
           session is built around. For the tutor the chip IS the deploy trigger
@@ -406,6 +486,16 @@ export function SessionClassroom({
             />
           </DialogContent>
         </Dialog>
+      ) : null}
+
+      {/* Room closed — the tutor ended it, or the server's duration timeout did. */}
+      {ended ? (
+        <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-slate-950/95 px-6 text-center text-white">
+          <p className="text-lg font-semibold">This session has ended</p>
+          <p className="max-w-sm text-sm text-white/70">
+            The room is closed. You can leave a review from your dashboard.
+          </p>
+        </div>
       ) : null}
     </div>
   )

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -490,11 +490,18 @@ export function SessionClassroom({
 
       {/* Room closed — the tutor ended it, or the server's duration timeout did. */}
       {ended ? (
-        <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-slate-950/95 px-6 text-center text-white">
+        <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-slate-950/95 px-6 text-center text-white">
           <p className="text-lg font-semibold">This session has ended</p>
           <p className="max-w-sm text-sm text-white/70">
             The room is closed. You can leave a review from your dashboard.
           </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-xl bg-white px-4 py-2 text-sm font-semibold text-slate-900 hover:bg-slate-100"
+          >
+            Leave
+          </button>
         </div>
       ) : null}
     </div>

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -2629,6 +2629,26 @@ export async function initEnhancedSocketServer(server: NetServer) {
       }
     )
 
+    // --- Tutor ends the session for everyone ---
+    // Mirrors the server's own duration-timeout end (mark the LiveSession ended +
+    // broadcast session:ended), just triggered on demand by the tutor. The
+    // booking-completion sweep runs independently, so this only closes the live
+    // room early — no refund/series side effects.
+    socket.on('tutor:end_session', async (data: { roomId: string }) => {
+      if (socket.data.role !== 'tutor') return
+      const roomId = data?.roomId || socket.data.roomId
+      if (!roomId) return
+      try {
+        await drizzleDb
+          .update(liveSession)
+          .set({ status: 'ended', endedAt: new Date() })
+          .where(eq(liveSession.sessionId, roomId))
+      } catch (err) {
+        console.warn('[tutor:end_session] failed to mark session ended:', err)
+      }
+      io.to(roomId).emit('session:ended', { sessionId: roomId, reason: 'tutor' })
+    })
+
     // Enhanced disconnect handler with cleanup
     socket.on('disconnect', async () => {
       console.log(`Client disconnected: ${socket.id}`)

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -2637,14 +2637,22 @@ export async function initEnhancedSocketServer(server: NetServer) {
     socket.on('tutor:end_session', async (data: { roomId: string }) => {
       if (socket.data.role !== 'tutor') return
       const roomId = data?.roomId || socket.data.roomId
-      if (!roomId) return
+      if (!roomId || !socket.data.userId) return
       try {
-        await drizzleDb
+        // Scope the end to a session THIS tutor owns — `roomId` is client-supplied,
+        // so without the tutorId predicate any tutor could end (and kick everyone
+        // out of) any session by id. Only broadcast if a row was actually ended.
+        const ended = await drizzleDb
           .update(liveSession)
           .set({ status: 'ended', endedAt: new Date() })
-          .where(eq(liveSession.sessionId, roomId))
+          .where(
+            and(eq(liveSession.sessionId, roomId), eq(liveSession.tutorId, socket.data.userId))
+          )
+          .returning({ id: liveSession.sessionId })
+        if (ended.length === 0) return // not this tutor's session — do nothing
       } catch (err) {
         console.warn('[tutor:end_session] failed to mark session ended:', err)
+        return
       }
       io.to(roomId).emit('session:ended', { sessionId: roomId, reason: 'tutor' })
     })


### PR DESCRIPTION
Final classroom feature-parity item: a **countdown timer** + a tutor **End session** control.

## What
- **Countdown chip (everyone)** — time remaining / overdue, computed from the session's `scheduledAt + durationMinutes` (fetched from the existing `/api/one-on-one/session-status`), ticked every 20s. Turns red when overdue.
- **Tutor "End session"** — confirms, then emits a new `tutor:end_session` socket event. The server handler marks the `LiveSession` ended (`status='ended'`, `endedAt`) and broadcasts `session:ended`. This mirrors the server's own **duration-timeout end path**, so it only closes the live room early — the booking-completion sweep (`one-on-one/complete.ts`) runs independently, so **no refund/series side effects**.
- **Ended overlay** — on `session:ended` (tutor end OR the server timeout), everyone gets a "session has ended" overlay closing the room.

## Safety
- The end action mirrors the existing timeout logic (same `status='ended' + endedAt` + `session:ended` broadcast); it does not touch bookings/refunds.
- Tutor-gated on both client (button only for `isTutor`) and server (`socket.data.role !== 'tutor'` guard).

## Verification
- `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)