### PR TITLE
feat(test-mode): unify Test and Live LLM grading, DMI auto-grade, and…

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/CourseBuilder.tsx
@@ -217,6 +217,7 @@ import {
   mergeLoadedWithPendingEdits,
 } from '@/lib/courses/course-builder-guards'
 import { resolvePciComposition, inferDocumentKindFromProvenance } from '@/lib/ai/guardrails'
+import { buildClassroomSummaryRequest } from '@/lib/ai/session-tutor-summary'
 import { useMarkingScheme } from './hooks/use-marking-scheme'
 import { useDmiEditor } from './hooks/use-dmi-editor'
 import { usePci } from './hooks/use-pci'
@@ -229,6 +230,7 @@ import { TestTaskChat, type TestTaskChatState, type TestTaskChatMsg } from './Te
 import type { TaskChatMessagePayload } from '@/lib/socket'
 import { splitDocIntoSections } from '@/lib/documents/split-sections'
 import { assessmentDmiReadiness } from '@/lib/assessment/dmi-readiness'
+import { type AutoGradeResult } from '@/lib/grading/auto-grade'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { SlidingPillTabsList } from '@/components/sliding-pill-tabs'
@@ -1554,21 +1556,22 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         classroomStudentAnswers.current[key] = bucket
 
         const totalStudents = testPciTabs.filter(t => t.id.startsWith('student')).length || 2
-        const completedCount = bucket.length
-        const allAnswers = bucket.flatMap(s => s.answers)
-        const summaryRequest = [
-          'The following student answers have been submitted for this task.',
-          `Total students enrolled in this session: ${totalStudents}.`,
-          `Students who have submitted/completed so far: ${completedCount}.`,
-          'Provide 2-3 concise bullets summarizing class-level patterns, common misconceptions, or completion status only.',
-          'Do NOT name, number, or describe individual students.',
-          'Do NOT evaluate, judge, or comment on any individual answer.',
-          'Do NOT add meta-commentary about what you are not doing or what guidelines you are following.',
-          'Do NOT say all students completed unless the submitted count equals the enrolled count.',
-          '',
-          'Submitted answers:',
-          ...allAnswers.map(a => `- ${a}`),
-        ].join('\n')
+        const { message: summaryRequest, context: summaryContext } = buildClassroomSummaryRequest(
+          bucket,
+          {
+            taskId: loadedTaskId || undefined,
+            taskName: ext ? ext.name : taskBuilder.title,
+            courseName,
+            taskContent: ext ? ext.content : taskBuilder.taskContent,
+            taskPci: ext ? ext.pci : taskBuilder.taskPci,
+            taskPciSpec: ext ? undefined : taskBuilder.pciSpec,
+            extensionName: ext?.name ?? null,
+            enrolledStudents: totalStudents,
+            currentDate: new Date().toLocaleDateString(),
+            sessionNumber: 1,
+            attendance: totalStudents > 0 ? '100%' : '0%',
+          }
+        )
 
         try {
           const res = await fetchWithCsrf('/api/ai/session-tutor', {
@@ -1576,15 +1579,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               message: summaryRequest,
-              context: {
-                taskId: loadedTaskId || undefined,
-                taskName: ext ? ext.name : taskBuilder.title,
-                courseName,
-                taskContent: ext ? ext.content : taskBuilder.taskContent,
-                taskPci: ext ? ext.pci : taskBuilder.taskPci,
-                taskPciSpec: ext ? undefined : taskBuilder.pciSpec,
-                extensionName: ext?.name ?? null,
-              },
+              context: summaryContext,
               history: [],
             }),
           })
@@ -1640,6 +1635,10 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
     const [testDmiAnswers, setTestDmiAnswers] = useState<Record<string, string>>({})
     const [testDmiResults, setTestDmiResults] = useState<
       Record<string, { loading?: boolean; score?: number | null; feedback?: string }>
+    >({})
+    // Deterministic live-style auto-grade preview for DMI answers.
+    const [testDmiAutoResults, setTestDmiAutoResults] = useState<
+      Record<string, AutoGradeResult & { loading?: boolean }>
     >({})
     // How the last-generated DMI was classified (per source). Lets the tutor
     // override a confidently-wrong call — e.g. numbered study notes read as a
@@ -1984,32 +1983,29 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
         const task = insightsProps?.liveTasks?.find(t => t.id === taskId)
         if (!task) return
         const enrolledStudents = insightsProps?.students?.length ?? 0
