### PR TITLE
fix(schedule): materialize sessions when adding a schedule from the dashboard

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
@@ -10,9 +10,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withAuth, withCsrf } from '@/lib/api/middleware'
 import { verifyCourseOwnership } from '@/lib/api/course-helpers'
 import { drizzleDb } from '@/lib/db/drizzle'
-import { courseSchedule, course } from '@/lib/db/schema'
+import { courseSchedule, course, calendarAvailability } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { notifyStudentsOfScheduleChange } from '@/lib/notifications/reschedule'
+import { materializeScheduleSessions } from '@/lib/sessions/materialize-schedule'
 import crypto from 'crypto'
 
 // GET all schedules for a course
@@ -103,7 +104,42 @@ export const POST = withCsrf(
             updatedAt: courseSchedule.updatedAt,
           })
 
-        return NextResponse.json({ schedule: newSchedule[0] })
+        // Materialize the schedule into real LiveSession + CalendarEvent rows so
+        // it shows on the calendar (this endpoint previously only stored the
+        // pattern, so schedules added here never appeared). Best-effort: the
+        // schedule is already saved, so a materialization hiccup shouldn't fail
+        // the request — the count is surfaced so the UI can warn if it's zero.
+        let sessionsCreated = 0
+        try {
+          const slots = Array.isArray(body.schedule) ? body.schedule : []
+          if (slots.length > 0) {
+            const [tzRow] = await drizzleDb
+              .select({ timezone: calendarAvailability.timezone })
+              .from(calendarAvailability)
+              .where(eq(calendarAvailability.tutorId, userId))
+              .limit(1)
+            const [courseRow] = await drizzleDb
+              .select({ name: course.name, categories: course.categories })
+              .from(course)
+              .where(eq(course.courseId, courseId))
+              .limit(1)
+            sessionsCreated = await materializeScheduleSessions({
+              tutorId: userId,
+              courseId,
+              scheduleId: newSchedule[0].scheduleId,
+              slots,
+              weeksToSchedule: body.weeksToSchedule ?? 8,
+              timezone: tzRow?.timezone || 'UTC',
+              maxStudents: body.maxStudents ?? null,
+              title: courseRow?.name || 'Live Session',
+              category: courseRow?.categories?.[0] || 'General',
+            })
+          }
+        } catch (matErr) {
+          console.error('[POST /api/tutor/courses/[id]/schedules] materialize failed:', matErr)
+        }
+
+        return NextResponse.json({ schedule: newSchedule[0], sessionsCreated })
       } catch (error: any) {
         console.error('[POST /api/tutor/courses/[id]/schedules] Error:', error)
         return NextResponse.json(

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -127,11 +127,20 @@ export function ScheduleViewModal({
         },
         body: JSON.stringify({ schedule: slots, weeksToSchedule: draftWeeks }),
       })
+      const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
         throw new Error(data?.error || 'Failed to create schedule')
       }
