### PR TITLE
feat(comms): full-width "Chat" ribbon on the Messaging tab

### DIFF
--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -223,7 +223,15 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
           ]}
         >
           <TabsContent value="messaging" className="flex h-full flex-col">
-            <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
+            <CollapsibleCard
+              title="Chat"
+              icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
+              defaultOpen
+              fillHeight
+              className="flex-1"
+            >
+              <MessagingPanel activeSection={activeSection} onSectionChange={setActiveSection} />
+            </CollapsibleCard>
           </TabsContent>
 
           {role === 'student' && (

--- a/tutorme-app/src/components/communications/messaging-panel.tsx
+++ b/tutorme-app/src/components/communications/messaging-panel.tsx
@@ -204,7 +204,7 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
   const totalUnread = conversations.reduce((sum, c) => sum + c.unreadCount, 0)
 
   return (
-    <div className="flex h-full w-full overflow-hidden rounded-2xl border border-[#E5E7EB] bg-white shadow-[0_8px_20px_rgba(0,0,0,0.08)]">
+    <div className="flex h-full w-full overflow-hidden bg-white">
       {/* Left menu rail */}
       <div className="flex w-40 flex-col items-center gap-2 border-r border-gray-200 py-4">
         {topItems.map(item => {
@@ -309,11 +309,6 @@ export default function MessagingPanel({ activeSection, onSectionChange }: Messa
 
       {/* Detail / chat area */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-50/30">
-        {/* Chat header */}
-        <div className="flex h-12 shrink-0 items-center justify-center bg-gradient-to-br from-[#2563EB] to-[#1D4ED8] px-4 text-sm font-semibold text-white">
-          Chat
-        </div>
-
         {/* Chat viewport */}
         <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto">
           {!selectedConversation ? (


### PR DESCRIPTION
## What

On the communications page, the **Requests** tab has a full-width "1-on-1 Requests" ribbon (the shared `CollapsibleCard` header) that spans the entire section. The **Messaging** tab had no such ribbon — just a small blue "Chat" bar over the rightmost chat-detail column only.

This makes the Messaging tab's "Chat" header match: wrap `MessagingPanel` in the same `CollapsibleCard` titled **Chat**, so the ribbon spans all three columns of the section (same format + size as "1-on-1 Requests").

## Changes
- `communications-page.tsx` — wrap `MessagingPanel` in `CollapsibleCard` (title "Chat", `MessageSquare` icon, `defaultOpen`, `fillHeight`), mirroring the Requests/Notifications tabs.
- `messaging-panel.tsx` — remove the now-redundant inner blue "Chat" bar and the panel's own outer border/shadow/rounding so it sits flush inside the ribbon card.

Applies to both roles (the Messaging tab is shared student/tutor).

## Verification
`npm run typecheck` and `npm run build` pass. Only pre-existing lint warnings (unused `Send`/`roleLabel`/`totalUnread`), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)