### PR TITLE
test(live): lock the session student-auth (enrolled OR participant)

### DIFF
--- a/tutorme-app/src/__tests__/integration/session-student-auth.test.ts
+++ b/tutorme-app/src/__tests__/integration/session-student-auth.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { user, course, liveSession, courseEnrollment, sessionParticipant } from '@/lib/db/schema'
+import { authorizeSessionStudent } from '@/lib/live/session-student-auth'
+
+/**
+ * Regression guard for #1197/#1198: a 1-on-1/group attendee joins a session via a
+ * SessionParticipant seat, NOT courseEnrollment. The socket join gate must accept
+ * that seat — otherwise the participant is silently dropped from the room roster
+ * (empty Monitor/Boards) AND cannot submit tasks (task:complete gates on being in
+ * room.students). This locks the enrolled-OR-participant authorization.
+ */
+const sfx = crypto.randomUUID().slice(0, 8)
+const tutorId = `t-auth-${sfx}`
+const enrolledStudent = `s-enr-${sfx}`
+const participantStudent = `s-part-${sfx}`
+const outsiderStudent = `s-out-${sfx}`
+const courseId = `c-auth-${sfx}`
+const courseSession = `sess-course-${sfx}`
+const courselessSession = `sess-none-${sfx}`
+
+describe('authorizeSessionStudent (integration)', () => {
+  beforeAll(async () => {
+    const now = new Date()
+    await drizzleDb.insert(user).values(
+      [tutorId, enrolledStudent, participantStudent, outsiderStudent].map((id, i) => ({
+        userId: id,
+        email: `${id}@example.test`,
+        role: i === 0 ? ('TUTOR' as const) : ('STUDENT' as const),
+        createdAt: now,
+        updatedAt: now,
+      }))
+    )
+    await drizzleDb
+      .insert(course)
+      .values({ courseId, name: `Auth Course ${sfx}`, creatorId: tutorId })
+    await drizzleDb.insert(liveSession).values([
+      {
+        sessionId: courseSession,
+        tutorId,
+        courseId,
+        title: 'Course-linked',
+        category: 'general',
+        status: 'active',
+        scheduledAt: now,
+      },
+      {
+        sessionId: courselessSession,
+        tutorId,
+        courseId: null,
+        title: 'Course-less',
+        category: 'general',
+        status: 'active',
+        scheduledAt: now,
+      },
+    ])
+    await drizzleDb.insert(courseEnrollment).values({
+      enrollmentId: `enr-${sfx}`,
+      studentId: enrolledStudent,
+      courseId,
+    })
+    await drizzleDb.insert(sessionParticipant).values({
+      participantId: `part-${sfx}`,
+      sessionId: courseSession,
+      studentId: participantStudent,
+    })
+  })
+
+  afterAll(async () => {
+    await drizzleDb
+      .delete(sessionParticipant)
+      .where(eq(sessionParticipant.sessionId, courseSession))
+    await drizzleDb.delete(courseEnrollment).where(eq(courseEnrollment.courseId, courseId))
+    await drizzleDb
+      .delete(liveSession)
+      .where(inArray(liveSession.sessionId, [courseSession, courselessSession]))
+    await drizzleDb.delete(course).where(eq(course.courseId, courseId))
+    await drizzleDb
+      .delete(user)
+      .where(inArray(user.userId, [tutorId, enrolledStudent, participantStudent, outsiderStudent]))
+  })
+
+  it('authorizes an ENROLLED student on a course-linked session', async () => {
+    expect(await authorizeSessionStudent(enrolledStudent, courseSession)).toBe(true)
+  })
+
+  it('authorizes a SessionParticipant (booking seat) who is NOT enrolled', async () => {
+    expect(await authorizeSessionStudent(participantStudent, courseSession)).toBe(true)
+  })
+
+  it('rejects a student who is neither enrolled nor a participant', async () => {
+    expect(await authorizeSessionStudent(outsiderStudent, courseSession)).toBe(false)
+  })
+
+  it('authorizes anyone on a course-less session (no enrollment gate)', async () => {
+    expect(await authorizeSessionStudent(outsiderStudent, courselessSession)).toBe(true)
+  })
+
+  it('rejects empty inputs', async () => {
+    expect(await authorizeSessionStudent('', courseSession)).toBe(false)
+    expect(await authorizeSessionStudent(enrolledStudent, '')).toBe(false)
+  })
+})

