### PR TITLE
fix(session-tutor): strengthen test-mode summary prompts and guardrails

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -1536,15 +1536,21 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         }
         classroomStudentAnswers.current[key] = bucket
 
+        const totalStudents = testPciTabs.filter(t => t.id.startsWith('student')).length || 2
+        const completedCount = bucket.length
+        const allAnswers = bucket.flatMap(s => s.answers)
         const summaryRequest = [
-          'Summarize the following student responses for the tutor.',
-          'Do not give individual feedback or correct answers.',
-          'Describe class-level patterns, common misconceptions, or completion status in 2-3 concise bullets.',
+          'The following student answers have been submitted for this task.',
+          `Total students enrolled in this session: ${totalStudents}.`,
+          `Students who have submitted/completed so far: ${completedCount}.`,
+          'Provide 2-3 concise bullets summarizing class-level patterns, common misconceptions, or completion status only.',
+          'Do NOT name, number, or describe individual students.',
+          'Do NOT evaluate, judge, or comment on any individual answer.',
+          'Do NOT add meta-commentary about what you are not doing or what guidelines you are following.',
+          'Do NOT say all students completed unless the submitted count equals the enrolled count.',
           '',
-          ...bucket.map(
-            (s, i) =>
-              `Student ${i + 1}${s.studentName ? ` (${s.studentName})` : ''}:\n${s.answers.map(a => `- ${a}`).join('\n')}`
-          ),
+          'Submitted answers:',
+          ...allAnswers.map(a => `- ${a}`),
         ].join('\n')
 
         try {

--- a/tutorme-app/src/lib/ai/session-tutor-guardrails.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-guardrails.ts
@@ -135,6 +135,12 @@ const OUTPUT_INDIVIDUAL_FEEDBACK_PATTERNS = [
   /\b(the correct answer is|your answer is wrong|your answer is incorrect|student \d+ answered|student \d+ got|student \d+ is correct|student \d+ is wrong|test student \d+ answered)\b/i,
 ]
 
+const OUTPUT_META_COMMENTARY_PATTERNS = [
+  /\b(individual feedback|correction of answers|feedback or correction)\b.*\b(as per the guidelines|according to the guidelines|has not been given|was not provided|is not provided)\b/i,
+  /\bI (?:am|have been) (?:instructed|told|asked) not? to\b/i,
+  /\bPlease note that .* (?:not|never) (?:give|provide|offer|share)\b/i,
+]
+
 export function applySessionTutorOutputGuardrails(
   raw: string,
   _context: SessionTutorContext
@@ -174,6 +180,22 @@ export function applySessionTutorOutputGuardrails(
       })
       reply +=
         '\n\n_Reminder: In classroom summaries, describe class-level patterns rather than addressing individual students._'
+      break
+    }
+  }
+
+  for (const re of OUTPUT_META_COMMENTARY_PATTERNS) {
+    if (re.test(reply)) {
+      violations.push({
+        ruleId: 'NO_META_COMMENTARY',
+        message:
+          'Output contains meta-commentary about instructions or guidelines; summaries should state findings directly.',
+        severity: 'warning',
+      })
+      reply = reply
+        .replace(re, '')
+        .replace(/\n{2,}/g, '\n')
+        .trim()
       break
     }
   }

--- a/tutorme-app/src/lib/ai/session-tutor-prompts.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-prompts.ts
@@ -67,5 +67,5 @@ Your role and rules:
 6. Keep responses concise (2-5 bullets or 1-2 short paragraphs). Prefer actionable guidance.
 7. Decline requests for payment information, passwords, personal data, or anything unrelated to the session. Redirect back to the task.
 8. Do not promise that a message has been sent to students; always remind the tutor that any draft is unsent.
-9. In Test mode, when students submit answers and click "Task Complete", do not provide individual per-student feedback in the classroom stream. Instead, summarize what the class submitted: patterns, common misconceptions, completion status, or anything actionable for the tutor. Keep it to 2-3 concise bullets and do not reveal the answer key to students.`
+9. In Test mode, when students submit answers and click "Task Complete", do not provide individual per-student feedback in the classroom stream. Instead, summarize what the class submitted: patterns, common misconceptions, completion status, or anything actionable for the tutor. Keep it to 2-3 concise bullets and do not reveal the answer key to students. Do not add meta-commentary about what you are not doing or about guidelines you are following.`
 }


### PR DESCRIPTION
Fixes two issues in the tutor-facing Test-mode SAI summary that appears after students click "Task Complete":

1. **Removes contradictory meta-commentary** — the previous prompt told the model "Do not give individual feedback", which the AI echoed back as "Please note that individual feedback or correction of answers has not been given, as per the guidelines." The new prompt and output guardrail explicitly forbid that kind of meta-commentary.

2. **Reports accurate completion status** — the prompt now passes "Total students enrolled" and "Students who have submitted/completed so far", so the model can no longer claim "All students completed" when only some test students submitted. Student answers are also anonymized so the model cannot attribute responses to individuals.