### PR TITLE
fix(schedule): persist schedule from dialog Save + surface skip feedback

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/[id]/components/VariantManager.tsx
@@ -80,7 +80,7 @@ interface VariantManagerProps {
 export type VariantManagerHandle = {
   publish: () => Promise<void>
   /** Persist schedule edits to already-published variants without publishing. */
-  saveSchedules: () => Promise<void>
+  saveSchedules: () => Promise<SaveSchedulesResult | null>
   setPanelsOpen: (open: boolean) => void
 }
 
@@ -102,7 +102,27 @@ type VariantApiItem = {
 type PublishResponse = {
   variants?: Array<{ isPublished?: boolean }>
   count?: number
+  skippedCount?: number
+  skippedSessions?: Array<{ reason?: string }>
   error?: string
+}
+
+/** Outcome of a schedules-only save, so callers can message the tutor. */
+type SaveSchedulesResult = { ok: boolean; processed: number; skipped: number }
+
+/** Turn the server's skip reasons into a short human phrase for a toast. */
+function summarizeSkipReasons(skipped?: Array<{ reason?: string }>): string {
+  const labels: Record<string, string> = {
+    outside_availability: 'outside your availability',
+    exception: 'blocked by a calendar exception',
+    calendar_event: 'conflicting with another event',
+    one_on_one: 'conflicting with a 1-on-1',
+    other_course_live_session: 'conflicting with another course',
+  }
+  const reasons = Array.from(
+    new Set((skipped ?? []).map(s => labels[s.reason ?? ''] ?? 'unavailable'))
+  )
+  return reasons.length > 0 ? reasons.join('; ') : 'unavailable'
 }
 
 function getCountryName(code: string): string {
@@ -140,6 +160,7 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
     )
     const [variants, setVariants] = useState<VariantConfig[]>([])
     const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false)
+    const [savingSchedule, setSavingSchedule] = useState(false)
     const [scheduleDialogVariantIndex, setScheduleDialogVariantIndex] = useState<number | null>(
       null
     )
@@ -431,8 +452,8 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
     // Persist schedule edits to already-published variants WITHOUT publishing
     // anything new (schedulesOnly). Used by the page's Save button so a tutor can
     // save schedule changes on a live course without putting more of it live.
-    const handleSaveSchedules = useCallback(async () => {
-      if (variants.length === 0) return
+    const handleSaveSchedules = useCallback(async (): Promise<SaveSchedulesResult | null> => {
+      if (variants.length === 0) return null
       try {
         const payload = variants.map(v => ({
           ...v,
@@ -443,13 +464,38 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ variants: payload, schedulesOnly: true }),
         })
+        const data: PublishResponse = await res.json().catch(() => ({}))
         if (!res.ok) {
-          const data = await res.json().catch(() => ({}))
           toast.error(data?.error || 'Failed to save schedules')
+          return { ok: false, processed: 0, skipped: 0 }
         }
+        const processed = typeof data.count === 'number' ? data.count : 0
+        const skipped = typeof data.skippedCount === 'number' ? data.skippedCount : 0
+        const hasScheduleSlots = variants.some(
+          v =>
+            Array.isArray(v.schedules) &&
+            v.schedules.some(s => Array.isArray(s.schedule) && s.schedule.length > 0)
+        )
+        // Surface the actionable cases so a silently-skipped schedule isn't
+        // mistaken for success (clean success is messaged by the caller). A
+        // schedules-only save only materialises sessions for PUBLISHED variants,
+        // so processed === 0 with real slots means nothing reached the calendar.
+        if (processed === 0 && hasScheduleSlots) {
+          toast.warning(
+            'Schedule saved, but no sessions were added to your calendar — publish this course first (schedules only appear once the course is live).'
+          )
+        } else if (skipped > 0) {
+          toast.warning(
+            `Schedule saved. ${skipped} session${skipped === 1 ? '' : 's'} skipped (${summarizeSkipReasons(
+              data.skippedSessions
+            )}); the rest were added to your calendar.`
+          )
+        }
+        return { ok: true, processed, skipped }
       } catch (err) {
         console.error(err)
         toast.error('Failed to save schedules')
+        return { ok: false, processed: 0, skipped: 0 }
       }
     }, [variants, templateCourseId])
 
@@ -979,11 +1025,31 @@ export const VariantManager = forwardRef<VariantManagerHandle, VariantManagerPro
               )}
 
               <div className="mt-6 flex justify-end gap-3">
-                <Button type="button" variant="modal-secondary-dark" onClick={cancelScheduleDialog}>
+                <Button
+                  type="button"
+                  variant="modal-secondary-dark"
+                  disabled={savingSchedule}
+                  onClick={cancelScheduleDialog}
+                >
                   Cancel
                 </Button>
-                <Button type="button" variant="modal-primary-dark" onClick={closeScheduleDialog}>
-                  Save
+                <Button
+                  type="button"
+                  variant="modal-primary-dark"
+                  disabled={savingSchedule}
+                  onClick={async () => {
+                    // Persist immediately so "Save" actually saves — the schedule
+                    // edit is already in `variants` state via onScheduleChange.
+                    setSavingSchedule(true)
+                    const result = await handleSaveSchedules()
+                    setSavingSchedule(false)
+                    if (result?.ok && result.processed > 0 && result.skipped === 0) {
+                      toast.success('Schedule saved — sessions added to your calendar.')
+                    }
+                    closeScheduleDialog()
+                  }}
+                >
+                  {savingSchedule ? 'Saving…' : 'Save'}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Problem

A tutor reported adding a schedule to a **published** course (with times inside their availability) but it never appeared on the calendar — and there was no error.

## Investigation

Traced the full pipeline (schedule dialog → save → `schedulesOnly` publish → `generateSessionDates` → `createSession` → `/api/tutor/calendar/events`). The materialisation path is correct for a published, in-availability schedule and the calendar filters by `tutorId` (so the template/published id split can't hide sessions). Two real defects explained the silent failure:

1. **The dialog "Save" didn't persist.** `closeScheduleDialog` only closed the dialog and staged the edit in local `variants` state. Persistence + calendar materialisation happened only when the tutor later clicked the *page-level* "Save". Clicking the dialog "Save" and navigating away persisted nothing.
2. **The schedules-only save was silent.** `handleSaveSchedules` showed nothing on success and ignored the server's `skippedCount` / `skippedSessions`, so a schedule that materialised **zero** sessions (variant not actually published, or every slot skipped by a conflict) looked like a success.

## Fix

- The schedule dialog's **Save** now actually persists (calls the schedules-only save) and confirms with a toast — the edit is already in state via `onScheduleChange`.
- `handleSaveSchedules` now surfaces the outcome:
  - nothing processed (with real slots) → *"publish this course first — schedules only appear once the course is live"*
  - some sessions skipped → lists why (*outside availability / calendar conflict / 1-on-1 / another course*)
  - clean success → *"sessions added to your calendar"*

No change to the materialisation logic itself — only the persistence trigger and user feedback, so if any residual data-specific skip remains, the tutor now sees exactly why.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)