### PR TITLE
fix(directory): include courses the student is a session participant in

### DIFF
--- a/tutorme-app/src/app/api/student/directory/route.ts
+++ b/tutorme-app/src/app/api/student/directory/route.ts
@@ -7,8 +7,10 @@ import {
   profile,
   deployedMaterial,
   studentTaskReport,
+  sessionParticipant,
+  liveSession,
 } from '@/lib/db/schema'
-import { eq, inArray, and } from 'drizzle-orm'
+import { eq, inArray, and, isNotNull, isNull } from 'drizzle-orm'
 import { expandFamilyWithMap } from '@/lib/courses/variant-family'
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
 
@@ -102,6 +104,41 @@ export const GET = withAuth(
       errors.push(`enrollments query failed: ${err?.message || String(err)}`)
       // Return early with empty directory but show the error
       return NextResponse.json({ directory: {}, errors }, { status: 200 })
+    }
+
+    // Also include courses the student is a PARTICIPANT in (1-on-1 / group live
+    // sessions) — they join by a booking seat, not courseEnrollment, so without
+    // this a participant-only student sees an empty directory. Same shape as an
+    // enrollment; unioned + deduped by courseId below.
+    try {
+      const participantCourses = await drizzleDb
+        .selectDistinct({
+          studentId: sessionParticipant.studentId,
+          courseId: course.courseId,
+          courseName: course.name,
+          tutorId: course.creatorId,
+          tutorName: profile.name,
+        })
+        .from(sessionParticipant)
+        .innerJoin(liveSession, eq(liveSession.sessionId, sessionParticipant.sessionId))
+        .innerJoin(course, eq(course.courseId, liveSession.courseId))
+        .leftJoin(profile, eq(course.creatorId, profile.userId))
+        .where(
+          and(
+            eq(sessionParticipant.studentId, studentId),
+            isNotNull(liveSession.courseId),
+            isNull(course.deletedAt)
+          )
+        )
+      const seen = new Set(enrollments.map(e => e.courseId))
+      for (const p of participantCourses) {
+        if (p.courseId && !seen.has(p.courseId)) {
+          seen.add(p.courseId)
+          enrollments.push(p)
+        }
+      }
+    } catch (err: any) {
+      errors.push(`participant courses query failed: ${err?.message || String(err)}`)
     }
 
     if (enrollments.length === 0) {


### PR DESCRIPTION
## The report
The Directory panel opens but shows no tutors/courses in the 1-on-1/group classroom.

## Cause
`/api/student/directory` was built purely from **`CourseEnrollment`** (and returns an empty directory when there are 0 enrollments). But a 1-on-1/group student joins via a **`SessionParticipant`** booking seat, not enrollment — so a participant-only student got an empty directory. (Same class of gap as the roster fix #1197.) Confirmed in prod: several participants have 0 enrollments.

## Fix
Union the enrolled courses with the courses of the student's **live sessions** (`SessionParticipant → LiveSession.courseId → Course`, deduped by courseId, non-deleted courses only). The rest of the flow (variant-family expansion, deployed materials, reports) then covers those courses too.

Same endpoint → **both classrooms stay identical** (and both now also surface a student's 1-on-1/group courses, which is more complete).

## Verification (prod, read-only)
0-enrollment participants now surface their real courses + tutors, e.g.:
- Bread Butter → "Introductory Biology — Singapore" (asd der), "New TOEIC — Singapore" (Kon Bae Kim)
- Kon Bae Kim → "SAT - Global" (Jason Kim)

`tsc` clean · `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)