### PR TITLE
fix(landing): live-demo cache-busting and diagnostics for missing cards

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -1938,12 +1938,21 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
         const [coursesResults, tutorsResults, goLivesResults] = await Promise.all([
           fetchTiered('courses', q, selectedCountryCode),
           fetchTiered('tutors', q, selectedCountryCode),
-          fetchWithTimeout('/api/public/live-sessions?type=GO_LIVE_DEMO&status=active', {
-            signal: controller.signal,
-          })
+          fetchWithTimeout(
+            `/api/public/live-sessions?type=GO_LIVE_DEMO&status=active&_t=${Date.now()}`,
+            {
+              signal: controller.signal,
+              cache: 'no-store',
+            }
+          )
             .then(async res => {
-              if (!res.ok) return []
+              if (!res.ok) {
+                const body = await res.text().catch(() => '')
+                console.warn('[Landing] live-sessions API returned non-OK:', res.status, body)
+                return []
+              }
               const json = await res.json()
+              console.log('[Landing] live-sessions received:', json.sessions?.length ?? 0)
               return json.sessions || []
             })
             .catch(err => {

--- a/tutorme-app/src/app/api/public/live-sessions/route.ts
+++ b/tutorme-app/src/app/api/public/live-sessions/route.ts
@@ -33,6 +33,13 @@ export async function GET(request: NextRequest) {
 
     const pageSize = Math.min(60, Math.max(1, Number(searchParams.get('pageSize')) || 24))
 
+    console.log('[GET /api/public/live-sessions] params:', {
+      sessionType,
+      statusParam,
+      statuses,
+      pageSize,
+    })
+
     // Self-healing schema guard: the LiveSession table may not yet have the
     // sessionType column in older environments. Add it idempotently before any
     // query depends on it.
@@ -61,6 +68,7 @@ export async function GET(request: NextRequest) {
         tutorCountry: sql<
           string | null
         >`coalesce(${profile.countryOfResidence}, ${profile.nationality})`.as('tutorCountry'),
+        tutorRole: user.role,
         courseName: course.name,
       })
       .from(liveSession)
@@ -76,6 +84,29 @@ export async function GET(request: NextRequest) {
       )
       .orderBy(desc(liveSession.scheduledAt))
       .limit(pageSize)
+
+    console.log(`[GET /api/public/live-sessions] found ${rows.length} session(s)`)
+
+    if (rows.length === 0) {
+      try {
+        const allDemos = await drizzleDb
+          .select({ count: sql<number>`count(*)::int`.as('count') })
+          .from(liveSession)
+          .where(eq(liveSession.sessionType, 'GO_LIVE_DEMO'))
+        const allActive = await drizzleDb
+          .select({ count: sql<number>`count(*)::int`.as('count') })
+          .from(liveSession)
+          .where(
+            inArray(liveSession.status, ['active', 'live', 'scheduled'] as LiveSessionStatus[])
+          )
+        console.log('[GET /api/public/live-sessions] diagnostics:', {
+          totalGoLiveDemoSessions: allDemos[0]?.count ?? 0,
+          totalActiveOrLiveOrScheduledSessions: allActive[0]?.count ?? 0,
+        })
+      } catch (diagErr) {
+        console.warn('[GET /api/public/live-sessions] diagnostic query failed:', diagErr)
+      }
+    }
 
     const sessions = rows.map(row => ({
       id: row.sessionId,


### PR DESCRIPTION
## Problem\nA newly created Go Live demo session does not appear on the landing page Demo Classes strip even though the tutor dashboard shows it was created.\n\n## Changes\n- Adds cache: no-store and a timestamp query param to the landing page fetch for /api/public/live-sessions so the browser cannot serve a stale empty response.\n- Adds server-side logging and zero-result diagnostics to the public live-sessions API so we can see the filters applied and how many total demo/active sessions exist in the database.\n\n## Verification\n- npm run typecheck passes\n- npm run format passes\n- ESLint reports only pre-existing warnings, no new errors