### PR TITLE
fix(builder-utils): force landscape orientation for text-only task PDF

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/builder-utils.ts
@@ -492,7 +492,7 @@ export function isTaskSlideOverflowing(content: string): boolean {
  * generated snapshot format changes so existing auto-generated PDFs are
  * invalidated and regenerated.
  */
-export const TASK_TEXT_SNAPSHOT_VERSION = 6
+export const TASK_TEXT_SNAPSHOT_VERSION = 7
 
 /**
  * Generate a simple PDF from a task's typed content so that text-only
@@ -568,7 +568,7 @@ export async function generateTaskTextPDF(
     const ptWidth = VIEWPORT_WIDTH * 0.75
     const ptHeight = VIEWPORT_HEIGHT * 0.75
 
-    const doc = new jsPDF({ unit: 'pt', format: [ptWidth, ptHeight] })
+    const doc = new jsPDF({ unit: 'pt', format: [ptWidth, ptHeight], orientation: 'landscape' })
     const imgData = canvas.toDataURL('image/png')
     doc.addImage(imgData, 'PNG', 0, 0, ptWidth, ptHeight)
 


### PR DESCRIPTION
Fixes the text-only task slide PDF being generated as portrait despite the 1100 x 620 landscape viewport.

- jsPDF defaults to portrait and silently swaps explicit [width, height] dimensions when orientation is omitted, so the page ended up 465 x 825 pt.
- Adds orientation: "landscape" to the jsPDF constructor.
- Bumps TASK_TEXT_SNAPSHOT_VERSION 6 -> 7 so existing cached portrait PDFs are invalidated and regenerated.