### PR TITLE
feat(1on1): route live sessions to the shared course-builder classroom

### DIFF
--- a/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
+++ b/tutorme-app/src/app/[locale]/call/[sessionId]/page.tsx
@@ -1,24 +1,23 @@
 'use client'
 
 /**
- * Dedicated two-way video room for a 1-on-1 session — used by BOTH the student
- * and the tutor (the course classrooms are role-specific and can't host a
- * course-less 1-on-1).
+ * Thin lobby + role router for a live session (1-on-1 or group).
  *
- * Flow: check session status → if it isn't open yet, show a pre-join LOBBY with a
- * live countdown that brings you in automatically the moment the room opens (or
- * the tutor starts early); once open, mint a join token via
- * /api/class/rooms/[id]/join and render DailyVideoFrame in two-way mode.
+ * The classroom itself is now the shared **course-builder** classroom — this page
+ * no longer hosts its own video room. Flow: check session status → if it isn't open
+ * yet, show a pre-join LOBBY with a live countdown that brings you in automatically
+ * the moment the room opens (or the tutor starts early); once open, redirect by role
+ * to the course-builder classroom (student → /student/feedback, tutor →
+ * /tutor/classroom), which mints its own join token via /api/class/rooms/[id]/join.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { Loader2, ArrowLeft, Video, CalendarClock } from 'lucide-react'
-import { SessionClassroom } from '@/components/one-on-one/session-classroom'
 import { formatCountdown } from '@/lib/one-on-one/format'
 
-type Phase = 'checking' | 'lobby' | 'joining' | 'inRoom' | 'ended' | 'error'
+type Phase = 'checking' | 'lobby' | 'redirecting' | 'ended' | 'error'
 
 interface LobbyInfo {
   title: string
@@ -28,16 +27,6 @@ interface LobbyInfo {
   viewerIsTutor: boolean
 }
 
-interface VideoInfo {
-  roomUrl: string | null
-  token: string | null
-  isTutor?: boolean
-  twoWay?: boolean
-  error?: string
-  courseId?: string | null
-  courseName?: string | null
-}
-
 const LOBBY_POLL_MS = 20_000
 
 export default function OneOnOneCallPage() {
@@ -45,72 +34,30 @@ export default function OneOnOneCallPage() {
   const params = useParams()
   const router = useRouter()
   const sessionId = (params?.sessionId as string) || ''
+  const locale = (params?.locale as string) || 'en'
+  const viewerRoleIsTutor = session?.user?.role === 'TUTOR'
 
   const [phase, setPhase] = useState<Phase>('checking')
   const [lobby, setLobby] = useState<LobbyInfo | null>(null)
-  const [video, setVideo] = useState<VideoInfo | null>(null)
-  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [errorMsg] = useState<string | null>(null)
   const [now, setNow] = useState(0)
-  const joinStarted = useRef(false)
+  const redirectStarted = useRef(false)
 
-  /** Mint a token and enter the room (the original join flow). */
-  const runJoin = useCallback(async () => {
-    if (joinStarted.current) return
-    joinStarted.current = true
-    setPhase('joining')
+  /** Hand off to the shared course-builder classroom for the viewer's role. */
+  const redirectByRole = useCallback(
+    (isTutor: boolean) => {
+      if (redirectStarted.current) return
+      redirectStarted.current = true
+      setPhase('redirecting')
+      const dest = isTutor
+        ? `/${locale}/tutor/classroom?sessionId=${encodeURIComponent(sessionId)}`
+        : `/${locale}/student/feedback?sessionId=${encodeURIComponent(sessionId)}`
+      router.replace(dest)
+    },
+    [locale, sessionId, router]
+  )
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 30000)
-    try {
-      const csrfRes = await fetch('/api/csrf', {
-        credentials: 'include',
-        signal: controller.signal,
-      })
-      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token ?? null
-      const res = await fetch(`/api/class/rooms/${sessionId}/join`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
-        signal: controller.signal,
-      })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        setErrorMsg(data?.error || 'Could not join the session.')
-        setPhase('error')
-        return
-      }
-      const tutorId = data?.session?.tutorId
-      const isTutor =
-        tutorId && session?.user?.id ? tutorId === session.user.id : session?.user?.role === 'TUTOR'
-      if (!data?.roomUrl) {
-        setErrorMsg(data?.videoError || 'No video room is available for this session yet.')
-        setPhase('error')
-        return
-      }
-      setVideo({
-        roomUrl: data.roomUrl,
-        token: data.token ?? null,
-        isTutor,
-        twoWay: data?.twoWay ?? true,
-        error: data?.videoError || undefined,
-        courseId: data?.session?.courseId ?? null,
-        courseName: data?.session?.course?.name ?? null,
-      })
-      setPhase('inRoom')
-    } catch (err) {
-      const timedOut = err instanceof DOMException && err.name === 'AbortError'
-      setErrorMsg(
-        timedOut
-          ? 'Joining is taking too long. Please check your connection and try again.'
-          : 'Could not join the session.'
-      )
-      setPhase('error')
-    } finally {
-      clearTimeout(timeoutId)
-    }
-  }, [sessionId, session?.user?.id, session?.user?.role])
-
-  /** Check status; open the room if joinable, otherwise show the lobby. */
+  /** Check status; hand off to the classroom if joinable, otherwise show the lobby. */
   const checkStatus = useCallback(async () => {
     try {
       const res = await fetch(
@@ -119,8 +66,9 @@ export default function OneOnOneCallPage() {
       )
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        // No status (e.g. an odd/legacy session) — fall back to attempting the join.
-        void runJoin()
+        // No status (e.g. an odd/legacy session) — route by the viewer's role and let
+        // the classroom gate access.
+        redirectByRole(viewerRoleIsTutor)
         return
       }
       if (data.ended) {
@@ -134,12 +82,12 @@ export default function OneOnOneCallPage() {
         opensAt: data.opensAt,
         viewerIsTutor: !!data.viewerIsTutor,
       })
-      if (data.joinable) void runJoin()
+      if (data.joinable) redirectByRole(!!data.viewerIsTutor)
       else setPhase('lobby')
     } catch {
-      void runJoin()
+      redirectByRole(viewerRoleIsTutor)
     }
-  }, [sessionId, runJoin])
+  }, [sessionId, redirectByRole, viewerRoleIsTutor])
 
   // Initial status check.
   useEffect(() => {
@@ -157,22 +105,22 @@ export default function OneOnOneCallPage() {
     const tick = setInterval(() => {
       const t = Date.now()
       setNow(t)
-      if (t >= opensAtMs) void runJoin()
+      if (t >= opensAtMs) redirectByRole(!!lobby?.viewerIsTutor)
     }, 1000)
     const poll = setInterval(checkStatus, LOBBY_POLL_MS)
     return () => {
       clearInterval(tick)
       clearInterval(poll)
     }
-  }, [phase, lobby?.opensAt, checkStatus, runJoin])
+  }, [phase, lobby?.opensAt, lobby?.viewerIsTutor, checkStatus, redirectByRole])
 
   // --- Render ---
 
