### PR TITLE
fix(1on1): task deploys reach students + tutor chat-task preview

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 import type { StudentDmiItem } from '@/lib/assessment/student-dmi'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
+import { TaskChatPanel } from '@/app/[locale]/student/feedback/TaskChatPanel'
 import { sanitizeHtml } from '@/lib/security/sanitize'
 import { isImportPlaceholder } from '@/lib/tasks/import-placeholder'
 
@@ -133,6 +134,22 @@ export function SessionDeployPanel({
       active = false
     }
   }, [courseId, refreshKey])
+
+  // Surface server-side deploy rejections. The `task:deploy` emit is optimistic
+  // (we toast success immediately), so without this a rejected deploy — e.g. the
+  // session status gate — would silently look successful while nothing reached
+  // the students.
+  useEffect(() => {
+    if (!socket) return
+    const onDeployError = (e: { error?: string }) => {
+      toast.error(e?.error ? `Couldn't deploy: ${e.error}` : "Couldn't deploy — please try again.")
+      setDeployingId(null)
+    }
+    socket.on('task:deploy:error', onDeployError)
+    return () => {
+      socket.off('task:deploy:error', onDeployError)
+    }
+  }, [socket])
 
   // Group the flat task list into course → lesson → tasks, filtered by the
   // search query (matches task title, course name or lesson title).