--- a/tutorme-app/src/lib/live/session-student-auth.ts
+++ b/tutorme-app/src/lib/live/session-student-auth.ts
@@ -1,0 +1,50 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { liveSession, courseEnrollment, sessionParticipant } from '@/lib/db/schema'
+import { expandToCourseFamily } from '@/lib/courses/variant-family'
+
+/**
+ * May this student be a live participant of `sessionId`?
+ *
+ * Mirrors the HTTP room-join authorization so the socket layer and the HTTP layer
+ * never disagree:
+ *  - a course-linked session accepts an ENROLLED student — matched across the whole
+ *    template↔published variant family (a raw courseId match would wrongly reject a
+ *    student enrolled under a sibling variant) — OR a booking-seat holder
+ *    (`SessionParticipant`, how 1-on-1/group attendees join);
+ *  - a course-less session gates on neither.
+ *
+ * The participant branch is what lets a 1-on-1/group attendee appear in the tutor's
+ * roster and submit tasks — without it a legitimate participant is left in the socket
+ * room (whiteboard works) but never tracked in `room.students`.
+ */
+export async function authorizeSessionStudent(userId: string, sessionId: string): Promise<boolean> {
+  if (!userId || !sessionId) return false
+
+  const [ls] = await drizzleDb
+    .select({ courseId: liveSession.courseId })
+    .from(liveSession)
+    .where(eq(liveSession.sessionId, sessionId))
+    .limit(1)
+  // No course to gate on (course-less session, or no such session) → not rejected,
+  // matching the original join gate. Course-linked sessions fall through to the
+  // enrollment / participant checks below.
+  if (!ls?.courseId) return true
+
+  const family = await expandToCourseFamily([ls.courseId])
+  const [enrolled] = await drizzleDb
+    .select({ studentId: courseEnrollment.studentId })
+    .from(courseEnrollment)
+    .where(and(eq(courseEnrollment.studentId, userId), inArray(courseEnrollment.courseId, family)))
+    .limit(1)
+  if (enrolled) return true
+
+  const [participant] = await drizzleDb
+    .select({ id: sessionParticipant.participantId })
+    .from(sessionParticipant)
+    .where(
+      and(eq(sessionParticipant.sessionId, sessionId), eq(sessionParticipant.studentId, userId))
+    )
+    .limit(1)
+  return !!participant
+}

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -9,6 +9,7 @@ import Redis from 'ioredis'
 import * as Sentry from '@sentry/nextjs'
 import { eq, and, inArray, desc } from 'drizzle-orm'
 import { expandToCourseFamily } from '@/lib/courses/variant-family'
+import { authorizeSessionStudent } from '@/lib/live/session-student-auth'
 import { drizzleDb } from '@/lib/db/drizzle'
 import {
   liveSession,
@@ -2729,37 +2730,6 @@ export async function initEnhancedSocketServer(server: NetServer) {
 }
 
 // Helper functions (implementing join_class logic)
-/**
- * May this student be a live participant of `sessionId`? Mirrors the HTTP room-join
- * authorization so the two never disagree: a course-linked session accepts an
- * ENROLLED student (matched across the whole template↔published variant family) OR
- * a booking-seat holder (SessionParticipant, how 1-on-1/group attendees join); a
- * course-less session gates on neither. Returning the seat check is what lets a
- * 1-on-1/group participant appear in the tutor's roster + submit tasks.
- */
-async function authorizeSessionStudent(userId: string, sessionId: string): Promise<boolean> {
-  if (!userId || !sessionId) return false
-  const liveSessionRow = await drizzleDb.query.liveSession.findFirst({
-    where: eq(liveSession.sessionId, sessionId),
-  })
-  if (!liveSessionRow?.courseId) return true // course-less session — no enrollment gate
-  const enrolledFamily = await expandToCourseFamily([liveSessionRow.courseId])
-  const enrolled = await drizzleDb.query.courseEnrollment.findFirst({
-    where: and(
-      eq(courseEnrollment.studentId, userId),
-      inArray(courseEnrollment.courseId, enrolledFamily)
-    ),
-  })
-  if (enrolled) return true
-  const [participant] = await drizzleDb
-    .select({ id: sessionParticipant.participantId })
-    .from(sessionParticipant)
-    .where(
-      and(eq(sessionParticipant.sessionId, sessionId), eq(sessionParticipant.studentId, userId))
-    )
-    .limit(1)
-  return !!participant
-}
 
 async function addStudentToRoom(socket: Socket, room: ClassRoom) {
   const studentState: StudentState = {


### PR DESCRIPTION
Locks the auth fix from #1197/#1198 with a real integration test (the bug was silent + high-impact: empty roster **and** blocked task submission for 1-on-1/group participants).

## What
- **Extracted** `authorizeSessionStudent` from the (heavy) socket-server file into a standalone lib `src/lib/live/session-student-auth.ts` — same logic, now importable/testable in isolation. The socket server imports it (behaviour-preserving).
- **Integration test** (`session-student-auth.test.ts`), verified locally against real Postgres — 5/5 pass:
  - enrolled student on a course-linked session → **authorized**
  - `SessionParticipant` (booking seat, NOT enrolled) → **authorized** ← the case that regressed
  - neither enrolled nor participant → **rejected**
  - course-less session → **authorized** (no enrollment gate)
  - empty inputs → **rejected**

## Verification
- `tsc` clean · `npm run build` passes · integration test 5/5 green locally (docker Postgres) — CI runs it too via `drizzle-kit push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)