### PR TITLE
fix(dmi): read PDFs stored by fileKey so auto-generation actually produces a DMI

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -3694,7 +3694,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         : currentAssessmentDocument
 
       const hasContent = content.trim().length > 0
-      const hasPdf = sourceDoc?.mimeType === 'application/pdf' && sourceDoc.fileUrl
+      // Accept a fileKey-only PDF (assets stored by storage key with an empty
+      // fileUrl): the extractor/renderer below already fall back to the by-key
+      // proxy. Requiring fileUrl here silently skipped PDF reading for
+      // asset-library uploads, so auto-generation produced nothing.
+      const hasPdf =
+        sourceDoc?.mimeType === 'application/pdf' && !!(sourceDoc.fileUrl || sourceDoc.fileKey)
 
       if (!hasContent && !hasPdf) {
         toast.error('Please add Assessment content or load a PDF first')


### PR DESCRIPTION
## Root cause (found via a full runtime trace)

"DMI doesn't auto-generate" — asset-library uploads store the document with **`fileUrl: ''`** and only a **`fileKey`**. `handleGenerateDMI` gated PDF reading on:

```
const hasPdf = sourceDoc?.mimeType === 'application/pdf' && sourceDoc.fileUrl
```

which is **false** for a fileKey-only doc. So the auto-generate effect *did* fire, but the PDF was never read — it fell back to placeholder text (`[Asset: name]`) and produced nothing, so nothing appeared.

The extractor/renderer already accept `fileKey` (`proxyFetchUrl` prefers the `/api/proxy-file?key=…` by-key proxy). The only blocker was the `fileUrl` requirement.

## Fix
```
const hasPdf = sourceDoc?.mimeType === 'application/pdf' && !!(sourceDoc.fileUrl || sourceDoc.fileKey)
```

Now a loaded question paper is actually read and a real DMI is generated — and the "Analyzing PDF with AI…" toast appears, confirming it fired.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)