### PR TITLE
fix(course-builder): rename state labels and fix Test/Classroom border color

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -10150,8 +10150,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                   <Card
                     padding="none"
                     className={cn(
-                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]',
-                      mainTab === 'live' ? 'border-orange-300' : 'border-violet-300'
+                      'flex h-full w-full min-w-0 flex-1 flex-col overflow-hidden rounded-[20px] border-0 bg-[#FFFFFF] shadow-[0_18px_45px_rgba(0,0,0,0.12),0_4px_12px_rgba(0,0,0,0.06)]'
                     )}
                   >
                     <div
@@ -10628,7 +10627,14 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                       </div>
                                     ) : null
                                   ) : (
-                                    <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl bg-white p-0">
+                                    <div
+                                      className={cn(
+                                        'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border bg-white p-0',
+                                        mainTab === 'live'
+                                          ? 'border-orange-300'
+                                          : 'border-violet-300'
+                                      )}
+                                    >
                                       <PanelErrorBoundary
                                         label="this view"
                                         resetKeys={[


### PR DESCRIPTION
## What this PR does

Renames the course-builder state labels to match the actual persistence behavior:

- **Creating** — local-only course (was labeled "Editing" or "Draft").
- **Editing** — persisted to the DB but not published (was labeled "Live").
- **Published** — visible to students.

### Changes
- Mode switcher now shows **Editing** / **Creating** instead of Live / Editing.
- Course selector is split into three sections: **Editing Courses**, **Published Courses**, **Creating Courses**.
- Save/delete/create toast messages and empty-state labels updated to the new terminology.
- Internal `saveMode` values (`'live'` / `'draft'`) and variable names are unchanged, so no API or database behavior changes.
- Includes the `diagnose-tutor-save.ts` script for read-only DB checks when a tutor cannot save lessons.

### Verification
- `npm run typecheck` passes in `tutorme-app/`.

## Notes
- The "Go Live" button and live-session UI were not changed because they refer to launching a real-time classroom, not the course state.
- The Course Properties dialog has a separate `Status` toggle labeled `Live` / `Draft` that appears to control the `isLiveOnline` delivery format; it was left untouched pending clarification.
