### PR TITLE
feat(dmi): auto-generate on document load; drop the up-front format step

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -3722,10 +3722,6 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         contentSource,
         sourcesDisagree,
       })
-      if (dmiGate === 'format') {
-        setDmiFormatDialog({ type })
-        return
-      }
       if (dmiGate === 'source') {
         setDmiSourceDialog({ type })
         return
@@ -12623,7 +12619,13 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               {dmiGenerating ? (
                                                 <Loader2 className="mr-1 h-3 w-3 animate-spin" />
                                               ) : null}
-                                              Generate DMI
+                                              {/* A loaded document auto-generates the DMI, so the
+                                                  manual control becomes a re-run; only a text-only
+                                                  assessment still needs an initial "Generate". */}
+                                              {currentAssessmentDocument?.mimeType ===
+                                                'application/pdf' || assessmentDmiItems.length > 0
+                                                ? 'Regenerate DMI'
+                                                : 'Generate DMI'}
                                             </Button>
 
                                             {assessmentDmiItems.length > 0 && (

--- a/tutorme-app/src/lib/assessment/dmi-generate-gate.test.ts
+++ b/tutorme-app/src/lib/assessment/dmi-generate-gate.test.ts
@@ -11,76 +11,47 @@ const base: DmiGateInput = {
 }
 
 describe('nextDmiGate — single step', () => {
-  it('asks the format chooser first on a fresh assessment run', () => {
-    expect(nextDmiGate({ ...base })).toBe('format')
+  it('proceeds straight to generation on a fresh assessment run (no format step)', () => {
+    expect(nextDmiGate({ ...base })).toBe('proceed')
   })
 
-  it('never asks the format chooser for a task (assessment-only)', () => {
+  it('proceeds for a task', () => {
     expect(nextDmiGate({ ...base, type: 'task' })).toBe('proceed')
   })
 
-  it('skips the format chooser once a spec / kind / skip flag is present', () => {
-    expect(nextDmiGate({ ...base, hasQuestionSpec: true })).toBe('proceed')
-    expect(nextDmiGate({ ...base, hasDocumentKindOverride: true })).toBe('proceed')
-    expect(nextDmiGate({ ...base, skipFormatPrompt: true })).toBe('proceed')
+  it('asks the source chooser when the PDF and typed text disagree and no pick yet', () => {
+    expect(nextDmiGate({ ...base, sourcesDisagree: true })).toBe('source')
   })
 
-  it('asks the source chooser only after format is resolved and sources disagree', () => {
-    expect(nextDmiGate({ ...base, skipFormatPrompt: true, sourcesDisagree: true })).toBe('source')
+  it('proceeds once a source pick has been made, even if the sources disagree', () => {
+    expect(nextDmiGate({ ...base, sourcesDisagree: true, contentSource: 'text' })).toBe('proceed')
+    expect(nextDmiGate({ ...base, sourcesDisagree: true, contentSource: 'document' })).toBe(
+      'proceed'
+    )
   })
 
-  it('does not ask the source chooser when the tutor already picked a source', () => {
-    expect(
-      nextDmiGate({
-        ...base,
-        skipFormatPrompt: true,
-        sourcesDisagree: true,
-        contentSource: 'text',
-      })
-    ).toBe('proceed')
+  it('proceeds when the sources agree (no chooser needed)', () => {
+    expect(nextDmiGate({ ...base, sourcesDisagree: false })).toBe('proceed')
   })
 
-  it('does not ask the source chooser when the sources agree (unedited text)', () => {
-    expect(nextDmiGate({ ...base, skipFormatPrompt: true, sourcesDisagree: false })).toBe('proceed')
-  })
-
-  it('asks the source chooser for a task with a genuine disagreement', () => {
+  it('asks the source chooser for a task too (source step is type-agnostic)', () => {
     expect(nextDmiGate({ ...base, type: 'task', sourcesDisagree: true })).toBe('source')
   })
 })
 
-describe('nextDmiGate — ordering invariant (regression guard)', () => {
-  // The original loop bug put the source step BEFORE the format step. If both
-  // conditions hold at once, the format step MUST win; deferring the source
-  // question is what lets multiple-choice papers skip it entirely and is what
-  // keeps the chain from ping-ponging source↔format. Do not "simplify" this.
-  it('prefers format over source when both would otherwise fire', () => {
-    expect(nextDmiGate({ ...base, sourcesDisagree: true })).toBe('format')
-  })
-})
-
 /**
- * Drives the whole pre-generation chain the way CourseBuilder's dialog handlers
- * do, and asserts it always terminates (never loops) while asking each chooser
- * at most once.
- *
- * Handler model (mirrors CourseBuilder):
- * - format → 'mcq'  : builds locally, does NOT re-invoke the generator (terminal).
- * - format → 'free' : re-invoke with skipFormatPrompt = true.
- * - source → pick   : re-invoke with skipFormatPrompt = true AND the pick set
- *                     (the pick persists via a ref, so later server-driven
- *                     re-invocations keep it too).
- * - proceed         : generation runs; the server may then re-invoke for kind /
- *                     spec, which we simulate as extra steps.
+ * The generator re-invokes itself after each dialog. With the format step gone,
+ * the only dialog is the source chooser, and after the pick the server may still
+ * ask for kind / question-spec (each of which just re-runs → 'proceed'). This
+ * guards against a re-introduced loop: the chain must terminate at 'proceed'.
  */
 function runChain(opts: {
   type: 'task' | 'assessment'
   sourcesDisagree: boolean
-  formatChoice: 'mcq' | 'free'
   sourcePick?: 'document' | 'text'
-  /** Simulate the server asking for kind then spec after the first proceed. */
+  /** Extra server round-trips after the first proceed (kind / spec). */
   serverAsks?: Array<'kind' | 'spec'>
-}): { seen: DmiGate[]; ended: 'proceed' | 'mcq' } {
+}): { seen: DmiGate[]; ended: 'proceed' } {
   let state: DmiGateInput = {
     type: opts.type,
     hasQuestionSpec: false,
@@ -91,21 +62,14 @@ function runChain(opts: {
   }
   const seen: DmiGate[] = []
   const serverQueue = [...(opts.serverAsks ?? [])]
-
-  for (let step = 0; step < 20; step++) {
+  for (let i = 0; i < 12; i++) {
     const gate = nextDmiGate(state)
     seen.push(gate)
-
-    if (gate === 'format') {
-      if (opts.formatChoice === 'mcq') return { seen, ended: 'mcq' }
-      state = { ...state, skipFormatPrompt: true }
-      continue
-    }
     if (gate === 'source') {
-      state = { ...state, skipFormatPrompt: true, contentSource: opts.sourcePick ?? 'text' }
+      state = { ...state, contentSource: opts.sourcePick ?? 'text' }
       continue
     }
-    // gate === 'proceed' — generation ran. Let the server ask for kind/spec next.
+    // gate === 'proceed' — generation ran. Let the server ask kind/spec next.
     const next = serverQueue.shift()
     if (!next) return { seen, ended: 'proceed' }
     if (next === 'kind') state = { ...state, hasDocumentKindOverride: true }
@@ -115,63 +79,33 @@ function runChain(opts: {
 }
 
 describe('Generate DMI chain — terminates, no loop (regression guard)', () => {
-  it('assessment + PDF + edited text, free-response: asks format then source once, then proceeds', () => {
+  it('assessment + PDF + edited text: asks source once, then proceeds', () => {
     const { seen, ended } = runChain({
       type: 'assessment',
       sourcesDisagree: true,
-      formatChoice: 'free',
       sourcePick: 'text',
     })
     expect(ended).toBe('proceed')
-    expect(seen.filter(g => g === 'format')).toHaveLength(1)
     expect(seen.filter(g => g === 'source')).toHaveLength(1)
-    expect(seen).toEqual(['format', 'source', 'proceed'])
+    expect(seen).toEqual(['source', 'proceed'])
   })
 
-  it('assessment + PDF + edited text, MULTIPLE CHOICE: never asks the source chooser', () => {
+  it('assessment through server kind + spec: source pick persists, no re-prompt', () => {
     const { seen, ended } = runChain({
       type: 'assessment',
       sourcesDisagree: true,
-      formatChoice: 'mcq',
-    })
-    expect(ended).toBe('mcq')
-    expect(seen).not.toContain('source')
-    expect(seen).toEqual(['format'])
-  })
-
-  it('assessment free-response through server kind + spec: no re-prompt, source pick persists', () => {
-    const { seen, ended } = runChain({
-      type: 'assessment',
-      sourcesDisagree: true,
-      formatChoice: 'free',
       sourcePick: 'document',
       serverAsks: ['kind', 'spec'],
     })
     expect(ended).toBe('proceed')
-    expect(seen.filter(g => g === 'format')).toHaveLength(1)
     expect(seen.filter(g => g === 'source')).toHaveLength(1)
-    // format, source, proceed(→kind), proceed(→spec), proceed(done)
-    expect(seen).toEqual(['format', 'source', 'proceed', 'proceed', 'proceed'])
+    // source, proceed(→kind), proceed(→spec), proceed(done)
+    expect(seen).toEqual(['source', 'proceed', 'proceed', 'proceed'])
   })
 
-  it('task + PDF + edited text: asks source once (no format), then proceeds', () => {
-    const { seen, ended } = runChain({
-      type: 'task',
-      sourcesDisagree: true,
-      formatChoice: 'free',
-      sourcePick: 'text',
-    })
+  it('agreeing sources: proceeds immediately with no dialog', () => {
+    const { seen, ended } = runChain({ type: 'assessment', sourcesDisagree: false })
     expect(ended).toBe('proceed')
-    expect(seen).toEqual(['source', 'proceed'])
-  })
-
-  it('assessment, unedited text (sources agree): asks only format, then proceeds', () => {
-    const { seen, ended } = runChain({
-      type: 'assessment',
-      sourcesDisagree: false,
-      formatChoice: 'free',
-    })
-    expect(ended).toBe('proceed')
-    expect(seen).toEqual(['format', 'proceed'])
+    expect(seen).toEqual(['proceed'])
   })
 })

--- a/tutorme-app/src/lib/assessment/dmi-generate-gate.ts
+++ b/tutorme-app/src/lib/assessment/dmi-generate-gate.ts
@@ -1,26 +1,22 @@
 /**
- * Pre-network dialog routing for "Generate DMI".
+ * Pre-network dialog routing for auto-generating a DMI.
  *
- * Generating a DMI resolves through a chain of dialogs, each of which pauses the
- * flow and re-invokes the generator from the top once answered:
+ * A DMI now generates automatically the moment a document is loaded (and via the
+ * manual Generate / Regenerate control). The former "response format" step —
+ * which asked MCQ vs free-response up front — was removed: the model reads the
+ * paper and detects the question mix itself. So the ONLY remaining pre-network
+ * dialog is the content-source chooser, shown when an attached PDF and the typed
+ * text genuinely disagree and no pick has been made yet:
  *
- *   format (MCQ vs free-response, assessment only)
- *     └─ free-response → source (which content: attached PDF vs edited text)
- *                          └─ proceed → (server may then ask kind → question-spec)
+ *   proceed  (default — run generation)
+ *     └─ source  (only when PDF ≠ typed text; then proceed → server may still
+ *                 ask kind → question-spec for study material)
  *
- * This helper decides ONLY the next pre-network step. It is deliberately pure
- * and framework-free so the routing — including the property that the format
- * step is always resolved before the source step — is unit-tested directly,
- * away from the giant CourseBuilder component.
- *
- * Ordering matters. The source chooser MUST come after the format chooser:
- * multiple-choice papers are built locally and never read the content, so they
- * return at the format step and are never asked which source to use. Putting the
- * source step first (and dropping the pick on each re-invocation) is exactly the
- * bug that once looped source↔format forever — see the tests.
+ * This helper decides ONLY the next pre-network step. It is deliberately pure and
+ * framework-free so the routing is unit-tested away from the giant CourseBuilder.
  */
 
-export type DmiGate = 'format' | 'source' | 'proceed'
+export type DmiGate = 'source' | 'proceed'
 
 export interface DmiGateInput {
   type: 'task' | 'assessment'
@@ -44,23 +40,13 @@ export interface DmiGateInput {
 
 /**
  * The next pre-network step for a Generate DMI (re-)invocation:
- * - `'format'`  → open the response-format chooser (assessment, not yet chosen).
- * - `'source'`  → open the content-source chooser (free-response, sources disagree,
- *                 no pick yet). Only reachable once the format step is resolved.
+ * - `'source'`  → open the content-source chooser (an attached PDF and the typed
+ *                 text disagree and no pick has been made yet).
  * - `'proceed'` → no dialog needed; run generation.
  */
 export function nextDmiGate(input: DmiGateInput): DmiGate {
-  // Format first: a fresh assessment run with no downstream choice yet.
-  if (
-    input.type === 'assessment' &&
-    !input.hasQuestionSpec &&
-    !input.hasDocumentKindOverride &&
-    !input.skipFormatPrompt
-  ) {
-    return 'format'
-  }
-  // Then source: only after format is resolved, and only when the two content
-  // sources genuinely disagree and the tutor hasn't already picked one.
+  // The only pre-network dialog: pick a source when the attached PDF and the
+  // typed text genuinely disagree and the tutor hasn't already picked one.
   if (input.sourcesDisagree && !input.contentSource) {
     return 'source'
   }


### PR DESCRIPTION
## What

Removes the manual "Generate DMI → Multiple choice or free response?" step for assessments built from a document.

- A loaded document **already** auto-fires generation; the flow just stopped at a format dialog. That **format gate is removed** — the model reads the paper and detects the question mix (MCQ vs free-response) **per item** itself.
- **Detected question paper** → generates straight through, no clicks.
- **Detected study material** → still opens the question-type spec dialog (unchanged).
- The kind-confirmation ("Is this a question paper?") dialog is unchanged.

## Changes
- `dmi-generate-gate.ts`: `DmiGate` is now `'source' | 'proceed'` — the format branch is gone; the content-source chooser remains for the PDF-vs-typed-text conflict case. Tests rewritten (loop/termination guard kept).
- `CourseBuilder.tsx`: drop the now-dead format-gate branch; the manual control reads **"Regenerate DMI"** once a document is loaded or a DMI exists, and stays **"Generate DMI"** only for a text-only assessment with no document.

Per the agreed decisions: the manual MCQ builder is removed from the flow (now unreachable — the format/MCQ dialogs are neutralized, safe to delete in a follow-up); a Generate button remains for the no-document case; a Regenerate control remains.

## Verification
`npm run typecheck`, `npm run build`, and `npm run test` (705) pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)