### PR TITLE
fix(polls): send the tutor's actual options (1–10 default no longer becomes A–E)

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -2126,6 +2126,9 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     }
 
     const resolvePollOptions = (): string[] | undefined => {
+      // '1-10' is the DEFAULT mode; without this case it returned undefined and
+      // the server fell back to A–E, so students saw the wrong options.
+      if (pollOptionMode === '1-10') return Array.from({ length: 10 }, (_, i) => String(i + 1))
       if (pollOptionMode === 'tf') return ['True', 'False']
       if (pollOptionMode === 'yn') return ['Yes', 'No']
       if (pollOptionMode === 'likert') {

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -2598,12 +2598,13 @@ export async function initEnhancedSocketServer(server: NetServer) {
         }
 
         if (type === 'poll') {
-          // Tutor-chosen labels (True/False, Yes/No, custom); fall back to A–E.
-          // Sanitized: trimmed, non-empty, deduped-by-position, capped at 8.
+          // Tutor-chosen labels (True/False, Yes/No, 1–10, custom); fall back to
+          // A–E. Sanitized: trimmed, non-empty, capped at 10 (a 1–10 scale is the
+          // default option set, so the cap must fit all ten).
           const rawLabels = Array.isArray(data.options)
             ? data.options.map(o => String(o ?? '').trim()).filter(Boolean)
             : []
-          const labels = rawLabels.length >= 2 ? rawLabels.slice(0, 8) : ['A', 'B', 'C', 'D', 'E']
+          const labels = rawLabels.length >= 2 ? rawLabels.slice(0, 10) : ['A', 'B', 'C', 'D', 'E']
           const poll: LiveTaskPoll = {
             id: `poll-${taskId}-${Date.now()}`,
             taskId,


### PR DESCRIPTION
## Yes, it's real — here's why

Tutors reported that poll options change to something else on the student side. Confirmed:

- The poll composer's `resolvePollOptions()` (CourseBuilder) handled `tf`/`yn`/`likert`/`ae` but had **no case for `1-10`** — which is the **default** mode — so it returned `undefined`.
- With `options` undefined, the socket `insight:send` poll handler fell back to `['A','B','C','D','E']`.
- Students render `poll.optionLabels`, so they saw **A–E** instead of the **1–10** scale the tutor selected (and that the tutor's own composer displayed).

So any poll left on the default `1-10` (the most common case) reached students as A–E.

## Fix

- `resolvePollOptions`: add the `1-10` case → `['1' … '10']`.
- `insight:send`: raise the option cap from 8 → 10 so a full 1–10 scale isn't truncated.

The other modes (True/False, Yes/No, Likert, A–E) already produced correct options and are unchanged.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)