### PR TITLE
fix(dmi): stop the auto-generate flag being consumed before it can fire

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -7769,19 +7769,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
 
     // Auto-generate the DMI the moment a freshly uploaded assessment document
     // commits to state. Gated on `pendingAutoGenDmiRef` (set only by the upload
-    // handlers) so opening an EXISTING assessment never re-generates, and it
-    // reads fresh state (unlike the old stale-closure setTimeout). Skips when a
-    // DMI already exists or one is already generating.
+    // handlers) so opening an EXISTING assessment never triggers it, and it reads
+    // fresh state (unlike the old stale-closure setTimeout).
+    //
+    // Crucially: only CLEAR the flag when we actually fire (or the doc can never
+    // qualify). A transient `!canEdit` / `dmiGenerating` on the first render must
+    // NOT consume the flag — otherwise the auto-generate is silently cancelled
+    // before conditions settle. That was the bug that stopped it firing at all.
     useEffect(() => {
       const doc = currentAssessmentDocument
       const docId = doc?.fileKey || doc?.fileUrl || null
       if (!docId || pendingAutoGenDmiRef.current !== docId) return
+      // Non-PDF can't be auto-read — retire the flag and bail (no retry).
+      if (doc?.mimeType !== 'application/pdf') {
+        pendingAutoGenDmiRef.current = null
+        return
+      }
+      // Wait WITHOUT clearing until editing is allowed and nothing is generating,
+      // so a transient state doesn't cancel the pending auto-generate.
+      if (!canEdit || dmiGenerating) return
       pendingAutoGenDmiRef.current = null
-      if (doc?.mimeType !== 'application/pdf' || !canEdit) return
-      if (dmiGenerating || assessmentDmiItems.length > 0) return
       void handleGenerateDMI('assessment')
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentAssessmentDocument, assessmentDmiItems.length, dmiGenerating, canEdit])
+    }, [currentAssessmentDocument, dmiGenerating, canEdit])
 
     // An image scan or an Office file (Word / PowerPoint, modern or legacy) —
     // documents whose figures text/OCR extraction drops, but that we can turn


### PR DESCRIPTION
The DMI still didn't auto-generate. Root cause: the auto-generate effect **cleared its pending flag before checking its guards**, so a transient/stale guard on the first render silently cancelled the pending auto-generate — and it never ran. The specific tripwire was `assessmentDmiItems.length > 0` matching **items left over from a previously-open assessment** (`canEdit` is always `true`, so that wasn't it).

## Fix
- Only clear the flag when we **actually fire** (or the doc is a non-PDF that can never auto-read).
- On a transient `dmiGenerating`, **wait without clearing** so it fires once conditions settle.
- **Drop the stale-items guard** — the flag is set only by the upload handlers, so it already means a fresh upload; regenerating over a stale/previous DMI on a new upload is correct.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)