-      toast.success('Schedule created')
+      const created = typeof data?.sessionsCreated === 'number' ? data.sessionsCreated : 0
+      if (created > 0) {
+        toast.success(
+          `Schedule created — ${created} session${created === 1 ? '' : 's'} added to your calendar.`
+        )
+      } else {
+        toast.warning(
+          'Schedule created, but no upcoming sessions were added — check the dates are in the future.'
+        )
+      }
       setAddOpen(false)
       await loadSchedules()
     } catch (err) {

--- a/tutorme-app/src/lib/sessions/materialize-schedule.ts
+++ b/tutorme-app/src/lib/sessions/materialize-schedule.ts
@@ -1,0 +1,158 @@
+/**
+ * Materialize a course's weekly schedule into real LiveSession + CalendarEvent
+ * rows so it shows on the tutor/student calendars.
+ *
+ * The full publish flow (`/api/tutor/courses/[id]/publish`) does this inline with
+ * availability/conflict checks. The lighter "add a schedule" entry points (the
+ * dashboard ScheduleViewModal → `POST /api/tutor/courses/[id]/schedules`) only
+ * persisted the CourseSchedule pattern and never created sessions, so the schedule
+ * never reached the calendar. This shared helper closes that gap.
+ */
+
+import { zonedWallClockToUtc, zonedWeekday, zonedDateParts } from '@/lib/time/tz'
+import { createSession } from './create-session'
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
+import type * as schema from '@/lib/db/schema'
+
+const DAY_MAP: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+}
+
+export interface ScheduleSlotInput {
+  dayOfWeek: string
+  startTime: string
+  durationMinutes?: number
+  /** Expanded slots carry a concrete `YYYY-MM-DD`; pure weekly patterns don't. */
+  date?: string
+}
+
+/**
+ * Generate the future session instants for a schedule, in the tutor's timezone.
+ * Mirrors the publish route's generateSessionDates: honours per-slot dates when
+ * present, otherwise repeats the weekday for `weeksAhead` weeks, and skips any
+ * instant within the next hour.
+ */
+export function generateScheduleSessionDates(
+  schedule: ScheduleSlotInput[],
+  weeksAhead = 8,
+  timeZone = 'UTC'
+): Array<{ scheduledAt: Date; durationMinutes: number }> {
+  const sessions: Array<{ scheduledAt: Date; durationMinutes: number }> = []
+  const cutoffMs = Date.now() + 60 * 60 * 1000 // skip sessions within the next hour
+
+  const addDays = (year: number, month: number, day: number, n: number) => {
+    const t = new Date(Date.UTC(year, month - 1, day + n))
+    return { year: t.getUTCFullYear(), month: t.getUTCMonth() + 1, day: t.getUTCDate() }
+  }
+
+  for (const slot of schedule) {
+    const targetDay = DAY_MAP[slot.dayOfWeek]
+    if (targetDay === undefined) continue
+
+    const timeParts = (slot.startTime ?? '').split(':')
+    if (timeParts.length !== 2) continue
+    const hours = parseInt(timeParts[0], 10)
+    const minutes = parseInt(timeParts[1], 10)
+    if (
+      !Number.isInteger(hours) ||
+      !Number.isInteger(minutes) ||
+      hours < 0 ||
+      hours > 23 ||
+      minutes < 0 ||
+      minutes > 59
+    )
+      continue
+
+    const durationMinutes = slot.durationMinutes || 60
+
+    if (slot.date) {
+      const [year, month, day] = slot.date.split('-').map(Number)
+      if (!year || !month || !day) continue
+      const sessionDate = zonedWallClockToUtc(year, month, day, hours, minutes, timeZone)
+      if (isNaN(sessionDate.getTime())) continue
+      if (sessionDate.getTime() < cutoffMs) continue
+      sessions.push({ scheduledAt: sessionDate, durationMinutes })
+      continue
+    }
+
+    // Next occurrence of this weekday in the tutor's timezone.
+    const now = new Date()
+    const todayZ = zonedDateParts(now, timeZone)
+    const todayWeekday = zonedWeekday(now, timeZone)
+    const daysUntil = (targetDay - todayWeekday + 7) % 7
+    let occ = addDays(todayZ.year, todayZ.month, todayZ.day, daysUntil)
+    let first = zonedWallClockToUtc(occ.year, occ.month, occ.day, hours, minutes, timeZone)
+    if (first.getTime() < cutoffMs) {
+      occ = addDays(occ.year, occ.month, occ.day, 7)
+      first = zonedWallClockToUtc(occ.year, occ.month, occ.day, hours, minutes, timeZone)
+    }
+
+    for (let w = 0; w < weeksAhead; w++) {
+      const wk = addDays(occ.year, occ.month, occ.day, w * 7)
+      const sessionDate = zonedWallClockToUtc(wk.year, wk.month, wk.day, hours, minutes, timeZone)
+      if (isNaN(sessionDate.getTime())) continue
+      sessions.push({ scheduledAt: sessionDate, durationMinutes })
+    }
+  }
+
+  sessions.sort((a, b) => a.scheduledAt.getTime() - b.scheduledAt.getTime())
+  return sessions
+}
+
+export interface MaterializeScheduleOptions {
+  tutorId: string
+  courseId: string
+  scheduleId: string
+  slots: ScheduleSlotInput[]
+  weeksToSchedule?: number
+  /** Tutor's timezone (from calendarAvailability); defaults to UTC. */
+  timezone?: string
+  maxStudents?: number | null
+  title: string
+  category: string
+  description?: string | null
+}
+
+/**
+ * Create LiveSession + CalendarEvent rows for every future occurrence of a
+ * schedule. Returns the number of sessions created.
+ */
+export async function materializeScheduleSessions(
+  opts: MaterializeScheduleOptions,
+  tx?: NodePgDatabase<typeof schema>
+): Promise<number> {
+  const dates = generateScheduleSessionDates(
+    opts.slots,
+    opts.weeksToSchedule ?? 8,
+    opts.timezone ?? 'UTC'
+  )
+
+  let created = 0
+  for (const d of dates) {
+    await createSession(
+      {
+        tutorId: opts.tutorId,
+        title: opts.title,
+        scheduledAt: d.scheduledAt,
+        durationMinutes: d.durationMinutes,
+        category: opts.category,
+        type: 'COURSE',
+        courseId: opts.courseId,
+        scheduleId: opts.scheduleId,
+        description: opts.description ?? undefined,
+        status: 'scheduled',
+        maxStudents: opts.maxStudents ?? 50,
+        timezone: 'UTC',
+      },
+      tx
+    )
+    created++
+  }
+  return created
+}


### PR DESCRIPTION
## Problem

Tutor dashboard → **Sessions** tab → course card **"Schedule"** → **"New schedule" → "Create schedule"** added a schedule that never appeared on the calendar.

## Root cause

That button posts to `POST /api/tutor/courses/[id]/schedules`, which only inserted a `CourseSchedule` *pattern* row and **never created `LiveSession`/`CalendarEvent` rows**. The calendar reads only those tables, so the schedule was invisible — unlike the publish flow, which materializes sessions.

## Fix (surgical)

- New shared helper `lib/sessions/materialize-schedule.ts` — turns a schedule's future slots into real sessions via the existing `createSession` (mirrors the publish route's date generation: tutor-timezone aware, honours per-slot dates, skips past slots).
- The schedules `POST` now calls it after inserting the pattern (best-effort; the pattern is already saved) and returns `sessionsCreated`.
- `ScheduleViewModal` reports the result: *"Schedule created — N sessions added to your calendar"*, or a warning if none.

Only the direct schedules-POST path changes. The publish materialization is untouched, and its existing-session conflict check keeps a later publish from duplicating these sessions. Each modal "New schedule" is a distinct `scheduleId`, so no double-creation.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)