### PR TITLE
feat(classroom): live in-session polls for 1-on-1/group sessions

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -25,6 +25,7 @@ import {
   MessageSquare,
   Users,
   Clock,
+  BarChart3,
 } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
@@ -40,11 +41,12 @@ import {
 import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
 import { SessionChatPanel } from '@/components/one-on-one/session-chat-panel'
 import { SessionMonitorPanel } from '@/components/one-on-one/session-monitor-panel'
+import { SessionPollPanel, SessionPollCard } from '@/components/one-on-one/session-poll'
 import { toast } from 'sonner'
 import { FallbackBoundary } from '@/components/ui/fallback-boundary'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 
-type ActivePanel = 'deploy' | 'materials' | 'responses' | 'chat' | 'monitor' | null
+type ActivePanel = 'deploy' | 'materials' | 'responses' | 'chat' | 'monitor' | 'poll' | null
 interface BoardTarget {
   ownerId: string
   ownerName: string
@@ -212,8 +214,15 @@ export function SessionClassroom({
   // Canonical deployed-task + submission state, owned here (mounted from join)
   // so the panels — which mount only when opened — hydrate from the join-time
   // room_state replay instead of missing everything that happened before.
-  const { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students, chatMessages } =
-    useSessionRoomState(socket, session?.user?.id)
+  const {
+    tasks,
+    responsesByTask,
+    myCompletedTaskIds,
+    myResultByTask,
+    students,
+    chatMessages,
+    activePoll,
+  } = useSessionRoomState(socket, session?.user?.id)
 
   // The call feed rides along as the whiteboard's draggable video overlay.
   const video = (
@@ -328,6 +337,17 @@ export function SessionClassroom({
               <Users className="h-3.5 w-3.5" />
               Monitor
             </button>
+            <button
+              type="button"
+              onClick={() => toggle('poll')}
+              className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+            >
+              <BarChart3 className="h-3.5 w-3.5" />
+              Poll
+              {activePoll ? (
+                <span className="ml-0.5 h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              ) : null}
+            </button>
             {courseId ? (
               <button
                 type="button"
@@ -438,6 +458,14 @@ export function SessionClassroom({
                 onClose={() => setActivePanel(null)}
               />
             ) : null}
+            {activePanel === 'poll' && isTutor ? (
+              <SessionPollPanel
+                sessionId={sessionId}
+                socket={socket}
+                activePoll={activePoll}
+                onClose={() => setActivePanel(null)}
+              />
+            ) : null}
             {activePanel === 'monitor' && isTutor ? (
               <SessionMonitorPanel
                 sessionId={sessionId}
@@ -486,6 +514,19 @@ export function SessionClassroom({
             />
           </DialogContent>
         </Dialog>
+      ) : null}
+
+      {/* Live poll — auto-shown to students while one is active (the tutor drives it
+          from the Poll panel). Keyed by poll id so a new poll resets the card. */}
+      {activePoll && !isTutor ? (
+        <div className="pointer-events-none absolute bottom-4 left-1/2 z-40 -translate-x-1/2">
+          <SessionPollCard
+            key={activePoll.id}
+            sessionId={sessionId}
+            socket={socket}
+            poll={activePoll}
+          />
+        </div>
       ) : null}
 
       {/* Room closed — the tutor ended it, or the server's duration timeout did. */}

--- a/tutorme-app/src/components/one-on-one/session-poll.tsx
+++ b/tutorme-app/src/components/one-on-one/session-poll.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState } from 'react'
+import type { Socket } from 'socket.io-client'
+import { X, Plus, BarChart3, Send, Trash2 } from 'lucide-react'
+import type { SessionActivePoll } from './use-session-room-state'
+
+/**
+ * Live in-session poll — an ephemeral pulse-check. The tutor launches a question
+ * with 2–8 options (`poll:launch`); students vote (`poll:vote`); everyone sees the
+ * live tally; the tutor closes it (`poll:close`). State is owned by the classroom
+ * (`useSessionRoomState.activePoll`, hydrated on join) and passed in.
+ */
+
+export function SessionPollPanel({
+  sessionId,
+  socket,
+  activePoll,
+  onClose,
+}: {
+  sessionId: string
+  socket: Socket | null
+  activePoll: SessionActivePoll | null
+  onClose: () => void
+}) {
+  const [question, setQuestion] = useState('')
+  const [options, setOptions] = useState<string[]>(['', ''])
+
+  const setOption = (i: number, v: string) =>
+    setOptions(prev => prev.map((o, idx) => (idx === i ? v : o)))
+  const addOption = () => setOptions(prev => (prev.length >= 8 ? prev : [...prev, '']))
+  const removeOption = (i: number) =>
+    setOptions(prev => (prev.length <= 2 ? prev : prev.filter((_, idx) => idx !== i)))
+
+  const launch = () => {
+    const q = question.trim()
+    const opts = options.map(o => o.trim()).filter(Boolean)
+    if (!q || opts.length < 2 || !socket) return
+    socket.emit('poll:launch', { roomId: sessionId, question: q, options: opts })
+    setQuestion('')
+    setOptions(['', ''])
+  }
+  const close = () => {
+    if (activePoll && socket)
+      socket.emit('poll:close', { roomId: sessionId, pollId: activePoll.id })
+  }
+
+  return (
+    <div className="pointer-events-auto flex h-full w-80 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+          <BarChart3 className="h-4 w-4 text-blue-600" />
+          Poll
+        </h3>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {activePoll ? (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm font-semibold text-slate-900">{activePoll.question}</p>
+            <PollResults poll={activePoll} />
+            <button
+              onClick={close}
+              className="mt-1 inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-600 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-500"
+            >
+              End poll
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <label className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              Question
+            </label>
+            <input
+              value={question}
+              onChange={e => setQuestion(e.target.value)}
+              placeholder="Ask the room a question…"
+              className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none"
+            />
+            <label className="mt-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              Options
+            </label>
+            {options.map((o, i) => (
+              <div key={i} className="flex items-center gap-1.5">
+                <input
+                  value={o}
+                  onChange={e => setOption(i, e.target.value)}
+                  placeholder={`Option ${i + 1}`}
+                  className="min-w-0 flex-1 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none"
+                />
+                {options.length > 2 ? (
+                  <button
+                    onClick={() => removeOption(i)}
+                    aria-label="Remove option"
+                    className="shrink-0 rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-rose-500"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+              </div>
+            ))}
+            {options.length < 8 ? (
+              <button
+                onClick={addOption}
+                className="inline-flex w-fit items-center gap-1 rounded-lg px-1 py-0.5 text-xs font-medium text-blue-600 hover:bg-blue-50"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add option
+              </button>
+            ) : null}
+            <button
+              onClick={launch}
+              disabled={!socket || !question.trim() || options.filter(o => o.trim()).length < 2}
+              className="mt-2 inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
+            >
+              <Send className="h-3.5 w-3.5" />
+              Launch poll
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Auto-shown to students while a poll is active: tap an option to vote, then see the
+ * live results. Uses the hydrated `myOptionIndex` so a reconnect resumes the vote.
+ */
+export function SessionPollCard({
+  sessionId,
+  socket,
+  poll,
+}: {
+  sessionId: string
+  socket: Socket | null
+  poll: SessionActivePoll
+}) {
+  const [voted, setVoted] = useState<number | null>(poll.myOptionIndex ?? null)
+
+  const vote = (i: number) => {
+    if (voted != null || !socket) return
+    socket.emit('poll:vote', { roomId: sessionId, pollId: poll.id, optionIndex: i })
+    setVoted(i)
+  }
+
+  return (
+    <div className="pointer-events-auto w-[22rem] max-w-[92vw] rounded-2xl border border-slate-200 bg-white p-4 shadow-2xl">
+      <p className="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-blue-500">
+        <BarChart3 className="h-3 w-3" /> Live poll
+      </p>
+      <p className="mb-3 text-sm font-semibold text-slate-900">{poll.question}</p>
+      {voted == null ? (
+        <ul className="flex flex-col gap-1.5">
+          {poll.options.map((o, i) => (
+            <li key={i}>
+              <button
+                onClick={() => vote(i)}
+                disabled={!socket}
+                className="w-full rounded-lg border border-slate-200 px-3 py-2 text-left text-sm text-slate-800 hover:border-blue-500 hover:bg-blue-50 disabled:opacity-60"
+              >
+                {o}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <>
+          <PollResults poll={poll} highlight={voted} />
+          <p className="mt-2 text-center text-[11px] text-slate-400">Your answer is in.</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+/** Horizontal tally bars with per-option count + percentage. */
+function PollResults({ poll, highlight }: { poll: SessionActivePoll; highlight?: number }) {
+  const counts = poll.tally?.counts ?? poll.options.map(() => 0)
+  const total = poll.tally?.total ?? 0
+  return (
+    <div className="flex flex-col gap-1.5">
+      {poll.options.map((o, i) => {
+        const count = counts[i] ?? 0
+        const pct = total > 0 ? Math.round((count / total) * 100) : 0
+        return (
+          <div key={i}>
+            <div className="mb-0.5 flex items-center justify-between text-xs">
+              <span className={highlight === i ? 'font-semibold text-blue-700' : 'text-slate-700'}>
+                {o}
+              </span>
+              <span className="shrink-0 text-slate-400">
+                {count} · {pct}%
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+              <div
+                className={highlight === i ? 'h-full bg-blue-600' : 'h-full bg-blue-400'}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        )
+      })}
+      <p className="mt-0.5 text-[11px] text-slate-400">
+        {total} vote{total === 1 ? '' : 's'}
+      </p>
+    </div>
+  )
+}

--- a/tutorme-app/src/components/one-on-one/use-session-room-state.ts
+++ b/tutorme-app/src/components/one-on-one/use-session-room-state.ts
@@ -43,6 +43,22 @@ export interface SessionStudentResponse {
   correctAnswers?: Record<string, string> | null
 }
 
+export interface SessionPollTally {
+  pollId: string
+  counts: number[]
+  total: number
+}
+
+/** The active in-session live poll as the client tracks it. */
+export interface SessionActivePoll {
+  id: string
+  question: string
+  options: string[]
+  tally?: SessionPollTally | null
+  /** This user's chosen option (hydrated on join; set locally on vote). */
+  myOptionIndex?: number | null
+}
+
 /** A room chat message (mirrors the socket server's ChatMessage). */
 export interface SessionChatMessage {
   id: string
@@ -81,6 +97,7 @@ interface RoomStatePayload {
   students?: Array<Partial<SessionRosterStudent> & { userId: string }>
   tasks?: Array<SessionRoomTask & { responses?: Record<string, Record<string, string>> }>
   chatHistory?: SessionChatMessage[]
+  activePoll?: SessionActivePoll | null
 }
 
 interface TaskCompletedEvent {
@@ -123,6 +140,9 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
   // Room chat — hydrated from room_state on join, appended live. Held here (in the
   // always-mounted classroom) so the chat panel shows history even when opened late.
   const [chatMessages, setChatMessages] = useState<SessionChatMessage[]>([])
+  // The active in-session live poll (null when none). Hydrated on join, updated by
+  // poll:started / poll:tally / poll:closed.
+  const [activePoll, setActivePoll] = useState<SessionActivePoll | null>(null)
 
   useEffect(() => {
     if (!socket) return
@@ -170,6 +190,7 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     const onRoomState = (state: RoomStatePayload) => {
       if (Array.isArray(state?.students)) mergeStudents(state.students)
       if (Array.isArray(state?.chatHistory)) mergeChat(state.chatHistory)
+      if (state?.activePoll !== undefined) setActivePoll(state.activePoll)
       if (!Array.isArray(state?.tasks)) return
       const nameById = new Map((state.students ?? []).map(s => [s.userId, s.name || 'Student']))
       setTasks(prev => {
@@ -269,6 +290,21 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       if (msg?.id && typeof msg.text === 'string') mergeChat([msg])
     }
 
+    const onPollStarted = (p: { id: string; question: string; options: string[] }) => {
+      if (!p?.id) return
+      setActivePoll({
+        id: p.id,
+        question: p.question,
+        options: p.options ?? [],
+        tally: { pollId: p.id, counts: (p.options ?? []).map(() => 0), total: 0 },
+        myOptionIndex: null,
+      })
+    }
+    const onPollTally = (t: SessionPollTally) =>
+      setActivePoll(cur => (cur && cur.id === t?.pollId ? { ...cur, tally: t } : cur))
+    const onPollClosed = (t: SessionPollTally) =>
+      setActivePoll(cur => (cur && cur.id === t?.pollId ? null : cur))
+
     socket.on('room_state', onRoomState)
     socket.on('task:deployed', onDeployed)
     socket.on('task:updated', onUpdated)
@@ -277,6 +313,9 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     socket.on('student_joined', onStudentJoined)
     socket.on('chat_message', onChatMessage)
     socket.on('student_state_update', onStudentState)
+    socket.on('poll:started', onPollStarted)
+    socket.on('poll:tally', onPollTally)
+    socket.on('poll:closed', onPollClosed)
     return () => {
       socket.off('room_state', onRoomState)
       socket.off('task:deployed', onDeployed)
@@ -286,6 +325,9 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
       socket.off('student_joined', onStudentJoined)
       socket.off('chat_message', onChatMessage)
       socket.off('student_state_update', onStudentState)
+      socket.off('poll:started', onPollStarted)
+      socket.off('poll:tally', onPollTally)
+      socket.off('poll:closed', onPollClosed)
     }
   }, [socket])
 
@@ -314,5 +356,13 @@ export function useSessionRoomState(socket: Socket | null, myUserId: string | un
     return out
   }, [responsesByTask, myUserId])
 
-  return { tasks, responsesByTask, myCompletedTaskIds, myResultByTask, students, chatMessages }
+  return {
+    tasks,
+    responsesByTask,
+    myCompletedTaskIds,
+    myResultByTask,
+    students,
+    chatMessages,
+    activePoll,
+  }
 }

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -59,6 +59,17 @@ export interface StudentState {
   joinedAt: number
 }
 
+/** An ephemeral in-session live poll (one active per room). Not persisted — a
+ *  quick pulse-check the tutor runs live; cleared when closed or the room ends. */
+export interface LivePoll {
+  id: string
+  question: string
+  options: string[]
+  /** studentId → chosen option index. */
+  votes: Record<string, number>
+  startedAt: number
+}
+
 export interface ClassRoom {
   id: string
   tutorId: string
@@ -67,6 +78,7 @@ export interface ClassRoom {
   chatHistory: ChatMessage[]
   tasks: LiveTask[]
   polls?: any[]
+  activePoll?: LivePoll | null
   codeEditorContent?: string
   codeLanguage?: string
   createdAt: Date
@@ -872,6 +884,56 @@ export async function initEnhancedSocketServer(server: NetServer) {
             console.error('[chat_message] Failed to persist chat message:', err)
           })
       }
+    })
+
+    // --- Live poll (ephemeral, one active per room) ---
+    // Tutor launches a quick poll; students vote; everyone sees the live tally.
+    socket.on('poll:launch', (data: { roomId: string; question?: string; options?: string[] }) => {
+      if (socket.data.role !== 'tutor') return
+      const roomId = data?.roomId || socket.data.roomId
+      const room = roomId ? activeRooms.get(roomId) : null
+      if (!room) return
+      const question = String(data?.question ?? '')
+        .slice(0, 300)
+        .trim()
+      const options = (Array.isArray(data?.options) ? data.options : [])
+        .map(o => String(o).slice(0, 140).trim())
+        .filter(Boolean)
+        .slice(0, 8)
+      if (!question || options.length < 2) return
+      const poll: LivePoll = {
+        id: crypto.randomUUID(),
+        question,
+        options,
+        votes: {},
+        startedAt: Date.now(),
+      }
+      room.activePoll = poll
+      room.lastActivity = Date.now()
+      io.to(roomId).emit('poll:started', { id: poll.id, question, options })
+    })
+
+    socket.on('poll:vote', (data: { roomId: string; pollId: string; optionIndex: number }) => {
+      const roomId = data?.roomId || socket.data.roomId
+      const room = roomId ? activeRooms.get(roomId) : null
+      const poll = room?.activePoll
+      const uid = socket.data.userId
+      if (!room || !poll || !uid || poll.id !== data?.pollId) return
+      const idx = data?.optionIndex
+      if (typeof idx !== 'number' || idx < 0 || idx >= poll.options.length) return
+      poll.votes[uid] = idx
+      room.lastActivity = Date.now()
+      io.to(roomId).emit('poll:tally', pollTally(poll))
+    })
+
+    socket.on('poll:close', (data: { roomId: string; pollId: string }) => {
+      if (socket.data.role !== 'tutor') return
+      const roomId = data?.roomId || socket.data.roomId
+      const room = roomId ? activeRooms.get(roomId) : null
+      if (!room || !room.activePoll || room.activePoll.id !== data?.pollId) return
+      const tally = pollTally(room.activePoll)
+      room.activePoll = null
+      io.to(roomId).emit('poll:closed', tally)
     })
 
     // Enhanced room management with authentication
@@ -2731,6 +2793,24 @@ export async function initEnhancedSocketServer(server: NetServer) {
 
 // Helper functions (implementing join_class logic)
 
+function pollTally(poll: LivePoll): { pollId: string; counts: number[]; total: number } {
+  const counts = new Array(poll.options.length).fill(0)
+  for (const idx of Object.values(poll.votes)) if (idx >= 0 && idx < counts.length) counts[idx]++
+  return { pollId: poll.id, counts, total: Object.keys(poll.votes).length }
+}
+
+/** The active poll as a joining client should see it: options + live tally + the
+ *  joiner's own vote (so a late-joiner or reconnect resumes exactly where they were). */
+function formatActivePoll(poll: LivePoll, userId: string) {
+  return {
+    id: poll.id,
+    question: poll.question,
+    options: poll.options,
+    tally: pollTally(poll),
+    myOptionIndex: userId in poll.votes ? poll.votes[userId] : null,
+  }
+}
+
 async function addStudentToRoom(socket: Socket, room: ClassRoom) {
   const studentState: StudentState = {
     userId: socket.data.userId,
@@ -2769,6 +2849,7 @@ async function addStudentToRoom(socket: Socket, room: ClassRoom) {
     chatHistory: room.chatHistory.slice(-50),
     whiteboardData: room.whiteboardData,
     tasks: refreshedTasks,
+    activePoll: room.activePoll ? formatActivePoll(room.activePoll, socket.data.userId) : null,
   })
 }
 
@@ -2789,6 +2870,7 @@ async function addTutorToRoom(socket: Socket, room: ClassRoom) {
     chatHistory: room.chatHistory,
     whiteboardData: room.whiteboardData,
     tasks: refreshedTasks,
+    activePoll: room.activePoll ? formatActivePoll(room.activePoll, socket.data.userId) : null,
   })
 }
 

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -892,7 +892,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
       if (socket.data.role !== 'tutor') return
       const roomId = data?.roomId || socket.data.roomId
       const room = roomId ? activeRooms.get(roomId) : null
-      if (!room) return
+      // `roomId` is client-supplied — only the room's OWN tutor may run a poll in it,
+      // else any tutor could clobber another room's poll (mirrors tutor:end_session).
+      if (!room || room.tutorId !== socket.data.userId) return
       const question = String(data?.question ?? '')
         .slice(0, 300)
         .trim()
@@ -918,7 +920,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
       const room = roomId ? activeRooms.get(roomId) : null
       const poll = room?.activePoll
       const uid = socket.data.userId
-      if (!room || !poll || !uid || poll.id !== data?.pollId) return
+      // Only a member of THIS room's roster may vote (defense in depth: the pollId
+      // is only broadcast to room members, but don't rely on that alone).
+      if (!room || !poll || !uid || poll.id !== data?.pollId || !room.students.has(uid)) return
       const idx = data?.optionIndex
       if (typeof idx !== 'number' || idx < 0 || idx >= poll.options.length) return
       poll.votes[uid] = idx
@@ -930,7 +934,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
       if (socket.data.role !== 'tutor') return
       const roomId = data?.roomId || socket.data.roomId
       const room = roomId ? activeRooms.get(roomId) : null
-      if (!room || !room.activePoll || room.activePoll.id !== data?.pollId) return
+      if (!room || room.tutorId !== socket.data.userId) return
+      if (!room.activePoll || room.activePoll.id !== data?.pollId) return
       const tally = pollTally(room.activePoll)
       room.activePoll = null
       io.to(roomId).emit('poll:closed', tally)


### PR DESCRIPTION
The last interactive feature the 1-on-1/group classroom lacked vs the course-builder: a **live poll** / pulse-check.

## What (MVP — ephemeral, socket-based)
One active poll per room, entirely over the socket (no dependency on the half-wired REST poll path):
- **Server:** `poll:launch` (tutor, 2–8 options) → `room.activePoll` + broadcast `poll:started`; `poll:vote` (student) → record + broadcast `poll:tally`; `poll:close` (tutor) → clear + broadcast `poll:closed`. The active poll — with its **live tally and the joiner's own vote** — is hydrated in `room_state`, so a late-joiner or reconnect resumes exactly.
- **Client:** the room-state hook tracks `activePoll`; the tutor **Poll panel** composes (question + add/remove options) and shows the **live tally + End**; students get an **auto-appearing card** to vote, then see results (own choice highlighted).

## Guards
- `poll:launch`/`poll:close` are tutor-only (`socket.data.role` — JWT-server-set); inputs clamped (question ≤300, ≤8 options); votes validated against the active poll + option range.

## Scope note
Ephemeral (not persisted) — a quick in-session pulse. DB-backed polls / the course-builder's 5 option modes + AI generation can follow.

## Verification
- `tsc` clean · `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)