-  if (phase === 'checking' || phase === 'joining') {
+  if (phase === 'checking' || phase === 'redirecting') {
     return (
       <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950">
         <Loader2 className="h-8 w-8 animate-spin text-white/70" />
-        {phase === 'joining' ? <p className="text-sm text-white/50">Joining…</p> : null}
+        {phase === 'redirecting' ? <p className="text-sm text-white/50">Joining…</p> : null}
       </div>
     )
   }
@@ -232,25 +180,7 @@ export default function OneOnOneCallPage() {
       <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
         <p className="text-lg font-semibold">This session has ended</p>
         <p className="max-w-md text-sm text-white/70">
-          The 1-on-1 is over. You can leave a review from your dashboard.
-        </p>
-        <button
-          onClick={() => router.back()}
-          className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-medium hover:bg-white/10"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Go back
-        </button>
-      </div>
-    )
-  }
-
-  if (phase === 'error' || !video?.roomUrl) {
-    return (
-      <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
-        <p className="text-lg font-semibold">Couldn’t start the session</p>
-        <p className="max-w-md text-sm text-white/70">
-          {errorMsg || 'No video room is available for this session yet.'}
+          The session is over. You can leave a review from your dashboard.
         </p>
         <button
           onClick={() => router.back()}
@@ -264,15 +194,18 @@ export default function OneOnOneCallPage() {
   }
 
   return (
-    <SessionClassroom
-      sessionId={sessionId}
-      roomUrl={video.roomUrl}
-      token={video.token}
-      isTutor={video.isTutor}
-      twoWay={video.twoWay}
-      courseId={video.courseId ?? null}
-      courseName={video.courseName ?? null}
-      onRefreshToken={runJoin}
-    />
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-3 bg-slate-950 px-6 text-center text-white">
+      <p className="text-lg font-semibold">Couldn’t start the session</p>
+      <p className="max-w-md text-sm text-white/70">
+        {errorMsg || 'No video room is available for this session yet.'}
+      </p>
+      <button
+        onClick={() => router.back()}
+        className="mt-2 inline-flex items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-medium hover:bg-white/10"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Go back
+      </button>
+    </div>
   )
 }

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1834,6 +1834,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       languageOfInstruction: string | null
       roomUrl: string | null
       token: string | null
+      // 1-on-1 (<=2 seats): both sides transmit, so the tutor's video renders the
+      // other participant's camera (see DailyVideoFrame twoWay).
+      twoWay: boolean
     } | null>(null)
     // Student roster is maintained upstream in insights/page.tsx (socket handlers)
     // and passed via insightsProps.students so it survives remounts.
