### PR TITLE
feat(1on1): per-student board links in Monitor + follow-the-tutor

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/TaskChatPanel.tsx
@@ -28,6 +28,7 @@ export function TaskChatPanel({
   sourceDocument,
   onCompleted,
   previewMode = false,
+  onInteract,
 }: {
   taskId: string
   taskTitle?: string
@@ -41,6 +42,9 @@ export function TaskChatPanel({
    *  test tasks in the course-builder Test tab, not here). The box still shows
    *  exactly what the student gets. */
   previewMode?: boolean
+  /** Fired when the student starts answering (first chat message). Used by the
+   *  live session to stop auto-following the tutor. */
+  onInteract?: () => void
 }) {
   const [messages, setMessages] = useState<ChatMsg[]>([])
   const [draft, setDraft] = useState('')
@@ -117,6 +121,7 @@ export function TaskChatPanel({
   const addAnswer = () => {
     const a = draft.trim()
     if (!a || busy) return
+    onInteract?.()
     setMessages(prev => [...prev, { role: 'student', content: a }])
     setDraft('')
   }

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -12,7 +12,7 @@
  * task deployment) are intentionally absent — a course-less session has none.
  */
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSession } from 'next-auth/react'
 import {
   Send,
@@ -240,6 +240,7 @@ export function SessionClassroom({
   // stops when the student starts answering (see onInteract) or toggles it off.
   const followKey = `sc:follow:${sessionId}`
   const [followTutor, setFollowTutor] = useState(true)
+  const followHydrated = useRef(false)
   useEffect(() => {
     if (isTutor) return
     try {
@@ -248,9 +249,12 @@ export function SessionClassroom({
     } catch {
       /* private mode / unavailable — default stays on */
     }
+    followHydrated.current = true
   }, [followKey, isTutor])
   useEffect(() => {
-    if (isTutor) return
+    // Don't persist until we've read the stored value, so the initial default
+    // can't clobber it on first mount.
+    if (isTutor || !followHydrated.current) return
     try {
       localStorage.setItem(followKey, followTutor ? '1' : '0')
     } catch {

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -20,7 +20,6 @@ import {
   ListChecks,
   Pencil,
   PenTool,
-  LayoutGrid,
   BookOpen,
   MessageSquare,
   Users,
@@ -94,7 +93,6 @@ export function SessionClassroom({
   // Private-board overlay: whose board is open (own = editable, student = tutor
   // viewing read-only), plus the tutor's student-board picker.
   const [boardTarget, setBoardTarget] = useState<BoardTarget | null>(null)
-  const [showBoardsPicker, setShowBoardsPicker] = useState(false)
   const [showCourseEditor, setShowCourseEditor] = useState(false)
   // Bumped when the Edit-course modal (iframe) reports a save, so the deploy
   // panel refetches instead of serving pre-edit task content.
@@ -233,6 +231,42 @@ export function SessionClassroom({
     chatMessages,
     activePoll,
   } = useSessionRoomState(socket, session?.user?.id)
+
+  // ── Follow the tutor (students) ─────────────────────────────────────────────
+  // Like the course-builder classroom: a student's view follows the tutor's — the
+  // shared whiteboard by default, and whatever task/assessment the tutor presents.
+  // The tutor presents by DEPLOYING (the newest deployed item is what everyone is
+  // on), so a following student auto-opens the latest deployed task. Following
+  // stops when the student starts answering (see onInteract) or toggles it off.
+  const followKey = `sc:follow:${sessionId}`
+  const [followTutor, setFollowTutor] = useState(true)
+  useEffect(() => {
+    if (isTutor) return
+    try {
+      const v = localStorage.getItem(followKey)
+      if (v != null) setFollowTutor(v === '1')
+    } catch {
+      /* private mode / unavailable — default stays on */
+    }
+  }, [followKey, isTutor])
+  useEffect(() => {
+    if (isTutor) return
+    try {
+      localStorage.setItem(followKey, followTutor ? '1' : '0')
+    } catch {
+      /* ignore */
+    }
+  }, [followKey, followTutor, isTutor])
+
+  // The newest deployed task is what the tutor is presenting (tasks are appended
+  // on deploy). While following, surface it: open the Lessons panel and hand the
+  // id to the panel, which drills into it.
+  const latestTaskId = tasks.length > 0 ? tasks[tasks.length - 1].id : null
+  const following = !isTutor && followTutor
+  useEffect(() => {
+    if (!following || !latestTaskId) return
+    setActivePanel('materials')
+  }, [following, latestTaskId])
 
   // The call feed rides along as the whiteboard's draggable video overlay.
   const video = (
@@ -376,27 +410,6 @@ export function SessionClassroom({
                 Edit course
               </button>
             ) : null}
-            <div className="pointer-events-auto relative">
-              <button
-                type="button"
-                onClick={() => setShowBoardsPicker(v => !v)}
-                title="View a student's board"
-                className="inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
-              >
-                <LayoutGrid className="h-3.5 w-3.5" />
-                Boards
-              </button>
-              {showBoardsPicker ? (
-                <BoardsPicker
-                  students={students}
-                  onPick={s => {
-                    setBoardTarget({ ownerId: s.userId, ownerName: s.name, mine: false })
-                    setShowBoardsPicker(false)
-                  }}
-                  onClose={() => setShowBoardsPicker(false)}
-                />
-              ) : null}
-            </div>
           </>
         ) : null}
         {myId ? (
@@ -432,14 +445,41 @@ export function SessionClassroom({
         {/* Lessons (deployed tasks/assessments) is a student affordance — the tutor
             deploys/reviews via the Deploy and Submissions panels, so they don't need it. */}
         {!isTutor ? (
-          <button
-            type="button"
-            onClick={() => toggle('materials')}
-            className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
-          >
-            <FolderOpen className="h-3.5 w-3.5" />
-            Lessons
-          </button>
+          <>
+            {/* Follow the tutor: on by default, mirrors the course-builder classroom.
+                A pulsing dot when active; click to stop/resume following. */}
+            <button
+              type="button"
+              onClick={() => setFollowTutor(v => !v)}
+              title={
+                followTutor
+                  ? 'Following the tutor — your view opens what they present. Click to stop.'
+                  : 'Follow the tutor — auto-open what they present.'
+              }
+              className={
+                'pointer-events-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur ' +
+                (followTutor
+                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
+                  : 'bg-white/90 text-slate-800 hover:bg-white')
+              }
+            >
+              <span
+                className={
+                  'h-2 w-2 rounded-full ' +
+                  (followTutor ? 'animate-pulse bg-white' : 'bg-slate-400')
+                }
+              />
+              {followTutor ? 'Following' : 'Follow'}
+            </button>
+            <button
+              type="button"
+              onClick={() => toggle('materials')}
+              className="pointer-events-auto inline-flex items-center gap-1.5 rounded-xl bg-white/90 px-3 py-2 text-xs font-semibold text-slate-800 shadow-lg backdrop-blur hover:bg-white"
+            >
+              <FolderOpen className="h-3.5 w-3.5" />
+              Lessons
+            </button>
+          </>
         ) : null}
         <button
           type="button"
@@ -501,6 +541,9 @@ export function SessionClassroom({
                 students={students}
                 tasks={tasks}
                 responsesByTask={responsesByTask}
+                onViewBoard={(userId, name) =>
+                  setBoardTarget({ ownerId: userId, ownerName: name, mine: false })
+                }
                 onClose={() => setActivePanel(null)}
               />
             ) : null}
@@ -537,6 +580,8 @@ export function SessionClassroom({
             tasks={tasks}
             completedTaskIds={myCompletedTaskIds}
             resultByTask={myResultByTask}
+            followTaskId={following ? latestTaskId : null}
+            onInteract={isTutor ? undefined : () => setFollowTutor(false)}
             onClose={() => setActivePanel(null)}
           />
         </FallbackBoundary>

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -88,10 +88,16 @@ export function SessionDeployedPanel({
   }
 
   // Follow: open the tutor's current task when it changes (only when the id is a
-  // new value, so the student can still tap Back without being re-yanked).
+  // new value, so the student can still tap Back without being re-yanked). When
+  // following turns off (followTaskId null) reset the ref, so re-enabling follow
+  // re-opens the current task even if it hasn't changed.
   const lastFollowRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!followTaskId || followTaskId === lastFollowRef.current) return
+    if (!followTaskId) {
+      lastFollowRef.current = null
+      return
+    }
+    if (followTaskId === lastFollowRef.current) return
     lastFollowRef.current = followTaskId
     if (tasks.some(t => t.id === followTaskId)) openTask(followTaskId)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deployed-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import {
   X,
@@ -55,6 +55,8 @@ export function SessionDeployedPanel({
   tasks,
   completedTaskIds,
   resultByTask,
+  followTaskId,
+  onInteract,
   onClose,
 }: {
   sessionId: string
@@ -63,6 +65,12 @@ export function SessionDeployedPanel({
   tasks: SessionRoomTask[]
   completedTaskIds: Set<string>
   resultByTask: Record<string, SessionGradeResult>
+  /** While a student is following the tutor, the task to auto-open. When it
+   *  changes to a new id the panel opens it (they follow the tutor's view). */
+  followTaskId?: string | null
+  /** Called when the student starts answering — used to stop auto-following so a
+   *  new deploy can't yank them away mid-answer. */
+  onInteract?: () => void
   onClose: () => void
 }) {
   // Master-detail, mirroring the course-builder "Lessons" panel: the default
@@ -78,6 +86,16 @@ export function SessionDeployedPanel({
     setActiveId(id)
     setSeenIds(prev => (prev.has(id) ? prev : new Set(prev).add(id)))
   }
+
+  // Follow: open the tutor's current task when it changes (only when the id is a
+  // new value, so the student can still tap Back without being re-yanked).
+  const lastFollowRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!followTaskId || followTaskId === lastFollowRef.current) return
+    lastFollowRef.current = followTaskId
+    if (tasks.some(t => t.id === followTaskId)) openTask(followTaskId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [followTaskId, tasks])
 
   // Newest first, matching the reference panel's ordering.
   const orderedTasks = [...tasks].reverse()
@@ -204,6 +222,7 @@ export function SessionDeployedPanel({
                       taskTitle={active.title}
                       sourceDocument={active.sourceDocument}
                       previewMode={!!isTutor}
+                      onInteract={onInteract}
                       onCompleted={
                         isTutor
                           ? undefined
@@ -244,6 +263,7 @@ export function SessionDeployedPanel({
                       isTutor={isTutor}
                       alreadySubmitted={completedTaskIds.has(active.id)}
                       result={resultByTask[active.id]}
+                      onInteract={onInteract}
                     />
                   </div>
                 </div>
@@ -273,6 +293,7 @@ export function SessionDeployedPanel({
                       isTutor={isTutor}
                       alreadySubmitted={completedTaskIds.has(active.id)}
                       result={resultByTask[active.id]}
+                      onInteract={onInteract}
                     />
                   ) : !active.sourceDocument && !active.content ? (
                     <p className="text-xs text-slate-400">This item has no preview.</p>
@@ -440,6 +461,7 @@ function DeployedQuestions({
   isTutor,
   alreadySubmitted,
   result,
+  onInteract,
 }: {
   sessionId: string
   taskId: string
@@ -448,6 +470,7 @@ function DeployedQuestions({
   isTutor?: boolean
   alreadySubmitted?: boolean
   result?: SessionGradeResult
+  onInteract?: () => void
 }) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
@@ -517,7 +540,10 @@ function DeployedQuestions({
           <SessionDmiAnswerField
             item={it}
             value={answers[it.id] ?? ''}
-            onValueChange={next => setAnswers(prev => ({ ...prev, [it.id]: next }))}
+            onValueChange={next => {
+              onInteract?.()
+              setAnswers(prev => ({ ...prev, [it.id]: next }))
+            }}
           />
         </QuestionBlock>
       ))}

--- a/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
@@ -3,7 +3,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Socket } from 'socket.io-client'
 import { toast } from 'sonner'
-import { X, RefreshCw, MessageSquare, Send, Loader2, Users, Sparkles } from 'lucide-react'
+import {
+  X,
+  RefreshCw,
+  MessageSquare,
+  Send,
+  Loader2,
+  Users,
+  Sparkles,
+  LayoutGrid,
+} from 'lucide-react'
 import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import type {
   SessionRosterStudent,
@@ -26,6 +35,7 @@ export function SessionMonitorPanel({
   students,
   tasks,
   responsesByTask,
+  onViewBoard,
   onClose,
 }: {
   sessionId: string
@@ -33,6 +43,9 @@ export function SessionMonitorPanel({
   students: SessionRosterStudent[]
   tasks: SessionRoomTask[]
   responsesByTask: Record<string, Record<string, SessionStudentResponse>>
+  /** Open a student's private whiteboard (read-only) — replaces the standalone
+   *  Boards picker. */
+  onViewBoard?: (userId: string, name: string) => void
   onClose: () => void
 }) {
   const [comprehension, setComprehension] = useState<
@@ -185,6 +198,16 @@ export function SessionMonitorPanel({
                     >
                       {badge.label}
                     </span>
+                    {onViewBoard ? (
+                      <button
+                        onClick={() => onViewBoard(s.userId, s.name)}
+                        title={`View ${s.name}'s whiteboard`}
+                        aria-label={`View ${s.name}'s whiteboard`}
+                        className="shrink-0 rounded-lg border border-slate-200 p-1 text-slate-500 hover:bg-slate-50"
+                      >
+                        <LayoutGrid className="h-3.5 w-3.5" />
+                      </button>
+                    ) : null}
                     <button
                       onClick={() => {
                         setDmFor(cur => (cur === s.userId ? null : s.userId))


### PR DESCRIPTION
Two classroom features.

## 1. Student board links in the Monitor (replaces the Boards button/picker)

Each student row in the tutor's **Monitor** panel now has a whiteboard icon that opens that student's board (read-only). The standalone **Boards** button + its picker dropdown are removed — the entry point moved into the roster where the tutor already sees who's who. The board viewer itself (`SessionBoardsOverlay`) is unchanged.

## 2. Follow the tutor (students) — mirrors the course-builder classroom

A student **follows the tutor by default** (persisted to `localStorage` per session), with a **Following / Follow** toggle in their toolbar (emerald + pulsing dot when active).

- The tutor "presents" by **deploying** — so while following, the newest deployed task/assessment **auto-opens full-page** for the student.
- Between deploys they see the **shared whiteboard** (already collaborative), i.e. the tutor's board.
- Following **stops** when the student **starts answering** (`TaskChatPanel.addAnswer` / `DeployedQuestions.onValueChange` → `setFollowTutor(false)`) so a new deploy can't yank them mid-answer — or when they **toggle it off**. Re-enabling follow re-opens the tutor's current task.
- All follow behaviour is gated to students; tutors are never followed/yanked.

An adversarial review pass drove two fixes: clearing the follow ref on disable (so re-enable re-opens), and guarding the persist effect against clobbering the stored preference on first mount.

## Test plan
- [x] `npm run build`, `npx tsc --noEmit` — clean
- Tutor: Monitor → click a student's board icon → their board opens; no standalone Boards button.
- Student: **Following** on by default; tutor deploys a task → it auto-opens; student starts answering → toggle flips to **Follow** (off); next deploy no longer yanks them; toggling back on re-opens the current task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)