### PR TITLE
fix(1on1): make each student's board a clear button in the Monitor

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
+++ b/tutorme-app/src/components/one-on-one/session-monitor-panel.tsx
@@ -201,11 +201,12 @@ export function SessionMonitorPanel({
                     {onViewBoard ? (
                       <button
                         onClick={() => onViewBoard(s.userId, s.name)}
-                        title={`View ${s.name}'s whiteboard`}
-                        aria-label={`View ${s.name}'s whiteboard`}
-                        className="shrink-0 rounded-lg border border-slate-200 p-1 text-slate-500 hover:bg-slate-50"
+                        title={`Open ${s.name}'s whiteboard`}
+                        aria-label={`Open ${s.name}'s whiteboard`}
+                        className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-blue-200 bg-blue-50 px-2 py-1 text-[11px] font-semibold text-blue-700 hover:bg-blue-100"
                       >
-                        <LayoutGrid className="h-3.5 w-3.5" />
+                        <LayoutGrid className="h-3 w-3" />
+                        Board
                       </button>
                     ) : null}
                     <button


### PR DESCRIPTION
The per-student board opener in the Monitor was a bare 14px grey grid icon right next to the identical-looking message icon, so it read as "no board icon." This makes it an unmistakable labeled **Board** button. It opens that student's own private board (`{sessionId}:board:{studentId}`) read-only — behavior unchanged.

Note: this makes each student's board *reachable*; whether it shows content depends on the student having drawn on their own board (in the 1-on-1 the main whiteboard is currently shared). Separate follow-up if we want each student's primary board to be their own.

- [x] tsc + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)