### PR TITLE
feat(1on1): AI chat box for chat-tasks in the live session

### DIFF
--- a/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
@@ -21,7 +21,13 @@ import { getServerSession, authOptions } from '@/lib/auth'
 import { getParamAsync } from '@/lib/api/params'
 import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { builderTask, courseEnrollment, taskSubmission } from '@/lib/db/schema'
+import {
+  builderTask,
+  courseEnrollment,
+  taskSubmission,
+  sessionParticipant,
+  liveSession,
+} from '@/lib/db/schema'
 import { ASK_SYSTEM_PROMPT } from '@/lib/ai/task-chat-prompts'
 import { generateWithKimi } from '@/lib/ai/kimi'
 import { runTaskGuardrails } from '@/lib/ai/guardrails'
@@ -66,6 +72,7 @@ export async function POST(
         content: builderTask.content,
         pci: builderTask.pci,
         pciSpec: builderTask.pciSpec,
+        tutorId: builderTask.tutorId,
       })
       .from(builderTask)
       .where(eq(builderTask.taskId, taskId))
@@ -75,8 +82,12 @@ export async function POST(
       return NextResponse.json({ error: 'Task not found' }, { status: 404 })
     }
 
-    // Ownership: the student must be enrolled in the task's course, OR already
-    // have a submission for it (so follow-ups keep working).
+    // Access: the caller must be enrolled in the task's course, already have a
+    // submission (so follow-ups keep working), be a live-session PARTICIPANT of the
+    // course (1-on-1/group students join by a booking seat, not enrollment), or be
+    // the task's OWNER tutor (an in-session preview of what students get). The
+    // owner-tutor path is stateless — it never writes a taskSubmission.
+    const isOwnerTutor = !!task.tutorId && task.tutorId === studentId
     const taskCourseFamily = await expandToCourseFamily(task.courseId ? [task.courseId] : [])
     const [enrolled] = await drizzleDb
       .select({ id: courseEnrollment.enrollmentId })
