### PR TITLE
feat(pci): label the DMI version-history button "DMI" instead of an icon

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -472,7 +472,6 @@ import {
   X,
   Lightbulb,
   Sparkles,
-  History,
   RotateCcw,
   Check,
   Zap,
@@ -12786,7 +12785,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                               onClick={() => setShowDmiVersionList(true)}
                                               title="View DMI Versions"
                                             >
-                                              <History className="h-3 w-3" />
+                                              DMI
                                               {assessmentDmiVersions.length > 0 && (
                                                 <span className="ml-1">
                                                   ({assessmentDmiVersions.length})


### PR DESCRIPTION
On the assessment PCI tab, the DMI version-history button showed a History (clock) icon. Per request, it now reads **"DMI"** (keeping the `(N)` version count and the same click behavior — opens the DMI Versions list). Removed the now-unused `History` icon import.

## Verification
`npm run typecheck` and `npm run build` pass; only pre-existing lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)