### PR TITLE
fix(builder): add snapshot version invalidation for text-only task PDFs

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -348,6 +348,7 @@ import {
   CONTENT_TEMPLATES,
   generateQuestionPaperPDF,
   generateTaskTextPDF,
+  TASK_TEXT_SNAPSHOT_VERSION,
   resolveSelectedItem,
   stringToColor,
   formatDuration,
@@ -4608,12 +4609,20 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         : taskBuilder.sourceDocument
       // If a real uploaded document is present, never overwrite it.
       if (existingDoc && !existingDoc.generatedFromText) return
-      // Already generated and content hasn't changed → nothing to do.
-      if (existingDoc?.generatedFromText && existingDoc.extractedText === content) return
+      // Already generated and content hasn't changed AND snapshot version matches → nothing to do.
+      if (
+        existingDoc?.generatedFromText &&
+        existingDoc.extractedText === content &&
+        existingDoc.snapshotVersion === TASK_TEXT_SNAPSHOT_VERSION
+      )
+        return
 
       generatingTaskDocRef.current = true
       try {
-        const { blob, fileName } = await generateTaskTextPDF(taskBuilder.title || 'Task', content)
+        const { blob, fileName, snapshotVersion } = await generateTaskTextPDF(
+          taskBuilder.title || 'Task',
+          content
+        )
         const file = new File([blob], fileName, { type: 'application/pdf' })
         const formData = new FormData()
         formData.append('file', file)
@@ -4636,6 +4645,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           uploadedAt: new Date().toISOString(),
           extractedText: content,
           generatedFromText: true,
+          snapshotVersion,
         }
 
         if (isExtension) {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-types.ts
@@ -34,6 +34,10 @@ export interface ImportedLearningResource {
   fileKey?: string
   extractedText?: string
   uploadedAt: string
+  /** True when this document was auto-generated from typed text rather than uploaded. */
+  generatedFromText?: boolean
+  /** Version of the snapshot generator that produced this document. Bumping it forces re-generation of older auto-snapshots. */
+  snapshotVersion?: number
 }
 
 export interface VisibleDocumentPayload {

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -456,6 +456,13 @@ export async function generateQuestionPaperPDF(
 }
 
 /**
+ * Version of the text-only task snapshot renderer. Bump this whenever the
+ * generated snapshot format changes so existing auto-generated PDFs are
+ * invalidated and regenerated.
+ */
+export const TASK_TEXT_SNAPSHOT_VERSION = 2
+
+/**
  * Generate a simple PDF from a task's typed content so that text-only
  * tasks can be previewed and deployed exactly like uploaded PDF documents.
  *
@@ -471,7 +478,7 @@ export async function generateQuestionPaperPDF(
 export async function generateTaskTextPDF(
   title: string,
   content: string
-): Promise<{ blob: Blob; fileName: string }> {
+): Promise<{ blob: Blob; fileName: string; snapshotVersion: number }> {
   if (typeof document === 'undefined') {
     throw new Error('generateTaskTextPDF must be called in a browser')
   }
@@ -525,7 +532,11 @@ export async function generateTaskTextPDF(
     doc.addImage(imgData, 'PNG', 0, 0, ptWidth, ptHeight)
 
     const safeTitle = title.trim().replace(/[^a-zA-Z0-9_-]/g, '_') || 'Task'
-    return { blob: doc.output('blob'), fileName: `${safeTitle}.pdf` }
+    return {
+      blob: doc.output('blob'),
+      fileName: `${safeTitle}.pdf`,
+      snapshotVersion: TASK_TEXT_SNAPSHOT_VERSION,
+    }
   } finally {
     if (viewport.parentNode) {
       document.body.removeChild(viewport)


### PR DESCRIPTION
The landscape viewport snapshot format change did not appear to take effect because existing auto-generated PDFs were cached by content hash. As long as the typed content was unchanged, ensureTaskTextDocument reused the old purple-card snapshot.

- Add TASK_TEXT_SNAPSHOT_VERSION to builder-utils and return it from generateTaskTextPDF.
- Add generatedFromText and snapshotVersion fields to ImportedLearningResource.
- In ensureTaskTextDocument, only skip regeneration when the stored snapshot version matches the current generator version. Bumping the version now forces all older auto-generated task PDFs to regenerate with the new format.