@@ -539,6 +556,11 @@ function TaskPreviewOverlay({
     .replace(/&nbsp;/gi, ' ')
     .trim()
   const showContent = visibleText.length > 0 && !isImportPlaceholder(contentText)
+  // A chat task (a plain task with no structured questions) is answered by
+  // chatting with the AI — the same box the student gets. Preview it interactively
+  // here: the tutor owns the task, so the task-chat endpoint runs it statelessly
+  // (nothing is saved). The source document is rendered inside TaskChatPanel.
+  const isChatTask = task.type === 'task' && task.dmiItems.length === 0
   // The right column holds the authored content + questions. When both a document
   // and a right column exist they sit side by side; either one alone fills the row.
   // No visible content AND no questions → the document fills the whole modal.
@@ -573,98 +595,126 @@ function TaskPreviewOverlay({
           </button>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 lg:flex-row">
-          {/* Document (left) — split 50/50 with the right column via flex-1 (stacked
-              on mobile, side by side on lg+); fills the whole row when alone. */}
-          {task.sourceDocument ? (
+        {isChatTask ? (
+          // Chat task: interactive AI chat preview (same box students get). The
+          // document, if any, is rendered inside TaskChatPanel — not standalone.
+          // onCompleted is omitted: this is a pre-deploy preview, so no live
+          // completion is ever emitted, and the owner-tutor call never persists.
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-4">
+            <p className="shrink-0 rounded-md bg-slate-50 px-2.5 py-1.5 text-xs text-slate-500">
+              Preview — try the chat as a student would. Nothing is saved.
+            </p>
+            {showContent ? (
+              <div
+                className="prose prose-sm max-h-40 shrink-0 overflow-y-auto pr-1 text-slate-700"
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(task.content) }}
+              />
+            ) : null}
             <div className="min-h-0 flex-1">
-              <TaskDocumentCard sourceDocument={task.sourceDocument} alwaysOpen />
+              <TaskChatPanel
+                taskId={task.taskId}
+                taskTitle={task.title}
+                sourceDocument={task.sourceDocument}
+              />
             </div>
-          ) : null}
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 lg:flex-row">
+            {/* Document (left) — split 50/50 with the right column via flex-1 (stacked
+              on mobile, side by side on lg+); fills the whole row when alone. */}
+            {task.sourceDocument ? (
+              <div className="min-h-0 flex-1">
+                <TaskDocumentCard sourceDocument={task.sourceDocument} alwaysOpen />
+              </div>
+            ) : null}
 
-          {/* Content + questions (right) — scrolls independently. */}
-          {hasRightColumn ? (
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              {/* Hide the auto-generated "[Imported file.docx]" placeholder content —
+            {/* Content + questions (right) — scrolls independently. */}
+            {hasRightColumn ? (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                {/* Hide the auto-generated "[Imported file.docx]" placeholder content —
                   it's noise once the actual document is shown. Only real authored
                   content is rendered. */}
-              {showContent ? (
-                <div
-                  className="prose prose-sm mb-4 max-w-none text-slate-700"
-                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(task.content) }}
-                />
-              ) : null}
+                {showContent ? (
+                  <div
+                    className="prose prose-sm mb-4 max-w-none text-slate-700"
+                    dangerouslySetInnerHTML={{ __html: sanitizeHtml(task.content) }}
+                  />
+                ) : null}
 
-              {task.dmiItems.length > 0 ? (
-                <ol className="flex flex-col gap-4">
-                  {task.dmiItems.map((q, i) => (
-                    <li key={q.id} className="rounded-lg border border-slate-200 p-3">
-                      <div className="mb-1.5 flex items-baseline justify-between gap-2">
-                        <span className="text-xs font-semibold text-slate-500">
-                          {q.questionLabel || `Question ${q.questionNumber || i + 1}`}
-                        </span>
-                        {typeof q.marks === 'number' ? (
-                          <span className="shrink-0 text-[11px] text-slate-400">
-                            {q.marks} mark{q.marks === 1 ? '' : 's'}
+                {task.dmiItems.length > 0 ? (
+                  <ol className="flex flex-col gap-4">
+                    {task.dmiItems.map((q, i) => (
+                      <li key={q.id} className="rounded-lg border border-slate-200 p-3">
+                        <div className="mb-1.5 flex items-baseline justify-between gap-2">
+                          <span className="text-xs font-semibold text-slate-500">
+                            {q.questionLabel || `Question ${q.questionNumber || i + 1}`}
                           </span>
+                          {typeof q.marks === 'number' ? (
+                            <span className="shrink-0 text-[11px] text-slate-400">
+                              {q.marks} mark{q.marks === 1 ? '' : 's'}
+                            </span>
+                          ) : null}
+                        </div>
+                        {q.questionText ? (
+                          <p className="mb-2 whitespace-pre-wrap text-sm text-slate-800">
+                            {q.questionText}
+                          </p>
                         ) : null}
-                      </div>
-                      {q.questionText ? (
-                        <p className="mb-2 whitespace-pre-wrap text-sm text-slate-800">
-                          {q.questionText}
-                        </p>
-                      ) : null}
-                      {q.hotspotImageUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={q.hotspotImageUrl}
-                          alt=""
-                          className="mb-2 max-h-64 w-auto rounded border border-slate-200"
-                        />
-                      ) : null}
-                      {q.options && q.options.length > 0 ? (
-                        <ul className="flex flex-col gap-1">
-                          {q.options.map((opt, oi) => (
-                            <li key={oi} className="flex items-start gap-2 text-sm text-slate-700">
-                              <span className="shrink-0 font-semibold text-slate-400">
-                                {String.fromCharCode(65 + oi)}.
-                              </span>
-                              <span className="whitespace-pre-wrap">{opt}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
-                      {q.matchPrompts && q.matchPrompts.length > 0 ? (
-                        <div className="grid grid-cols-2 gap-3 text-sm text-slate-700">
+                        {q.hotspotImageUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={q.hotspotImageUrl}
+                            alt=""
+                            className="mb-2 max-h-64 w-auto rounded border border-slate-200"
+                          />
+                        ) : null}
+                        {q.options && q.options.length > 0 ? (
                           <ul className="flex flex-col gap-1">
-                            {q.matchPrompts.map((p, pi) => (
-                              <li key={pi} className="whitespace-pre-wrap">
-                                {pi + 1}. {p}
+                            {q.options.map((opt, oi) => (
+                              <li
+                                key={oi}
+                                className="flex items-start gap-2 text-sm text-slate-700"
+                              >
+                                <span className="shrink-0 font-semibold text-slate-400">
+                                  {String.fromCharCode(65 + oi)}.
+                                </span>
+                                <span className="whitespace-pre-wrap">{opt}</span>
                               </li>
                             ))}
                           </ul>
-                          {q.matchBank && q.matchBank.length > 0 ? (
-                            <ul className="flex flex-col gap-1 text-slate-500">
-                              {q.matchBank.map((b, bi) => (
-                                <li key={bi} className="whitespace-pre-wrap">
-                                  • {b}
+                        ) : null}
+                        {q.matchPrompts && q.matchPrompts.length > 0 ? (
+                          <div className="grid grid-cols-2 gap-3 text-sm text-slate-700">
+                            <ul className="flex flex-col gap-1">
+                              {q.matchPrompts.map((p, pi) => (
+                                <li key={pi} className="whitespace-pre-wrap">
+                                  {pi + 1}. {p}
                                 </li>
                               ))}
                             </ul>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </li>
-                  ))}
-                </ol>
-              ) : null}
-            </div>
-          ) : null}
+                            {q.matchBank && q.matchBank.length > 0 ? (
+                              <ul className="flex flex-col gap-1 text-slate-500">
+                                {q.matchBank.map((b, bi) => (
+                                  <li key={bi} className="whitespace-pre-wrap">
+                                    • {b}
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ol>
+                ) : null}
+              </div>
+            ) : null}
 
-          {!hasAnyPreview ? (
-            <p className="text-sm text-slate-400">This item has no previewable content.</p>
-          ) : null}
-        </div>
+            {!hasAnyPreview ? (
+              <p className="text-sm text-slate-400">This item has no previewable content.</p>
+            ) : null}
+          </div>
+        )}
 
         <div className="flex items-center justify-end gap-2 border-t px-5 py-3">
           <button

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -7,7 +7,7 @@ import { Server as NetServer } from 'http'
 import { Server as SocketIOServer, Socket } from 'socket.io'
 import Redis from 'ioredis'
 import * as Sentry from '@sentry/nextjs'
-import { eq, and, inArray, desc } from 'drizzle-orm'
+import { eq, and, inArray, desc, sql } from 'drizzle-orm'
 import { expandToCourseFamily } from '@/lib/courses/variant-family'
 import { authorizeSessionStudent } from '@/lib/live/session-student-auth'
 import { drizzleDb } from '@/lib/db/drizzle'
@@ -1039,7 +1039,9 @@ export async function initEnhancedSocketServer(server: NetServer) {
         try {
           await drizzleDb
             .update(liveSession)
-            .set({ status: 'active', startedAt: new Date() })
+            // Preserve an existing startedAt (COALESCE) so a re-promotion can never
+            // reset the recorded start time / session-duration metric.
+            .set({ status: 'active', startedAt: sql`COALESCE(${liveSession.startedAt}, now())` })
             .where(and(eq(liveSession.sessionId, roomId), eq(liveSession.status, 'scheduled')))
         } catch (goLiveErr) {
           console.warn('[join_class] failed to promote session to active:', goLiveErr)
@@ -1286,7 +1288,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
     // Helper: check if a session is currently in a state where tutors can deploy content
     async function canDeployToSession(
       sessionId: string,
-      source?: string
+      source?: string,
+      deployerId?: string
     ): Promise<{ ok: true } | { ok: false; reason: string }> {
       try {
         const [sessionRec] = await drizzleDb
@@ -1295,12 +1298,22 @@ export async function initEnhancedSocketServer(server: NetServer) {
             scheduledAt: liveSession.scheduledAt,
             startedAt: liveSession.startedAt,
             endedAt: liveSession.endedAt,
+            tutorId: liveSession.tutorId,
           })
           .from(liveSession)
           .where(eq(liveSession.sessionId, sessionId))
           .limit(1)
 
         if (!sessionRec) return { ok: false, reason: 'Session not found' }
+
+        // Ownership: only the session's own tutor may deploy into it. The handler
+        // only checks role === 'tutor' and recreates the room on demand, so without
+        // this any tutor could deploy to any session by id (and then read its
+        // students' submissions). Skip only when the caller is unknown or the row
+        // has no tutor (legacy/ad-hoc) to preserve prior behaviour in those cases.
+        if (deployerId && sessionRec.tutorId && sessionRec.tutorId !== deployerId) {
+          return { ok: false, reason: 'Not authorized for this session' }
+        }
 
         // Homework can be dropped even after session ends
         if (source !== 'homework') {
@@ -1358,7 +1371,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
         console.log(`[task:deploy] Recreated room ${roomId} on demand`)
       }
 
-      const deployCheck = await canDeployToSession(roomId, task.source)
+      const deployCheck = await canDeployToSession(roomId, task.source, socket.data.userId)
       if (!deployCheck.ok) {
         socket.emit('task:deploy:error', { error: deployCheck.reason })
         return
@@ -2503,7 +2516,7 @@ export async function initEnhancedSocketServer(server: NetServer) {
           return
         }
 
-        const deployCheck = await canDeployToSession(roomId)
+        const deployCheck = await canDeployToSession(roomId, undefined, socket.data.userId)
         if (!deployCheck.ok) {
           socket.emit('insight:send:error', { error: deployCheck.reason })
           return

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1025,6 +1025,27 @@ export async function initEnhancedSocketServer(server: NetServer) {
         }
       }
 
+      // A 1-on-1 session (and anything created via create-session) starts life as
+      // 'scheduled' and nothing ever flips it live — unlike group/ad-hoc sessions,
+      // which set 'active' on their explicit start action. But status-gated
+      // features depend on it: `canDeployToSession` requires an active/live status,
+      // so with the session stuck 'scheduled' every task deploy was rejected server-
+      // side ("Session has not started yet") and never reached students. When the
+      // scheduled tutor actually enters the room, promote the session to 'active'.
+      // Guarded to only promote from 'scheduled' (ended/paused/active are left
+      // alone) and best-effort so a write hiccup never blocks the join. boardIdx<0
+      // skips private-whiteboard sub-rooms (no LiveSession row of their own).
+      if (effectiveRole !== 'student' && boardIdx < 0) {
+        try {
+          await drizzleDb
+            .update(liveSession)
+            .set({ status: 'active', startedAt: new Date() })
+            .where(and(eq(liveSession.sessionId, roomId), eq(liveSession.status, 'scheduled')))
+        } catch (goLiveErr) {
+          console.warn('[join_class] failed to promote session to active:', goLiveErr)
+        }
+      }
+
       if (!room) {
         const roomTutorId =
           effectiveRole !== 'student'
@@ -1287,11 +1308,16 @@ export async function initEnhancedSocketServer(server: NetServer) {
           if (sessionRec.endedAt) return { ok: false, reason: 'Session has ended' }
         }
 
-        // Must be active or live to deploy (or ended for homework)
+        // Must be started (or ended, for homework) to deploy. 'scheduled' is
+        // allowed too: a tutor can only deploy from inside the live room, and
+        // joining promotes the session to 'active' (see join_class) — but that
+        // write races the first deploy, and 1-on-1 sessions historically never
+        // left 'scheduled' at all. 'ended'/endedAt are still blocked above for
+        // non-homework, so this only opens the not-yet-started window.
         const allowedStatuses =
           source === 'homework'
-            ? ['active', 'live', 'preparing', 'paused', 'ended']
-            : ['active', 'live', 'preparing', 'paused']
+            ? ['active', 'live', 'preparing', 'paused', 'ended', 'scheduled']
+            : ['active', 'live', 'preparing', 'paused', 'scheduled']
         if (!allowedStatuses.includes(sessionRec.status)) {
           return { ok: false, reason: 'Session has not started yet' }
         }


### PR DESCRIPTION
Fixes two problems reported in the 1-on-1 / group live session.

## 1. Deploys never landed on the student side (root cause)

A 1-on-1 `liveSession` (anything created via `create-session`) starts life as **`scheduled`** and nothing ever flips it live — unlike group/ad-hoc sessions, which set `active` on their explicit start action. But `canDeployToSession` requires an active/live status, so **every task/assessment deploy was rejected server-side** with *"Session has not started yet"* and never broadcast to students.

It looked like it worked because the tutor's `task:deploy` emit is **optimistic** (toasts success immediately) and **nothing listened for `task:deploy:error`**.

**Fixes:**
- `join_class` promotes a `scheduled` session to `active` (+`startedAt`) when the scheduled tutor enters the room — the missing "go live" signal. This mirrors the existing HTTP start path (`tutor/classes/[id]`), whose own comment says *"the tutor's presence is what takes a class live."* Guarded to only promote from `scheduled`; skips whiteboard sub-rooms.
- `canDeployToSession` also allows `scheduled` (removes the join→deploy race and is resilient if the flip write hiccups). `ended`/`endedAt` remain blocked for non-homework.
- The deploy panel now surfaces `task:deploy:error` as a toast, so a rejected deploy can never masquerade as success again.

## 2. Tutor's "View" on a task had no AI chat box

"View" opens the deploy panel's **preview modal**, whose right pane showed *"This item has no previewable content"* for a chat task — I'd previously only added the chat to the Materials panel. The preview modal now renders `TaskChatPanel` for a chat task (`type 'task'`, no `dmiItems`) as a **stateless interactive preview** (the owner tutor's `task-chat` calls never persist; no completion is emitted).

## Test plan
- [x] `npm run build`, `npx tsc --noEmit` — clean
- Tutor starts a 1-on-1 session → deploys a task/assessment → it appears on the student side (Materials).
- Tutor clicks View on a chat task → interactive AI chat preview on the right.
- A genuinely rejected deploy now shows an error toast instead of false success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)