### PR TITLE
feat(1on1): full-page opened task for students + rename to Lessons

### DIFF
--- a/tutorme-app/src/components/class/enhanced-whiteboard.tsx
+++ b/tutorme-app/src/components/class/enhanced-whiteboard.tsx
@@ -204,6 +204,10 @@ interface EnhancedWhiteboardProps {
   onToggleVideoFullscreen?: () => void
   isVideoFullscreen?: boolean
   videoComponent?: React.ReactNode
+  /** Tailwind z-index class for the floating-video wrapper. Defaults to `z-10`
+   *  (above the canvas). The 1-on-1 classroom raises it so the tutor's video
+   *  stays above a full-page opened task. */
+  videoZClassName?: string
   // External page control
   pages?: Page[]
   currentPageIndex?: number
@@ -240,6 +244,7 @@ export function EnhancedWhiteboard({
   onToggleVideoFullscreen,
   isVideoFullscreen = false,
   videoComponent,
+  videoZClassName = 'z-10',
   pages: externalPages,
   currentPageIndex: externalPageIndex,
   onPagesChange,
@@ -2747,7 +2752,7 @@ export function EnhancedWhiteboard({
               // the handle drag (they fight and the frame jumps).
               onPointerDown={e => e.stopPropagation()}
               onMouseDown={e => e.stopPropagation()}
-              className="absolute z-10 overflow-hidden rounded-lg border border-slate-600 bg-black shadow-lg"
+              className={`absolute ${videoZClassName} overflow-hidden rounded-lg border border-slate-600 bg-black shadow-lg`}
               style={{
                 width: `${videoSize.width}px`,
                 height: `${videoSize.height}px`,

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -261,6 +261,9 @@ export function SessionClassroom({
           userName={session?.user?.name || undefined}
           videoOverlay
           videoComponent={video}
+          // A student can open a deployed task full-page (z-30, below the toolbar);
+          // keep their video above it so the tutor stays visible while they read.
+          videoZClassName={!isTutor ? 'z-[35]' : 'z-10'}
         />
       </FallbackBoundary>
 
@@ -432,7 +435,7 @@ export function SessionClassroom({
           className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
         >
           <FolderOpen className="h-3.5 w-3.5" />
-          Materials
+          {isTutor ? 'Materials' : 'Lessons'}
         </button>
         <button
           type="button"
@@ -456,8 +459,9 @@ export function SessionClassroom({
         onClose={() => setBoardTarget(null)}
       />
 
-      {/* Side panels — wrapped so a panel crash closes to nothing, never the room. */}
-      {activePanel ? (
+      {/* Side panels — wrapped so a panel crash closes to nothing, never the room.
+          Materials/Lessons is handled separately below (self-positioned). */}
+      {activePanel && activePanel !== 'materials' ? (
         <FallbackBoundary label="session panel" fallback={null}>
           <div className="pointer-events-none absolute bottom-3 right-3 top-16 z-40 flex">
             {activePanel === 'deploy' && isTutor ? (
@@ -511,18 +515,26 @@ export function SessionClassroom({
                 onClose={() => setActivePanel(null)}
               />
             ) : null}
-            {activePanel === 'materials' ? (
-              <SessionDeployedPanel
-                sessionId={sessionId}
-                socket={socket}
-                isTutor={isTutor}
-                tasks={tasks}
-                completedTaskIds={myCompletedTaskIds}
-                resultByTask={myResultByTask}
-                onClose={() => setActivePanel(null)}
-              />
-            ) : null}
           </div>
+        </FallbackBoundary>
+      ) : null}
+
+      {/* Materials/Lessons is rendered OUTSIDE the shared z-40 container and
+          self-positions: as a side panel normally, or full-page (z-30) when a
+          student opens a task. Keeping it out of the container's z-40 stacking
+          context is what lets the toolbar (z-40) and video (z-[35]) overlay the
+          opened task. */}
+      {activePanel === 'materials' ? (
+        <FallbackBoundary label="session materials" fallback={null}>
+          <SessionDeployedPanel
+            sessionId={sessionId}
+            socket={socket}
+            isTutor={isTutor}
+            tasks={tasks}
+            completedTaskIds={myCompletedTaskIds}
+            resultByTask={myResultByTask}
+            onClose={() => setActivePanel(null)}
+          />
         </FallbackBoundary>
       ) : null}
 

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -82,21 +82,37 @@ export function SessionDeployedPanel({
   // Newest first, matching the reference panel's ordering.
   const orderedTasks = [...tasks].reverse()
 
+  // A student opens a deployed task FULL-PAGE (portaled to <body> at z-30, so the
+  // toolbar buttons (z-40) and the student's video (z-[35]) overlay it). Tutors
+  // keep the compact side panel. The label is "Lessons" for students (matching the
+  // course-builder classroom) and "Materials" for tutors.
+  const studentFullPage = !!active && !isTutor
+  const panelTitle = isTutor ? 'Materials' : 'Lessons'
+
+  // Self-positioned (a direct child of the classroom root, NOT the shared z-40
+  // panel container) so the full-page task shares one stacking context with the
+  // toolbar (z-40) and video (z-[35]) and reliably sits under them at z-30.
   return (
-    <div className="pointer-events-auto flex h-full w-96 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl">
+    <div
+      className={
+        studentFullPage
+          ? 'pointer-events-auto absolute inset-0 z-30 flex flex-col bg-white'
+          : 'pointer-events-auto absolute bottom-3 right-3 top-16 z-40 flex w-96 flex-col rounded-2xl border border-slate-200 bg-white shadow-2xl'
+      }
+    >
       <div className="flex items-center justify-between gap-2 border-b px-4 py-3">
         <div className="flex min-w-0 items-center gap-2">
           {active ? (
             <button
               onClick={() => setActiveId(null)}
               aria-label="Back to list"
-              className="rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+              className="inline-flex items-center gap-1 rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
             >
               <ArrowLeft className="h-4 w-4" />
             </button>
           ) : null}
           <h3 className="truncate text-sm font-semibold text-slate-900">
-            {active ? 'Back to materials' : 'Materials'}
+            {active ? active.title : panelTitle}
           </h3>
         </div>
         <button
@@ -169,9 +185,6 @@ export function SessionDeployedPanel({
                 // (one scrollbar) rather than a viewport-height box inside the
                 // already-scrollable parent.
                 <div className="flex h-full flex-col">
-                  <p className="mb-3 shrink-0 text-sm font-semibold text-slate-900">
-                    {active.title}
-                  </p>
                   {active.content && !isImportPlaceholder(active.content) ? (
                     <div
                       className="prose prose-sm mb-3 max-h-40 shrink-0 overflow-y-auto pr-1 text-slate-700"
@@ -213,12 +226,9 @@ export function SessionDeployedPanel({
               ) : (
                 <>
                   {active.sourceDocument ? (
-                    <>
-                      <p className="mb-3 text-sm font-semibold text-slate-900">{active.title}</p>
-                      <div className="h-[60vh] w-full">
-                        <TaskDocumentCard sourceDocument={active.sourceDocument} alwaysOpen />
-                      </div>
-                    </>
+                    <div className="h-[60vh] w-full">
+                      <TaskDocumentCard sourceDocument={active.sourceDocument} alwaysOpen />
+                    </div>
                   ) : (
                     <ActiveTaskBody
                       key={active.id}


### PR DESCRIPTION
Two student-side refinements to the 1-on-1 / group session classroom.

## 1. Opening a deployed task now fills the page (buttons + video overlay it)

When a **student** clicks a deployed task/assessment it opens **full-page** instead of in the narrow side panel, so there's room to read/answer — while the toolbar buttons and the tutor's video stay visible on top.

Layering (all within one stacking context):
- opened task → **z-30**
- student's floating video → **z-[35]** (raised from the default z-10)
- toolbar buttons → **z-40**

So `task < video < buttons`. To make this reliable, the Materials/Lessons panel is now rendered as a **direct child of the classroom root** (self-positioned) rather than inside the shared `z-40` side-panel container — that container's stacking context would otherwise trap the full-page task *above* the toolbar. `EnhancedWhiteboard` gains a `videoZClassName` prop (default `z-10`); the 1-on-1 classroom passes `z-[35]` for students only, so the course classroom and the tutor view are unchanged. Tutors keep the compact side panel.

## 2. "Materials" → "Lessons" on the student side

The panel header and toolbar button now read **Lessons** for students (matching the course-builder classroom). Tutors still see **Materials**.

## Test plan
- [x] `npm run build`, `npx tsc --noEmit` — clean; `z-[35]` confirmed emitted in built CSS
- Student opens a deployed task → it fills the page; the top-right buttons and the video PiP remain on top and clickable; **back** returns to the list; **X** closes.
- Tutor view unchanged (side panel, "Materials").

🤖 Generated with [Claude Code](https://claude.com/claude-code)