### PR TITLE
fix(dmi): auto-generate when loading a paper from the asset library

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -6532,13 +6532,12 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       setLoadAsModalOpen(false)
       setAssetToLoad(null)
 
-      // DMI-first: generate the DMI (questions + answers/marks)
-      // right away. The marking-policy (PCI) chat stays locked
-      // until the DMI is ready. handleGenerateDMI detects the
-      // document kind and asks the tutor to confirm if unsure.
-      setTimeout(() => {
-        handleGenerateDMI('assessment')
-      }, 500)
+      // DMI-first: auto-generate the DMI once the loaded assessment commits.
+      // Flag it for the auto-generate effect (which reads FRESH state) rather
+      // than a stale-closure setTimeout that read the previously-open
+      // assessment's state — that was why loading a paper from the asset library
+      // never generated anything.
+      pendingAutoGenDmiRef.current = asset.fileKey || asset.url || null
     }
 
     const handleLoadAsset = (


### PR DESCRIPTION
## The real path (confirmed with the reporter)

The tutor **picks an already-uploaded paper from the asset library** ("Load as"). That handler sets the assessment document via `loadAssessmentIntoBuilder` and still used the **old stale-closure `setTimeout(handleGenerateDMI)`**, which reads the **previously-open assessment's** state — so it never generated for the just-loaded paper. Symptom matched exactly: **"Loaded … into Assessment"** showed, but **"Analyzing PDF with AI…"** never did.

The two earlier-instrumented paths (fresh upload / drag) already used the robust `pendingAutoGenDmiRef` + effect; this third path did not.

## Fix
Route the asset-library "Load as" path through the same `pendingAutoGenDmiRef` flag, so the auto-generate effect fires with **fresh state** after the assessment commits (and, combined with #1252's fileKey PDF fix, actually reads the document).

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)