### PR TITLE
feat(course-builder): auto-trigger task PCI summary on first PCI open

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -8090,6 +8090,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [loadedAssessmentId, assessmentDmiReady, canEdit])
 
+    // Task PCI first-open kickoff: when the tutor opens the PCI tab for a task
+    // (or task extension) and the chat is empty, auto-request the grounded summary
+    // so the tutor does not have to type a first message. Fires once per target.
+    useEffect(() => {
+      if (taskBuilderActiveTab !== 'pci') return
+      const taskId = loadedTaskId
+      if (!taskId) return
+      const extId = taskBuilder.activeExtensionId
+      const targetId = extId ? `ext:${extId}` : `task:${taskId}`
+      if (activeTaskThread.messages.length > 0 || activeTaskThread.loading) return
+      if (pciKickoffRef.current.has(targetId)) return
+      pciKickoffRef.current.add(targetId)
+      const t = setTimeout(() => {
+        handlePciSend(
+          'task',
+          'Please summarize this task based on the provided context, including its role in the lesson and course.',
+          true
+        )
+      }, 300)
+      return () => clearTimeout(t)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [taskBuilderActiveTab, loadedTaskId, taskBuilder.activeExtensionId])
+
     // Auto-scroll the task PCI chat so new messages / the loading indicator
     // stays pinned to the bottom without manual scrolling. Also re-pin when the
     // PCI tab becomes active, so the tutor always lands on the latest turn.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
@@ -73,6 +73,7 @@ export type PciAction =
   | { type: 'setInput'; target: PciTarget; input: string }
   | { type: 'loadMessages'; target: PciTarget; messages: PciMessage[] }
   | { type: 'sendStart'; target: PciTarget; userMessage: string }
+  | { type: 'sendStartSilent'; target: PciTarget }
   | {
       type: 'sendSuccess'
       target: PciTarget
@@ -130,6 +131,11 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
         ],
         loading: true,
       })
+
+    case 'sendStartSilent':
+      // Start loading without appending a visible user message. Used for the
+      // automatic first-turn summary when the PCI panel is opened.
+      return patch(state, action.target, { loading: true })
 
     case 'sendSuccess': {
       // Append the assistant reply, hold any finalized draft + structured spec,

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -133,7 +133,11 @@ export function usePci(deps: UsePciDeps) {
     toast.success('Rubric applied to PCI')
   }
 
-  const handlePciSend = async (type: 'task' | 'assessment', overrideMessage?: string) => {
+  const handlePciSend = async (
+    type: 'task' | 'assessment',
+    overrideMessage?: string,
+    silent?: boolean
+  ) => {
     const isTask = type === 'task'
     let taskId = deps.loadedTaskId
     let assessmentId = deps.loadedAssessmentId
@@ -159,7 +163,11 @@ export function usePci(deps: UsePciDeps) {
     // Clear the input box only on a real send (not a quick-action override), then
     // append the user's message + start loading.
     if (!overrideMessage) dispatch({ type: 'setInput', target, input: '' })
-    dispatch({ type: 'sendStart', target, userMessage })
+    if (silent) {
+      dispatch({ type: 'sendStartSilent', target })
+    } else {
+      dispatch({ type: 'sendStart', target, userMessage })
+    }
 
     try {
       const { taskBuilder, assessmentBuilder } = deps


### PR DESCRIPTION
The TASK-22 guardrail and operating procedure already instruct the engine to produce a grounded task summary on first opening the PCI panel, but the client never sent a first-turn request when the PCI tab was opened. The tutor had to type a message before the summary appeared, which contradicted the guardrail intent of not waiting for the tutor to ask.

- Add a sendStartSilent PCI reducer action that starts loading without appending a visible user message.
- Extend handlePciSend with an optional silent flag so the auto-request does not clutter the chat transcript.
- Add a useEffect in CourseBuilder that auto-kicks the task PCI summary when the PCI tab becomes active and the thread is empty, firing once per task or extension.