### PR TITLE
Fix: stop appending country to course names, enforce 25-char limit, widen selector

### DIFF
--- a/tutorme-app/src/__tests__/integration/multi-country-publish.test.ts
+++ b/tutorme-app/src/__tests__/integration/multi-country-publish.test.ts
@@ -5,8 +5,8 @@
  * per (category × nationality) combination — on the course details page. The
  * publish route (`/api/tutor/courses/[id]/publish`) then materializes, for each
  * variant, a published `course` row plus a `courseVariant` link row that ties it
- * back to the template. Published courses are named `"{templateName} — {nationality}"`,
- * except a `Global` variant which keeps the bare template name.
+ * back to the template. Published courses keep the bare template name (no
+ * nationality/flag suffix).
  *
  * This test drives that exact route against a real Postgres:
  *   1. Seed a tutor + a template course (with a lesson) owned by the tutor.
@@ -193,8 +193,8 @@ describe('Multi-country course publish end-to-end', () => {
     expect(new Set(variantRows.map(r => r.nationality))).toEqual(new Set(['Singapore', 'Korea']))
     expect(variantRows.every(r => r.category === CATEGORY)).toBe(true)
 
-    // The 2 linked published courses exist, are published, and are named with the
-    // nationality suffix.
+    // The 2 linked published courses exist, are published, and keep the bare
+    // template name (no nationality suffix).
     const publishedRows = await drizzleDb
       .select({
         courseId: course.courseId,
@@ -211,9 +211,7 @@ describe('Multi-country course publish end-to-end', () => {
 
     expect(publishedRows).toHaveLength(2)
     expect(publishedRows.every(r => r.isPublished === true)).toBe(true)
-    expect(new Set(publishedRows.map(r => r.name))).toEqual(
-      new Set([`${templateName} — Singapore`, `${templateName} — Korea`])
-    )
+    expect(new Set(publishedRows.map(r => r.name))).toEqual(new Set([templateName]))
   })
 
   it('surfaces both variants via the GET handler', async () => {

--- a/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/courses/components/CourseBuilderInsightsRoute.tsx
@@ -892,7 +892,7 @@ function CourseBuilderInsightsRouteInner({
                             // theme, so use a hardcoded dark text colour — the theme
                             // token text-foreground flips to white under dark themes
                             // and made the course name unreadable here.
-                            'h-9 min-w-[220px] max-w-[420px] border border-slate-300 bg-transparent text-sm font-semibold text-[#1F2933] shadow-none transition-colors focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0',
+                            'h-9 min-w-[300px] max-w-[540px] border border-slate-300 bg-transparent text-sm font-semibold text-[#1F2933] shadow-none transition-colors focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0',
                             hasNoCourses ? 'cursor-not-allowed opacity-60' : 'hover:bg-slate-100'
                           )}
                         >
@@ -916,7 +916,7 @@ function CourseBuilderInsightsRouteInner({
                             })()}
                           </SelectValue>
                         </SelectTrigger>
-                        <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[420px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
+                        <SelectContent className="w-[var(--radix-select-trigger-width)] max-w-[540px] border-white/10 bg-[rgba(31,41,51,0.60)] shadow-2xl backdrop-blur-xl">
                           {courseStateFilter === 'unpublished' &&
                             courses &&
                             courses.filter(c => !c.isPublished).length > 0 && (
@@ -1442,17 +1442,38 @@ function CourseBuilderInsightsRouteInner({
             <DialogTitle>Rename Course</DialogTitle>
             <DialogDescription>Enter a new name for this course.</DialogDescription>
           </DialogHeader>
-          <Input
-            value={renameValue}
-            onChange={e => setRenameValue(e.target.value)}
-            placeholder="Course name"
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                onCourseNameChange?.(renameValue)
-                setIsRenameDialogOpen(false)
-              }
-            }}
-          />
+          <div className="space-y-2">
+            <Input
+              value={renameValue}
+              onChange={e => {
+                const value = e.target.value
+                if (value.length <= 25) {
+                  setRenameValue(value)
+                }
+              }}
+              placeholder="Course name"
+              maxLength={25}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  onCourseNameChange?.(renameValue)
+                  setIsRenameDialogOpen(false)
+                }
+              }}
+            />
+            <div className="flex justify-end">
+              <span
+                className={`text-xs font-medium ${
+                  (renameValue?.length || 0) >= 25
+                    ? 'text-red-500'
+                    : (renameValue?.length || 0) >= 20
+                      ? 'text-orange-500'
+                      : 'text-gray-500'
+                }`}
+              >
+                {renameValue?.length || 0}/25
+              </span>
+            </div>
+          </div>
           <DialogFooter>
             <Button variant="modal-secondary-dark" onClick={() => setIsRenameDialogOpen(false)}>
               Cancel

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -229,9 +229,7 @@ function TutorInsightsPageInner() {
         const raw = localStorage.getItem(draftStorageKey)
         const parsed = raw ? JSON.parse(raw) : []
         const updated = parsed.map((c: any) =>
-          c.id === courseId
-            ? { ...c, name: trimmed, updatedAt: new Date().toISOString() }
-            : c
+          c.id === courseId ? { ...c, name: trimmed, updatedAt: new Date().toISOString() } : c
         )
         localStorage.setItem(draftStorageKey, JSON.stringify(updated))
       } catch {

--- a/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/insights/page.tsx
@@ -215,13 +215,14 @@ function TutorInsightsPageInner() {
 
   const handleCourseNameChange = useCallback(
     async (newName: string) => {
-      setCourseName(newName)
+      const trimmed = newName.trim().slice(0, 25)
+      setCourseName(trimmed)
       if (!courseId || courseId === 'insights-draft') return
 
       // Optimistically update BOTH lists so dropdown matches instantly
       // regardless of which saveMode is currently active
-      setDraftCourses(prev => prev.map(c => (c.id === courseId ? { ...c, name: newName } : c)))
-      setCourses(prev => prev.map(c => (c.id === courseId ? { ...c, name: newName } : c)))
+      setDraftCourses(prev => prev.map(c => (c.id === courseId ? { ...c, name: trimmed } : c)))
+      setCourses(prev => prev.map(c => (c.id === courseId ? { ...c, name: trimmed } : c)))
 
       // Also update localStorage drafts
       try {
@@ -229,7 +230,7 @@ function TutorInsightsPageInner() {
         const parsed = raw ? JSON.parse(raw) : []
         const updated = parsed.map((c: any) =>
           c.id === courseId
-            ? { ...c, name: newName.trim(), updatedAt: new Date().toISOString() }
+            ? { ...c, name: trimmed, updatedAt: new Date().toISOString() }
             : c
         )
         localStorage.setItem(draftStorageKey, JSON.stringify(updated))
@@ -239,12 +240,12 @@ function TutorInsightsPageInner() {
 
       // Persist to API for live courses (and drafts that have a DB id)
       const match = [...courses, ...draftCourses].find(c => c.id === courseId)
-      if (match && newName.trim() !== match.name) {
+      if (match && trimmed !== match.name) {
         try {
           await fetchWithCsrf(`/api/tutor/courses/${courseId}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: newName.trim() }),
+            body: JSON.stringify({ name: trimmed }),
           })
         } catch {
           // silent fail

--- a/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/publish/route.ts
@@ -404,10 +404,7 @@ export const POST = withCsrf(
             // In schedules-only mode, only touch variants that are already
             // published; never create/publish anything new.
             if (schedulesOnly && (!existing || !existing.isPublished)) continue
-            const courseName =
-              v.nationality === 'Global'
-                ? templateCourse.name
-                : `${templateCourse.name} — ${v.nationality}`
+            const courseName = templateCourse.name
             const isFree =
               typeof v.isFree === 'boolean' ? v.isFree : (templateCourse.isFree ?? false)
             const price = isFree ? 0 : typeof v.price === 'number' ? v.price : null

--- a/tutorme-app/src/app/api/tutor/courses/[id]/route.ts
+++ b/tutorme-app/src/app/api/tutor/courses/[id]/route.ts
@@ -20,7 +20,7 @@ import { getPaymentGateway, type GatewayName } from '@/lib/payments'
 import { LIVE_SESSION_OPEN_STATUSES } from '@/lib/sessions/live-session-status'
 
 const patchCourseSchema = z.strictObject({
-  name: z.string().min(1).optional(),
+  name: z.string().min(1).max(25).optional(),
   description: z.string().max(200).optional(),
   languageOfInstruction: z.string().optional(),
   price: z.number().optional(),

--- a/tutorme-app/src/lib/validation/schemas.ts
+++ b/tutorme-app/src/lib/validation/schemas.ts
@@ -195,7 +195,7 @@ const ScheduleItemSchema = z.object({
 })
 
 export const CreateCourseSchema = z.object({
-  title: z.string().min(1).max(200),
+  title: z.string().min(1).max(25),
   description: z.string().max(2000).optional(),
   difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
   estimatedHours: z.number().min(0).max(1000).optional(),
@@ -218,7 +218,7 @@ export const EnrollCourseSchema = z.object({
 })
 
 export const UpdateCourseSettingsSchema = z.object({
-  name: z.string().min(1).max(200).optional().nullable(),
+  name: z.string().min(1).max(25).optional().nullable(),
   description: z.string().max(2000).optional().nullable(),
   difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional().nullable(),
   languageOfInstruction: z.string().min(1).max(20).optional().nullable(),


### PR DESCRIPTION
## What\n- Removes the auto country/flag label that was appended when publishing a course.\n- Makes the existing 25-character UI course-name limit the system-wide limit (Zod create/update schemas + PATCH API + rename dialog).\n- Widens the course selector trigger and dropdown so the full label (25-char name + category + flag) fits without truncation.\n\n## Notes\n- Existing published courses that already have the country baked into their names are not automatically backfilled; only newly published courses stop adding the country.\n- Typecheck passed.\n