-        const summaryRequest = [
-          'Summarize the following student responses for the tutor.',
-          'Do not give individual feedback or correct answers.',
-          'Describe class-level patterns, common misconceptions, or completion status in 2-3 concise bullets.',
-          '',
-          `Student: ${studentName}`,
-          ...answers.map(a => `- ${a}`),
-        ].join('\n')
+        const { message: summaryRequest, context: summaryContext } = buildClassroomSummaryRequest(
+          [{ studentName, answers }],
+          {
+            taskId,
+            taskName: task.title?.trim() || 'Untitled task',
+            courseName,
+            taskContent: task.content || '',
+            taskPci: task.pci,
+            taskPciSpec: task.pciSpec,
+            extensionName: null,
+            enrolledStudents,
+            currentDate: new Date().toLocaleDateString(),
+            sessionNumber: 1,
+            attendance: enrolledStudents > 0 ? '100%' : '0%',
+          }
+        )
         try {
           const res = await fetchWithCsrf('/api/ai/session-tutor', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               message: summaryRequest,
-              context: {
-                taskId,
-                taskName: task.title?.trim() || 'Untitled task',
-                courseName,
-                taskContent: task.content || '',
-                taskPci: task.pci,
-                taskPciSpec: task.pciSpec,
-                enrolledStudents,
-                currentDate: new Date().toLocaleDateString(),
-                sessionNumber: 1,
-                attendance: enrolledStudents > 0 ? '100%' : '0%',
-              },
+              context: summaryContext,
               history: [],
             }),
           })
@@ -3454,6 +3450,63 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
           ...prev,
           [key]: { feedback: e instanceof Error ? e.message : 'Failed to grade' },
         }))
+      }
+    }
+
+    // Live-style deterministic auto-grade preview for a single DMI answer.
+    // This matches the socket `task:complete` grading path used in live sessions.
+    const autoGradeTestDmiItem = async (item: DMIQuestion) => {
+      const key = `${testPciActiveTab}:${item.id}`
+      const answer = (testDmiAnswers[key] || '').trim()
+      if (!answer) return
+      setTestDmiAutoResults(prev => ({
+        ...prev,
+        [key]: {
+          loading: true,
+          score: null,
+          questionResults: null,
+          gradable: 0,
+          correct: 0,
+          needsReview: 0,
+          pointsPossible: 0,
+          pointsEarned: 0,
+        },
+      }))
+      try {
+        const res = await fetchWithCsrf('/api/tutor/auto-grade-preview', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: [
+              {
+                id: String(item.id),
+                answer: item.answer || '',
+                marks: item.marks,
+                questionText: item.questionText,
+              },
+            ],
+            answers: { [String(item.id)]: answer },
+          }),
+        })
+        const data = (await res.json().catch(() => ({}))) as AutoGradeResult
+        if (!res.ok)
+          throw new Error((data as unknown as { error?: string }).error || 'Failed to auto-grade')
+        setTestDmiAutoResults(prev => ({ ...prev, [key]: { ...data, loading: false } }))
+      } catch (e) {
+        setTestDmiAutoResults(prev => ({
+          ...prev,
+          [key]: {
+            loading: false,
+            score: null,
+            questionResults: null,
+            gradable: 0,
+            correct: 0,
+            needsReview: 0,
+            pointsPossible: 0,
+            pointsEarned: 0,
+          },
+        }))
+        toast.error(e instanceof Error ? e.message : 'Failed to auto-grade')
       }
     }
 
