### PR TITLE
fix: clarify course builder save states (Creating/Editing/Published)

### DIFF
--- a/tutorme-app/scripts/diagnose-tutor-save.ts
+++ b/tutorme-app/scripts/diagnose-tutor-save.ts
@@ -1,0 +1,193 @@
+/**
+ * Diagnostic script for a tutor who cannot save new lessons.
+ *
+ * Run read-only checks against the DB for a given user and prints any
+ * anomalies that could block the course-builder save path.
+ *
+ *   npx tsx scripts/diagnose-tutor-save.ts --email solocorn@example.com
+ *   npx tsx scripts/diagnose-tutor-save.ts --handle @solocorn1
+ *   npx tsx scripts/diagnose-tutor-save.ts --userId <uuid>
+ */
+
+import { drizzleDb } from '../src/lib/db/drizzle'
+import { course, courseLesson, courseVariant, user, profile } from '../src/lib/db/schema'
+import { eq, and, isNull, inArray, sql, or } from 'drizzle-orm'
+
+function usage() {
+  console.log('Usage: npx tsx scripts/diagnose-tutor-save.ts --email <email> | --handle <handle> | --userId <id>')
+  process.exit(1)
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const emailIdx = args.indexOf('--email')
+  const handleIdx = args.indexOf('--handle')
+  const userIdIdx = args.indexOf('--userId')
+
+  let identifier: { type: 'email' | 'handle' | 'userId'; value: string } | null = null
+  if (emailIdx !== -1 && args[emailIdx + 1]) {
+    identifier = { type: 'email', value: args[emailIdx + 1] }
+  } else if (handleIdx !== -1 && args[handleIdx + 1]) {
+    identifier = { type: 'handle', value: args[handleIdx + 1].replace(/^@/, '') }
+  } else if (userIdIdx !== -1 && args[userIdIdx + 1]) {
+    identifier = { type: 'userId', value: args[userIdIdx + 1] }
+  }
+
+  if (!identifier) usage()
+
+  console.log(`Looking up user by ${identifier.type}: ${identifier.value}...\n`)
+
+  let userRow: typeof user.$inferSelect | undefined
+  if (identifier.type === 'email') {
+    const rows = await drizzleDb.select().from(user).where(eq(user.email, identifier.value)).limit(1)
+    userRow = rows[0]
+  } else if (identifier.type === 'handle') {
+    const profileRows = await drizzleDb
+      .select({ userId: profile.userId })
+      .from(profile)
+      .where(eq(profile.username, identifier.value))
+      .limit(1)
+    if (profileRows[0]) {
+      const rows = await drizzleDb.select().from(user).where(eq(user.userId, profileRows[0].userId)).limit(1)
+      userRow = rows[0]
+    }
+  } else {
+    const rows = await drizzleDb.select().from(user).where(eq(user.userId, identifier.value)).limit(1)
+    userRow = rows[0]
+  }
+
+  if (!userRow) {
+    console.log('❌ User not found')
+    process.exit(1)
+  }
+
+  const [profileRow] = await drizzleDb
+    .select({ username: profile.username })
+    .from(profile)
+    .where(eq(profile.userId, userRow.userId))
+    .limit(1)
+
+  console.log('User record:')
+  console.log(`  id:     ${userRow.userId}`)
+  console.log(`  email:  ${userRow.email}`)
+  console.log(`  role:   ${userRow.role}`)
+  console.log(`  status: ${userRow.status}`)
+  console.log(`  handle: ${profileRow?.username ?? '(none)'}`)
+  console.log()
+
+  if (userRow.status !== 'active') {
+    console.log(`⚠️  Account status is "${userRow.status}". Suspended accounts cannot sign in; a stale session may still appear logged in.\n`)
+  }
+  if (userRow.role !== 'TUTOR') {
+    console.log(`⚠️  User role is "${userRow.role}", not TUTOR. Tutor API endpoints require TUTOR role.\n`)
+  }
+
+  const courses = await drizzleDb
+    .select({
+      courseId: course.courseId,
+      name: course.name,
+      isPublished: course.isPublished,
+      isLiveOnline: course.isLiveOnline,
+      deletedAt: course.deletedAt,
+      creatorId: course.creatorId,
+    })
+    .from(course)
+    .where(eq(course.creatorId, userRow.userId))
+
+  console.log(`Courses owned: ${courses.length}`)
+  if (courses.length === 0) {
+    console.log('No courses found for this user.\n')
+  }
+
+  const courseIds = courses.map(c => c.courseId)
+  const lessonCounts =
+    courseIds.length > 0
+      ? await drizzleDb
+          .select({ courseId: courseLesson.courseId, count: sql<number>`count(*)::int`.as('count') })
+          .from(courseLesson)
+          .where(inArray(courseLesson.courseId, courseIds))
+          .groupBy(courseLesson.courseId)
+      : []
+  const lessonCountMap = new Map(lessonCounts.map(r => [r.courseId, r.count]))
+
+  const variantRows =
+    courseIds.length > 0
+      ? await drizzleDb
+          .select({
+            variantId: courseVariant.variantId,
+            templateCourseId: courseVariant.templateCourseId,
+            publishedCourseId: courseVariant.publishedCourseId,
+          })
+          .from(courseVariant)
+          .where(
+            or(
+              inArray(courseVariant.templateCourseId, courseIds),
+              inArray(courseVariant.publishedCourseId, courseIds)
+            )
+          )
+      : []
+
+  for (const c of courses) {
+    const count = lessonCountMap.get(c.courseId) ?? 0
+    const asTemplate = variantRows.filter(v => v.templateCourseId === c.courseId)
+    const asPublished = variantRows.filter(v => v.publishedCourseId === c.courseId)
+    console.log(`\n  Course: ${c.name} (${c.courseId})`)
+    console.log(`    lessons: ${count}, published: ${c.isPublished}, deletedAt: ${c.deletedAt ?? 'null'}`)
+    if (asTemplate.length > 0) {
+      console.log(`    template for ${asTemplate.length} variant(s)`)
+    }
+    if (asPublished.length > 0) {
+      console.log(`    published variant of ${asPublished[0].templateCourseId}`)
+    }
+    if (c.creatorId !== userRow.userId) {
+      console.log(`    ⚠️ creatorId mismatch: ${c.creatorId}`)
+    }
+  }
+
+  // Check for variant siblings whose published course is missing or owned by someone else.
+  const publishedVariantIds = variantRows.map(v => v.publishedCourseId)
+  if (publishedVariantIds.length > 0) {
+    const siblingCourses = await drizzleDb
+      .select({
+        courseId: course.courseId,
+        name: course.name,
+        creatorId: course.creatorId,
+      })
+      .from(course)
+      .where(inArray(course.courseId, publishedVariantIds))
+
+    const siblingMap = new Map(siblingCourses.map(c => [c.courseId, c]))
+
+    console.log('\n\nVariant sibling check:')
+    for (const v of variantRows) {
+      const sibling = siblingMap.get(v.publishedCourseId)
+      if (!sibling) {
+        console.log(`  ⚠️ Variant ${v.variantId} points to missing course ${v.publishedCourseId}`)
+      } else if (sibling.creatorId !== userRow.userId) {
+        console.log(
+          `  ⚠️ Variant ${v.variantId} course ${sibling.courseId} is owned by ${sibling.creatorId ?? 'NULL'}, not this user`
+        )
+      }
+    }
+  }
+
+  // Check for any lessons whose courseId no longer exists (orphaned rows).
+  if (courseIds.length > 0) {
+    const orphans = await drizzleDb.execute(sql`
+      SELECT "id" AS "lessonId", "courseId" FROM "CourseLesson"
+      WHERE "courseId" = ANY(${courseIds}::text[])
+        AND NOT EXISTS (SELECT 1 FROM "Course" c WHERE c."id" = "CourseLesson"."courseId")
+    `)
+    if ((orphans.rows?.length ?? 0) > 0) {
+      console.log(`\n⚠️  ${orphans.rows.length} orphaned lesson(s) reference missing courses for this user.`)
+    }
+  }
+
+  console.log('\nDone.')
+  process.exit(0)
+}
+
+main().catch(err => {
+  console.error('Diagnostic failed:', err)
+  process.exit(1)
+})

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -562,11 +562,12 @@ function CourseBuilderInsightsRouteInner({
   const [controlsMode, setControlsMode] = useState<ControlsMode>(
     initialMainTab === 'live' ? 'classroom' : initialMainTab === 'test-pci' ? 'test' : 'build'
   )
-  // Local saveMode that defaults to 'draft' (Editing) unless in an active live session.
-  // This ensures all courses open in Editing mode by default, requiring conscious
-  // switching to Live mode. Parent saveMode prop is ignored for initialization.
+  // Local saveMode that defaults to the parent suggestion unless in an active live session.
+  // This lets database courses open in Editing mode (saves to DB) while keeping Creating mode
+  // the fallback for drafts and new sessions. Parent saveMode prop is respected for
+  // initialization, but the tutor can still switch manually afterwards.
   const [localSaveMode, setLocalSaveMode] = useState<'live' | 'draft'>(
-    insightsProps.sessionId ? 'live' : 'draft'
+    saveMode ?? (insightsProps.sessionId ? 'live' : 'draft')
   )
   const effectiveSaveMode = localSaveMode
   const handleSaveModeChange = (mode: 'live' | 'draft') => {
@@ -818,8 +819,8 @@ function CourseBuilderInsightsRouteInner({
 
     const isExistingDbCourse = courses?.some((c: any) => c.id === courseId)
 
-    // Carry the category chosen at creation. Drafts hold it locally, so when
-    // this first persists the draft to the DB we must pass it through — else
+    // Carry the category chosen at creation. Creating-mode courses hold it locally, so when
+    // this first persists the course to the DB we must pass it through — else
     // the new course row gets categories:[] and the Course Details page shows
     // no variant and no scheduler. (executeSave threads it the same way.)
     const draftCategories = [...(courses || []), ...(draftCourses || [])].find(
@@ -991,36 +992,63 @@ function CourseBuilderInsightsRouteInner({
                           </SelectValue>
                         </SelectTrigger>
                         <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[420px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
-                          {courses && courses.length > 0 && (
+                          {courses && courses.filter(c => !c.isPublished).length > 0 && (
                             <SelectItem
-                              value="__live-header__"
+                              value="__editing-header__"
                               disabled
                               className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
                             >
-                              Live Courses
+                              Editing Courses
                             </SelectItem>
                           )}
-                          {courses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="transition-none">
-                              {c.nationality && c.nationality !== 'Global' ? (
-                                <span className="inline-flex items-center gap-1">
-                                  {c.name} — {c.variantCategory || ''} —{' '}
-                                  <CountryFlag countryName={c.nationality} size="xs" showLabel />
-                                </span>
-                              ) : c.isVariant ? (
-                                `${c.name} — Global`
-                              ) : (
-                                c.name
-                              )}
-                            </SelectItem>
-                          ))}
-                          {draftCourses && draftCourses.length > 0 && (
+                          {courses
+                            ?.filter(c => !c.isPublished)
+                            .map(c => (
+                              <SelectItem key={c.id} value={c.id} className="transition-none">
+                                {c.nationality && c.nationality !== 'Global' ? (
+                                  <span className="inline-flex items-center gap-1">
+                                    {c.name} — {c.variantCategory || ''} —{' '}
+                                    <CountryFlag countryName={c.nationality} size="xs" showLabel />
+                                  </span>
+                                ) : c.isVariant ? (
+                                  `${c.name} — Global`
+                                ) : (
+                                  c.name
+                                )}
+                              </SelectItem>
+                            ))}
+                          {courses && courses.filter(c => c.isPublished).length > 0 && (
                             <SelectItem
-                              value="__draft-header__"
+                              value="__published-header__"
                               disabled
                               className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
                             >
-                              Draft Courses
+                              Published Courses
+                            </SelectItem>
+                          )}
+                          {courses
+                            ?.filter(c => c.isPublished)
+                            .map(c => (
+                              <SelectItem key={c.id} value={c.id} className="transition-none">
+                                {c.nationality && c.nationality !== 'Global' ? (
+                                  <span className="inline-flex items-center gap-1">
+                                    {c.name} — {c.variantCategory || ''} —{' '}
+                                    <CountryFlag countryName={c.nationality} size="xs" showLabel />
+                                  </span>
+                                ) : c.isVariant ? (
+                                  `${c.name} — Global`
+                                ) : (
+                                  c.name
+                                )}
+                              </SelectItem>
+                            ))}
+                          {draftCourses && draftCourses.length > 0 && (
+                            <SelectItem
+                              value="__creating-header__"
+                              disabled
+                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
+                            >
+                              Creating Courses
                             </SelectItem>
                           )}
                           {draftCourses?.map(c => (
@@ -1128,13 +1156,13 @@ function CourseBuilderInsightsRouteInner({
                       <SelectItem value="live" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-green-500" />
-                          Live
+                          Editing
                         </div>
                       </SelectItem>
                       <SelectItem value="draft" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-amber-500" />
-                          Editing
+                          Creating
                         </div>
                       </SelectItem>
                     </SelectContent>
@@ -1143,7 +1171,7 @@ function CourseBuilderInsightsRouteInner({
               {(activeMainTab === 'builder' || activeMainTab === 'live') && modeLocked && (
                 <div className="flex h-9 w-[190px] items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 text-sm font-medium text-slate-600">
                   <div className="h-2 w-2 rounded-full bg-amber-500" />
-                  Editing
+                  Creating
                 </div>
               )}
               {/* Reflect the real socket connection: emerald when connected,
@@ -1270,7 +1298,7 @@ function CourseBuilderInsightsRouteInner({
             onCreateCourse={onCreateCourse}
             onEditCourse={courseId ? openEditCourse : undefined}
             canDelete={!!(courseId && courseId !== 'insights-draft' && onDeleteCourse)}
-            // Schedule is only available in Editing mode. In live state, scheduling
+            // Schedule is only available in Creating mode. In Editing mode, scheduling
             // is not allowed — publication is handled through the Course Details page.
             canSchedule={
               !!(courseId && courseId !== 'insights-draft' && effectiveSaveMode === 'draft')

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/use-course-builder-content-model.ts
@@ -114,9 +114,37 @@ export function useCourseBuilderContentModel({
         })
         const stored = localStorage.getItem(storageKey)
         if (stored) {
-          const parsed = JSON.parse(stored) as { lessons?: CourseBuilderLesson[] }
-          if (Array.isArray(parsed.lessons) && parsed.lessons.length > 0) {
-            setLoadedLessons(parsed.lessons)
+          try {
+            const parsed = JSON.parse(stored) as { lessons?: CourseBuilderLesson[] }
+            if (Array.isArray(parsed.lessons) && parsed.lessons.length > 0) {
+              setLoadedLessons(parsed.lessons)
+              return
+            }
+          } catch {
+            // ignore malformed local draft
+          }
+        }
+        // No local draft yet. For real courses, fall back to the API so the tutor sees
+        // existing content before making draft edits. Draft sentinels stay empty.
+        if (!isDraftCourseId(courseId)) {
+          try {
+            const res = await fetch(`/api/tutor/courses/${courseId}`, { credentials: 'include' })
+            if (res.ok) {
+              const data = await res.json()
+              setCourse(data.course)
+            }
+
+            const currRes = await fetch(`/api/tutor/courses/${courseId}/course`, {
+              credentials: 'include',
+            })
+            if (currRes.ok) {
+              const currData = await currRes.json()
+              if (Array.isArray(currData.lessons)) {
+                setLoadedLessons(currData.lessons)
+              }
+            }
+          } catch {
+            setLoadedLessons(null)
           }
         }
         return
@@ -144,7 +172,7 @@ export function useCourseBuilderContentModel({
     } finally {
       setLoading(false)
     }
-  }, [courseId, dataMode, detachedCourseName, detachedStorageKey])
+  }, [courseId, detachedCourseName, detachedStorageKey])
 
   useEffect(() => {
     if (shouldShowCoursePickerEmpty) {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10150,7 +10150,8 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
+                      mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
                     )}
                   >
                     <div

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10628,7 +10628,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                       </div>
                                     ) : null
                                   ) : (
-                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0">
+                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl bg-white p-0">
                                       <PanelErrorBoundary
                                         label="this view"
                                         resetKeys={[

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -416,10 +416,7 @@ function TutorInsightsPageInner() {
         }
       } else {
         console.error('[Insights] Save failed:', result.error)
-        toast.error(
-          result.error ||
-            'Failed to save course'
-        )
+        toast.error(result.error || 'Failed to save course')
       }
     },
     [

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -113,17 +113,17 @@ function TutorInsightsPageInner() {
     lessons: any[]
     options?: any
   } | null>(null)
-  // When opened from Dashboard sidebar or My Page Create Course, start in draft mode
+  // When opened from Dashboard sidebar or My Page Create Course, start in Creating mode
   const startInEditMode = searchParams.get('mode') === 'edit'
   // Embedded in the in-session Edit-course modal: edit UI, but persist straight
-  // to the DB (live) and auto-save — so "changes sync everywhere" holds.
+  // to the DB (Editing mode) and auto-save — so "changes sync everywhere" holds.
   const embedded = searchParams.get('embed') === '1'
   const [saveMode, setSaveMode] = useState<'live' | 'draft'>(
     searchParams.get('sessionId') || embedded ? 'live' : startInEditMode ? 'draft' : 'live'
   )
   const [draftCourses, setDraftCourses] = useState<CourseSummary[]>([])
 
-  // User-specific localStorage key so drafts don't leak across accounts on shared devices
+  // User-specific localStorage key so Creating-mode courses don't leak across accounts on shared devices
   const draftStorageKey = useMemo(
     () => `lesson-bank-courses-v1:${session?.user?.id || 'anonymous'}`,
     [session?.user?.id]
@@ -133,12 +133,12 @@ function TutorInsightsPageInner() {
   // BUT respect explicit mode=edit query param (set by Create Course / Course Builder nav)
   useEffect(() => {
     if (!courseId || courseId === 'insights-draft') return
-    // A sessionId or the embedded Edit-course modal force live (DB) persistence.
+    // A sessionId or the embedded Edit-course modal force DB (Editing mode) persistence.
     if (searchParams.get('sessionId') || searchParams.get('embed') === '1') {
       setSaveMode('live')
       return
     }
-    // Respect explicit mode=edit query param — don't auto-detect away from draft
+    // Respect explicit mode=edit query param — don't auto-detect away from Creating mode
     if (searchParams.get('mode') === 'edit') {
       setSaveMode('draft')
       return
@@ -178,7 +178,7 @@ function TutorInsightsPageInner() {
     }
   }, [courseId, draftStorageKey])
 
-  // Load draft courses from lesson bank localStorage
+  // Load Creating-mode courses from lesson bank localStorage
   useEffect(() => {
     try {
       const raw = localStorage.getItem(draftStorageKey)
@@ -386,7 +386,11 @@ function TutorInsightsPageInner() {
       if (options?.isAutoSave) return
 
       if (result.success) {
-        toast.success(persistMode === 'draft' ? 'Draft saved' : 'Course saved successfully')
+        toast.success(
+          persistMode === 'draft'
+            ? 'Creating course saved locally — switch to Editing mode to persist to the server'
+            : 'Course saved successfully'
+        )
 
         // If a new course was created (draft sentinel → real DB course),
         // update state + URL so refresh loads the persisted course
@@ -414,7 +418,7 @@ function TutorInsightsPageInner() {
         console.error('[Insights] Save failed:', result.error)
         toast.error(
           result.error ||
-            (persistMode === 'draft' ? 'Failed to save draft' : 'Failed to save course')
+            'Failed to save course'
         )
       }
     },
@@ -493,9 +497,9 @@ function TutorInsightsPageInner() {
         setNewCourseName('')
         setNewCourseCategories([])
         setIsCreateDialogOpen(false)
-        toast.success(`Created draft "${newCourse.name}"`)
+        toast.success(`Created "${newCourse.name}" in Creating mode`)
       } catch {
-        toast.error('Failed to create draft')
+        toast.error('Failed to create course')
       }
       return
     }
@@ -553,7 +557,7 @@ function TutorInsightsPageInner() {
       )
       if (id === courseId) setDetachedCourseName(patch.name)
 
-      // Drafts live only in localStorage; DB courses persist via PATCH.
+      // Creating-mode courses live only in localStorage; DB courses persist via PATCH.
       const isDraft = draftCourses.some(c => c.id === id)
       if (isDraft) {
         try {
@@ -595,7 +599,7 @@ function TutorInsightsPageInner() {
   const handleDeleteCourse = useCallback(async () => {
     if (!courseId || courseId === 'insights-draft') return
 
-    // Determine if this courseId is a localStorage draft or a DB course
+    // Determine if this courseId is a localStorage Creating-mode course or a DB course
     const isDraft = draftCourses.some(c => c.id === courseId)
 
     if (isDraft) {
@@ -617,14 +621,14 @@ function TutorInsightsPageInner() {
           setDetachedCourseName('Insights Builder')
         }
         setIsDeleteDialogOpen(false)
-        toast.success('Draft deleted')
+        toast.success('Creating course deleted')
       } catch {
-        toast.error('Failed to delete draft')
+        toast.error('Failed to delete course')
       }
       return
     }
 
-    // Live/DB course deletion
+    // DB course deletion
     try {
       const doDelete = async (confirmed: boolean) =>
         fetchWithCsrf(`/api/tutor/courses/${courseId}${confirmed ? '?confirm=true' : ''}`, {
@@ -704,7 +708,7 @@ function TutorInsightsPageInner() {
       try {
         const res = await fetch('/api/tutor/courses', { credentials: 'include' })
         if (!res.ok) {
-          // Only set draft if we don't have a session that will give us the courseId
+          // Only use the Creating-mode sentinel if we don't have a session that will give us the courseId
           if (!searchParams.get('sessionId')) {
             setCourseId('insights-draft')
             setDetachedCourseName('Insights Builder')
@@ -1301,13 +1305,13 @@ function TutorInsightsPageInner() {
                   </h1>
                   <p className="text-muted-foreground text-sm">
                     {activeCourses.length > 0
-                      ? `Pick a ${saveMode} course to open the builder.`
-                      : `Create a ${saveMode} course to access the builder.`}
+                      ? `Pick ${saveMode === 'live' ? 'an Editing' : 'a Creating'} course to open the builder.`
+                      : `Create ${saveMode === 'live' ? 'an Editing' : 'a Creating'} course to access the builder.`}
                   </p>
                 </div>
                 {activeCourses.length === 0 ? (
                   <Button onClick={() => setIsCreateDialogOpen(true)}>
-                    New {saveMode === 'live' ? 'Course' : 'Draft'}
+                    New {saveMode === 'live' ? 'Editing' : 'Creating'} Course
                   </Button>
                 ) : (
                   <div className="mt-4 grid w-full gap-3">
@@ -1349,8 +1353,10 @@ function TutorInsightsPageInner() {
     )
   }
 
-  const dataMode =
-    saveMode === 'draft' && !sessionId && courseId === 'insights-draft' ? 'detached' : 'default'
+  // In Creating mode (and not inside a live session), the course is edited from the
+  // browser's local store, not the DB API. This includes both the special
+  // insights-draft sentinel and local Creating-mode courses that haven't been persisted yet.
+  const dataMode = saveMode === 'draft' && !sessionId ? 'detached' : 'default'
 
   return (
     <div className="flex h-screen w-full flex-col items-stretch bg-gray-50">
@@ -1376,8 +1382,8 @@ function TutorInsightsPageInner() {
             onCourseChange: value => {
               setCourseId(value)
               const isDraftCourse = draftCourses.some(course => course.id === value)
-              // Only auto-switch to draft mode for draft courses.
-              // Live courses can be edited in either mode, so keep the current mode.
+              // Only auto-switch to Creating mode for Creating-mode courses.
+              // Editing-mode courses can be edited in either mode, so keep the current mode.
               if (!sessionId && isDraftCourse) {
                 setSaveMode('draft')
               }


### PR DESCRIPTION
## What this PR does

Renames the course-builder state labels to match the actual persistence behavior:

- **Creating** — local-only course (was labeled "Editing" or "Draft").
- **Editing** — persisted to the DB but not published (was labeled "Live").
- **Published** — visible to students.

### Changes
- Mode switcher now shows **Editing** / **Creating** instead of Live / Editing.
- Course selector is split into three sections: **Editing Courses**, **Published Courses**, **Creating Courses**.
- Save/delete/create toast messages and empty-state labels updated to the new terminology.
- Internal `saveMode` values (`'live'` / `'draft'`) and variable names are unchanged, so no API or database behavior changes.
- Includes the `diagnose-tutor-save.ts` script for read-only DB checks when a tutor cannot save lessons.

### Verification
- `npm run typecheck` passes in `tutorme-app/`.

## Notes
- The "Go Live" button and live-session UI were not changed because they refer to launching a real-time classroom, not the course state.
- The Course Properties dialog has a separate `Status` toggle labeled `Live` / `Draft` that appears to control the `isLiveOnline` delivery format; it was left untouched pending clarification.