@@ -2416,6 +2419,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             languageOfInstruction: data?.session?.languageOfInstruction ?? null,
             roomUrl: data?.session?.roomUrl ?? null,
             token: data?.session?.token ?? null,
+            twoWay: (data?.session?.maxStudents ?? 0) <= 2,
           })
           // Student roster maintained upstream in insights/page.tsx
         } catch {
@@ -2859,6 +2863,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             token: sessionContext.token,
             autoRecord: !isStudentView,
             isTutor: true,
+            twoWay: sessionContext.twoWay,
           })
         },
         triggerSync: () => {

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -77,6 +77,9 @@ function TutorInsightsPageInner() {
   const [sessions, setSessions] = useState<InsightsSessionOption[]>([])
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [linkedCourseId, setLinkedCourseId] = useState<string | null>(null)
+  // Whether we've finished resolving the session's linked course — so a
+  // course-less session (1-on-1) renders the classroom instead of spinning forever.
+  const [linkedCourseResolved, setLinkedCourseResolved] = useState(false)
   const [sessionCategory, setSessionCategory] = useState<string | null>(null)
   const [sessionNationality, setSessionNationality] = useState<string | null>(null)
   // Canonical "Category — Nationality" label from the API (formatCourseVariantName),
@@ -812,6 +815,7 @@ function TutorInsightsPageInner() {
   useEffect(() => {
     if (!sessionId) return
     let cancelled = false
+    setLinkedCourseResolved(false)
     const loadLinkedCourse = async () => {
       try {
         const res = await fetch(`/api/tutor/classes/${sessionId}`, { credentials: 'include' })
@@ -824,6 +828,8 @@ function TutorInsightsPageInner() {
         setSessionVariantName(data?.session?.variantName || null)
       } catch {
         // Ignore; keep existing selection
+      } finally {
+        if (!cancelled) setLinkedCourseResolved(true)
       }
     }
     loadLinkedCourse()
@@ -831,6 +837,14 @@ function TutorInsightsPageInner() {
       cancelled = true
     }
   }, [sessionId])
+
+  // Course-less session (e.g. a 1-on-1) — once we've confirmed there's no linked
+  // course, render the classroom with the ad-hoc draft sentinel instead of the
+  // infinite "resolving the linked course" spinner below.
+  useEffect(() => {
+    if (!sessionId || !linkedCourseResolved || linkedCourseId) return
+    setCourseId(prev => prev ?? 'insights-draft')
+  }, [sessionId, linkedCourseResolved, linkedCourseId])
 
   useEffect(() => {
     if (!linkedCourseId) return
@@ -1291,8 +1305,10 @@ function TutorInsightsPageInner() {
   }
 
   if (!courseId) {
-    // If a sessionId is in the URL, we're still resolving the linked course — show spinner
-    if (searchParams.get('sessionId')) {
+    // A sessionId is in the URL and we're STILL resolving its linked course — spin.
+    // Once resolved (even to no course, e.g. a 1-on-1) the effect above sets a draft
+    // courseId, so we fall through and render the classroom instead of spinning.
+    if (searchParams.get('sessionId') && !linkedCourseResolved) {
       return (
         <div className="flex h-full w-full flex-1 items-center justify-center">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-blue-600" />


### PR DESCRIPTION
## What

1-on-1 and group live sessions now open the **shared course-builder classroom** instead of the custom `SessionClassroom`, so there's one classroom to maintain rather than two divergent ones.

`/call/[sessionId]` becomes a **thin lobby + role router**:
- Keeps the pre-join countdown, auto-entry, and payment/`joinable` gate (via `/api/one-on-one/session-status`).
- Once the session opens, redirects by role:
  - student → `/{locale}/student/feedback?sessionId={id}`
  - tutor → `/{locale}/tutor/classroom?sessionId={id}` (→ `/tutor/insights?view=classroom`)
- The destination mints its own join token via `/api/class/rooms/[id]/join`, so auth/payment gating is unchanged.

## Changes
- **`/call` page:** drop the join/`SessionClassroom` render; add `redirectByRole` using `viewerIsTutor` from session-status (falls back to the viewer's role when status is unavailable).
- **insights:** render the classroom with the `insights-draft` sentinel once a course-less session resolves with no linked course — fixes the infinite spinner for course-less 1-on-1s.
- **CourseBuilder:** thread `twoWay` (`maxStudents<=2`) into the tutor's video overlay so a 1-on-1 tutor↔student are two-way.

## Not in this PR
The old `one-on-one/` room components + room-only APIs are left in place (neutralized by the redirect, and backed up locally). Deleting them is a follow-up cleanup PR.

## Verification
- `npm run typecheck`, `npm run build`, and `npm run test` (709 tests) all pass.
- Lint clean on the changed `/call` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)