### PR TITLE
feat(db): enforce the courseId → Course foreign keys

### DIFF
--- a/tutorme-app/package.json
+++ b/tutorme-app/package.json
@@ -50,7 +50,8 @@
     "audit:orphaned-courses": "tsx scripts/audit-orphaned-courses.ts",
     "cleanup:orphaned-courses": "tsx scripts/cleanup-orphaned-courses.ts",
     "copy-pdf-worker": "node scripts/copy-pdf-worker.js",
-    "postinstall": "node scripts/copy-pdf-worker.js"
+    "postinstall": "node scripts/copy-pdf-worker.js",
+    "recover:protected-courses": "tsx scripts/recover-protected-courses.ts"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.87.0",

--- a/tutorme-app/scripts/recover-protected-courses.ts
+++ b/tutorme-app/scripts/recover-protected-courses.ts
@@ -1,0 +1,119 @@
+/**
+ * Recreate a minimal placeholder Course row for every course that was hard-deleted
+ * but still has rows pointing at it (after `cleanup-orphaned-courses.ts` runs, these
+ * are exactly the submission-bearing courses it protected). This restores a valid FK
+ * parent for that orphaned student work so the missing `courseId` foreign keys can
+ * finally be enforced — without resurrecting the courses in the UI.
+ *
+ * The placeholders are created SOFT-DELETED (deletedAt set) so course listings (which
+ * filter `deletedAt IS NULL`) don't show them; they exist only for referential
+ * integrity. `creatorId` is recovered from the orphaned rows' tutorId (nullable if
+ * none is found). Idempotent — onConflictDoNothing, so re-running is a no-op.
+ *
+ * DRY RUN (default) — reports what it would create; writes NOTHING:
+ *   npm run recover:protected-courses
+ * APPLY — creates the placeholders (against the DIRECT url):
+ *   npm run recover:protected-courses -- --apply
+ */
+
+import { sql } from 'drizzle-orm'
+import { drizzleDb } from '../src/lib/db/drizzle'
+import { course } from '../src/lib/db/schema'
+
+const APPLY = process.argv.includes('--apply')
+
+// Parent tables whose courseId can point at a (now-missing) Course.
+const PARENTS = [
+  'LiveSession',
+  'CourseLesson',
+  'CalendarEvent',
+  'CourseEnrollment',
+  'BuilderTask',
+  'OneOnOneBookingRequest',
+  'GroupSession',
+]
+
+async function rows<T = Record<string, unknown>>(q: ReturnType<typeof sql>): Promise<T[]> {
+  const res = await drizzleDb.execute(q)
+  return res.rows as T[]
+}
+
+async function main() {
+  console.log(`=== Recover protected courses (${APPLY ? 'APPLY' : 'DRY RUN'}) ===\n`)
+
+  // Every courseId referenced by a parent table that has no Course row.
+  const missing = new Set<string>()
+  for (const t of PARENTS) {
+    const found = await rows<{ cid: string }>(
+      sql.raw(`
+      SELECT DISTINCT t."courseId" AS cid FROM "${t}" t
+      WHERE t."courseId" IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM "Course" c WHERE c."id" = t."courseId")
+    `)
+    )
+    for (const r of found) missing.add(r.cid)
+  }
+
+  if (missing.size === 0) {
+    console.log('No orphaned courseIds — nothing to recover.')
+    return
+  }
+
+  // Recover a creatorId (tutorId) for each, from its orphaned rows.
+  const now = new Date()
+  const toInsert: { courseId: string; creatorId: string | null; nTutor: string | null }[] = []
+  for (const cid of missing) {
+    const [t] = await rows<{ tutorId: string | null }>(sql`
+      SELECT "tutorId" FROM "BuilderTask" WHERE "courseId" = ${cid} AND "tutorId" IS NOT NULL
+      UNION
+      SELECT "tutorId" FROM "LiveSession" WHERE "courseId" = ${cid} AND "tutorId" IS NOT NULL
+      LIMIT 1
+    `)
+    // Only use the tutor if the User still exists (creatorId FK).
+    let creatorId: string | null = null
+    if (t?.tutorId) {
+      const u = await rows(sql`SELECT 1 FROM "User" WHERE "id" = ${t.tutorId} LIMIT 1`)
+      if (u.length > 0) creatorId = t.tutorId
+    }
+    toInsert.push({ courseId: cid, creatorId, nTutor: t?.tutorId ?? null })
+  }
+
+  console.log(`Orphaned courseIds to recover: ${toInsert.length}\n`)
+  for (const r of toInsert) {
+    console.log(
+      `  · ${r.courseId}  creatorId=${r.creatorId ? r.creatorId.slice(0, 10) + '…' : 'NULL'}`
+    )
+  }
+
+  if (!APPLY) {
+    console.log(
+      '\n[dry-run] Nothing written. Re-run with --apply (against the DIRECT url) to recover.'
+    )
+    return
+  }
+
+  await drizzleDb
+    .insert(course)
+    .values(
+      toInsert.map(r => ({
+        courseId: r.courseId,
+        name: 'Recovered course (archived)',
+        creatorId: r.creatorId,
+        isPublished: false,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: now, // soft-deleted: satisfies the FK, hidden from course lists
+      }))
+    )
+    .onConflictDoNothing({ target: course.courseId })
+
+  console.log('\n[applied] Placeholder courses created (soft-deleted).')
+  console.log('Next: verify 0 orphans, then enforce the courseId FKs via startup-schema-fix.')
+}
+
+main()
+  .catch(err => {
+    console.error('[recover] failed (nothing committed):', err)
+    process.exit(1)
+  })
+  .finally(() => process.exit(0))