@@ -97,9 +108,26 @@ export async function POST(
       .from(taskSubmission)
       .where(and(eq(taskSubmission.taskId, taskId), eq(taskSubmission.studentId, studentId)))
       .limit(1)
-    if (!enrolled && !existing) {
+    let isParticipant = false
+    if (!enrolled && !existing && !isOwnerTutor && taskCourseFamily.length > 0) {
+      const [p] = await drizzleDb
+        .select({ id: sessionParticipant.participantId })
+        .from(sessionParticipant)
+        .innerJoin(liveSession, eq(liveSession.sessionId, sessionParticipant.sessionId))
+        .where(
+          and(
+            eq(sessionParticipant.studentId, studentId),
+            inArray(liveSession.courseId, taskCourseFamily)
+          )
+        )
+        .limit(1)
+      isParticipant = !!p
+    }
+    if (!enrolled && !existing && !isOwnerTutor && !isParticipant) {
       return NextResponse.json({ error: 'Not enrolled in this task' }, { status: 403 })
     }
+    // The tutor previewing their own task never persists a submission.
+    const persist = !isOwnerTutor
 
     const body = (await request.json().catch(() => ({}))) as {
       answers?: unknown
@@ -162,33 +190,36 @@ export async function POST(
         answersRecord[String(i + 1)] = a
       })
 
-      // Persist the completed attempt (idempotent on re-complete).
-      await drizzleDb
-        .insert(taskSubmission)
-        .values({
-          submissionId: randomUUID(),
-          taskId,
-          studentId,
-          answers: answersRecord,
-          timeSpent: 0,
-          attempts: 1,
-          score: avgScore,
-          maxScore: 100,
-          status: 'submitted',
-          tutorApproved: false,
-          aiFeedback,
-          submittedAt: new Date(),
-        })
-        .onConflictDoUpdate({
-          target: [taskSubmission.taskId, taskSubmission.studentId],
-          set: {
+      // Persist the completed attempt (idempotent on re-complete) — unless this is
+      // the owner tutor's stateless preview.
+      if (persist) {
+        await drizzleDb
+          .insert(taskSubmission)
+          .values({
+            submissionId: randomUUID(),
+            taskId,
+            studentId,
             answers: answersRecord,
+            timeSpent: 0,
+            attempts: 1,
             score: avgScore,
+            maxScore: 100,
             status: 'submitted',
+            tutorApproved: false,
             aiFeedback,
             submittedAt: new Date(),
-          },
-        })
+          })
+          .onConflictDoUpdate({
+            target: [taskSubmission.taskId, taskSubmission.studentId],
+            set: {
+              answers: answersRecord,
+              score: avgScore,
+              status: 'submitted',
+              aiFeedback,
+              submittedAt: new Date(),
+            },
+          })
+      }
 
       return NextResponse.json({
         mode: 'complete',
@@ -267,8 +298,9 @@ export async function POST(
       )
     }
 
-    // Persist the follow-up for tutor visibility (best-effort).
-    if (existing) {
+    // Persist the follow-up for tutor visibility (best-effort). Never for the
+    // owner tutor's stateless preview.
+    if (persist && existing) {
       try {
         const list = Array.isArray(existing.followUps) ? (existing.followUps as unknown[]) : []
         const next = [

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -124,15 +124,26 @@ export function SessionDeployedPanel({
                 // rendered inside TaskChatPanel (not standalone). Students get the
                 // real (persisted) flow; the tutor gets a stateless interactive
                 // preview (onCompleted omitted → no live completion is emitted).
-                <>
-                  <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
+                // Fill the panel as a flex column so the chat scrolls internally
+                // (one scrollbar) rather than a viewport-height box inside the
+                // already-scrollable parent.
+                <div className="flex h-full flex-col">
+                  <p className="mb-3 shrink-0 text-sm font-semibold text-slate-900">
+                    {active.title}
+                  </p>
                   {active.content && !isImportPlaceholder(active.content) ? (
                     <div
-                      className="prose prose-sm mb-4 max-w-none text-slate-700"
+                      className="prose prose-sm mb-3 max-h-40 shrink-0 overflow-y-auto pr-1 text-slate-700"
                       dangerouslySetInnerHTML={{ __html: sanitizeHtml(active.content) }}
                     />
                   ) : null}
-                  <div className="h-[70vh] max-h-[calc(100vh-200px)] min-h-[420px]">
+                  {isTutor ? (
+                    <p className="mb-3 shrink-0 rounded-md bg-slate-50 px-2.5 py-1.5 text-xs text-slate-500">
+                      Preview — try the chat as a student would. Nothing is saved and no completion
+                      is sent to the room from here.
+                    </p>
+                  ) : null}
+                  <div className="min-h-[320px] flex-1">
                     <TaskChatPanel
                       key={active.id}
                       taskId={active.id}
@@ -156,7 +167,7 @@ export function SessionDeployedPanel({
                       }
                     />
                   </div>
-                </>
+                </div>
               ) : (
                 <>
                   {active.sourceDocument ? (

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -119,30 +119,44 @@ export function SessionDeployedPanel({
               isChatTask(active) ? (
                 // A chat task (source 'task', no structured questions) is answered
                 // via the AI chat — the same box as the course-builder classroom.
-                // Students get the real (persisted) flow; the tutor gets a stateless
+                // Mirrors the student feedback page: the task title + instructional
+                // content sit above the panel, and the source document (if any) is
+                // rendered inside TaskChatPanel (not standalone). Students get the
+                // real (persisted) flow; the tutor gets a stateless interactive
                 // preview (onCompleted omitted → no live completion is emitted).
-                <TaskChatPanel
-                  key={active.id}
-                  taskId={active.id}
-                  taskTitle={active.title}
-                  sourceDocument={active.sourceDocument}
-                  onCompleted={
-                    isTutor
-                      ? undefined
-                      : answers => {
-                          const record: Record<string, string> = {}
-                          answers.forEach((a, i) => {
-                            record[String(i + 1)] = a
-                          })
-                          socket?.emit('task:complete', {
-                            roomId: sessionId,
-                            taskId: active.id,
-                            answers: record,
-                            aiHandled: true,
-                          })
-                        }
-                  }
-                />
+                <>
+                  <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
+                  {active.content && !isImportPlaceholder(active.content) ? (
+                    <div
+                      className="prose prose-sm mb-4 max-w-none text-slate-700"
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(active.content) }}
+                    />
+                  ) : null}
+                  <div className="h-[70vh] max-h-[calc(100vh-200px)] min-h-[420px]">
+                    <TaskChatPanel
+                      key={active.id}
+                      taskId={active.id}
+                      taskTitle={active.title}
+                      sourceDocument={active.sourceDocument}
+                      onCompleted={
+                        isTutor
+                          ? undefined
+                          : answers => {
+                              const record: Record<string, string> = {}
+                              answers.forEach((a, i) => {
+                                record[String(i + 1)] = a
+                              })
+                              socket?.emit('task:complete', {
+                                roomId: sessionId,
+                                taskId: active.id,
+                                answers: record,
+                                aiHandled: true,
+                              })
+                            }
+                      }
+                    />
+                  </div>
+                </>
               ) : (
                 <>
                   {active.sourceDocument ? (

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
+import { TaskChatPanel } from '@/app/[locale]/student/feedback/TaskChatPanel'
 import { normalizeDmiQuestionType } from '@/lib/assessment/question-types'
 import { sanitizeHtml } from '@/lib/security/sanitize'
 import { isImportPlaceholder } from '@/lib/tasks/import-placeholder'
@@ -36,6 +37,16 @@ import type {
  * course classroom uses, which the server auto-grades by taskId). Tutors see the
  * questions read-only.
  */
+
+/**
+ * A chat task carries no structured questions — it's answered by chatting with
+ * the AI (the same box the course-builder classroom uses). Mirrors the student
+ * feedback page's `isChatTask`: source 'task' + no `dmiItems`.
+ */
+function isChatTask(t: SessionRoomTask): boolean {
+  return t.source === 'task' && (!t.dmiItems || t.dmiItems.length === 0)
+}
+
 export function SessionDeployedPanel({
   sessionId,
   socket,
@@ -105,39 +116,68 @@ export function SessionDeployedPanel({
           {/* Active item */}
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
             {active ? (
-              <>
-                {active.sourceDocument ? (
-                  <>
-                    <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
-                    <div className="h-[60vh] w-full">
-                      <TaskDocumentCard sourceDocument={active.sourceDocument} alwaysOpen />
-                    </div>
-                  </>
-                ) : (
-                  <ActiveTaskBody
-                    key={active.id}
-                    task={active}
-                    socket={socket}
-                    sessionId={sessionId}
-                    canEdit={!!isTutor}
-                  />
-                )}
+              isChatTask(active) ? (
+                // A chat task (source 'task', no structured questions) is answered
+                // via the AI chat — the same box as the course-builder classroom.
+                // Students get the real (persisted) flow; the tutor gets a stateless
+                // preview (onCompleted omitted → no live completion is emitted).
+                <TaskChatPanel
+                  key={active.id}
+                  taskId={active.id}
+                  taskTitle={active.title}
+                  sourceDocument={active.sourceDocument}
+                  onCompleted={
+                    isTutor
+                      ? undefined
+                      : answers => {
+                          const record: Record<string, string> = {}
+                          answers.forEach((a, i) => {
+                            record[String(i + 1)] = a
+                          })
+                          socket?.emit('task:complete', {
+                            roomId: sessionId,
+                            taskId: active.id,
+                            answers: record,
+                            aiHandled: true,
+                          })
+                        }
+                  }
+                />
+              ) : (
+                <>
+                  {active.sourceDocument ? (
+                    <>
+                      <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
+                      <div className="h-[60vh] w-full">
+                        <TaskDocumentCard sourceDocument={active.sourceDocument} alwaysOpen />
+                      </div>
+                    </>
+                  ) : (
+                    <ActiveTaskBody
+                      key={active.id}
+                      task={active}
+                      socket={socket}
+                      sessionId={sessionId}
+                      canEdit={!!isTutor}
+                    />
+                  )}
 
-                {active.dmiItems && active.dmiItems.length > 0 ? (
-                  <DeployedQuestions
-                    key={active.id}
-                    sessionId={sessionId}
-                    taskId={active.id}
-                    items={active.dmiItems}
-                    socket={socket}
-                    isTutor={isTutor}
-                    alreadySubmitted={completedTaskIds.has(active.id)}
-                    result={resultByTask[active.id]}
-                  />
-                ) : !active.sourceDocument && !active.content ? (
-                  <p className="text-xs text-slate-400">This item has no preview.</p>
-                ) : null}
-              </>
+                  {active.dmiItems && active.dmiItems.length > 0 ? (
+                    <DeployedQuestions
+                      key={active.id}
+                      sessionId={sessionId}
+                      taskId={active.id}
+                      items={active.dmiItems}
+                      socket={socket}
+                      isTutor={isTutor}
+                      alreadySubmitted={completedTaskIds.has(active.id)}
+                      result={resultByTask[active.id]}
+                    />
+                  ) : !active.sourceDocument && !active.content ? (
+                    <p className="text-xs text-slate-400">This item has no preview.</p>
+                  ) : null}
+                </>
+              )
             ) : null}
           </div>
         </>


### PR DESCRIPTION
## What

Adds the course-builder classroom's per-task **AI chat box** to the 1-on-1 / group session classroom. When a tutor (or student) opens a **chat task** — `source: 'task'` with no structured `dmiItems` — the Materials panel now renders the same `TaskChatPanel` the student feedback page uses, instead of falling through to *"This item has no preview."*

## Delivery logic (mirrors the course builder)

- **Students** get the real, persisted flow: each chatted answer is graded against the task PCI, the completed attempt is saved to `taskSubmission`, and on complete the panel emits `task:complete {aiHandled:true}` so the tutor sees the answers + AI feedback via the **Submissions** panel (tutor-only via `emitToUser`; never room-broadcast).
- **The owner tutor** gets a stateless **interactive preview** — they can try the chat exactly as a student would, but nothing is written and no completion is emitted.

## Endpoint change (`/api/student/assignments/[taskId]/task-chat`)

- Authorizes three new callers in addition to the enrolled student: an existing submitter (follow-ups keep working), a **live-session participant** (1-on-1/group students join by a booking seat, not `courseEnrollment`), and the task's **owner tutor** (in-session preview).
- `persist = !isOwnerTutor`: the owner-tutor path skips every `taskSubmission` write (both complete-mode insert and ask-mode follow-up append).

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsc --noEmit` — clean
- Student in a 1-on-1 session opens a deployed chat task → chats, completes → tutor sees the answers + AI feedback in Submissions.
- Tutor clicks View on a chat task → same chat box, can try it, nothing persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)