### PR TITLE
feat(schedule): edit re-materializes + remove a schedule (no enrollments)

### DIFF
--- a/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/schedules/route.ts
@@ -13,8 +13,49 @@ import { drizzleDb } from '@/lib/db/drizzle'
 import { courseSchedule, course, calendarAvailability } from '@/lib/db/schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { notifyStudentsOfScheduleChange } from '@/lib/notifications/reschedule'
-import { materializeScheduleSessions } from '@/lib/sessions/materialize-schedule'
+import {
+  materializeScheduleSessions,
+  clearFutureScheduleSessions,
+} from '@/lib/sessions/materialize-schedule'
 import crypto from 'crypto'
+
+/**
+ * Fetch the tutor's timezone + course display fields, then materialize a
+ * schedule's future occurrences into real sessions. Shared by POST (create) and
+ * PUT (edit). Returns the number of sessions created.
+ */
+async function materializeForSchedule(
+  courseId: string,
+  userId: string,
+  scheduleId: string,
+  slots: unknown,
+  weeksToSchedule: unknown,
+  maxStudents: unknown
+): Promise<number> {
+  const list = Array.isArray(slots) ? slots : []
+  if (list.length === 0) return 0
+  const [tzRow] = await drizzleDb
+    .select({ timezone: calendarAvailability.timezone })
+    .from(calendarAvailability)
+    .where(eq(calendarAvailability.tutorId, userId))
+    .limit(1)
+  const [courseRow] = await drizzleDb
+    .select({ name: course.name, categories: course.categories })
+    .from(course)
+    .where(eq(course.courseId, courseId))
+    .limit(1)
+  return materializeScheduleSessions({
+    tutorId: userId,
+    courseId,
+    scheduleId,
+    slots: list,
+    weeksToSchedule: typeof weeksToSchedule === 'number' ? weeksToSchedule : 8,
+    timezone: tzRow?.timezone || 'UTC',
+    maxStudents: typeof maxStudents === 'number' ? maxStudents : null,
+    title: courseRow?.name || 'Live Session',
+    category: courseRow?.categories?.[0] || 'General',
+  })
+}
 
 // GET all schedules for a course
 export const GET = withAuth(
@@ -111,30 +152,14 @@ export const POST = withCsrf(
         // the request — the count is surfaced so the UI can warn if it's zero.
         let sessionsCreated = 0
         try {
-          const slots = Array.isArray(body.schedule) ? body.schedule : []
-          if (slots.length > 0) {
-            const [tzRow] = await drizzleDb
-              .select({ timezone: calendarAvailability.timezone })
-              .from(calendarAvailability)
-              .where(eq(calendarAvailability.tutorId, userId))
-              .limit(1)
-            const [courseRow] = await drizzleDb
-              .select({ name: course.name, categories: course.categories })
-              .from(course)
-              .where(eq(course.courseId, courseId))
-              .limit(1)
-            sessionsCreated = await materializeScheduleSessions({
-              tutorId: userId,
-              courseId,
-              scheduleId: newSchedule[0].scheduleId,
-              slots,
-              weeksToSchedule: body.weeksToSchedule ?? 8,
-              timezone: tzRow?.timezone || 'UTC',
-              maxStudents: body.maxStudents ?? null,
-              title: courseRow?.name || 'Live Session',
-              category: courseRow?.categories?.[0] || 'General',
-            })
-          }
+          sessionsCreated = await materializeForSchedule(
+            courseId,
+            userId,
+            newSchedule[0].scheduleId,
+            body.schedule,
+            body.weeksToSchedule,
+            body.maxStudents
+          )
         } catch (matErr) {
           console.error('[POST /api/tutor/courses/[id]/schedules] materialize failed:', matErr)
         }
@@ -214,6 +239,7 @@ export const PUT = withCsrf(
         const scheduleChanged =
           body.schedule !== undefined &&
           JSON.stringify(before?.schedule ?? null) !== JSON.stringify(body.schedule)
+        let sessionsCreated = 0
         if (scheduleChanged) {
           const [row] = await drizzleDb
             .select({ name: course.name })
@@ -221,9 +247,26 @@ export const PUT = withCsrf(
             .where(eq(course.courseId, courseId))
             .limit(1)
           await notifyStudentsOfScheduleChange({ courseId, courseName: row?.name })
+
+          // Re-materialize: retire the old upcoming sessions for this schedule and
+          // create fresh ones at the new times. Clearing first avoids duplicates.
+          // Best-effort — the schedule row is already updated.
+          try {
+            await clearFutureScheduleSessions(scheduleId)
+            sessionsCreated = await materializeForSchedule(
+              courseId,
+              userId,
+              scheduleId,
+              body.schedule,
+              body.weeksToSchedule ?? updated[0].weeksToSchedule,
+              body.maxStudents ?? updated[0].maxStudents
+            )
+          } catch (matErr) {
+            console.error('[PUT /api/tutor/courses/[id]/schedules] re-materialize failed:', matErr)
+          }
         }
 
-        return NextResponse.json({ schedule: updated[0] })
+        return NextResponse.json({ schedule: updated[0], sessionsCreated })
       } catch (error: any) {
         console.error('[PUT /api/tutor/courses/[id]/schedules] Error:', error)
         return NextResponse.json(
@@ -273,6 +316,17 @@ export const DELETE = withCsrf(
           return NextResponse.json(
             { error: 'Cannot delete schedule with enrolled students' },
             { status: 409 }
+          )
+        }
+
+        // Retire this schedule's upcoming sessions so they leave the calendar too
+        // (not just the pattern row). Best-effort.
+        try {
+          await clearFutureScheduleSessions(scheduleId)
+        } catch (clearErr) {
+          console.error(
+            '[DELETE /api/tutor/courses/[id]/schedules] clear sessions failed:',
+            clearErr
           )
         }
 

--- a/tutorme-app/src/components/course/ScheduleViewModal.tsx
+++ b/tutorme-app/src/components/course/ScheduleViewModal.tsx
@@ -10,7 +10,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Loader2, CalendarClock, Plus } from 'lucide-react'
+import { Loader2, CalendarClock, Plus, Pencil, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { VariantScheduleEditor } from '@/app/[locale]/tutor/courses/[id]/components/VariantScheduleEditor'
 import { DAYS, type ScheduleItem } from '@/app/[locale]/tutor/courses/[id]/constants'
@@ -74,11 +74,14 @@ export function ScheduleViewModal({
   const [error, setError] = useState<string | null>(null)
   const [switchingId, setSwitchingId] = useState<string | null>(null)
 
-  // "Add schedule" editor dialog (tutor only).
+  // "Add / edit schedule" editor dialog (tutor only).
   const [addOpen, setAddOpen] = useState(false)
   const [draftSlots, setDraftSlots] = useState<ScheduleItem[]>([])
   const [draftWeeks, setDraftWeeks] = useState(8)
   const [saving, setSaving] = useState(false)
+  /** null = creating a new schedule; set = editing this one. */
+  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   const loadSchedules = useCallback(async () => {
     if (!courseId) return
@@ -102,51 +105,98 @@ export function ScheduleViewModal({
   }, [courseId, loadSchedules])
 
   const openAdd = () => {
+    setEditingScheduleId(null)
     setDraftSlots([{ dayOfWeek: DAYS[0], startTime: '09:00', durationMinutes: 60 }])
     setDraftWeeks(8)
     setAddOpen(true)
   }
 
-  const handleCreate = async () => {
+  const openEdit = (s: CourseSchedule) => {
+    setEditingScheduleId(s.scheduleId)
+    setDraftSlots((Array.isArray(s.slots) ? s.slots : []) as ScheduleItem[])
+    setDraftWeeks(s.weeksToSchedule || 8)
+    setAddOpen(true)
+  }
+
+  const csrfHeader = async (): Promise<Record<string, string>> => {
+    const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
+    const csrfToken = (await csrfRes.json().catch(() => ({})))?.token as string | undefined
+    return csrfToken ? { 'X-CSRF-Token': csrfToken } : {}
+  }
+
+  const handleSave = async () => {
     if (!courseId || saving) return
     const slots = draftSlots.filter(s => s?.dayOfWeek && s?.startTime)
     if (slots.length === 0) {
       toast.error('Add at least one time slot.')
       return
     }
+    const isEdit = !!editingScheduleId
     setSaving(true)
     try {
-      const csrfRes = await fetch('/api/csrf', { credentials: 'include' })
-      const csrfToken = (await csrfRes.json().catch(() => ({})))?.token as string | undefined
       const res = await fetch(`/api/tutor/courses/${courseId}/schedules`, {
-        method: 'POST',
+        method: isEdit ? 'PUT' : 'POST',
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}),
-        },
-        body: JSON.stringify({ schedule: slots, weeksToSchedule: draftWeeks }),
+        headers: { 'Content-Type': 'application/json', ...(await csrfHeader()) },
+        body: JSON.stringify(
+          isEdit
+            ? { scheduleId: editingScheduleId, schedule: slots, weeksToSchedule: draftWeeks }
+            : { schedule: slots, weeksToSchedule: draftWeeks }
+        ),
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        throw new Error(data?.error || 'Failed to create schedule')
+        throw new Error(data?.error || 'Failed to save schedule')
       }
       const created = typeof data?.sessionsCreated === 'number' ? data.sessionsCreated : 0
       if (created > 0) {
         toast.success(
-          `Schedule created — ${created} session${created === 1 ? '' : 's'} added to your calendar.`
+          `Schedule ${isEdit ? 'updated' : 'created'} — ${created} session${
+            created === 1 ? '' : 's'
+          } added to your calendar.`
         )
+      } else if (isEdit) {
+        toast.success('Schedule updated.')
       } else {
         toast.warning(
           'Schedule created, but no upcoming sessions were added — check the dates are in the future.'
         )
       }
       setAddOpen(false)
+      setEditingScheduleId(null)
       await loadSchedules()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create schedule')
+      toast.error(err instanceof Error ? err.message : 'Failed to save schedule')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleDelete = async (s: CourseSchedule) => {
+    if (!courseId || s.enrolledCount > 0 || deletingId) return
+    if (
+      !window.confirm(
+        `Remove "${s.name}"? Its upcoming sessions will be taken off your calendar. This can't be undone.`
+      )
+    ) {
+      return
+    }
+    setDeletingId(s.scheduleId)
+    try {
+      const res = await fetch(
+        `/api/tutor/courses/${courseId}/schedules?scheduleId=${encodeURIComponent(s.scheduleId)}`,
+        { method: 'DELETE', credentials: 'include', headers: await csrfHeader() }
+      )
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(data?.error || 'Failed to remove schedule')
+      }
+      toast.success('Schedule removed')
+      await loadSchedules()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove schedule')
+    } finally {
+      setDeletingId(null)
     }
   }
 
@@ -247,6 +297,39 @@ export function ScheduleViewModal({
                           {s.isFull ? 'Full' : 'Switch to this schedule'}
                         </Button>
                       )}
+                      {canCreate && (
+                        <div className="mt-3 flex gap-2 border-t border-gray-100 pt-3">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1.5"
+                            disabled={deletingId === s.scheduleId}
+                            onClick={() => openEdit(s)}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                            Edit
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1.5 text-red-600 hover:bg-red-50 hover:text-red-700 disabled:text-gray-400"
+                            disabled={s.enrolledCount > 0 || deletingId === s.scheduleId}
+                            title={
+                              s.enrolledCount > 0
+                                ? 'Students are enrolled — cannot remove this schedule'
+                                : 'Remove this schedule'
+                            }
+                            onClick={() => handleDelete(s)}
+                          >
+                            {deletingId === s.scheduleId ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <Trash2 className="h-3.5 w-3.5" />
+                            )}
+                            Remove
+                          </Button>
+                        </div>
+                      )}
                     </div>
                   )
                 })}
@@ -286,11 +369,13 @@ export function ScheduleViewModal({
             <div className="flex h-full flex-col">
               <DialogHeader>
                 <DialogTitle className="flex items-center gap-2">
-                  <CalendarClock className="h-5 w-5" /> New schedule
+                  <CalendarClock className="h-5 w-5" />{' '}
+                  {editingScheduleId ? 'Edit schedule' : 'New schedule'}
                 </DialogTitle>
                 <DialogDescription>
-                  Click a time slot to add or remove a 1-hour session. It saves as &ldquo;Schedule{' '}
-                  {schedules.length + 1}&rdquo;.
+                  {editingScheduleId
+                    ? 'Click a time slot to add or remove a 1-hour session. Saving updates your upcoming calendar sessions.'
+                    : `Click a time slot to add or remove a 1-hour session. It saves as “Schedule ${schedules.length + 1}”.`}
                 </DialogDescription>
               </DialogHeader>
 
@@ -308,9 +393,9 @@ export function ScheduleViewModal({
                 <Button variant="outline" onClick={() => setAddOpen(false)} disabled={saving}>
                   Cancel
                 </Button>
-                <Button onClick={handleCreate} disabled={saving}>
+                <Button onClick={handleSave} disabled={saving}>
                   {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
-                  Create schedule
+                  {editingScheduleId ? 'Save changes' : 'Create schedule'}
                 </Button>
               </DialogFooter>
             </div>

--- a/tutorme-app/src/lib/sessions/materialize-schedule.ts
+++ b/tutorme-app/src/lib/sessions/materialize-schedule.ts
@@ -9,6 +9,9 @@
  * never reached the calendar. This shared helper closes that gap.
  */
 
+import { and, eq, gt, inArray } from 'drizzle-orm'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { liveSession, calendarEvent } from '@/lib/db/schema'
 import { zonedWallClockToUtc, zonedWeekday, zonedDateParts } from '@/lib/time/tz'
 import { createSession } from './create-session'
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres'
@@ -155,4 +158,37 @@ export async function materializeScheduleSessions(
     created++
   }
   return created
+}
+
+/**
+ * Retire the FUTURE, not-yet-started sessions materialized from a schedule so
+ * they leave the calendar — used when a schedule's times change (before
+ * re-materializing) or when a schedule is removed. Past/active sessions are
+ * left untouched. Soft-retires (status 'ended' + calendarEvent cancelled) rather
+ * than hard-deleting, to avoid touching rows other tables may reference.
+ * Returns the number of sessions retired.
+ */
+export async function clearFutureScheduleSessions(scheduleId: string): Promise<number> {
+  const now = new Date()
+  const future = await drizzleDb
+    .select({ sessionId: liveSession.sessionId })
+    .from(liveSession)
+    .where(
+      and(
+        eq(liveSession.scheduleId, scheduleId),
+        eq(liveSession.status, 'scheduled'),
+        gt(liveSession.scheduledAt, now)
+      )
+    )
+  if (future.length === 0) return 0
+  const ids = future.map(s => s.sessionId)
+  await drizzleDb
+    .update(liveSession)
+    .set({ status: 'ended', endedAt: now })
+    .where(inArray(liveSession.sessionId, ids))
+  await drizzleDb
+    .update(calendarEvent)
+    .set({ isCancelled: true, deletedAt: now })
+    .where(inArray(calendarEvent.externalId, ids))
+  return ids.length
 }


### PR DESCRIPTION
Follow-ups to the dashboard schedule materializer (#1244), both on the `ScheduleViewModal` (dashboard Sessions → course card → Schedule).

## 1. Editing a schedule now updates the calendar
- The schedules **PUT**, when the times change, **retires the schedule's upcoming (unstarted) sessions and re-materializes** at the new times (clearing first avoids duplicates).
- New `clearFutureScheduleSessions()` soft-retires future sessions (`status: 'ended'` + `calendarEvent` cancelled) so they leave the calendar without hard deletes / FK risk.
- The modal's schedule card gains an **Edit** button that reuses the same grid editor and saves via PUT, reporting how many sessions were updated.

## 2. Remove a schedule when no student is enrolled
- The DELETE endpoint already blocked `enrolledCount > 0`; surfaced it as a **Remove** button on each card — disabled with a tooltip while students are enrolled (server still enforces it).
- DELETE now also retires the schedule's upcoming sessions so they leave the calendar (not just the pattern row).

## Notes
- Editing is allowed even with enrollments (a reschedule notifies students via the existing `notifyStudentsOfScheduleChange`); removal is not.
- Like the create path, this lighter endpoint materializes without the publish route's availability/conflict checks — the publish flow remains the fully-checked path.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)