### PR TITLE
fix(student/courses): paginate course cards at 4 per page

### DIFF
--- a/tutorme-app/src/app/[locale]/student/courses/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/courses/page.tsx
@@ -916,7 +916,7 @@ function CourseSection({
   onUnregister?: (c: Course) => void
   unregisteringId?: string | null
 }) {
-  const ITEMS_PER_PAGE = 8
+  const ITEMS_PER_PAGE = 4
   const [currentPage, setCurrentPage] = useState(1)
   const totalPages = Math.max(1, Math.ceil(courses.length / ITEMS_PER_PAGE))
   const paginatedCourses = courses.slice(


### PR DESCRIPTION
Changes student course card pagination from 8 to 4 cards per page while keeping the existing panel/wrapper and grid sizing unchanged.