### PR TITLE
fix(test-task-chat): auto-close PDF popup when student submits an answer

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -171,6 +171,7 @@ export function TestTaskChat({
       setMessages(nextMessages)
     }
     setDraft('')
+    setPdfPopupOpen(false)
     onPersist?.({ messages: nextMessages, draft: '', completed })
     onBroadcast?.(msg)
     onAddAnswer?.(a)
@@ -196,6 +197,7 @@ export function TestTaskChat({
         setMessages(nextMessages)
       }
       setDraft('')
+      setPdfPopupOpen(false)
       onPersist?.({ messages: nextMessages, draft: '', completed })
       onBroadcast?.(pendingMsg)
     }


### PR DESCRIPTION
When a student has the task document PDF popup open in the Test tab and submits an answer (via the send button/Enter or Task complete), the popup now closes automatically so they can see their answer appear in the chat stream.