@@ -11172,6 +11225,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             return (
                                               <div className="h-full min-h-0 w-full">
                                                 <TestTaskChat
+                                                  taskId={loadedTaskId || undefined}
                                                   pci={
                                                     (previewExt
                                                       ? previewExt.pci
@@ -11370,6 +11424,7 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                             return (
                                               <div className="h-full min-h-0 w-full">
                                                 <TestTaskChat
+                                                  taskId={taskId}
                                                   mode="classroom"
                                                   pci={activeLiveChatTask.pci}
                                                   pciSpec={activeLiveChatTask.pciSpec}
@@ -11613,11 +11668,15 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                           </p>
                                                         )}
                                                         {mainTab === 'test-pci' &&
-                                                          testPciSource === 'assessment' &&
                                                           canEdit &&
                                                           (() => {
                                                             const ak = `${testPciActiveTab}:${item.id}`
-                                                            const result = testDmiResults[ak]
+                                                            const answer = (
+                                                              testDmiAnswers[ak] || ''
+                                                            ).trim()
+                                                            const autoResult =
+                                                              testDmiAutoResults[ak]
+                                                            const llmResult = testDmiResults[ak]
                                                             return (
                                                               <div className="mt-2 border-t border-gray-200 pt-2">
                                                                 <textarea
@@ -11633,39 +11692,105 @@ export const CourseBuilder = forwardRef<CourseBuilderRef, CourseBuilderProps>(
                                                                   aria-label={`Test answer for question ${item.questionLabel ?? item.questionNumber}`}
                                                                   className="w-full resize-none rounded-md border border-gray-300 px-2 py-1.5 text-sm text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-violet-400"
                                                                 />
-                                                                <div className="mt-1 flex items-center gap-2">
+                                                                <div className="mt-1 flex flex-wrap items-center gap-2">
                                                                   <button
                                                                     type="button"
                                                                     disabled={
-                                                                      result?.loading ||
-                                                                      !(
-                                                                        testDmiAnswers[ak] || ''
-                                                                      ).trim()
+                                                                      autoResult?.loading || !answer
                                                                     }
                                                                     onClick={() =>
-                                                                      gradeTestDmiItem(item)
+                                                                      autoGradeTestDmiItem(item)
                                                                     }
-                                                                    aria-label={`Grade test answer for question ${item.questionLabel ?? item.questionNumber}`}
-                                                                    className="rounded-md bg-violet-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-violet-700 disabled:opacity-50"
+                                                                    aria-label={`Auto-grade test answer for question ${item.questionLabel ?? item.questionNumber}`}
+                                                                    className="rounded-md bg-emerald-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
                                                                   >
-                                                                    {result?.loading
-                                                                      ? 'Grading…'
-                                                                      : 'Grade'}
+                                                                    {autoResult?.loading
+                                                                      ? 'Auto-grading…'
+                                                                      : 'Auto-grade'}
                                                                   </button>
-                                                                  {result &&
-                                                                    !result.loading &&
-                                                                    typeof result.score ===
-                                                                      'number' && (
-                                                                      <span className="text-xs font-semibold text-violet-700">
-                                                                        Score: {result.score}%
+                                                                  {testPciSource ===
+                                                                    'assessment' && (
+                                                                    <button
+                                                                      type="button"
+                                                                      disabled={
+                                                                        llmResult?.loading ||
+                                                                        !answer
+                                                                      }
+                                                                      onClick={() =>
+                                                                        gradeTestDmiItem(item)
+                                                                      }
+                                                                      aria-label={`Debug LLM grade test answer for question ${item.questionLabel ?? item.questionNumber}`}
+                                                                      className="rounded-md bg-slate-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-slate-700 disabled:opacity-50"
+                                                                    >
+                                                                      {llmResult?.loading
+                                                                        ? 'Grading…'
+                                                                        : 'Debug LLM grade'}
+                                                                    </button>
+                                                                  )}
+                                                                  {autoResult &&
+                                                                    !autoResult.loading &&
+                                                                    autoResult.score !== null && (
+                                                                      <span className="text-xs font-semibold text-emerald-700">
+                                                                        Score: {autoResult.score}%
                                                                       </span>
                                                                     )}
                                                                 </div>
-                                                                {result &&
-                                                                  !result.loading &&
-                                                                  result.feedback && (
+                                                                {autoResult &&
+                                                                  !autoResult.loading &&
+                                                                  Array.isArray(
+                                                                    autoResult.questionResults
+                                                                  ) &&
+                                                                  autoResult.questionResults
+                                                                    .length > 0 && (
+                                                                    <div className="mt-1 space-y-1">
+                                                                      {autoResult.questionResults.map(
+                                                                        r => (
+                                                                          <div
+                                                                            key={r.questionId}
+                                                                            className="flex items-center gap-2 text-xs"
+                                                                          >
+                                                                            {r.correct ? (
+                                                                              <span className="font-medium text-emerald-700">
+                                                                                Correct
+                                                                              </span>
+                                                                            ) : r.needsReview ? (
+                                                                              <span className="font-medium text-amber-700">
+                                                                                Needs review
+                                                                              </span>
+                                                                            ) : (
+                                                                              <span className="font-medium text-red-700">
+                                                                                Incorrect
+                                                                              </span>
+                                                                            )}
+                                                                            {typeof r.pointsEarned ===
+                                                                              'number' &&
+                                                                              typeof r.pointsMax ===
+                                                                                'number' &&
+                                                                              r.pointsMax > 0 && (
+                                                                                <span className="text-slate-600">
+                                                                                  {r.pointsEarned}/
+                                                                                  {r.pointsMax}
+                                                                                </span>
+                                                                              )}
+                                                                          </div>
+                                                                        )
+                                                                      )}
+                                                                    </div>
+                                                                  )}
+                                                                {llmResult &&
+                                                                  !llmResult.loading &&
+                                                                  typeof llmResult.score ===
+                                                                    'number' && (
+                                                                    <span className="mt-1 block text-xs font-semibold text-violet-700">
+                                                                      Debug LLM score:{' '}
+                                                                      {llmResult.score}%
+                                                                    </span>
+                                                                  )}
+                                                                {llmResult &&
+                                                                  !llmResult.loading &&
+                                                                  llmResult.feedback && (
                                                                     <p className="mt-1 whitespace-pre-wrap rounded bg-violet-50 px-2 py-1 text-xs text-violet-900">
-                                                                      {result.feedback}
+                                                                      {llmResult.feedback}
                                                                     </p>
                                                                   )}
                                                               </div>

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/TestTaskChat.tsx
@@ -66,6 +66,7 @@ export function TestTaskChat({
   onAsk,
   onComplete,
   onGrade,
+  taskId,
 }: {
   pci?: string
   pciSpec?: unknown
@@ -94,8 +95,10 @@ export function TestTaskChat({
   onAsk?: (question: string) => void
   /** Called when the student clicks "Task complete" (Test mode only). */
   onComplete?: (answers: string[]) => void
-  /** Optional grading request handler. When provided, complete/ask POST through this instead of /api/tutor/test-grade. */
+  /** Optional grading request handler. When provided, complete/ask POST through this instead of /api/tutor/task-chat-preview. */
   onGrade?: (body: Record<string, unknown>) => Promise<Response>
+  /** Task id used by the default preview endpoint. Required when onGrade is not provided. */
+  taskId?: string
 }) {
   const [messages, setMessages] = useState<ChatMsg[]>(initialState?.messages ?? [])
   const [draft, setDraft] = useState(initialState?.draft ?? '')
@@ -156,10 +159,10 @@ export function TestTaskChat({
 
   const post = (extra: Record<string, unknown>) => {
     if (onGrade) return onGrade(extra)
-    return fetchWithCsrf('/api/tutor/test-grade', {
+    return fetchWithCsrf('/api/tutor/task-chat-preview', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ pci, pciSpec, questionText, ...extra }),
+      body: JSON.stringify({ taskId, pci, pciSpec, questionText, ...extra }),
     })
   }
 

--- a/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
+++ b/tutorme-app/src/app/api/student/assignments/[taskId]/task-chat/route.ts
@@ -28,15 +28,12 @@ import {
   sessionParticipant,
   liveSession,
 } from '@/lib/db/schema'
-import { ASK_SYSTEM_PROMPT } from '@/lib/ai/task-chat-prompts'
-import { generateWithKimi } from '@/lib/ai/kimi'
-import { runTaskGuardrails } from '@/lib/ai/guardrails'
-import { gradeAnswerAgainstBasis, renderGradingSpec } from '@/lib/grading/pci-grader'
-
-const MAX_ANSWERS = 12
-const MAX_ANSWER_LEN = 3000
-const MAX_QUESTION = 800
-const MAX_HISTORY_TURNS = 6
+import {
+  gradeTaskChatComplete,
+  gradeTaskChatAsk,
+  sanitizeTaskChatAnswers,
+  type TaskChatTask,
+} from '@/lib/grading/task-chat-grader'
 
 interface HistoryTurn {
   role: 'user' | 'assistant'
@@ -135,63 +132,23 @@ export async function POST(
       history?: HistoryTurn[]
     }
 
-    const specText = renderGradingSpec(task.pciSpec)
-    const taskContext = `${task.title}\n\n${task.content}`.trim().slice(0, 4000)
+    const taskChatTask: TaskChatTask = {
+      taskId,
+      title: task.title,
+      content: task.content,
+      pci: task.pci,
+      pciSpec: task.pciSpec,
+    }
 
     // ─── COMPLETE: respond to each chatted answer, grounded in the PCI ──────────
     if (Array.isArray(body.answers) && body.answers.length > 0) {
-      const answers = body.answers
-        .map(a =>
-          String(a ?? '')
-            .trim()
-            .slice(0, MAX_ANSWER_LEN)
-        )
-        .filter(Boolean)
-        .slice(0, MAX_ANSWERS)
+      const answers = sanitizeTaskChatAnswers(body.answers)
       if (answers.length === 0) {
         return NextResponse.json({ error: 'No answers to respond to' }, { status: 400 })
       }
 
-      const responses: { answer: string; response: string; score: number | null }[] = []
-      let anyBasis = false
-      let anyUnavailable = false
-      for (const answer of answers) {
-        const result = await gradeAnswerAgainstBasis({
-          pci: task.pci,
-          specText,
-          questionText: taskContext,
-          studentAnswer: answer,
-        })
-        anyBasis = anyBasis || result.hasBasis
-        anyUnavailable = anyUnavailable || result.aiUnavailable
-        const response = !result.hasBasis
-          ? "Your answer's recorded — your tutor hasn't set a marking policy for this task yet, so I can't check it here."
-          : result.aiUnavailable
-            ? "Your answer's recorded, but the assistant is unavailable right now — try asking again in a moment."
-            : result.feedback || 'Thanks — noted.'
-        responses.push({ answer, response, score: result.score })
-      }
+      const result = await gradeTaskChatComplete(taskChatTask, answers)
 
-      const graded = responses.map(r => r.score).filter((s): s is number => typeof s === 'number')
-      const avgScore = graded.length
-        ? Math.round(graded.reduce((a, b) => a + b, 0) / graded.length)
-        : null
-
-      const aiFeedback = {
-        generatedAt: new Date().toISOString(),
-        provider: 'kimi',
-        items: responses.map((r, i) => ({
-          questionId: String(i + 1),
-          explanation: r.response,
-        })),
-      }
-      const answersRecord: Record<string, string> = {}
-      answers.forEach((a, i) => {
-        answersRecord[String(i + 1)] = a
-      })
-
-      // Persist the completed attempt (idempotent on re-complete) — unless this is
-      // the owner tutor's stateless preview.
       if (persist) {
         await drizzleDb
           .insert(taskSubmission)
@@ -199,23 +156,23 @@ export async function POST(
             submissionId: randomUUID(),
             taskId,
             studentId,
-            answers: answersRecord,
+            answers: result.answersRecord,
             timeSpent: 0,
             attempts: 1,
-            score: avgScore,
+            score: result.avgScore,
             maxScore: 100,
             status: 'submitted',
             tutorApproved: false,
-            aiFeedback,
+            aiFeedback: result.aiFeedback,
             submittedAt: new Date(),
           })
           .onConflictDoUpdate({
             target: [taskSubmission.taskId, taskSubmission.studentId],
             set: {
-              answers: answersRecord,
-              score: avgScore,
+              answers: result.answersRecord,
+              score: result.avgScore,
               status: 'submitted',
-              aiFeedback,
+              aiFeedback: result.aiFeedback,
               submittedAt: new Date(),
             },
           })
@@ -223,16 +180,14 @@ export async function POST(
 
       return NextResponse.json({
         mode: 'complete',
-        responses,
-        hasBasis: anyBasis,
-        aiUnavailable: anyUnavailable && !anyBasis,
+        responses: result.responses,
+        hasBasis: result.hasBasis,
+        aiUnavailable: result.aiUnavailable,
       })
     }
 
     // ─── ASK: follow-up about the task / their answers, explained per PCI ───────
-    const question = String(body.question ?? '')
-      .trim()
-      .slice(0, MAX_QUESTION)
+    const question = String(body.question ?? '').trim()
     if (!question) {
       return NextResponse.json({ error: 'answers or question is required' }, { status: 400 })
     }
@@ -244,59 +199,12 @@ export async function POST(
             .filter(Boolean)
         : []
 
-    const pci = (task.pci ?? '').trim()
-    if (!pci && !specText) {
-      return NextResponse.json({
-        mode: 'ask',
-        answer:
-          "Your tutor hasn't set a marking policy for this task, so I can't explain it reliably — please ask your tutor directly.",
-      })
-    }
-
-    const history = Array.isArray(body.history) ? body.history.slice(-MAX_HISTORY_TURNS) : []
-    const historyBlock = history.length
-      ? `Conversation so far:\n${history
-          .map(
-            t =>
-              `${t.role === 'assistant' ? 'Tutor' : 'Student'}: ${String(t.content).slice(0, 800)}`
-          )
-          .join('\n')}\n\n`
-      : ''
-    const answersBlock = priorAnswers.length
-      ? `The student's answers to this task:\n${priorAnswers.map((a, i) => `${i + 1}. ${a.slice(0, 800)}`).join('\n')}\n\n`
-      : ''
-    const specBlock = specText ? `Structured marking guidance (PCI):\n${specText}\n\n` : ''
-    const prompt = `Tutor's marking policy (PCI):\n${pci.slice(0, 2000)}\n\n${specBlock}Task:\n${taskContext}\n\n${answersBlock}${historyBlock}The student's follow-up:\n${question}`
-
-    let answer: string
-    try {
-      answer = await generateWithKimi(prompt, {
-        systemPrompt: ASK_SYSTEM_PROMPT,
-        temperature: 0.4,
-        maxTokens: 400,
-        timeoutMs: 30000,
-      })
-    } catch (aiErr) {
-      console.warn('[task-chat] Kimi call failed:', aiErr)
-      return NextResponse.json(
-        { error: 'The tutor assistant is unavailable right now. Please try again.' },
-        { status: 503 }
-      )
-    }
-    answer = answer.trim().slice(0, 1500)
-    if (!answer) {
-      return NextResponse.json({ error: 'Could not generate an answer.' }, { status: 502 })
-    }
-
-    const guardrail = runTaskGuardrails(answer, {
-      sourceContent: [pci, specText].filter(Boolean).join('\n'),
+    const askResult = await gradeTaskChatAsk({
+      task: taskChatTask,
+      question,
+      priorAnswers,
+      history: Array.isArray(body.history) ? body.history : [],
     })
-    if (guardrail.violations.length > 0) {
-      console.warn(
-        '[task-chat] guardrail warnings:',
-        guardrail.violations.map(v => `${v.ruleId} ${v.severity}`).join(', ')
-      )
-    }
 
     // Persist the follow-up for tutor visibility (best-effort). Never for the
     // owner tutor's stateless preview.
@@ -305,7 +213,12 @@ export async function POST(
         const list = Array.isArray(existing.followUps) ? (existing.followUps as unknown[]) : []
         const next = [
           ...list,
-          { questionId: 'task', question, answer, at: new Date().toISOString() },
+          {
+            questionId: 'task',
+            question,
+            answer: askResult.answer,
+            at: new Date().toISOString(),
+          },
         ].slice(-50)
         await drizzleDb
           .update(taskSubmission)
@@ -316,7 +229,7 @@ export async function POST(
       }
     }
 
-    return NextResponse.json({ mode: 'ask', answer })
+    return NextResponse.json({ mode: 'ask', answer: askResult.answer })
   } catch (error) {
     return handleApiError(
       error,

--- a/tutorme-app/src/app/api/tutor/auto-grade-preview/route.ts
+++ b/tutorme-app/src/app/api/tutor/auto-grade-preview/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/tutor/auto-grade-preview
+ *
+ * Stateless deterministic preview of how DMI answers are graded in a live session.
+ * Runs the same `autoGradeDmi` engine used by the socket `task:complete` handler
+ * so the tutor's Test tab matches live behavior. Never writes to the database.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
+import { autoGradeDmi, type DmiAnswerItem } from '@/lib/grading/auto-grade'
+
+const RequestSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      answer: z.string().optional(),
+      acceptableVariants: z.array(z.string()).optional(),
+      questionText: z.string().optional(),
+      marks: z.number().optional(),
+    })
+  ),
+  answers: z.record(z.string(), z.string()).default({}),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const csrfError = await requireCsrf(request)
+    if (csrfError) return csrfError
+
+    const body = await request.json().catch(() => null)
+    const parsed = RequestSchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request body', details: parsed.error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    const { items, answers } = parsed.data
+    const result = autoGradeDmi(items as DmiAnswerItem[], answers)
+
+    return NextResponse.json(result)
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to preview auto-grade',
+      'api/tutor/auto-grade-preview/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/app/api/tutor/task-chat-preview/route.ts
+++ b/tutorme-app/src/app/api/tutor/task-chat-preview/route.ts
@@ -1,0 +1,132 @@
+/**
+ * POST /api/tutor/task-chat-preview
+ *
+ * Stateless preview of the chat-based TASK flow for the course builder Test tab.
+ * Uses the exact same grading logic as the live student endpoint
+ * (/api/student/assignments/[taskId]/task-chat) but never writes to the database.
+ *
+ * The caller may optionally override content / PCI / PCI-spec so the preview can
+ * reflect an active extension rather than the parent task stored in the DB.
+ * Ownership is still verified against the DB task record.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { getServerSession, authOptions } from '@/lib/auth'
+import { handleApiError, requireCsrf, withRateLimitPreset } from '@/lib/api/middleware'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { builderTask } from '@/lib/db/schema'
+import {
+  gradeTaskChatComplete,
+  gradeTaskChatAsk,
+  sanitizeTaskChatAnswers,
+  type TaskChatTask,
+} from '@/lib/grading/task-chat-grader'
+
+interface HistoryTurn {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { response: rateLimitResponse } = await withRateLimitPreset(request, 'aiGenerate')
+    if (rateLimitResponse) return rateLimitResponse
+
+    const session = await getServerSession(authOptions, request)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    if (session.user.role !== 'TUTOR' && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const csrfError = await requireCsrf(request)
+    if (csrfError) return csrfError
+
+    const body = (await request.json().catch(() => ({}))) as {
+      taskId?: unknown
+      title?: unknown
+      content?: unknown
+      questionText?: unknown
+      pci?: unknown
+      pciSpec?: unknown
+      answers?: unknown
+      question?: unknown
+      history?: HistoryTurn[]
+    }
+
+    const taskId = typeof body.taskId === 'string' ? body.taskId.trim() : ''
+    if (!taskId || !/^[a-zA-Z0-9\-_]+$/.test(taskId) || taskId.length > 100) {
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
+    }
+
+    const [task] = await drizzleDb
+      .select({
+        title: builderTask.title,
+        content: builderTask.content,
+        pci: builderTask.pci,
+        pciSpec: builderTask.pciSpec,
+        tutorId: builderTask.tutorId,
+      })
+      .from(builderTask)
+      .where(eq(builderTask.taskId, taskId))
+      .limit(1)
+
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+    }
+
+    const isAdmin = session.user.role === 'ADMIN'
+    if (!isAdmin && task.tutorId !== session.user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const taskChatTask: TaskChatTask = {
+      taskId,
+      title: typeof body.title === 'string' ? body.title.trim() : task.title,
+      content:
+        typeof body.content === 'string'
+          ? body.content
+          : typeof body.questionText === 'string'
+            ? body.questionText
+            : task.content,
+      pci: typeof body.pci === 'string' ? body.pci : task.pci,
+      pciSpec: body.pciSpec !== undefined ? body.pciSpec : task.pciSpec,
+    }
+
+    if (Array.isArray(body.answers) && body.answers.length > 0) {
+      const answers = sanitizeTaskChatAnswers(body.answers)
+      if (answers.length === 0) {
+        return NextResponse.json({ error: 'No answers to respond to' }, { status: 400 })
+      }
+
+      const result = await gradeTaskChatComplete(taskChatTask, answers)
+      return NextResponse.json({
+        mode: 'complete',
+        responses: result.responses,
+        hasBasis: result.hasBasis,
+        aiUnavailable: result.aiUnavailable,
+      })
+    }
+
+    const question = typeof body.question === 'string' ? body.question.trim() : ''
+    if (!question) {
+      return NextResponse.json({ error: 'answers or question is required' }, { status: 400 })
+    }
+
+    const askResult = await gradeTaskChatAsk({
+      task: taskChatTask,
+      question,
+      history: Array.isArray(body.history) ? body.history : [],
+    })
+
+    return NextResponse.json({ mode: 'ask', answer: askResult.answer })
+  } catch (error) {
+    return handleApiError(
+      error,
+      'Failed to preview task chat',
+      'api/tutor/task-chat-preview/route.ts'
+    )
+  }
+}

--- a/tutorme-app/src/lib/ai/session-tutor-summary.ts
+++ b/tutorme-app/src/lib/ai/session-tutor-summary.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared summary request builder for the tutor-facing Session AI (SAI).
+ *
+ * Used in both:
+ *   - the course builder Test tab, when a test student clicks "Task Complete"
+ *   - the live classroom tutor view, when a real student submits a chat task
+ *
+ * Keeping the prompt and context shape identical in both places guarantees that
+ * the AI summary behaves the same way in Test mode and live sessions.
+ */
+
+import type { PciSpec } from '@/lib/assessment/pci-spec'
+
+export interface ClassroomSummaryStudentAnswers {
+  studentName?: string
+  answers: string[]
+}
+
+export interface ClassroomSummaryContext {
+  taskId?: string
+  taskName?: string
+  courseName?: string
+  taskContent?: string
+  taskPci?: string
+  taskPciSpec?: PciSpec | null
+  extensionName?: string | null
+  enrolledStudents?: number
+  currentDate?: string
+  sessionNumber?: number
+  attendance?: string
+}
+
+export function buildClassroomSummaryRequest(
+  students: ClassroomSummaryStudentAnswers[],
+  context: ClassroomSummaryContext
+): { message: string; context: ClassroomSummaryContext } {
+  const allAnswers = students.flatMap(s => s.answers)
+  const summaryRequest = [
+    'The following student answers have been submitted for this task.',
+    context.enrolledStudents != null
+      ? `Total students enrolled in this session: ${context.enrolledStudents}.`
+      : undefined,
+    `Students who have submitted/completed so far: ${students.length}.`,
+    'Provide 2-3 concise bullets summarizing class-level patterns, common misconceptions, or completion status only.',
+    'Do NOT name, number, or describe individual students.',
+    'Do NOT evaluate, judge, or comment on any individual answer.',
+    'Do NOT add meta-commentary about what you are not doing or what guidelines you are following.',
+    'Do NOT say all students completed unless the submitted count equals the enrolled count.',
+    '',
+    'Submitted answers:',
+    ...allAnswers.map(a => `- ${a}`),
+  ]
+    .filter((line): line is string => typeof line === 'string')
+    .join('\n')
+
+  return { message: summaryRequest, context }
+}

--- a/tutorme-app/src/lib/grading/task-chat-grader.ts
+++ b/tutorme-app/src/lib/grading/task-chat-grader.ts
@@ -1,0 +1,210 @@
+/**
+ * Shared grading logic for the chat-based TASK flow.
+ *
+ * Used by:
+ *   - POST /api/student/assignments/[taskId]/task-chat  (live student flow)
+ *   - POST /api/tutor/task-chat-preview                   (tutor test-mode preview)
+ *
+ * Keeping the prompt, model settings, guardrails, and parsing in one place
+ * guarantees that the Test tab behaves identically to the live student flow.
+ */
+
+import { ASK_SYSTEM_PROMPT } from '@/lib/ai/task-chat-prompts'
+import { generateWithKimi } from '@/lib/ai/kimi'
+import { runTaskGuardrails } from '@/lib/ai/guardrails'
+import { gradeAnswerAgainstBasis, renderGradingSpec } from '@/lib/grading/pci-grader'
+import { AISecurityManager } from '@/lib/security/ai-sanitization'
+
+const MAX_ANSWERS = 12
+const MAX_ANSWER_LEN = 3000
+const MAX_QUESTION = 800
+const MAX_HISTORY_TURNS = 6
+
+export interface TaskChatTask {
+  taskId: string
+  title: string
+  content?: string | null
+  pci?: string | null
+  pciSpec?: unknown
+}
+
+export interface TaskChatAnswerResponse {
+  answer: string
+  response: string
+  score: number | null
+}
+
+export interface TaskChatCompleteResult {
+  mode: 'complete'
+  responses: TaskChatAnswerResponse[]
+  hasBasis: boolean
+  aiUnavailable: boolean
+  /** aiFeedback payload ready for taskSubmission.aiFeedback. */
+  aiFeedback: {
+    generatedAt: string
+    provider: 'kimi'
+    items: Array<{ questionId: string; explanation: string }>
+  }
+  /** Answers keyed by 1-based index, ready for taskSubmission.answers. */
+  answersRecord: Record<string, string>
+  /** Average score over numeric scores, or null when none were gradable. */
+  avgScore: number | null
+}
+
+export interface TaskChatAskInput {
+  task: TaskChatTask
+  question: string
+  priorAnswers?: string[]
+  history?: Array<{ role: 'user' | 'assistant'; content: string }>
+}
+
+export interface TaskChatAskResult {
+  mode: 'ask'
+  answer: string
+}
+
+export function sanitizeTaskChatAnswers(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map(a =>
+      String(a ?? '')
+        .trim()
+        .slice(0, MAX_ANSWER_LEN)
+    )
+    .filter(Boolean)
+    .slice(0, MAX_ANSWERS)
+}
+
+export function buildTaskContext(task: TaskChatTask): string {
+  return `${task.title}\n\n${task.content ?? ''}`.trim().slice(0, 4000)
+}
+
+export async function gradeTaskChatComplete(
+  task: TaskChatTask,
+  answers: string[]
+): Promise<TaskChatCompleteResult> {
+  const specText = renderGradingSpec(task.pciSpec)
+  const taskContext = buildTaskContext(task)
+
+  const responses: TaskChatAnswerResponse[] = []
+  let anyBasis = false
+  let anyUnavailable = false
+
+  for (const answer of answers) {
+    const result = await gradeAnswerAgainstBasis({
+      pci: task.pci,
+      specText,
+      questionText: taskContext,
+      studentAnswer: answer,
+    })
+    anyBasis = anyBasis || result.hasBasis
+    anyUnavailable = anyUnavailable || result.aiUnavailable
+
+    const response = !result.hasBasis
+      ? "Your answer's recorded — your tutor hasn't set a marking policy for this task yet, so I can't check it here."
+      : result.aiUnavailable
+        ? "Your answer's recorded, but the assistant is unavailable right now — try asking again in a moment."
+        : result.feedback || 'Thanks — noted.'
+
+    responses.push({ answer, response, score: result.score })
+  }
+
+  const graded = responses.map(r => r.score).filter((s): s is number => typeof s === 'number')
+  const avgScore = graded.length
+    ? Math.round(graded.reduce((a, b) => a + b, 0) / graded.length)
+    : null
+
+  const answersRecord: Record<string, string> = {}
+  answers.forEach((a, i) => {
+    answersRecord[String(i + 1)] = a
+  })
+
+  const aiFeedback = {
+    generatedAt: new Date().toISOString(),
+    provider: 'kimi' as const,
+    items: responses.map((r, i) => ({
+      questionId: String(i + 1),
+      explanation: r.response,
+    })),
+  }
+
+  return {
+    mode: 'complete',
+    responses,
+    hasBasis: anyBasis,
+    aiUnavailable: anyUnavailable && !anyBasis,
+    aiFeedback,
+    answersRecord,
+    avgScore,
+  }
+}
+
+export async function gradeTaskChatAsk(input: TaskChatAskInput): Promise<TaskChatAskResult> {
+  const { task, question, priorAnswers = [], history = [] } = input
+  const q = AISecurityManager.sanitizeAiInput(question.trim()).slice(0, MAX_QUESTION)
+  if (!q) {
+    throw new Error('A non-empty question is required')
+  }
+
+  const specText = renderGradingSpec(task.pciSpec)
+  const taskContext = buildTaskContext(task)
+  const pci = (task.pci ?? '').trim()
+
+  if (!pci && !specText) {
+    return {
+      mode: 'ask',
+      answer:
+        "Your tutor hasn't set a marking policy for this task, so I can't explain it reliably — please ask your tutor directly.",
+    }
+  }
+
+  const trimmedHistory = history.slice(-MAX_HISTORY_TURNS)
+  const historyBlock = trimmedHistory.length
+    ? `Conversation so far:\n${trimmedHistory
+        .map(
+          t =>
+            `${t.role === 'assistant' ? 'Tutor' : 'Student'}: ${AISecurityManager.sanitizeAiInput(String(t.content)).slice(0, 800)}`
+        )
+        .join('\n')}\n\n`
+    : ''
+
+  const safePriorAnswers = priorAnswers
+    .map(a => AISecurityManager.sanitizeAiInput(String(a)).slice(0, 800))
+    .filter(Boolean)
+
+  const answersBlock = safePriorAnswers.length
+    ? `The student's answers to this task:\n${safePriorAnswers.map((a, i) => `${i + 1}. ${a}`).join('\n')}\n\n`
+    : ''
+  const specBlock = specText ? `Structured marking guidance (PCI):\n${specText}\n\n` : ''
+  const prompt = `Tutor's marking policy (PCI):\n${pci.slice(0, 2000)}\n\n${specBlock}Task:\n${taskContext}\n\n${answersBlock}${historyBlock}The student's follow-up:\n${q}`
+
+  let answer: string
+  try {
+    answer = await generateWithKimi(prompt, {
+      systemPrompt: ASK_SYSTEM_PROMPT,
+      temperature: 0.4,
+      maxTokens: 400,
+      timeoutMs: 30000,
+    })
+  } catch (aiErr) {
+    console.warn('[task-chat-grader] Kimi call failed:', aiErr)
+    throw new Error('The tutor assistant is unavailable right now. Please try again.')
+  }
+
+  answer = answer.trim().slice(0, 1500)
+  if (!answer) {
+    throw new Error('Could not generate an answer.')
+  }
+
+  const guardrail = runTaskGuardrails(answer, {
+    sourceContent: [pci, specText].filter(Boolean).join('\n'),
+  })
+  if (guardrail.violations.length > 0) {
+    console.warn(
+      '[task-chat-grader] guardrail warnings:',
+      guardrail.violations.map(v => `${v.ruleId} ${v.severity}`).join(', ')
+    )
+  }
+
+  return { mode: 'ask', answer }
+}


### PR DESCRIPTION
… SAI summary paths

- Shared task-chat grader used by student task-chat API and preview endpoint
- Test tab calls /api/tutor/task-chat-preview; taskId plumbed through CourseBuilder
- DMI Test tab uses live deterministic auto-grade with a separate Debug LLM grade basis
- Shared buildClassroomSummaryRequest helper for SAI summaries in Test and Live modes
- Strengthens summary guardrails: no individual feedback, no meta-commentary, accurate completion counts
- Fixes auto-grade-preview Zod v4 record schema (z.record(key, value))