### PR TITLE
fix(1on1): keep deployed task in course tree + visible Follow toggle

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -454,7 +454,18 @@ export function SessionClassroom({
                 A pulsing dot when active; click to stop/resume following. */}
             <button
               type="button"
-              onClick={() => setFollowTutor(v => !v)}
+              onClick={() => {
+                const next = !followTutor
+                setFollowTutor(next)
+                // Give the toggle an immediate, visible effect: resuming follow
+                // jumps to what the tutor is presenting (the latest deployed task);
+                // stopping follow drops back to the shared whiteboard.
+                if (next) {
+                  if (latestTaskId) setActivePanel('materials')
+                } else {
+                  setActivePanel(cur => (cur === 'materials' ? null : cur))
+                }
+              }}
               title={
                 followTutor
                   ? 'Following the tutor — your view opens what they present. Click to stop.'

--- a/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-deploy-panel.tsx
@@ -259,6 +259,10 @@ export function SessionDeployPanel({
     // auto-grade — it is never sent to the client here.
     socket.emit('task:deploy', {
       roomId: sessionId,
+      // The course this task belongs to, so a session whose liveSession.courseId
+      // is unset doesn't fall back to the hidden ad-hoc anchor — which the
+      // deployables tree filters out, making the task vanish after deploy.
+      courseId: t.courseId ?? courseId ?? undefined,
       task: {
         id: t.taskId,
         title: t.title,

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -1341,302 +1341,310 @@ export async function initEnhancedSocketServer(server: NetServer) {
       }
     }
 
-    socket.on('task:deploy', async (data: { roomId: string; task: LiveTask }) => {
-      if (socket.data.role !== 'tutor') {
-        socket.emit('task:deploy:error', { error: 'Only tutors can deploy tasks' })
-        return
-      }
-      const { roomId, task } = data
-      if (!roomId || !task?.id) {
-        socket.emit('task:deploy:error', { error: 'Invalid deploy data' })
-        return
-      }
-      let room = activeRooms.get(roomId)
-      if (!room) {
-        // Room may have been cleaned up — recreate it on demand
-        room = {
-          id: roomId,
-          tutorId: socket.data.userId || '',
-          students: new Map(),
-          chatHistory: [],
-          tasks: [],
-          polls: [],
-          whiteboardData: undefined,
-          codeEditorContent: '',
-          codeLanguage: 'javascript',
-          createdAt: new Date(),
-          lastActivity: Date.now(),
+    socket.on(
+      'task:deploy',
+      async (data: { roomId: string; task: LiveTask; courseId?: string }) => {
+        if (socket.data.role !== 'tutor') {
+          socket.emit('task:deploy:error', { error: 'Only tutors can deploy tasks' })
+          return
         }
-        activeRooms.set(roomId, room)
-        console.log(`[task:deploy] Recreated room ${roomId} on demand`)
-      }
-
-      const deployCheck = await canDeployToSession(roomId, task.source, socket.data.userId)
-      if (!deployCheck.ok) {
-        socket.emit('task:deploy:error', { error: deployCheck.reason })
-        return
-      }
-
-      // Refresh any GCS document URLs (re-sign from fileKey) before deploying so
-      // students get a live URL rather than a possibly-expired one, and render a
-      // raw Office document to PDF so students get an inline viewer rather than a
-      // download-only link. Never let this block the deploy — on failure it falls
-      // back to the original document.
-      let refreshedSourceDocument = task.sourceDocument
-      if (task.sourceDocument) {
-        try {
-          refreshedSourceDocument = await ensureViewableSourceDocument(task.sourceDocument)
-        } catch (err) {
-          console.warn('[task:deploy] source-document prep failed:', err)
+        const { roomId, task, courseId: payloadCourseId } = data
+        if (!roomId || !task?.id) {
+          socket.emit('task:deploy:error', { error: 'Invalid deploy data' })
+          return
         }
-      }
-
-      const normalizedTask: LiveTask = {
-        id: task.id,
-        title: task.title,
-        content: task.content,
-        source: task.source || 'task',
-        dmiItems: task.dmiItems,
-        deployedAt: task.deployedAt || Date.now(),
-        polls: Array.isArray(task.polls) ? task.polls : [],
-        questions: Array.isArray(task.questions) ? task.questions : [],
-        sourceDocument: refreshedSourceDocument,
-      }
-
-      const existingIndex = room!.tasks.findIndex(existing => existing.id === normalizedTask.id)
-      if (existingIndex >= 0) {
-        room!.tasks[existingIndex] = {
-          ...room!.tasks[existingIndex],
-          ...normalizedTask,
-          polls: room!.tasks[existingIndex].polls,
-          questions: room!.tasks[existingIndex].questions,
-        }
-      } else {
-        room!.tasks.push(normalizedTask)
-      }
-
-      room!.lastActivity = Date.now()
-      void persistRoomToRedis(roomId, room!)
-      io.to(roomId).emit('task:deployed', normalizedTask)
-      io.to(roomId).emit('task:updated', { task: normalizedTask })
-
-      // Create persistent notifications for students in the room
-      try {
-        const studentIds = Array.from(room!.students.keys())
-        if (studentIds.length > 0) {
-          void notifyMany({
-            userIds: studentIds,
-            type: 'assignment',
-            title: `New ${normalizedTask.source === 'assessment' ? 'Assessment' : 'Task'}: ${normalizedTask.title}`,
-            message: `Your tutor deployed "${normalizedTask.title}" in the live session.`,
-            data: { deployType: normalizedTask.source, taskId: normalizedTask.id, roomId },
-            actionUrl: `/student/feedback?sessionId=${roomId}`,
-          })
-        }
-      } catch (notifyErr) {
-        console.error('Failed to create task deployment notifications:', notifyErr)
-      }
-
-      // Persist to Database for Student Directory and Replays
-      try {
-        const { drizzleDb } = await import('./db/drizzle')
-        const { liveSession, deployedMaterial } = await import('./db/schema')
-        const { eq } = await import('drizzle-orm')
-
-        const sessionRec = await drizzleDb.query.liveSession.findFirst({
-          where: eq(liveSession.sessionId, roomId),
-          columns: { courseId: true, sessionId: true },
-        })
-
-        // Course-less sessions (1-on-1 / group) persist under a hidden ad-hoc
-        // anchor course — mirroring the task:complete handler — so their deploys
-        // are recorded and gradable instead of silently dropped.
-        const effectiveCourseId = sessionRec?.courseId || (await ensureAdhocAnchorCourseId())
-        if (effectiveCourseId) {
-          // Sequence orders a deploy within its course's sessions; an ad-hoc
-          // session has no course to order within, so it is always 1.
-          let sessionSequence = 1
-          if (sessionRec?.courseId) {
-            const courseSessions = await drizzleDb.query.liveSession.findMany({
-              where: eq(liveSession.courseId, sessionRec.courseId),
-              orderBy: (sessions, { asc }) => [asc(sessions.scheduledAt)],
-            })
-            const sessionIndex = courseSessions.findIndex(s => s.sessionId === roomId)
-            sessionSequence = sessionIndex >= 0 ? sessionIndex + 1 : 1
+        let room = activeRooms.get(roomId)
+        if (!room) {
+          // Room may have been cleaned up — recreate it on demand
+          room = {
+            id: roomId,
+            tutorId: socket.data.userId || '',
+            students: new Map(),
+            chatHistory: [],
+            tasks: [],
+            polls: [],
+            whiteboardData: undefined,
+            codeEditorContent: '',
+            codeLanguage: 'javascript',
+            createdAt: new Date(),
+            lastActivity: Date.now(),
           }
+          activeRooms.set(roomId, room)
+          console.log(`[task:deploy] Recreated room ${roomId} on demand`)
+        }
 
-          await drizzleDb.insert(deployedMaterial).values({
-            sessionId: roomId,
-            courseId: effectiveCourseId,
-            type: normalizedTask.source,
-            itemId: normalizedTask.id,
-            title: normalizedTask.title,
-            content: normalizedTask as unknown as Record<string, unknown>,
-            sessionSequence,
-            // Source lesson (deploy-only), so the Desk groups this under the real
-            // lesson instead of always "Lesson 1".
-            lessonId: typeof task.lessonId === 'string' && task.lessonId ? task.lessonId : null,
-            deployedAt: new Date(normalizedTask.deployedAt || Date.now()),
-          })
+        const deployCheck = await canDeployToSession(roomId, task.source, socket.data.userId)
+        if (!deployCheck.ok) {
+          socket.emit('task:deploy:error', { error: deployCheck.reason })
+          return
+        }
 
-          // We notify clients of the session sequence so they can append "(s1, s2)" etc.
-          io.to(roomId).emit('task:deployed:sequence', {
-            taskId: normalizedTask.id,
-            sequence: sessionSequence,
-          })
-
-          // Auto-create a BuilderTask row for this deployed task (if one doesn't
-          // already exist) so student completions can be persisted to
-          // TaskSubmission — whose taskId FK requires a builderTask. This makes
-          // EVERY deployed task gradable (even ad-hoc/unsaved ones) and ensures
-          // submissions reach the Grading page. Idempotent on the PK so a real
-          // saved task is never overwritten.
+        // Refresh any GCS document URLs (re-sign from fileKey) before deploying so
+        // students get a live URL rather than a possibly-expired one, and render a
+        // raw Office document to PDF so students get an inline viewer rather than a
+        // download-only link. Never let this block the deploy — on failure it falls
+        // back to the original document.
+        let refreshedSourceDocument = task.sourceDocument
+        if (task.sourceDocument) {
           try {
-            const tutorId = socket.data.userId
-            if (tutorId) {
-              // builderTask.lessonId is a NOT NULL FK. Prefer the lesson the task
-              // was actually deployed FROM (task.lessonId, sent on the deploy
-              // payload) so submissions group under the real lesson instead of
-              // always "Lesson 1". Fall back to the course's first lesson, then a
-              // placeholder (a course published with only a schedule has none).
-              let lesson: { lessonId: string } | undefined
-              if (typeof task.lessonId === 'string' && task.lessonId) {
-                const [preferred] = await drizzleDb
-                  .select({ lessonId: courseLesson.lessonId })
-                  .from(courseLesson)
-                  .where(
-                    and(
-                      eq(courseLesson.lessonId, task.lessonId),
-                      eq(courseLesson.courseId, effectiveCourseId)
-                    )
-                  )
-                  .limit(1)
-                if (preferred?.lessonId) lesson = preferred
-              }
-              if (!lesson) {
-                const [first] = await drizzleDb
-                  .select({ lessonId: courseLesson.lessonId })
-                  .from(courseLesson)
-                  .where(eq(courseLesson.courseId, effectiveCourseId))
-                  .orderBy(courseLesson.order)
-                  .limit(1)
-                lesson = first
-              }
-              // NOTE: set createdAt/updatedAt explicitly. These columns are
-              // declared notNull().defaultNow() in the schema, but the prod DB
-              // has drifted and lacks the column DEFAULT, so relying on the
-              // default inserts NULL and violates the not-null constraint
-              // (this is exactly what was silently breaking grading). $onUpdate
-              // does not apply to inserts, so it can't cover this either.
-              const now = new Date()
-              if (!lesson?.lessonId) {
-                const newLessonId = crypto.randomUUID()
-                await drizzleDb.insert(courseLesson).values({
-                  lessonId: newLessonId,
-                  courseId: effectiveCourseId,
-                  title: 'Live Session',
-                  order: 0,
-                  createdAt: now,
-                  updatedAt: now,
-                })
-                lesson = { lessonId: newLessonId }
-              }
-              // Tutor's marking basis, carried on the deploy payload (never in
-              // the student broadcast). Refreshed on each deploy so the live
-              // tutor + grader see the latest PCI; only these columns are
-              // updated on conflict, so a saved task's title/content is kept.
-              const taskPci = typeof task.pci === 'string' ? task.pci.slice(0, 20000) : ''
-              const taskPciSpec = normalizePciSpec(task.pciSpec)
-              await drizzleDb
-                .insert(builderTask)
-                .values({
-                  taskId: normalizedTask.id,
-                  courseId: effectiveCourseId,
-                  lessonId: lesson.lessonId,
-                  tutorId,
-                  title: normalizedTask.title || 'Untitled',
-                  content: normalizedTask.content || '',
-                  pci: taskPci,
-                  pciSpec: taskPciSpec,
-                  type: normalizedTask.source,
-                  status: 'published',
-                  publishedAt: now,
-                  createdAt: now,
-                  updatedAt: now,
-                })
-                .onConflictDoUpdate({
-                  target: builderTask.taskId,
-                  set: { pci: taskPci, pciSpec: taskPciSpec, updatedAt: now },
-                })
-
-              // Persist the answer key + marks server-side so live submissions
-              // auto-grade against it. Carried on the deploy payload's
-              // `answerKey` (never in the student broadcast). One row per task,
-              // refreshed on each deploy; the grader reads the latest by taskId.
-              const answerKey = Array.isArray(task.answerKey) ? task.answerKey : []
-              const gradableKey = answerKey.filter(
-                k => k && typeof k.id === 'string' && (k.answer ?? '').toString().trim().length > 0
-              )
-              if (gradableKey.length > 0) {
-                try {
-                  await drizzleDb
-                    .insert(builderTaskDmi)
-                    .values({
-                      dmiId: `dmi-${normalizedTask.id}`,
-                      taskId: normalizedTask.id,
-                      type: normalizedTask.source === 'assessment' ? 'assessment' : 'task',
-                      items: gradableKey,
-                      createdAt: now,
-                      updatedAt: now,
-                    })
-                    .onConflictDoUpdate({
-                      target: builderTaskDmi.dmiId,
-                      set: { items: gradableKey, updatedAt: now },
-                    })
-                } catch (dmiErr) {
-                  console.warn(
-                    '[task:deploy] BuilderTaskDmi answer-key persist failed (non-critical):',
-                    dmiErr
-                  )
-                }
-              }
-
-              // Persist the tutor's answer-reveal policy onto the task metadata
-              // so the async assignment GET/submit routes honor it. Merged into
-              // existing metadata so other keys are preserved.
-              const reveal = task.answerReveal
-              if (
-                reveal === 'instant' ||
-                reveal === 'after_submit' ||
-                reveal === 'hidden' ||
-                reveal === 'student_choice'
-              ) {
-                try {
-                  const { sql } = await import('drizzle-orm')
-                  await drizzleDb
-                    .update(builderTask)
-                    .set({
-                      metadata: sql`COALESCE(${builderTask.metadata}, '{}'::jsonb) || ${JSON.stringify(
-                        { answerReveal: reveal }
-                      )}::jsonb`,
-                    })
-                    .where(eq(builderTask.taskId, normalizedTask.id))
-                } catch (revealErr) {
-                  console.warn(
-                    '[task:deploy] answerReveal persist failed (non-critical):',
-                    revealErr
-                  )
-                }
-              }
-            }
-          } catch (btErr) {
-            console.warn('[task:deploy] BuilderTask auto-create failed (non-critical):', btErr)
+            refreshedSourceDocument = await ensureViewableSourceDocument(task.sourceDocument)
+          } catch (err) {
+            console.warn('[task:deploy] source-document prep failed:', err)
           }
         }
-      } catch (err) {
-        console.error('Failed to persist deployed material to DB:', err)
+
+        const normalizedTask: LiveTask = {
+          id: task.id,
+          title: task.title,
+          content: task.content,
+          source: task.source || 'task',
+          dmiItems: task.dmiItems,
+          deployedAt: task.deployedAt || Date.now(),
+          polls: Array.isArray(task.polls) ? task.polls : [],
+          questions: Array.isArray(task.questions) ? task.questions : [],
+          sourceDocument: refreshedSourceDocument,
+        }
+
+        const existingIndex = room!.tasks.findIndex(existing => existing.id === normalizedTask.id)
+        if (existingIndex >= 0) {
+          room!.tasks[existingIndex] = {
+            ...room!.tasks[existingIndex],
+            ...normalizedTask,
+            polls: room!.tasks[existingIndex].polls,
+            questions: room!.tasks[existingIndex].questions,
+          }
+        } else {
+          room!.tasks.push(normalizedTask)
+        }
+
+        room!.lastActivity = Date.now()
+        void persistRoomToRedis(roomId, room!)
+        io.to(roomId).emit('task:deployed', normalizedTask)
+        io.to(roomId).emit('task:updated', { task: normalizedTask })
+
+        // Create persistent notifications for students in the room
+        try {
+          const studentIds = Array.from(room!.students.keys())
+          if (studentIds.length > 0) {
+            void notifyMany({
+              userIds: studentIds,
+              type: 'assignment',
+              title: `New ${normalizedTask.source === 'assessment' ? 'Assessment' : 'Task'}: ${normalizedTask.title}`,
+              message: `Your tutor deployed "${normalizedTask.title}" in the live session.`,
+              data: { deployType: normalizedTask.source, taskId: normalizedTask.id, roomId },
+              actionUrl: `/student/feedback?sessionId=${roomId}`,
+            })
+          }
+        } catch (notifyErr) {
+          console.error('Failed to create task deployment notifications:', notifyErr)
+        }
+
+        // Persist to Database for Student Directory and Replays
+        try {
+          const { drizzleDb } = await import('./db/drizzle')
+          const { liveSession, deployedMaterial } = await import('./db/schema')
+          const { eq } = await import('drizzle-orm')
+
+          const sessionRec = await drizzleDb.query.liveSession.findFirst({
+            where: eq(liveSession.sessionId, roomId),
+            columns: { courseId: true, sessionId: true },
+          })
+
+          // Prefer the session's own course, then the course the deploy panel was
+          // scoped to (carried on the payload) — so a course-scoped session whose
+          // liveSession.courseId is unset still records under the real course
+          // instead of the hidden ad-hoc anchor, which the deployables tree filters
+          // out (making the task vanish from the tree after deploy). Course-less
+          // sessions still fall back to the ad-hoc anchor so deploys stay gradable.
+          const effectiveCourseId =
+            sessionRec?.courseId || payloadCourseId || (await ensureAdhocAnchorCourseId())
+          if (effectiveCourseId) {
+            // Sequence orders a deploy within its course's sessions; an ad-hoc
+            // session has no course to order within, so it is always 1.
+            let sessionSequence = 1
+            if (sessionRec?.courseId) {
+              const courseSessions = await drizzleDb.query.liveSession.findMany({
+                where: eq(liveSession.courseId, sessionRec.courseId),
+                orderBy: (sessions, { asc }) => [asc(sessions.scheduledAt)],
+              })
+              const sessionIndex = courseSessions.findIndex(s => s.sessionId === roomId)
+              sessionSequence = sessionIndex >= 0 ? sessionIndex + 1 : 1
+            }
+
+            await drizzleDb.insert(deployedMaterial).values({
+              sessionId: roomId,
+              courseId: effectiveCourseId,
+              type: normalizedTask.source,
+              itemId: normalizedTask.id,
+              title: normalizedTask.title,
+              content: normalizedTask as unknown as Record<string, unknown>,
+              sessionSequence,
+              // Source lesson (deploy-only), so the Desk groups this under the real
+              // lesson instead of always "Lesson 1".
+              lessonId: typeof task.lessonId === 'string' && task.lessonId ? task.lessonId : null,
+              deployedAt: new Date(normalizedTask.deployedAt || Date.now()),
+            })
+
+            // We notify clients of the session sequence so they can append "(s1, s2)" etc.
+            io.to(roomId).emit('task:deployed:sequence', {
+              taskId: normalizedTask.id,
+              sequence: sessionSequence,
+            })
+
+            // Auto-create a BuilderTask row for this deployed task (if one doesn't
+            // already exist) so student completions can be persisted to
+            // TaskSubmission — whose taskId FK requires a builderTask. This makes
+            // EVERY deployed task gradable (even ad-hoc/unsaved ones) and ensures
+            // submissions reach the Grading page. Idempotent on the PK so a real
+            // saved task is never overwritten.
+            try {
+              const tutorId = socket.data.userId
+              if (tutorId) {
+                // builderTask.lessonId is a NOT NULL FK. Prefer the lesson the task
+                // was actually deployed FROM (task.lessonId, sent on the deploy
+                // payload) so submissions group under the real lesson instead of
+                // always "Lesson 1". Fall back to the course's first lesson, then a
+                // placeholder (a course published with only a schedule has none).
+                let lesson: { lessonId: string } | undefined
+                if (typeof task.lessonId === 'string' && task.lessonId) {
+                  const [preferred] = await drizzleDb
+                    .select({ lessonId: courseLesson.lessonId })
+                    .from(courseLesson)
+                    .where(
+                      and(
+                        eq(courseLesson.lessonId, task.lessonId),
+                        eq(courseLesson.courseId, effectiveCourseId)
+                      )
+                    )
+                    .limit(1)
+                  if (preferred?.lessonId) lesson = preferred
+                }
+                if (!lesson) {
+                  const [first] = await drizzleDb
+                    .select({ lessonId: courseLesson.lessonId })
+                    .from(courseLesson)
+                    .where(eq(courseLesson.courseId, effectiveCourseId))
+                    .orderBy(courseLesson.order)
+                    .limit(1)
+                  lesson = first
+                }
+                // NOTE: set createdAt/updatedAt explicitly. These columns are
+                // declared notNull().defaultNow() in the schema, but the prod DB
+                // has drifted and lacks the column DEFAULT, so relying on the
+                // default inserts NULL and violates the not-null constraint
+                // (this is exactly what was silently breaking grading). $onUpdate
+                // does not apply to inserts, so it can't cover this either.
+                const now = new Date()
+                if (!lesson?.lessonId) {
+                  const newLessonId = crypto.randomUUID()
+                  await drizzleDb.insert(courseLesson).values({
+                    lessonId: newLessonId,
+                    courseId: effectiveCourseId,
+                    title: 'Live Session',
+                    order: 0,
+                    createdAt: now,
+                    updatedAt: now,
+                  })
+                  lesson = { lessonId: newLessonId }
+                }
+                // Tutor's marking basis, carried on the deploy payload (never in
+                // the student broadcast). Refreshed on each deploy so the live
+                // tutor + grader see the latest PCI; only these columns are
+                // updated on conflict, so a saved task's title/content is kept.
+                const taskPci = typeof task.pci === 'string' ? task.pci.slice(0, 20000) : ''
+                const taskPciSpec = normalizePciSpec(task.pciSpec)
+                await drizzleDb
+                  .insert(builderTask)
+                  .values({
+                    taskId: normalizedTask.id,
+                    courseId: effectiveCourseId,
+                    lessonId: lesson.lessonId,
+                    tutorId,
+                    title: normalizedTask.title || 'Untitled',
+                    content: normalizedTask.content || '',
+                    pci: taskPci,
+                    pciSpec: taskPciSpec,
+                    type: normalizedTask.source,
+                    status: 'published',
+                    publishedAt: now,
+                    createdAt: now,
+                    updatedAt: now,
+                  })
+                  .onConflictDoUpdate({
+                    target: builderTask.taskId,
+                    set: { pci: taskPci, pciSpec: taskPciSpec, updatedAt: now },
+                  })
+
+                // Persist the answer key + marks server-side so live submissions
+                // auto-grade against it. Carried on the deploy payload's
+                // `answerKey` (never in the student broadcast). One row per task,
+                // refreshed on each deploy; the grader reads the latest by taskId.
+                const answerKey = Array.isArray(task.answerKey) ? task.answerKey : []
+                const gradableKey = answerKey.filter(
+                  k =>
+                    k && typeof k.id === 'string' && (k.answer ?? '').toString().trim().length > 0
+                )
+                if (gradableKey.length > 0) {
+                  try {
+                    await drizzleDb
+                      .insert(builderTaskDmi)
+                      .values({
+                        dmiId: `dmi-${normalizedTask.id}`,
+                        taskId: normalizedTask.id,
+                        type: normalizedTask.source === 'assessment' ? 'assessment' : 'task',
+                        items: gradableKey,
+                        createdAt: now,
+                        updatedAt: now,
+                      })
+                      .onConflictDoUpdate({
+                        target: builderTaskDmi.dmiId,
+                        set: { items: gradableKey, updatedAt: now },
+                      })
+                  } catch (dmiErr) {
+                    console.warn(
+                      '[task:deploy] BuilderTaskDmi answer-key persist failed (non-critical):',
+                      dmiErr
+                    )
+                  }
+                }
+
+                // Persist the tutor's answer-reveal policy onto the task metadata
+                // so the async assignment GET/submit routes honor it. Merged into
+                // existing metadata so other keys are preserved.
+                const reveal = task.answerReveal
+                if (
+                  reveal === 'instant' ||
+                  reveal === 'after_submit' ||
+                  reveal === 'hidden' ||
+                  reveal === 'student_choice'
+                ) {
+                  try {
+                    const { sql } = await import('drizzle-orm')
+                    await drizzleDb
+                      .update(builderTask)
+                      .set({
+                        metadata: sql`COALESCE(${builderTask.metadata}, '{}'::jsonb) || ${JSON.stringify(
+                          { answerReveal: reveal }
+                        )}::jsonb`,
+                      })
+                      .where(eq(builderTask.taskId, normalizedTask.id))
+                  } catch (revealErr) {
+                    console.warn(
+                      '[task:deploy] answerReveal persist failed (non-critical):',
+                      revealErr
+                    )
+                  }
+                }
+              }
+            } catch (btErr) {
+              console.warn('[task:deploy] BuilderTask auto-create failed (non-critical):', btErr)
+            }
+          }
+        } catch (err) {
+          console.error('Failed to persist deployed material to DB:', err)
+        }
       }
-    })
+    )
 
     // Tutor requests course content sync to live session
     socket.on('course:sync', async (data: { roomId: string; courseId: string }) => {


### PR DESCRIPTION
Addresses two reported issues in the one-on-one session classroom.

## Issue 3 — a deployed task disappears from the tutor's course tree

Root cause: for a **course-scoped** session whose `liveSession.courseId` happens to be unset (NULL), the `task:deploy` handler computed `effectiveCourseId = sessionRec.courseId || adhocAnchor` → it fell back to the **hidden ad-hoc anchor course** when persisting the BuilderTask / DeployedMaterial. The deployables endpoint (which builds the tree) filters out `ADHOC_ANCHOR_COURSE_ID` tasks, so the task vanished from the tree after deploy.

Fix: the deploy panel now sends the task's `courseId` on the `task:deploy` payload, and the handler prefers `session.courseId → payload courseId → ad-hoc`. Course-scoped deploys are now recorded under the real course, so the task stays in the tree. Course-less sessions still fall back to the ad-hoc anchor (deploys stay gradable).

## Issue 2 — the Follow toggle "does nothing visible"

The toggle only changed *future* auto-open behaviour, so clicking it had no immediate effect. Now:
- **Resume follow** → jumps to what the tutor is presenting (the latest deployed task, full-page).
- **Stop follow** → drops back to the shared whiteboard (closes the task panel).

(Auto-open on a new deploy while following is unchanged.)

> Note: Issue 1 (a "Task complete" button on the tutor side) was skipped per your reply — both tutor task surfaces already pass `previewMode` to hide it, so I couldn't reproduce it; happy to revisit with the exact screen.

## Test plan
- [x] `npm run build`, `npx tsc --noEmit` — clean
- Course-scoped session: deploy a task → it stays in the course tree (and reappears on refetch).
- Student: toggle Follow off → returns to whiteboard; toggle on → jumps to the latest deployed task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)