### PR TITLE
fix(socket): track 1-on-1/group participants in the room roster (Monitor + Boards)

### DIFF
--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -254,8 +254,15 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       })
     }
 
-    const onStudentJoined = (data: { userId: string; name?: string }) => {
-      if (data?.userId) mergeStudents([data])
+    const onStudentJoined = (data: {
+      userId: string
+      name?: string
+      state?: Partial<SessionRosterStudent>
+    }) => {
+      // The server nests the live signals under `state` on join — flatten them so
+      // the Monitor shows engagement/status straight away, not only after the next
+      // student_state_update.
+      if (data?.userId) mergeStudents([{ userId: data.userId, name: data.name, ...data.state }])
     }
 
     const onChatMessage = (msg: SessionChatMessage) => {

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -966,8 +966,26 @@ export async function initEnhancedSocketServer(server: NetServer) {
             ),
           })
           if (!enrolled) {
-            socket.emit('error', { message: 'You are not enrolled in this course' })
-            return
+            // A 1-on-1 / group attendee isn't necessarily course-ENROLLED — they
+            // join via a booking / seat. The HTTP room-join already authorized them
+            // and wrote a SessionParticipant row, so accept that seat here too.
+            // Without this, a legit participant is left in the socket room (so the
+            // whiteboard works) but never added to room.students — making the
+            // tutor's Monitor + board viewer show an empty roster.
+            const [participant] = await drizzleDb
+              .select({ id: sessionParticipant.participantId })
+              .from(sessionParticipant)
+              .where(
+                and(
+                  eq(sessionParticipant.sessionId, roomId),
+                  eq(sessionParticipant.studentId, userId)
+                )
+              )
+              .limit(1)
+            if (!participant) {
+              socket.emit('error', { message: 'You are not enrolled in this course' })
+              return
+            }
           }
         }
       }


### PR DESCRIPTION
## The report
In a live session with students joined, the **Monitor** shows no students and the **Boards** picker shows no student boards.

## Root cause (confirmed against prod)
Both panels read the same `students` roster from `useSessionRoomState`, populated from the server's `room_state` / `student_joined`. The roster was empty because the socket **`join_class`** student gate authorizes only course-**ENROLLED** students:

```
courseEnrollment.findFirst(...) → if (!enrolled) { emit('error'); return }  // never added to room.students
```

But a 1-on-1/group attendee joins via a **booking / SessionParticipant seat**, not `courseEnrollment` (the HTTP room-join, `/api/class/rooms/[id]/join`, authorizes exactly that way and inserts a `SessionParticipant`). So for a **course-linked** session, a legit participant:
1. passes the HTTP join,
2. `socket.join(roomId)` (line 890) — so the **whiteboard works**,
3. then gets rejected before `addStudentToRoom` → **never enters `room.students`** → tutor's Monitor + board viewer are empty.

Verified on the live session "tttt" (courseId `2480cb2a`): participant is **not** course-enrolled. Course-**less** sessions were unaffected (the check is skipped when there's no courseId), which is why some sessions looked fine.

This is a pre-existing gap the new Monitor surfaced — the Boards picker was affected the whole time too.

## Fix
- In `join_class`, if the student isn't course-enrolled, **also accept a `SessionParticipant` seat** for this session before rejecting. Mirrors the HTTP join's authorization.
- Client: flatten the `student_joined` payload's nested `state` so a newly joined student shows engagement/status immediately (not only after their next ping).

## Note
Self-heals for live sessions on the next socket (re)connect; new joins after deploy work directly. Answer-key isolation and existing enrolled-student behavior are unchanged.

## Verification
- `tsc` clean · `npm run build` passes · prod query confirms the enrolled-vs-participant mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)