--- a/tutorme-app/src/lib/db/startup-schema-fix.ts
+++ b/tutorme-app/src/lib/db/startup-schema-fix.ts
@@ -447,6 +447,51 @@ BEGIN
 END $$;
 `)
 
+// Enforce the courseId → Course(id) foreign keys that the schema DEFINES but that
+// were never actually created in prod (so hard-deleting a Course left orphaned rows
+// behind — see scripts/cleanup-orphaned-courses.ts + recover-protected-courses.ts,
+// which cleared/backfilled every orphan so these can finally validate). Each FK is
+// added IF NOT EXISTS and wrapped in its own exception handler, so it's idempotent
+// and a stray orphan on one table never blocks the others (or crashes startup). The
+// ON DELETE action matches each table's schema definition.
+const ENFORCE_COURSE_FKS_SQL = sql.raw(`
+DO $$
+DECLARE
+  fk record;
+BEGIN
+  FOR fk IN
+    SELECT * FROM (VALUES
+      ('LiveSession',            'SET NULL'),
+      ('CourseLesson',           'CASCADE'),
+      ('CalendarEvent',          'SET NULL'),
+      ('CourseEnrollment',       'CASCADE'),
+      ('BuilderTask',            'CASCADE'),
+      ('OneOnOneBookingRequest', 'SET NULL'),
+      ('GroupSession',           'SET NULL')
+    ) AS t(tbl, on_delete)
+  LOOP
+    BEGIN
+      IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = fk.tbl)
+        AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = fk.tbl AND column_name = 'courseId')
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = fk.tbl || '_courseId_Course_id_fk'
+        )
+      THEN
+        EXECUTE format(
+          'ALTER TABLE %I ADD CONSTRAINT %I FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE %s',
+          fk.tbl, fk.tbl || '_courseId_Course_id_fk', fk.on_delete
+        );
+        RAISE NOTICE 'Added FK %_courseId_Course_id_fk', fk.tbl;
+      END IF;
+    EXCEPTION WHEN others THEN
+      -- e.g. a residual orphan would fail validation — log and keep going.
+      RAISE NOTICE 'Skipped FK %_courseId_Course_id_fk: %', fk.tbl, SQLERRM;
+    END;
+  END LOOP;
+END $$;
+`)
+
 export async function applyStartupSchemaFixes(): Promise<void> {
   // Always ensure new standalone tables exist, even when the drift check below
   // short-circuits (prod DBs whose LiveSession columns already look fine).
@@ -464,6 +509,14 @@ export async function applyStartupSchemaFixes(): Promise<void> {
     )
   } catch (err: any) {
     console.error('[SchemaFix] ❌ Failed to add COMPLETED booking status:', err?.message)
+  }
+
+  // Enforce the courseId → Course FKs (idempotent). Must run outside the drift
+  // check below, which short-circuits on a healthy LiveSession schema.
+  try {
+    await drizzleDb.execute(ENFORCE_COURSE_FKS_SQL)
+  } catch (err: any) {
+    console.error('[SchemaFix] ❌ Failed to enforce courseId FKs:', err?.message)
   }
 
   try {


### PR DESCRIPTION
Closes out the orphaned-course cleanup: the `courseId` foreign keys the schema *defines* were never actually created in prod, which is why hard-deleting a Course left orphaned rows. Now that the orphans are gone, enforce the FKs so it can't happen again.

## Sequence (already run against prod)
1. **Purged** the safe orphans — `cleanup-orphaned-courses --apply`: 424 hard-deleted courses' rows removed, the 6 submission-bearing courses skipped (11 submissions preserved).
2. **Recovered** the 6 protected courses — `recover-protected-courses --apply`: a **soft-deleted** placeholder `Course` per id (creatorId from the orphaned rows' tutor), so their student work has a valid FK parent but they stay hidden from course lists.
3. **Result:** 0 residual orphans across all 7 parent tables (verified).

## This PR
- **`startup-schema-fix`** → `ENFORCE_COURSE_FKS_SQL`: adds the 7 `courseId → Course(id)` FKs — `SET NULL` for LiveSession/CalendarEvent/OneOnOneBookingRequest/GroupSession, `CASCADE` for CourseLesson/CourseEnrollment/BuilderTask (matching the schema's `onDelete`). Each is `IF NOT EXISTS` + its own `EXCEPTION` handler → idempotent, and a stray orphan on one table never blocks the others or crashes startup. Runs on every startup, **outside** the early-returning drift check. **Verified against prod in a rolled-back transaction — all 7 validate cleanly (0 orphans).**
- **`scripts/recover-protected-courses.ts`** (+ `recover:protected-courses` npm script) — for the record.

## Effect
On the next prod deploy, `applyStartupSchemaFixes()` adds the 7 FKs; thereafter a Course delete SET-NULLs or CASCADEs its dependents instead of orphaning them.

## Verification
- `tsc` clean · `npm run build` passes · FK SQL proven against prod data (rolled back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)