### PR TITLE
feat(live-classroom): apply Test mode chat design to live chat tasks

### DIFF
--- a/tutorme-app/src/app/[locale]/student/feedback/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/feedback/page.tsx
@@ -31,6 +31,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { useSocket } from '@/hooks/use-socket'
 import { toast } from 'sonner'
 import { cn, resolvePublicUrl } from '@/lib/utils'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import {
   MessageSquare,
   Send,
@@ -75,7 +76,11 @@ import type {
 } from '@/lib/socket'
 import { normalizeDmiQuestionType, DMI_QUESTION_TYPE_LABELS } from '@/lib/assessment/question-types'
 import { TaskAiHelper } from './TaskAiHelper'
-import { TaskChatPanel } from './TaskChatPanel'
+import {
+  TestTaskChat,
+  type TestTaskChatState,
+  type TestTaskChatMsg,
+} from '@/app/[locale]/tutor/dashboard/components/TestTaskChat'
 import { TaskDocumentCard } from '@/components/task/TaskDocumentCard'
 
 type WhiteboardPages = NonNullable<ComponentProps<typeof EnhancedWhiteboard>['pages']>
@@ -942,6 +947,9 @@ function StudentFeedbackContent() {
   const [chatInput, setChatInput] = useState('')
   const [viewerZoom, setViewerZoom] = useState(1)
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
+  // Restored state + tutor messages for the live chat-task flow (mirrors Test mode).
+  const [taskChatInitial, setTaskChatInitial] = useState<TestTaskChatState | undefined>(undefined)
+  const [taskChatIncoming, setTaskChatIncoming] = useState<TestTaskChatMsg[]>([])
   const [sessionContext, setSessionContext] = useState<{
     topic: string | null
     objectives: string[] | null
@@ -1204,6 +1212,8 @@ function StudentFeedbackContent() {
     setTutorBoardPages(createDefaultWhiteboardPages())
     setTutorBoardPageIndex(0)
     setChatMessages([])
+    setTaskChatInitial(undefined)
+    setTaskChatIncoming([])
   }, [selectedSessionId])
 
   // Refs to track notification IDs for tasks/homework so we can mark them as read
@@ -1669,6 +1679,81 @@ function StudentFeedbackContent() {
     !!activeTask &&
     activeTask.source === 'task' &&
     !(Array.isArray(activeTask.dmiItems) && activeTask.dmiItems.length > 0)
+
+  // Restore a prior chat-task submission so a returning student sees their answers,
+  // the AI feedback, and any follow-ups — then they can continue asking questions.
+  useEffect(() => {
+    if (!activeTaskId || !isChatTask) {
+      setTaskChatInitial(undefined)
+      return
+    }
+    let active = true
+    fetch(`/api/student/assignments/${activeTaskId}`, { credentials: 'include' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!active) return
+        if (data?.alreadySubmitted) {
+          const answersObj =
+            data.existingAnswers && typeof data.existingAnswers === 'object'
+              ? (data.existingAnswers as Record<string, string>)
+              : {}
+          const answers = Object.keys(answersObj)
+            .sort((a, b) => Number(a) - Number(b))
+            .map(k => String(answersObj[k]))
+          const aiItems: Array<{ explanation?: string }> = data.existingAiFeedback?.items ?? []
+          const followUps: Array<{ question?: string; answer?: string }> = Array.isArray(
+            data.existingFollowUps
+          )
+            ? data.existingFollowUps
+            : []
+          const restored: TestTaskChatMsg[] = []
+          answers.forEach(a =>
+            restored.push({ role: 'student', content: a, timestamp: Date.now() })
+          )
+          aiItems.forEach((it, i) =>
+            restored.push({
+              role: 'ai',
+              content: it.explanation ?? '',
+              re: answers[i],
+              timestamp: Date.now(),
+            })
+          )
+          followUps.forEach(f => {
+            if (f.question)
+              restored.push({ role: 'student', content: f.question, timestamp: Date.now() })
+            if (f.answer) restored.push({ role: 'ai', content: f.answer, timestamp: Date.now() })
+          })
+          setTaskChatInitial({ messages: restored, draft: '', completed: restored.length > 0 })
+        } else {
+          setTaskChatInitial({ messages: [], draft: '', completed: false })
+        }
+      })
+      .catch(() => {
+        if (active) setTaskChatInitial({ messages: [], draft: '', completed: false })
+      })
+    return () => {
+      active = false
+    }
+  }, [activeTaskId, isChatTask])
+
+  // Listen for tutor task-chat messages and inject them into the student's chat.
+  useEffect(() => {
+    if (!socket || !activeTaskId) return
+    const handleTaskChatMessage = (msg: TestTaskChatMsg & { taskId?: string }) => {
+      if (msg.taskId && msg.taskId !== activeTaskId) return
+      setTaskChatIncoming(prev => [...prev, msg])
+    }
+    socket.on('task:chat_message', handleTaskChatMessage)
+    return () => {
+      socket.off('task:chat_message', handleTaskChatMessage)
+    }
+  }, [socket, activeTaskId])
+
+  // Clear cross-task message relay when the active chat task changes.
+  useEffect(() => {
+    setTaskChatIncoming([])
+  }, [activeTaskId])
+
   const currentSession = sessions.find(s => s.id === selectedSessionId) || null
   const isScheduled = currentSession?.status === 'scheduled'
   const isPassedSession =
@@ -2044,15 +2129,36 @@ function StudentFeedbackContent() {
                             PCI, then they can ask about what they got wrong. */}
                         {isChatTask && activeTaskId && (
                           <div className="mt-2 h-[78vh] max-h-[calc(100vh-160px)] min-h-[420px]">
-                            <TaskChatPanel
-                              taskId={activeTaskId}
-                              taskTitle={activeTask.title}
+                            <TestTaskChat
+                              key={activeTaskId}
+                              mode="test-student"
+                              questionText={`${activeTask.title}\n\n${activeTask.content}`}
                               sourceDocument={activeTask.sourceDocument}
-                              onCompleted={answers => {
-                                // Broadcast the live "completed" tick to the tutor.
-                                // aiHandled=true → the server only marks completion
-                                // and does NOT re-write the DB (the task-chat route
-                                // already persisted the answers + AI responses).
+                              initialState={taskChatInitial}
+                              incomingMessages={taskChatIncoming}
+                              studentAvatarUrl={session?.user?.image}
+                              onGrade={body =>
+                                fetchWithCsrf(
+                                  `/api/student/assignments/${activeTaskId}/task-chat`,
+                                  {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify(body),
+                                  }
+                                )
+                              }
+                              onBroadcast={msg => {
+                                if (!socket || !selectedSessionId) return
+                                socket.emit('task:chat_message', {
+                                  roomId: selectedSessionId,
+                                  taskId: activeTaskId,
+                                  role: 'student',
+                                  content: msg.content,
+                                  name: session?.user?.name || 'Student',
+                                  timestamp: Date.now(),
+                                })
+                              }}
+                              onComplete={answers => {
                                 if (!socket || !selectedSessionId || !activeTaskId) return
                                 const record: Record<string, string> = {}
                                 answers.forEach((a, i) => {
@@ -2109,7 +2215,7 @@ function StudentFeedbackContent() {
                 </div>
 
                 {/* Input row — the tutor-chat + socket "Task Complete". Hidden for
-                    chat tasks, which use the in-viewer TaskChatPanel instead. */}
+                    chat tasks, which use the in-viewer TestTaskChat instead. */}
                 {!isChatTask && (
                   <div className="mt-3 flex items-center gap-3">
                     <div className="relative flex-1">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -226,6 +226,7 @@ import { PCI_SPEC_FIELDS } from '@/lib/assessment/pci-spec'
 import { PciQuestionnaire } from './PciQuestionnaire'
 import { PciSpecSoFar } from './PciSpecSoFar'
 import { TestTaskChat, type TestTaskChatState, type TestTaskChatMsg } from './TestTaskChat'
+import type { TaskChatMessagePayload } from '@/lib/socket'
 import { splitDocIntoSections } from '@/lib/documents/split-sections'
 import { assessmentDmiReadiness } from '@/lib/assessment/dmi-readiness'
 import { Separator } from '@/components/ui/separator'
@@ -1470,6 +1471,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       }
     }, [classroomMessages])
 
+    // Shared state for the LIVE classroom chat stream. Keyed by live task id.
+    const [liveClassroomMessages, setLiveClassroomMessages] = useState<
+      Record<string, TestTaskChatMsg[]>
+    >({})
+
+    // Append a tutor-facing SAI message to the live classroom chat stream.
+    const appendLiveClassroomAiMessage = (taskId: string, content: string, name = 'SAI') => {
+      setLiveClassroomMessages(prev => ({
+        ...prev,
+        [taskId]: [
+          ...(prev[taskId] ?? []),
+          { role: 'ai' as const, name, content, timestamp: Date.now() },
+        ],
+      }))
+    }
+
     // Accumulator for test-student answers per extension, used to build a class-level
     // SAI summary when a student clicks "Task Complete".
     const classroomStudentAnswers = useRef<
@@ -1606,6 +1623,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
       courseName,
       classroomMessages,
     ])
+
     // Test-tab-only DEBUG control: grade against all available bases (default) or
     // isolate one (PCI / rubric / model answer) to see its effect alone. Never
     // affects student/production grading — only the tutor's test-grade requests.
@@ -1953,6 +1971,126 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     // Track currently loaded item for saving back
     const [loadedTaskId, setLoadedTaskId] = useState<string | null>(null)
     const [loadedAssessmentId, setLoadedAssessmentId] = useState<string | null>(null)
+
+    // Build a class-level SAI summary for a live chat task after a student submits.
+    const summarizeLiveClassroom = useCallback(
+      async (taskId: string, studentName: string, answers: string[]) => {
+        const task = insightsProps?.liveTasks?.find(t => t.id === taskId)
+        if (!task) return
+        const enrolledStudents = insightsProps?.students?.length ?? 0
+        const summaryRequest = [
+          'Summarize the following student responses for the tutor.',
+          'Do not give individual feedback or correct answers.',
+          'Describe class-level patterns, common misconceptions, or completion status in 2-3 concise bullets.',
+          '',
+          `Student: ${studentName}`,
+          ...answers.map(a => `- ${a}`),
+        ].join('\n')
+        try {
+          const res = await fetchWithCsrf('/api/ai/session-tutor', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              message: summaryRequest,
+              context: {
+                taskId,
+                taskName: task.title?.trim() || 'Untitled task',
+                courseName,
+                taskContent: task.content || '',
+                taskPci: task.pci,
+                taskPciSpec: task.pciSpec,
+                enrolledStudents,
+                currentDate: new Date().toLocaleDateString(),
+                sessionNumber: 1,
+                attendance: enrolledStudents > 0 ? '100%' : '0%',
+              },
+              history: [],
+            }),
+          })
+          const data = await res.json().catch(() => ({}))
+          if (!res.ok) throw new Error(data?.error || 'Failed to summarize')
+          appendLiveClassroomAiMessage(
+            taskId,
+            data.response || 'Students submitted their answers.',
+            'SAI'
+          )
+        } catch (e) {
+          console.warn('[summarizeLiveClassroom] summary failed:', e)
+          appendLiveClassroomAiMessage(
+            taskId,
+            `${studentName || 'A student'} submitted ${answers.length} answer(s).`,
+            'SAI'
+          )
+        }
+      },
+      [courseName, insightsProps?.liveTasks, insightsProps?.students]
+    )
+
+    // Seed the live classroom "Session ready." greeting when a chat task is selected.
+    useEffect(() => {
+      if (mainTab !== 'live' || testPciSource !== 'task') return
+      const task = insightsProps?.liveTasks?.find(t => t.id === loadedTaskId)
+      if (!task) return
+      if (task.source !== 'task' || (Array.isArray(task.dmiItems) && task.dmiItems.length > 0))
+        return
+      if (
+        liveClassroomMessages[task.id]?.some(
+          m => m.role === 'ai' && m.content.startsWith('Session ready.')
+        )
+      )
+        return
+      const enrolledStudents = insightsProps?.students?.length ?? 0
+      const summary = [
+        'Session ready.',
+        '',
+        `Task: ${task.title?.trim() || 'Untitled task'}`,
+        `Course: ${courseName?.trim() || 'Live Course'}`,
+        `Enrolled Students: ${enrolledStudents}`,
+        `Date: ${new Date().toLocaleDateString()}`,
+        'Session Number: 1',
+        `Attendance: ${enrolledStudents > 0 ? '100%' : '0%'}`,
+      ].join('\n')
+      appendLiveClassroomAiMessage(task.id, summary, 'SAI')
+    }, [
+      mainTab,
+      testPciSource,
+      loadedTaskId,
+      insightsProps?.liveTasks,
+      insightsProps?.students,
+      courseName,
+      liveClassroomMessages,
+    ])
+
+    // Listen for live task-chat messages and completions, and update the tutor
+    // classroom stream accordingly.
+    useEffect(() => {
+      if (!insightsProps?.socket || !insightsProps?.sessionId || !loadedTaskId) return
+      const socket = insightsProps.socket
+      const handleTaskChatMessage = (msg: TaskChatMessagePayload) => {
+        if (msg.taskId !== loadedTaskId) return
+        setLiveClassroomMessages(prev => ({
+          ...prev,
+          [msg.taskId]: [...(prev[msg.taskId] ?? []), msg],
+        }))
+      }
+      const handleTaskCompleted = (payload: {
+        taskId: string
+        studentId: string
+        studentName?: string
+        answers?: Record<string, string>
+      }) => {
+        if (payload.taskId !== loadedTaskId) return
+        const answers = Object.values(payload.answers ?? {})
+        if (answers.length === 0) return
+        void summarizeLiveClassroom(payload.taskId, payload.studentName || 'A student', answers)
+      }
+      socket.on('task:chat_message', handleTaskChatMessage)
+      socket.on('task:completed', handleTaskCompleted)
+      return () => {
+        socket.off('task:chat_message', handleTaskChatMessage)
+        socket.off('task:completed', handleTaskCompleted)
+      }
+    }, [insightsProps?.socket, insightsProps?.sessionId, loadedTaskId, summarizeLiveClassroom])
 
     const canMirrorToStudents = !!(
       insightsProps?.sessionId &&
@@ -11198,6 +11336,68 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                             extensionId: extKey,
                                                             studentName: studentTabName,
                                                           })
+                                                  }
+                                                />
+                                              </div>
+                                            )
+                                          }
+
+                                          // Live classroom chat task: use the same TestTaskChat
+                                          // component as Test mode so the tutor sees identical
+                                          // document popup / avatars / SAI summary behavior.
+                                          const activeLiveChatTask =
+                                            insightsProps?.liveTasks?.find(
+                                              t => t.id === loadedTaskId
+                                            ) ?? null
+                                          if (
+                                            mainTab === 'live' &&
+                                            testPciSource === 'task' &&
+                                            tab.id === 'classroom' &&
+                                            activeLiveChatTask &&
+                                            activeLiveChatTask.source === 'task' &&
+                                            !(
+                                              Array.isArray(activeLiveChatTask.dmiItems) &&
+                                              activeLiveChatTask.dmiItems.length > 0
+                                            )
+                                          ) {
+                                            const taskId = activeLiveChatTask.id
+                                            return (
+                                              <div className="h-full min-h-0 w-full">
+                                                <TestTaskChat
+                                                  mode="classroom"
+                                                  pci={activeLiveChatTask.pci}
+                                                  pciSpec={activeLiveChatTask.pciSpec}
+                                                  questionText={`${activeLiveChatTask.title}\n\n${activeLiveChatTask.content}`}
+                                                  sourceDocument={activeLiveChatTask.sourceDocument}
+                                                  incomingMessages={liveClassroomMessages[taskId]}
+                                                  tutorAvatarUrl={tutorAvatarUrl}
+                                                  onBroadcast={msg => {
+                                                    if (
+                                                      !insightsProps?.socket ||
+                                                      !insightsProps?.sessionId
+                                                    )
+                                                      return
+                                                    insightsProps.socket.emit('task:chat_message', {
+                                                      roomId: insightsProps.sessionId,
+                                                      taskId,
+                                                      role: 'tutor',
+                                                      content: msg.content,
+                                                      name: 'Tutor',
+                                                      timestamp: Date.now(),
+                                                    })
+                                                  }}
+                                                  onTutorNote={note =>
+                                                    appendLiveClassroomAiMessage(
+                                                      taskId,
+                                                      note,
+                                                      'SAI'
+                                                    )
+                                                  }
+                                                  onReset={() =>
+                                                    setLiveClassroomMessages(prev => ({
+                                                      ...prev,
+                                                      [taskId]: [],
+                                                    }))
                                                   }
                                                 />
                                               </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -65,6 +65,7 @@ export function TestTaskChat({
   onAddAnswer,
   onAsk,
   onComplete,
+  onGrade,
 }: {
   pci?: string
   pciSpec?: unknown
@@ -93,6 +94,8 @@ export function TestTaskChat({
   onAsk?: (question: string) => void
   /** Called when the student clicks "Task complete" (Test mode only). */
   onComplete?: (answers: string[]) => void
+  /** Optional grading request handler. When provided, complete/ask POST through this instead of /api/tutor/test-grade. */
+  onGrade?: (body: Record<string, unknown>) => Promise<Response>
 }) {
   const [messages, setMessages] = useState<ChatMsg[]>(initialState?.messages ?? [])
   const [draft, setDraft] = useState(initialState?.draft ?? '')
@@ -151,12 +154,14 @@ export function TestTaskChat({
     (!sourceDocument?.mimeType && /\.pdf($|\?|#)/i.test(sourceDocument?.fileName || rawUrl))
   const isImage = !!sourceDocument?.mimeType?.startsWith('image/')
 
-  const post = (extra: Record<string, unknown>) =>
-    fetchWithCsrf('/api/tutor/test-grade', {
+  const post = (extra: Record<string, unknown>) => {
+    if (onGrade) return onGrade(extra)
+    return fetchWithCsrf('/api/tutor/test-grade', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ pci, pciSpec, questionText, ...extra }),
     })
+  }
 
   const addAnswer = () => {
     const a = draft.trim()
@@ -209,20 +214,22 @@ export function TestTaskChat({
       if (!res.ok) throw new Error(data?.error || 'Failed to grade')
       const responses: Array<{
         answer: string
-        studentFeedback: string | null
-        tutorNote: string | null
-        score: number | null
-        hasBasis: boolean
+        studentFeedback?: string | null
+        response?: string | null
+        tutorNote?: string | null
+        score?: number | null
+        hasBasis?: boolean
       }> = Array.isArray(data.responses) ? data.responses : []
       const aiMsgs: ChatMsg[] = []
       responses.forEach(r => {
         if (r.tutorNote) {
           onTutorNote?.(r.tutorNote)
         }
-        if (r.studentFeedback) {
+        const feedback = r.studentFeedback || r.response
+        if (feedback) {
           aiMsgs.push({
             role: 'tutor' as const,
-            content: r.studentFeedback,
+            content: feedback,
             re: r.answer,
             timestamp: Date.now(),
           })

--- a/tutorme-app/src/lib/socket-server-enhanced.ts
+++ b/tutorme-app/src/lib/socket-server-enhanced.ts
@@ -30,7 +30,7 @@ import { autoGradeDmi } from '@/lib/grading/auto-grade'
 import { normalizePciSpec } from '@/lib/assessment/pci-spec'
 import { initFeedbackHandlers, initPollHandlers } from './socket-server'
 import { activePolls, sessionPolls, cleanupStaleSocketState } from '@/lib/socket'
-import type { PollState } from '@/lib/socket'
+import type { PollState, TaskChatMessagePayload } from '@/lib/socket'
 import { socketAuthMiddleware } from './socket/socket-auth'
 import { notifyMany } from '@/lib/notifications/notify'
 import { refreshDocumentUrls } from '@/lib/storage/gcs'
@@ -888,6 +888,44 @@ export async function initEnhancedSocketServer(server: NetServer) {
             console.error('[chat_message] Failed to persist chat message:', err)
           })
       }
+    })
+
+    // Task-scoped chat messages (chat-task flow). Distinct from the general
+    // chat_message so a live task's answer/comment stream can be rendered inside
+    // TestTaskChat on both tutor and student sides without mixing with the
+    // general room chat.
+    socket.on('task:chat_message', (data: TaskChatMessagePayload & { roomId?: string }) => {
+      const { taskId, role, content } = data
+      if (!taskId || typeof taskId !== 'string') return
+      if (!content || typeof content !== 'string' || !content.trim()) return
+      if (role !== 'tutor' && role !== 'student') return
+
+      const targetRoomId = data.roomId || socket.data.roomId
+      if (!targetRoomId) return
+
+      const room = activeRooms.get(targetRoomId)
+      if (!room) return
+
+      const userId = socket.data.userId
+      if (!userId) return
+
+      const isTutor = room.tutorId === userId
+      const isStudent = room.students.has(userId)
+      if (!isTutor && !isStudent) return
+      if (role === 'tutor' && !isTutor) return
+      if (role === 'student' && !isStudent) return
+
+      const message: TaskChatMessagePayload = {
+        taskId,
+        role,
+        content: content.trim().slice(0, 3000),
+        name: data.name || (isTutor ? 'Tutor' : room.students.get(userId)?.name || 'Student'),
+        re: data.re,
+        timestamp: data.timestamp || Date.now(),
+        userId,
+      }
+
+      io.to(targetRoomId).emit('task:chat_message', message)
     })
 
     // --- Live poll (ephemeral, one active per room) ---

--- a/tutorme-app/src/lib/socket/socket-types.ts
+++ b/tutorme-app/src/lib/socket/socket-types.ts
@@ -140,6 +140,16 @@ export interface LiveTask {
   completedBy?: string[]
 }
 
+export interface TaskChatMessagePayload {
+  taskId: string
+  role: 'tutor' | 'student'
+  content: string
+  name?: string
+  re?: string
+  timestamp?: number
+  userId?: string
+}
+
 export interface ClassRoom {
   id: string
   tutorId: string


### PR DESCRIPTION
## Summary
Mirrors the Test-mode chat UX in the live classroom for chat tasks.

## Changes
- Generalize `TestTaskChat` with an optional `onGrade` prop and accept both `studentFeedback` (test-grade) and `response` (task-chat) answer shapes.
- Add `TaskChatMessagePayload` type and a `task:chat_message` socket handler that validates role/room membership and broadcasts to the room.
- Replace `TaskChatPanel` with `TestTaskChat` in the live student classroom, restore prior submissions, emit student answers/completions, and listen for tutor messages.
- Render `TestTaskChat` in the live tutor classroom for chat tasks, seed the "Session ready." greeting, listen for `task:chat_message` and `task:completed`, and generate class-level SAI summaries via `/api/ai/session-tutor`.

## Verification
- `npm run typecheck` passes
- `npm run format:check` passes
- `npm run lint:ci` passes
- `npm run test` passes (713 tests in 114 files)
