### PR TITLE
Fit 4 course cards per row on student courses page

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -647,8 +647,8 @@ function CoursePageInner() {
         >
           <div className="scrollbar-hide flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-4">
             {isLoading ? (
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {[1, 2, 3].map(i => (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                {[1, 2, 3, 4].map(i => (
                   <Card key={i} className="animate-pulse">
                     <CardHeader className="h-48 bg-gray-200" />
                   </Card>
@@ -916,14 +916,14 @@ function CourseSection({
   unregisteringId?: string | null
 }) {
   return (
-    <section className="mx-auto max-w-7xl">
+    <section className="mx-auto w-full">
       <div className="mb-6">
         <div className="min-w-0">
           <h2 className="text-xl font-bold text-gray-900">{title}</h2>
           {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {courses.map(course => (
           <CourseCard
             key={course.id}


### PR DESCRIPTION
- Change student courses grid from 3 to 4 columns on large screens
- Tighten grid gap from 24px to 16px to keep cards as large as possible
- Remove internal max-w-7xl cap so the grid uses the full panel width
- Update loading skeleton to 4 items to match the new grid