### PR TITLE
feat(socket): self-heal the room roster + share the student-auth check

### DIFF
--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -951,42 +951,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
       }
 
       if (effectiveRole === 'student') {
-        const liveSessionRow = await drizzleDb.query.liveSession.findFirst({
-          where: eq(liveSession.sessionId, roomId),
-        })
-        if (liveSessionRow?.courseId) {
-          // Match the whole variant family: the session's courseId may be the
-          // template while the student enrolled under the published variant —
-          // a raw match would wrongly reject a legitimately enrolled student.
-          const enrolledFamily = await expandToCourseFamily([liveSessionRow.courseId])
-          const enrolled = await drizzleDb.query.courseEnrollment.findFirst({
-            where: and(
-              eq(courseEnrollment.studentId, userId),
-              inArray(courseEnrollment.courseId, enrolledFamily)
-            ),
-          })
-          if (!enrolled) {
-            // A 1-on-1 / group attendee isn't necessarily course-ENROLLED — they
-            // join via a booking / seat. The HTTP room-join already authorized them
-            // and wrote a SessionParticipant row, so accept that seat here too.
-            // Without this, a legit participant is left in the socket room (so the
-            // whiteboard works) but never added to room.students — making the
-            // tutor's Monitor + board viewer show an empty roster.
-            const [participant] = await drizzleDb
-              .select({ id: sessionParticipant.participantId })
-              .from(sessionParticipant)
-              .where(
-                and(
-                  eq(sessionParticipant.sessionId, roomId),
-                  eq(sessionParticipant.studentId, userId)
-                )
-              )
-              .limit(1)
-            if (!participant) {
-              socket.emit('error', { message: 'You are not enrolled in this course' })
-              return
-            }
-          }
+        if (!(await authorizeSessionStudent(userId, roomId))) {
+          socket.emit('error', { message: 'You are not enrolled in this course' })
+          return
         }
       }
 
@@ -1177,6 +1144,18 @@ export async function initEnhancedSocketServer(server: NetServer) {
         if (!room) return
         room.lastActivity = Date.now()
         const student = room.students.get(socket.data.userId)
+        if (!student && socket.data.role === 'student' && socket.data.userId) {
+          // Self-heal: a legitimate participant who's missing from the roster (the
+          // room was recreated in memory, or they were connected before the
+          // participant-auth fix) — re-verify and re-add so the tutor's Monitor /
+          // board viewer and task submission recover without a manual refresh.
+          const uid = socket.data.userId
+          void (async () => {
+            if (room.students.has(uid)) return
+            if (await authorizeSessionStudent(uid, room.id)) await addStudentToRoom(socket, room)
+          })()
+          return
+        }
         if (student) {
           student.lastActivity = Date.now()
           if (typeof data?.engagement === 'number') student.engagement = data.engagement
@@ -2750,6 +2729,38 @@ export async function initEnhancedSocketServer(server: NetServer) {
 }
 
 // Helper functions (implementing join_class logic)
+/**
+ * May this student be a live participant of `sessionId`? Mirrors the HTTP room-join
+ * authorization so the two never disagree: a course-linked session accepts an
+ * ENROLLED student (matched across the whole template↔published variant family) OR
+ * a booking-seat holder (SessionParticipant, how 1-on-1/group attendees join); a
+ * course-less session gates on neither. Returning the seat check is what lets a
+ * 1-on-1/group participant appear in the tutor's roster + submit tasks.
+ */
+async function authorizeSessionStudent(userId: string, sessionId: string): Promise<boolean> {
+  if (!userId || !sessionId) return false
+  const liveSessionRow = await drizzleDb.query.liveSession.findFirst({
+    where: eq(liveSession.sessionId, sessionId),
+  })
+  if (!liveSessionRow?.courseId) return true // course-less session — no enrollment gate
+  const enrolledFamily = await expandToCourseFamily([liveSessionRow.courseId])
+  const enrolled = await drizzleDb.query.courseEnrollment.findFirst({
+    where: and(
+      eq(courseEnrollment.studentId, userId),
+      inArray(courseEnrollment.courseId, enrolledFamily)
+    ),
+  })
+  if (enrolled) return true
+  const [participant] = await drizzleDb
+    .select({ id: sessionParticipant.participantId })
+    .from(sessionParticipant)
+    .where(
+      and(eq(sessionParticipant.sessionId, sessionId), eq(sessionParticipant.studentId, userId))
+    )
+    .limit(1)
+  return !!participant
+}
+
 async function addStudentToRoom(socket: Socket, room: ClassRoom) {
   const studentState: StudentState = {
     userId: socket.data.userId,


### PR DESCRIPTION
Follow-up to the roster fix (#1197): make the roster recover **without a manual refresh**, and dedupe the auth logic.

## What
- **Shared auth helper** — extracted the join-time student authorization into `authorizeSessionStudent(userId, sessionId)`: a course-linked session accepts an **enrolled** student (across the variant family) OR a **`SessionParticipant`** seat-holder (how 1-on-1/group attendees join); a course-less session gates on neither. `join_class` now calls it, so the join gate and the self-heal below can't drift.
- **Roster self-heal** — in `activity_ping`, if a student pings but is missing from `room.students` (the room was recreated in memory, or they were connected before #1197 deployed), re-verify + re-add them. The tutor's Monitor/board viewer and the student's task submission then recover on the next ping (~15–20s), no refresh required.

## Notes
- The self-heal's DB check only runs when a student is *missing* from the roster (skipped in the common case), fired-and-forgotten so it never blocks the ping.
- Behavior-preserving refactor of `join_class` (same enrolled-OR-participant logic).

## Verification
- `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)