### PR TITLE
Fix: persist Task PCI chat before Apply and replace rubric wording with policy

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -619,6 +619,7 @@ function writeDmiFormatPref(courseKey: string, value: DmiFormat): void {
 
 function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
   const noun = kind === 'assessment' ? 'assessment' : 'task'
+  const policyWord = kind === 'task' ? 'policy' : 'rubric'
   return (
     <details
       data-pci-anchor="guidance"
@@ -634,9 +635,9 @@ function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
         <p>
           <b>PCI is your marking instruction</b> for this {noun} — <i>how</i> you want answers
           marked, not the questions themselves. Chat your rules below; the assistant turns them into
-          a finalized <b>rubric</b>. Save it under <b>Current marking policy</b> (use <b>Edit</b> to
-          paste or refine) — it then guides the AI grading suggestions and how an uploaded marking
-          scheme is read.
+          a finalized <b>{policyWord}</b>. Save it under <b>Current marking policy</b> (use{' '}
+          <b>Edit</b> to paste or refine) — it then guides the AI grading suggestions and how an
+          uploaded marking scheme is read.
         </p>
         <p className="font-semibold">Things worth telling it:</p>
         <ul className="list-disc space-y-0.5 pl-4">
@@ -649,7 +650,7 @@ function PciGuidance({ kind }: { kind: 'task' | 'assessment' }) {
           <li>&ldquo;One mark per valid point, maximum 4.&rdquo;</li>
         </ul>
         <p className="text-blue-700/80">
-          Flow: chat &rarr; the assistant proposes a rubric &rarr; set it as your{' '}
+          Flow: chat &rarr; the assistant proposes a {policyWord} &rarr; set it as your{' '}
           <b>Current marking policy</b> &rarr; it&rsquo;s saved and used when grading. The answer
           key itself comes from the DMI / an uploaded marking scheme — PCI is the <i>policy</i> on
           top.
@@ -12216,7 +12217,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                           {taskPciDraft && (
                                             <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
                                               <span>
-                                                Rubric ready — click Apply to save it as your
+                                                Policy ready — click Apply to save it as your
                                                 marking policy.
                                               </span>
                                               <Button

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/PciQuestionnaire.tsx
@@ -405,7 +405,7 @@ export function PciQuestionnaire({
 
       <p className="mb-2 text-[11px] leading-snug text-slate-500">
         Policy only — keep answers, marks, and per-question rubric in the{' '}
-        {source === 'assessment' ? 'marking scheme' : 'rubric'}. Leave anything you don&rsquo;t want
+        {source === 'assessment' ? 'marking scheme' : 'policy'}. Leave anything you don&rsquo;t want
         to specify blank.
         {markingScheme?.length ? (
           <>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/pci-reducer.ts
@@ -21,9 +21,9 @@ export interface PciThread {
   input: string
   loading: boolean
   errorHint: string
-  /** Finalized rubric awaiting "Apply to PCI" (empty until the model finalizes). */
+  /** Finalized policy awaiting "Apply to PCI" (empty until the model finalizes). */
   draft: string
-  /** Structured form of the finalized rubric (TASK-6), when the model emitted one. */
+  /** Structured form of the finalized policy (TASK-6), when the model emitted one. */
   draftSpec?: import('@/lib/assessment/pci-spec').PciSpec
   /**
    * Partial structured policy the assistant has captured SO FAR this
@@ -72,6 +72,7 @@ export type PciTarget =
 export type PciAction =
   | { type: 'setInput'; target: PciTarget; input: string }
   | { type: 'loadMessages'; target: PciTarget; messages: PciMessage[] }
+  | { type: 'loadThread'; target: PciTarget; thread: Partial<PciThread> }
   | { type: 'sendStart'; target: PciTarget; userMessage: string }
   | { type: 'sendStartSilent'; target: PciTarget }
   | {
@@ -120,6 +121,17 @@ export function pciReducer(state: PciState, action: PciAction): PciState {
 
     case 'loadMessages':
       return patch(state, action.target, { messages: action.messages })
+
+    case 'loadThread':
+      // Restore a previously persisted thread (messages + draft state) without
+      // losing fields that were not saved.
+      return setThread(state, action.target, {
+        ...emptyThread(),
+        ...getThread(state, action.target),
+        ...action.thread,
+        loading: false,
+        errorHint: '',
+      })
 
     case 'sendStart':
       // Append the user's message and start loading. The input box is cleared

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/hooks/use-pci.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useReducer } from 'react'
+import { useReducer, useEffect } from 'react'
 import { toast } from 'sonner'
 import type { PciMessage, PciAuditRecord } from '@/lib/assessment/pci'
 import {
@@ -10,6 +10,7 @@ import {
   type PciState,
   type PciTarget,
   type PciGuardrailWarning,
+  type PciThread,
 } from './pci-reducer'
 
 interface PciSourceDoc {
@@ -65,7 +66,7 @@ interface UsePciDeps {
   taskPciVariant?: {
     documentKind?: 'question_paper' | 'study_material'
   }
-  /** Writes the finalized rubric to the active task/assessment PCI field. */
+  /** Writes the finalized policy to the active task/assessment PCI field. */
   setCurrentPci: (source: 'task' | 'assessment', text: string, audit?: PciAuditRecord) => void
   taskSourceDocument?: PciSourceDoc
   currentAssessmentDocument?: PciSourceDoc
@@ -94,7 +95,95 @@ export function usePci(deps: UsePciDeps) {
     dispatch({ type: 'setInput', target, input })
   const loadPciMessages = (target: PciTarget, messages: PciMessage[]) =>
     dispatch({ type: 'loadMessages', target, messages })
+  const loadPciThread = (target: PciTarget, thread: Partial<PciThread>) =>
+    dispatch({ type: 'loadThread', target, thread })
   const resetPci = () => dispatch({ type: 'reset' })
+
+  // Persist task PCI conversations to localStorage so a tutor doesn't lose a
+  // draft chat when switching tabs, items, or reloading the page. Stored per
+  // task / extension so each item keeps its own conversation history.
+  const taskStorageKey = (target: PciTarget) => {
+    if (target.kind === 'task') return `tutor-pci-thread:task:${deps.loadedTaskId}`
+    if (target.kind === 'taskExtension') {
+      return `tutor-pci-thread:task-ext:${deps.loadedTaskId}:${target.id}`
+    }
+    return `tutor-pci-thread:assessment:${deps.loadedAssessmentId}`
+  }
+
+  function loadStoredThread(target: PciTarget) {
+    const key = taskStorageKey(target)
+    if (!key || typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem(key)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as Partial<PciThread>
+      if (Array.isArray(parsed.messages) && parsed.messages.length > 0) {
+        loadPciThread(target, parsed)
+      }
+    } catch {
+      // Ignore corrupt or unavailable storage.
+    }
+  }
+
+  function saveStoredThread(target: PciTarget, thread: PciThread) {
+    const key = taskStorageKey(target)
+    if (!key || typeof window === 'undefined') return
+    try {
+      if (thread.messages.length > 0) {
+        window.localStorage.setItem(key, JSON.stringify(thread))
+      } else {
+        window.localStorage.removeItem(key)
+      }
+    } catch {
+      // Ignore storage failures (private mode / quota).
+    }
+  }
+
+  function removeStoredThread(target: PciTarget) {
+    const key = taskStorageKey(target)
+    if (!key || typeof window === 'undefined') return
+    try {
+      window.localStorage.removeItem(key)
+    } catch {
+      // ignore
+    }
+  }
+
+  // Load any previously persisted conversations when the item becomes known.
+  useEffect(() => {
+    if (!deps.loadedTaskId) return
+    loadStoredThread({ kind: 'task' })
+    for (const ext of deps.taskBuilder.extensions) {
+      loadStoredThread({ kind: 'taskExtension', id: ext.id })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deps.loadedTaskId])
+
+  useEffect(() => {
+    if (!deps.loadedAssessmentId) return
+    loadStoredThread({ kind: 'assessment', id: deps.loadedAssessmentId })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deps.loadedAssessmentId])
+
+  // Persist thread changes as they happen.
+  useEffect(() => {
+    if (!deps.loadedTaskId) return
+    saveStoredThread({ kind: 'task' }, pci.task)
+    for (const ext of deps.taskBuilder.extensions) {
+      const thread = pci.taskExtensions[ext.id]
+      if (thread) {
+        saveStoredThread({ kind: 'taskExtension', id: ext.id }, thread)
+      }
+    }
+  }, [pci.task, pci.taskExtensions, deps.loadedTaskId, deps.taskBuilder.extensions])
+
+  useEffect(() => {
+    if (!deps.loadedAssessmentId) return
+    const thread = pci.assessments[deps.loadedAssessmentId]
+    if (thread) {
+      saveStoredThread({ kind: 'assessment', id: deps.loadedAssessmentId }, thread)
+    }
+  }, [pci.assessments, deps.loadedAssessmentId])
 
   const applyTaskPciDraft = () => {
     const target = activeTaskTarget()
@@ -112,7 +201,8 @@ export function usePci(deps: UsePciDeps) {
     }
     deps.setCurrentPci('task', draft, audit)
     dispatch({ type: 'clearDraft', target })
-    toast.success('Rubric applied to PCI')
+    removeStoredThread(target)
+    toast.success('Policy applied to PCI')
   }
 
   const applyAssessmentPciDraft = (assessmentId: string) => {
@@ -130,6 +220,7 @@ export function usePci(deps: UsePciDeps) {
     }
     deps.setCurrentPci('assessment', draft, audit)
     dispatch({ type: 'clearDraft', target })
+    removeStoredThread(target)
     toast.success('Rubric applied to PCI')
   }
 


### PR DESCRIPTION
## What this PR does

- Persist Task PCI chat before Apply (Option B): Task and task-extension PCI conversations are now saved to localStorage keyed by item ID. Tutors won't lose a draft chat when switching tabs, selecting another item, or reloading the page. The stored thread is cleared once 'Apply to PCI' is clicked.
- Task PCI wording: Replaces 'rubric' with 'policy' in Task PCI UI copy only. Assessment PCI wording is intentionally unchanged.

## Files changed

- use-pci.ts: load/save/clear persisted threads via localStorage.
- pci-reducer.ts: new loadThread action to restore a persisted thread.
- CourseBuilder.tsx: task-only policy wording plus 'Policy ready' banner.
- PciQuestionnaire.tsx: task-only 'per-question rubric in the policy' label.

## Verification

- npm run typecheck passes.
- npm run format:check passes.
- pci-reducer and use-pci tests pass (21 tests).
- No new ESLint errors on touched files.