### PR TITLE
Fix text-only task PDF landscape + restore Test Mode tutor input

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -11524,12 +11524,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                               // For a TASK in the Test tab, preview the new chat-based
                               // flow students get (chat → Task complete → per-answer
                               // responses → follow-up); assessments keep the composer.
-                              (mainTab === 'test-pci' && testPciSource === 'task' ? (
-                                // A task is previewed via the chat flow rendered in the panel
-                                // above (the document collapses into the chat), so nothing
-                                // extra is needed here.
-                                <></>
-                              ) : mainTab === 'test-pci' && testPciSource === 'assessment' ? (
+                              (mainTab === 'test-pci' && testPciSource === 'assessment' ? (
                                 // Assessments are answered in the DMI: test-grade per question
                                 // above (type an answer under a question and click Grade) rather
                                 // than a separate free-text box, which caused confusion.

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -492,7 +492,7 @@ export function isTaskSlideOverflowing(content: string): boolean {
  * generated snapshot format changes so existing auto-generated PDFs are
  * invalidated and regenerated.
  */
-export const TASK_TEXT_SNAPSHOT_VERSION = 5
+export const TASK_TEXT_SNAPSHOT_VERSION = 6
 
 /**
  * Generate a simple PDF from a task's typed content so that text-only


### PR DESCRIPTION
## Changes
- Bump  from 5 to 6 to invalidate existing auto-generated text-only task PDFs and force regeneration with the landscape 1100x620 viewport format.
- Restore the bottom composer input in Test mode for tasks; the special case that hid it for  tasks has been removed so tutors can type messages again.

## Why
The deployed landscape PDF fix was not taking effect for existing tasks because the snapshot version remained at 5, so old portrait PDFs were reused. Bumping to 6 forces a one-time regeneration. The tutor input was intentionally hidden in an earlier edit, but this request restores it.

## Note
Existing text-only tasks will regenerate their PDF the first time they are opened in Test/Live mode after this deploy. This may cause a brief one-time delay for those tasks.