### PR TITLE
feat(1on1): per-person boards + follow the tutor's board; names on boards

### DIFF
--- a/tutorme-app/src/components/one-on-one/session-boards.tsx
+++ b/tutorme-app/src/components/one-on-one/session-boards.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { X, Users, PenTool } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
 import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
@@ -20,11 +20,22 @@ export function boardRoomId(sessionId: string, ownerId: string): string {
   return `${sessionId}:board:${ownerId}`
 }
 
+/** A persistent badge naming whose board this is, so it's never ambiguous. */
+export function BoardNameBadge({ label }: { label: string }) {
+  return (
+    <div className="pointer-events-none absolute left-3 top-3 z-30 inline-flex items-center gap-1.5 rounded-full bg-slate-900/80 px-3 py-1 text-xs font-semibold text-white shadow-lg backdrop-blur">
+      <PenTool className="h-3.5 w-3.5" />
+      {label}
+    </div>
+  )
+}
+
 /** One isolated board on its own connection. Editable for its owner, read-only
  *  when the tutor is viewing someone else's. */
 function IsolatedBoard({
   sessionId,
   ownerId,
+  ownerName,
   viewerId,
   viewerName,
   viewerIsTutor,
@@ -32,6 +43,7 @@ function IsolatedBoard({
 }: {
   sessionId: string
   ownerId: string
+  ownerName?: string
   viewerId: string
   viewerName?: string
   viewerIsTutor?: boolean
@@ -50,14 +62,65 @@ function IsolatedBoard({
   const { socket } = useSocket(socketOptions)
 
   return (
-    <EnhancedWhiteboard
-      socket={socket}
-      roomId={boardRoomId(sessionId, ownerId)}
-      userId={viewerId}
-      userName={viewerName || undefined}
-      readOnly={readOnly}
-      videoOverlay={false}
-    />
+    <div className="relative h-full w-full">
+      <EnhancedWhiteboard
+        socket={socket}
+        roomId={boardRoomId(sessionId, ownerId)}
+        userId={viewerId}
+        userName={viewerName || undefined}
+        readOnly={readOnly}
+        videoOverlay={false}
+      />
+      {ownerName ? <BoardNameBadge label={`${ownerName}'s board`} /> : null}
+    </div>
+  )
+}
+
+/**
+ * The user's OWN board — the primary drawing surface, editable, carrying the
+ * call video overlay. Each participant writes only on their own board; a
+ * following student sees the tutor's board through the read-only overlay instead.
+ */
+export function PrimaryBoard({
+  sessionId,
+  ownerId,
+  ownerName,
+  isTutor,
+  video,
+  videoZClassName,
+}: {
+  sessionId: string
+  ownerId: string
+  ownerName: string
+  isTutor?: boolean
+  video?: ReactNode
+  videoZClassName?: string
+}) {
+  const socketOptions =
+    sessionId && ownerId
+      ? {
+          roomId: boardRoomId(sessionId, ownerId),
+          userId: ownerId,
+          name: ownerName || (isTutor ? 'Tutor' : 'Student'),
+          role: isTutor ? ('tutor' as const) : ('student' as const),
+          forceNew: true,
+        }
+      : undefined
+  const { socket } = useSocket(socketOptions)
+
+  return (
+    <div className="relative h-full w-full">
+      <EnhancedWhiteboard
+        socket={socket}
+        roomId={boardRoomId(sessionId, ownerId)}
+        userId={ownerId}
+        userName={ownerName || undefined}
+        videoOverlay
+        videoComponent={video}
+        videoZClassName={videoZClassName}
+      />
+      <BoardNameBadge label={`${ownerName} · your board`} />
+    </div>
   )
 }
 
@@ -152,6 +215,7 @@ export function SessionBoardsOverlay({
                 key={viewingStudent.ownerId}
                 sessionId={sessionId}
                 ownerId={viewingStudent.ownerId}
+                ownerName={viewingStudent.ownerName}
                 viewerId={userId}
                 viewerName={userName}
                 viewerIsTutor={isTutor}

--- a/tutorme-app/src/components/one-on-one/session-classroom.tsx
+++ b/tutorme-app/src/components/one-on-one/session-classroom.tsx
@@ -19,7 +19,6 @@ import {
   FolderOpen,
   ListChecks,
   Pencil,
-  PenTool,
   MonitorPlay,
   BookOpen,
   MessageSquare,
@@ -29,14 +28,13 @@ import {
   FolderTree,
 } from 'lucide-react'
 import { useSocket } from '@/hooks/use-socket'
-import { EnhancedWhiteboard } from '@/components/class/enhanced-whiteboard'
 import { DailyVideoFrame } from '@/components/class/daily-video-frame'
 import { SessionDeployPanel } from '@/components/one-on-one/session-deploy-panel'
 import { SessionDeployedPanel } from '@/components/one-on-one/session-deployed-panel'
 import { SessionSubmissionsPanel } from '@/components/one-on-one/session-submissions-panel'
 import {
   SessionBoardsOverlay,
-  BoardsPicker,
+  PrimaryBoard,
   useOwnBoardOpened,
 } from '@/components/one-on-one/session-boards'
 import { useSessionRoomState } from '@/components/one-on-one/use-session-room-state'
@@ -103,6 +101,7 @@ export function SessionClassroom({
   const [nowTs, setNowTs] = useState(0)
   const [ended, setEnded] = useState(false)
   const myId = session?.user?.id ?? ''
+  const myName = session?.user?.name || (isTutor ? 'Tutor' : 'Student')
 
   // Listen for the embedded course-editor's save postMessage and refresh the
   // deploy panel's task list. Same-origin check guards against foreign frames.
@@ -269,8 +268,9 @@ export function SessionClassroom({
   // they deploy by default and can toggle back to the whiteboard.
   const latestTaskId = tasks.length > 0 ? tasks[tasks.length - 1].id : null
 
-  // TUTOR: presented view. Deploying a task presents it; a toggle shows the board.
-  const [presentWhiteboard, setPresentWhiteboard] = useState(false)
+  // TUTOR: presented view. Presents their own whiteboard by default; deploying a
+  // task presents it; the "Presenting" chip toggles between the two.
+  const [presentWhiteboard, setPresentWhiteboard] = useState(true)
   const lastDeployedRef = useRef<string | null>(null)
   useEffect(() => {
     if (!isTutor || !latestTaskId || latestTaskId === lastDeployedRef.current) return
@@ -281,6 +281,10 @@ export function SessionClassroom({
   const presentPayload = () => ({
     activeTab: tutorPresentTaskId ? 'task' : 'whiteboard',
     activeTaskId: tutorPresentTaskId,
+    // So a following student can view the tutor's own board when the tutor is on
+    // the whiteboard.
+    presenterId: myId,
+    presenterName: myName,
   })
 
   // Broadcast the tutor's presented view. The tutor's own screen isn't hijacked
@@ -311,50 +315,66 @@ export function SessionClassroom({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTutor, socket, tutorPresentTaskId, sessionId])
 
-  // STUDENT: the tutor's presented view, received live.
+  // STUDENT: the tutor's presented view + who's presenting (for their board).
   const [presentedTaskId, setPresentedTaskId] = useState<string | null>(null)
+  const [presenter, setPresenter] = useState<{ id: string; name: string } | null>(null)
+  type PresentPayload = {
+    activeTab?: string
+    activeTaskId?: string | null
+    presenterId?: string
+    presenterName?: string
+  }
+  const applyPresented = (p: PresentPayload | null | undefined) => {
+    if (!p) return
+    setPresentedTaskId(p.activeTab === 'whiteboard' ? null : (p.activeTaskId ?? null))
+    if (p.presenterId) setPresenter({ id: p.presenterId, name: p.presenterName || 'Tutor' })
+  }
   useEffect(() => {
     if (isTutor || !socket) return
-    const onReceive = (msg: {
-      type?: string
-      payload?: { activeTab?: string; activeTaskId?: string | null }
-    }) => {
+    const onReceive = (msg: { type?: string; payload?: PresentPayload }) => {
       if (msg?.type !== 'tutor:state_sync') return
-      const p = msg.payload || {}
-      setPresentedTaskId(p.activeTab === 'whiteboard' ? null : (p.activeTaskId ?? null))
+      applyPresented(msg.payload)
     }
     socket.on('insight:receive', onReceive)
     return () => {
       socket.off('insight:receive', onReceive)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTutor, socket])
 
   // Hydrate the presented view from room_state on (re)join — robust against the
   // live tutor:state_sync broadcast arriving before this client is listening.
   useEffect(() => {
     if (isTutor || !socket) return
-    const onRoomState = (state: {
-      presentedView?: { activeTab?: string; activeTaskId?: string | null } | null
-    }) => {
-      const pv = state?.presentedView
-      if (pv === undefined) return
-      setPresentedTaskId(pv && pv.activeTab !== 'whiteboard' ? (pv.activeTaskId ?? null) : null)
+    const onRoomState = (state: { presentedView?: PresentPayload | null }) => {
+      if (state?.presentedView === undefined) return
+      applyPresented(state.presentedView)
     }
     socket.on('room_state', onRoomState)
     return () => {
       socket.off('room_state', onRoomState)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTutor, socket])
 
-  // STUDENT following: mirror the tutor — open the presented task, or drop back to
-  // the whiteboard when the tutor presents it. Answering pauses follow (onInteract
-  // → setFollowTutor(false)); re-toggling jumps back to the tutor's current view.
+  // STUDENT following: mirror the tutor's view. A presented task → open it; the
+  // tutor's whiteboard → view the tutor's board read-only (overlay); not following
+  // → their own board. Answering pauses follow (onInteract → setFollowTutor(false)).
   const following = !isTutor && followTutor
   useEffect(() => {
-    if (!following) return
-    if (presentedTaskId) setActivePanel('materials')
-    else setActivePanel(cur => (cur === 'materials' ? null : cur))
-  }, [following, presentedTaskId])
+    if (isTutor) return // the tutor drives boardTarget from the Monitor, not follow
+    if (following && presentedTaskId) {
+      setActivePanel('materials')
+      setBoardTarget(null)
+    } else if (following && presenter) {
+      // tutor is on their whiteboard → mirror it read-only
+      setActivePanel(cur => (cur === 'materials' ? null : cur))
+      setBoardTarget({ ownerId: presenter.id, ownerName: presenter.name, mine: false })
+    } else {
+      // not following (or nothing to follow yet) → own board
+      setBoardTarget(null)
+    }
+  }, [isTutor, following, presentedTaskId, presenter])
 
   // The call feed rides along as the whiteboard's draggable video overlay.
   const video = (
@@ -376,16 +396,20 @@ export function SessionClassroom({
         label="session classroom"
         fallback={<div className="h-screen w-full bg-black">{video}</div>}
       >
-        <EnhancedWhiteboard
-          socket={socket}
-          roomId={sessionId}
-          userId={session?.user?.id}
-          userName={session?.user?.name || undefined}
-          videoOverlay
-          videoComponent={video}
-          // A student can open a deployed task full-page (z-30, below the toolbar);
-          // keep their video above it so the tutor stays visible while they read.
-          videoZClassName={!isTutor ? 'z-[35]' : 'z-10'}
+        {/* Each participant's PRIMARY surface is their OWN board (editable),
+            carrying the call video. Tutors write only on theirs, students only on
+            theirs; a following student views the tutor's board through the
+            read-only overlay below. A student can open a deployed task full-page
+            (z-30, below the toolbar); keep their video above it (z-[35]). */}
+        <PrimaryBoard
+          sessionId={sessionId}
+          ownerId={myId}
+          ownerName={myName}
+          isTutor={isTutor}
+          video={video}
+          // Keep the call video above the full-page task (z-30) and the board
+          // overlays (z-30) but below the toolbar (z-40).
+          videoZClassName="z-[35]"
         />
       </FallbackBoundary>
 
@@ -523,26 +547,6 @@ export function SessionClassroom({
             ) : null}
           </>
         ) : null}
-        {myId ? (
-          <button
-            type="button"
-            onClick={() =>
-              setBoardTarget(cur =>
-                cur?.mine ? null : { ownerId: myId, ownerName: 'Me', mine: true }
-              )
-            }
-            title="Your own private whiteboard"
-            className={
-              'pointer-events-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-semibold shadow-lg backdrop-blur ' +
-              (boardTarget?.mine
-                ? 'bg-blue-600 text-white hover:bg-blue-500'
-                : 'bg-white/90 text-slate-800 hover:bg-white')
-            }
-          >
-            <PenTool className="h-3.5 w-3.5" />
-            My board
-          </button>
-        ) : null}
         {!isTutor ? (
           <button
             type="button"
@@ -561,17 +565,9 @@ export function SessionClassroom({
                 A pulsing dot when active; click to stop/resume following. */}
             <button
               type="button"
-              onClick={() => {
-                const next = !followTutor
-                setFollowTutor(next)
-                // Resuming follow jumps to whatever the tutor is presenting right
-                // now (a task, or the whiteboard); stopping leaves the student where
-                // they are so they can work freely.
-                if (next) {
-                  if (presentedTaskId) setActivePanel('materials')
-                  else setActivePanel(cur => (cur === 'materials' ? null : cur))
-                }
-              }}
+              // The follow effect reacts to `following` — turning it on jumps to the
+              // tutor's current view (task or their board); off returns to own board.
+              onClick={() => setFollowTutor(v => !v)}
               title={
                 followTutor
                   ? 'Following the tutor — your view opens what they present. Click to stop.'

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -79,10 +79,16 @@ export interface ClassRoom {
   tasks: LiveTask[]
   polls?: any[]
   activePoll?: LivePoll | null
-  /** What the tutor is currently presenting (whiteboard vs a task) — so a late-
-   *  joining student hydrates the "follow" target from room_state, not just the
-   *  live tutor:state_sync broadcast (which could arrive before they're listening). */
-  presentedView?: { activeTab?: string; activeTaskId?: string | null } | null
+  /** What the tutor is currently presenting (whiteboard vs a task, + who the
+   *  presenter is so a follower can view their board) — so a late-joining student
+   *  hydrates the "follow" target from room_state, not just the live
+   *  tutor:state_sync broadcast (which could arrive before they're listening). */
+  presentedView?: {
+    activeTab?: string
+    activeTaskId?: string | null
+    presenterId?: string
+    presenterName?: string
+  } | null
   codeEditorContent?: string
   codeLanguage?: string
   createdAt: Date
@@ -2332,8 +2338,17 @@ export async function initEnhancedSocketServer(server: NetServer) {
     // require the sender to be a member — so without this check a crafted
     // `roomId = "<session>:board:<victim>"` could write to a board the sender was
     // rejected from. Base (non-board) rooms keep their existing behaviour.
-    const canWriteRoom = (roomId: string): boolean =>
-      !roomId.includes(':board:') || socket.rooms.has(roomId)
+    const canWriteRoom = (roomId: string): boolean => {
+      const boardIdx = roomId.indexOf(':board:')
+      if (boardIdx < 0) return true // base (non-board) room — existing behaviour
+      if (!socket.rooms.has(roomId)) return false
+      // Board sub-rooms are per-person: ONLY the owner may write. A viewer (the
+      // tutor watching a student's board, or a student following the tutor's
+      // board) is read-only server-side, not just in the UI — so no one can draw
+      // on someone else's board.
+      const ownerId = roomId.slice(boardIdx + ':board:'.length)
+      return socket.data.userId === ownerId
+    }
 
     // Incremental whiteboard delta sync handlers
     socket.on(
@@ -2530,6 +2545,8 @@ export async function initEnhancedSocketServer(server: NetServer) {
             room.presentedView = (payload ?? null) as {
               activeTab?: string
               activeTaskId?: string | null
+              presenterId?: string
+              presenterName?: string
             } | null
           io.to(roomId).emit('insight:receive', { type, payload })
           return


### PR DESCRIPTION
Implements the four board requests. Replaces the single **shared** whiteboard with **per-person** boards (the course-builder model).

## 1. Follow is student-only
Unchanged from before — the Follow toggle and all follow logic are gated to students; tutors **present**, they never follow.

## 2. Everyone writes only on their own board
- Each participant's **primary** surface is their **own** board (`PrimaryBoard`, `{sessionId}:board:{myId}`, editable, carrying the call video).
- **Server-enforced:** `canWriteRoom` now allows writes to a board sub-room only from its **owner** — a viewer (tutor watching a student, or a student following the tutor) is read-only server-side, not just in the UI. So no one can draw on someone else's board.

## 3. Following mirrors the tutor (whiteboard / task / assessment)
- The present payload carries `presenterId`/`presenterName`. When the tutor is on **their board**, a following student views the **tutor's board read-only** (overlay); a presented **task/assessment** opens the task; **not following** → their own board.
- The tutor presents their own whiteboard **by default**; deploying presents the task; the **"Presenting"** chip toggles. Late-join hydrates the presenter from `room_state.presentedView`.

## 4. Names on every board
`BoardNameBadge` labels each board (`Name · your board`, or `Name's board` when viewing). Removed the now-redundant **My board** button (your base *is* your own board).

An adversarial review confirmed: no student↔tutor cross-write (server-enforced now), the base board + Daily video never remount on follow toggle (owner id is stable), the tutor's Monitor board-view isn't clobbered by follow, correct z-layering, and complete presenter hydration on late-join.

## Test plan
- [x] `npm run build`, `npx tsc --noEmit` — clean
- Tutor and each student draw on separate boards; neither can draw on the other's.
- Student follows → sees the tutor's board (read-only) while the tutor draws; tutor deploys a task → student switches to it; unfollow → back to own board.
- Each board shows its owner's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)