### PR TITLE
ci: update npm before security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: tutorme-app/package-lock.json
 
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: tutorme-app/package-lock.json
-
-      - name: Update npm
-        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps


### PR DESCRIPTION
The CI security job started failing with:\n\n- Unknown command: "notice"

To see a list of supported npm commands, run:
  npm help\n- \n- Unknown command: "error"

To see a list of supported npm commands, run:
  npm help\n\nUpdating to the latest npm before running the audit lets it use the current advisory endpoint and parse the lockfile correctly.