### PR TITLE
refactor(course-builder): course-state filter toggle with Unpublished/Published/Creating

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -5,7 +5,7 @@
 
 'use client'
 
-import { Suspense, useCallback, useEffect, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import {
@@ -562,17 +562,38 @@ function CourseBuilderInsightsRouteInner({
   const [controlsMode, setControlsMode] = useState<ControlsMode>(
     initialMainTab === 'live' ? 'classroom' : initialMainTab === 'test-pci' ? 'test' : 'build'
   )
-  // Local saveMode that defaults to the parent suggestion unless in an active live session.
-  // This lets database courses open in Editing mode (saves to DB) while keeping Creating mode
-  // the fallback for drafts and new sessions. Parent saveMode prop is respected for
-  // initialization, but the tutor can still switch manually afterwards.
-  const [localSaveMode, setLocalSaveMode] = useState<'live' | 'draft'>(
-    saveMode ?? (insightsProps.sessionId ? 'live' : 'draft')
-  )
-  const effectiveSaveMode = localSaveMode
-  const handleSaveModeChange = (mode: 'live' | 'draft') => {
-    setLocalSaveMode(mode)
-    onSaveModeChange?.(mode)
+  type CourseStateFilter = 'creating' | 'unpublished' | 'published'
+
+  // Course-state filter for the toggle. It controls which courses appear in the
+  // dropdown and is updated automatically when the selected course changes.
+  const initialCourseStateFilter: CourseStateFilter =
+    saveMode === 'draft' ? 'creating' : 'unpublished'
+  const [courseStateFilter, setCourseStateFilter] =
+    useState<CourseStateFilter>(initialCourseStateFilter)
+
+  // The selected course's actual state (draft / unpublished / published).
+  const currentCourseState = useMemo((): CourseStateFilter => {
+    if (!courseId) return courseStateFilter
+    if (draftCourses?.some(c => c.id === courseId)) return 'creating'
+    const dbCourse = courses?.find(c => c.id === courseId)
+    if (dbCourse?.isPublished) return 'published'
+    return 'unpublished'
+  }, [courseId, courses, draftCourses, courseStateFilter])
+
+  // Persist mode is determined by the course itself, not by the toggle.
+  const effectiveSaveMode = useMemo((): 'live' | 'draft' => {
+    if (draftCourses?.some(c => c.id === courseId)) return 'draft'
+    return 'live'
+  }, [courseId, draftCourses])
+
+  // Sync the filter toggle to the selected course whenever the course changes.
+  useEffect(() => {
+    if (!courseId) return
+    setCourseStateFilter(prev => (prev === currentCourseState ? prev : currentCourseState))
+  }, [courseId, currentCourseState])
+
+  const handleCourseStateFilterChange = (filter: CourseStateFilter) => {
+    setCourseStateFilter(filter)
   }
   const [hasUnsyncedChanges, setHasUnsyncedChanges] = useState(false)
   const router = useRouter()
@@ -992,18 +1013,83 @@ function CourseBuilderInsightsRouteInner({
                           </SelectValue>
                         </SelectTrigger>
                         <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[420px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
-                          {courses && courses.filter(c => !c.isPublished).length > 0 && (
-                            <SelectItem
-                              value="__editing-header__"
-                              disabled
-                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
-                            >
-                              Editing Courses
-                            </SelectItem>
-                          )}
-                          {courses
-                            ?.filter(c => !c.isPublished)
-                            .map(c => (
+                          {courseStateFilter === 'unpublished' &&
+                            courses &&
+                            courses.filter(c => !c.isPublished).length > 0 && (
+                              <SelectItem
+                                value="__unpublished-header__"
+                                disabled
+                                className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
+                              >
+                                Unpublished Courses
+                              </SelectItem>
+                            )}
+                          {courseStateFilter === 'unpublished' &&
+                            courses
+                              ?.filter(c => !c.isPublished)
+                              .map(c => (
+                                <SelectItem key={c.id} value={c.id} className="transition-none">
+                                  {c.nationality && c.nationality !== 'Global' ? (
+                                    <span className="inline-flex items-center gap-1">
+                                      {c.name} — {c.variantCategory || ''} —{' '}
+                                      <CountryFlag
+                                        countryName={c.nationality}
+                                        size="xs"
+                                        showLabel
+                                      />
+                                    </span>
+                                  ) : c.isVariant ? (
+                                    `${c.name} — Global`
+                                  ) : (
+                                    c.name
+                                  )}
+                                </SelectItem>
+                              ))}
+                          {courseStateFilter === 'published' &&
+                            courses &&
+                            courses.filter(c => c.isPublished).length > 0 && (
+                              <SelectItem
+                                value="__published-header__"
+                                disabled
+                                className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
+                              >
+                                Published Courses
+                              </SelectItem>
+                            )}
+                          {courseStateFilter === 'published' &&
+                            courses
+                              ?.filter(c => c.isPublished)
+                              .map(c => (
+                                <SelectItem key={c.id} value={c.id} className="transition-none">
+                                  {c.nationality && c.nationality !== 'Global' ? (
+                                    <span className="inline-flex items-center gap-1">
+                                      {c.name} — {c.variantCategory || ''} —{' '}
+                                      <CountryFlag
+                                        countryName={c.nationality}
+                                        size="xs"
+                                        showLabel
+                                      />
+                                    </span>
+                                  ) : c.isVariant ? (
+                                    `${c.name} — Global`
+                                  ) : (
+                                    c.name
+                                  )}
+                                </SelectItem>
+                              ))}
+                          {courseStateFilter === 'creating' &&
+                            draftCourses &&
+                            draftCourses.length > 0 && (
+                              <SelectItem
+                                value="__creating-header__"
+                                disabled
+                                className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
+                              >
+                                Creating Courses
+                              </SelectItem>
+                            )}
+                          {courseStateFilter === 'creating' &&
+                            draftCourses?.map(c => (
                               <SelectItem key={c.id} value={c.id} className="transition-none">
                                 {c.nationality && c.nationality !== 'Global' ? (
                                   <span className="inline-flex items-center gap-1">
@@ -1017,54 +1103,6 @@ function CourseBuilderInsightsRouteInner({
                                 )}
                               </SelectItem>
                             ))}
-                          {courses && courses.filter(c => c.isPublished).length > 0 && (
-                            <SelectItem
-                              value="__published-header__"
-                              disabled
-                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
-                            >
-                              Published Courses
-                            </SelectItem>
-                          )}
-                          {courses
-                            ?.filter(c => c.isPublished)
-                            .map(c => (
-                              <SelectItem key={c.id} value={c.id} className="transition-none">
-                                {c.nationality && c.nationality !== 'Global' ? (
-                                  <span className="inline-flex items-center gap-1">
-                                    {c.name} — {c.variantCategory || ''} —{' '}
-                                    <CountryFlag countryName={c.nationality} size="xs" showLabel />
-                                  </span>
-                                ) : c.isVariant ? (
-                                  `${c.name} — Global`
-                                ) : (
-                                  c.name
-                                )}
-                              </SelectItem>
-                            ))}
-                          {draftCourses && draftCourses.length > 0 && (
-                            <SelectItem
-                              value="__creating-header__"
-                              disabled
-                              className="text-xs font-semibold text-white transition-none focus-visible:ring-0"
-                            >
-                              Creating Courses
-                            </SelectItem>
-                          )}
-                          {draftCourses?.map(c => (
-                            <SelectItem key={c.id} value={c.id} className="transition-none">
-                              {c.nationality && c.nationality !== 'Global' ? (
-                                <span className="inline-flex items-center gap-1">
-                                  {c.name} — {c.variantCategory || ''} —{' '}
-                                  <CountryFlag countryName={c.nationality} size="xs" showLabel />
-                                </span>
-                              ) : c.isVariant ? (
-                                `${c.name} — Global`
-                              ) : (
-                                c.name
-                              )}
-                            </SelectItem>
-                          ))}
                         </SelectContent>
                       </Select>
                     )}
@@ -1146,20 +1184,26 @@ function CourseBuilderInsightsRouteInner({
                 onSaveModeChange &&
                 !modeLocked && (
                   <Select
-                    value={effectiveSaveMode}
-                    onValueChange={(val: 'live' | 'draft') => handleSaveModeChange(val)}
+                    value={courseStateFilter}
+                    onValueChange={(val: CourseStateFilter) => handleCourseStateFilterChange(val)}
                   >
                     <SelectTrigger className="h-9 w-[190px] border-slate-200 bg-white text-sm font-medium">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="live" className="">
+                      <SelectItem value="unpublished" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-green-500" />
-                          Editing
+                          Unpublished
                         </div>
                       </SelectItem>
-                      <SelectItem value="draft" className="">
+                      <SelectItem value="published" className="">
+                        <div className="flex items-center gap-2">
+                          <div className="h-2 w-2 rounded-full bg-blue-500" />
+                          Published
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="creating" className="">
                         <div className="flex items-center gap-2">
                           <div className="h-2 w-2 rounded-full bg-amber-500" />
                           Creating
@@ -1262,7 +1306,7 @@ function CourseBuilderInsightsRouteInner({
               leftPanelHidden={leftPanelHidden}
               onLeftPanelHiddenChange={setLeftPanelHidden}
               saveMode={effectiveSaveMode}
-              onSaveModeChange={handleSaveModeChange}
+              onSaveModeChange={onSaveModeChange}
               onSyncToLiveSession={onSyncToLiveSession}
               onUnsyncedChangesChange={setHasUnsyncedChanges}
               focusLessonId={
@@ -1298,7 +1342,7 @@ function CourseBuilderInsightsRouteInner({
             onCreateCourse={onCreateCourse}
             onEditCourse={courseId ? openEditCourse : undefined}
             canDelete={!!(courseId && courseId !== 'insights-draft' && onDeleteCourse)}
-            // Schedule is only available in Creating mode. In Editing mode, scheduling
+            // Schedule is only available in Creating mode. In Unpublished mode, scheduling
             // is not allowed — publication is handled through the Course Details page.
             canSchedule={
               !!(courseId && courseId !== 'insights-draft' && effectiveSaveMode === 'draft')

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -116,7 +116,7 @@ function TutorInsightsPageInner() {
   // When opened from Dashboard sidebar or My Page Create Course, start in Creating mode
   const startInEditMode = searchParams.get('mode') === 'edit'
   // Embedded in the in-session Edit-course modal: edit UI, but persist straight
-  // to the DB (Editing mode) and auto-save — so "changes sync everywhere" holds.
+  // to the DB (Unpublished mode) and auto-save — so "changes sync everywhere" holds.
   const embedded = searchParams.get('embed') === '1'
   const [saveMode, setSaveMode] = useState<'live' | 'draft'>(
     searchParams.get('sessionId') || embedded ? 'live' : startInEditMode ? 'draft' : 'live'
@@ -133,7 +133,7 @@ function TutorInsightsPageInner() {
   // BUT respect explicit mode=edit query param (set by Create Course / Course Builder nav)
   useEffect(() => {
     if (!courseId || courseId === 'insights-draft') return
-    // A sessionId or the embedded Edit-course modal force DB (Editing mode) persistence.
+    // A sessionId or the embedded Edit-course modal force DB (Unpublished mode) persistence.
     if (searchParams.get('sessionId') || searchParams.get('embed') === '1') {
       setSaveMode('live')
       return
@@ -388,7 +388,7 @@ function TutorInsightsPageInner() {
       if (result.success) {
         toast.success(
           persistMode === 'draft'
-            ? 'Creating course saved locally — switch to Editing mode to persist to the server'
+            ? 'Creating course saved locally — switch to Unpublished mode to persist to the server'
             : 'Course saved successfully'
         )
 
@@ -1302,13 +1302,13 @@ function TutorInsightsPageInner() {
                   </h1>
                   <p className="text-muted-foreground text-sm">
                     {activeCourses.length > 0
-                      ? `Pick ${saveMode === 'live' ? 'an Editing' : 'a Creating'} course to open the builder.`
-                      : `Create ${saveMode === 'live' ? 'an Editing' : 'a Creating'} course to access the builder.`}
+                      ? `Pick ${saveMode === 'live' ? 'an Unpublished' : 'a Creating'} course to open the builder.`
+                      : `Create ${saveMode === 'live' ? 'an Unpublished' : 'a Creating'} course to access the builder.`}
                   </p>
                 </div>
                 {activeCourses.length === 0 ? (
                   <Button onClick={() => setIsCreateDialogOpen(true)}>
-                    New {saveMode === 'live' ? 'Editing' : 'Creating'} Course
+                    New {saveMode === 'live' ? 'Unpublished' : 'Creating'} Course
                   </Button>
                 ) : (
                   <div className="mt-4 grid w-full gap-3">
@@ -1380,7 +1380,7 @@ function TutorInsightsPageInner() {
               setCourseId(value)
               const isDraftCourse = draftCourses.some(course => course.id === value)
               // Only auto-switch to Creating mode for Creating-mode courses.
-              // Editing-mode courses can be edited in either mode, so keep the current mode.
+              // DB courses (Unpublished or Published) can be edited in either mode, so keep the current mode.
               if (!sessionId && isDraftCourse) {
                 setSaveMode('draft')
               }


### PR DESCRIPTION
## What this PR does\n\nTurns the course builder state toggle into a course-state filter and renames the middle state.\n\n- Renames 'Editing' to 'Unpublished'.\n- Adds 'Published' as a third filter option.\n- The toggle now filters the course dropdown by state (Creating / Unpublished / Published).\n- Save mode is derived automatically from the selected course (Creating → localStorage, DB courses → DB).\n- Updates dependent labels and toast messages.\n\n### Verification\n-  passes.\n-  passes.