### PR TITLE
fix(tutor/dashboard): rename My Live Demos to Classes and style cards emerald

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -73,6 +73,7 @@ import {
   DialogTitle,
   DialogPanel,
 } from '@/components/ui/dialog'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import './page.css'
@@ -2024,6 +2025,29 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
     return `Starts ${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear().toString().slice(-2)}`
   }
 
+  const ClampedDescription = ({
+    text,
+    children,
+    className,
+  }: {
+    text: string
+    children: React.ReactNode
+    className?: string
+  }) => (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className={cn('h-full overflow-hidden', className)}>
+            <div className="line-clamp-4 leading-relaxed">{children}</div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[220px]">
+          <p className="text-xs">{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+
   const CourseSlot = ({ item }: { item: any }) => (
     <div
       role="button"
@@ -2067,10 +2091,13 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
             </div>
           </div>
 
-          <div className="mt-3 min-h-0 flex-1 rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
-            <div className="line-clamp-6 text-[11px] leading-relaxed text-slate-200">
+          <div className="mt-3 h-[clamp(60px,7vw,88px)] shrink-0 overflow-hidden rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
+            <ClampedDescription
+              text={(item?.description || '').trim() || 'No course description provided yet.'}
+              className="text-[11px] text-slate-200"
+            >
               {(item?.description || '').trim() || 'No course description provided yet.'}
-            </div>
+            </ClampedDescription>
           </div>
           <div className="mt-3 flex items-center justify-between text-xs font-semibold">
             <div className="truncate text-slate-300">
@@ -2124,11 +2151,16 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
             </div>
           </div>
 
-          {/* Bio — expands to fill available space */}
-          <div className="mt-3 min-h-0 flex-1 rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
-            <div className="line-clamp-6 text-[11px] leading-relaxed text-slate-100">
+          {/* Bio — fixed height with clamp + tooltip */}
+          <div className="mt-3 h-[clamp(60px,7vw,88px)] shrink-0 overflow-hidden rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
+            <ClampedDescription
+              text={
+                (item?.bio || '').trim() || 'Experienced tutor ready to help you improve quickly.'
+              }
+              className="text-[11px] text-slate-100"
+            >
               {(item?.bio || '').trim() || 'Experienced tutor ready to help you improve quickly.'}
-            </div>
+            </ClampedDescription>
           </div>
 
           {/* Bottom row: courses (left) | country name (right) */}
@@ -2193,10 +2225,13 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
           </div>
 
           {/* Description area */}
-          <div className="mt-3 min-h-0 flex-1 overflow-hidden rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
-            <p className="line-clamp-4 text-xs leading-relaxed text-emerald-50/80">
+          <div className="mt-3 h-[clamp(60px,7vw,88px)] shrink-0 overflow-hidden rounded-[14px] border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2">
+            <ClampedDescription
+              text={item?.description || 'Live demo class'}
+              className="text-xs text-emerald-50/80"
+            >
               {item?.description || 'Live demo class'}
-            </p>
+            </ClampedDescription>
           </div>
 
           {/* Bottom row: country */}

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/GoLiveDialog.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/GoLiveDialog.tsx
@@ -5,13 +5,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
-  DialogPanel,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import {
   Select,
   SelectContent,
@@ -40,31 +37,20 @@ export function GoLiveDialog({
   onConfirmTeaching,
   onConfirmTeachingUnpublished,
   unpublishedCourses,
-  onConfirmTraining,
 }: GoLiveDialogProps) {
-  const [sessionType, setSessionType] = useState<'teaching' | 'training'>('teaching')
   const [loading, setLoading] = useState(false)
 
   // Teaching fields (only used when a dashboard caller provides unpublished courses)
   const [selectedCourseId, setSelectedCourseId] = useState('')
   const [description, setDescription] = useState('')
 
-  // Training fields
-  const [token, setToken] = useState('')
-  const [targetAudience, setTargetAudience] = useState('all')
-  const [category, setCategory] = useState('orientation')
-
   const handleConfirm = async () => {
     setLoading(true)
     try {
-      if (sessionType === 'teaching') {
-        if (unpublishedCourses && unpublishedCourses.length > 0) {
-          await onConfirmTeachingUnpublished?.(selectedCourseId, description)
-        } else {
-          await onConfirmTeaching?.()
-        }
+      if (unpublishedCourses && unpublishedCourses.length > 0) {
+        await onConfirmTeachingUnpublished?.(selectedCourseId, description)
       } else {
-        await onConfirmTraining({ token, targetAudience, category })
+        await onConfirmTeaching?.()
       }
       onOpenChange(false)
     } catch (_err) {
@@ -75,10 +61,7 @@ export function GoLiveDialog({
   }
 
   const confirmDisabled =
-    loading ||
-    (sessionType === 'training' && !token) ||
-    (sessionType === 'teaching' &&
-      Boolean(unpublishedCourses && unpublishedCourses.length > 0 && !selectedCourseId))
+    loading || Boolean(unpublishedCourses && unpublishedCourses.length > 0 && !selectedCourseId)
 
   return (
     <Dialog
@@ -93,126 +76,52 @@ export function GoLiveDialog({
         </DialogHeader>
 
         <div className="space-y-4 px-6 py-4">
-          <RadioGroup
-            value={sessionType}
-            onValueChange={v => setSessionType(v as 'teaching' | 'training')}
-            className="flex flex-col space-y-4"
-          >
-            <DialogPanel
-              className="flex cursor-pointer flex-col space-y-2 hover:bg-gray-50"
-              onClick={() => setSessionType('teaching')}
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="teaching" id="teaching" />
-                <Label htmlFor="teaching" className="flex-1 cursor-pointer">
-                  <div className="text-base font-semibold text-gray-900">Create a demo class</div>
-                  <div className="mt-1 text-sm font-normal text-gray-600">
-                    Create a demo lesson for your course.
-                  </div>
-                </Label>
+          <div className="space-y-2">
+            <div className="text-base font-semibold text-gray-900">Create a demo class</div>
+            <div className="text-sm font-normal text-gray-600">
+              Create a demo lesson for your course.
+            </div>
+          </div>
+
+          {unpublishedCourses && unpublishedCourses.length > 0 && (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label className="text-gray-900">Select an unpublished course</Label>
+                <Select value={selectedCourseId} onValueChange={setSelectedCourseId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose a course" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {unpublishedCourses.map(c => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-              {sessionType === 'teaching' &&
-                unpublishedCourses &&
-                unpublishedCourses.length > 0 && (
-                  <div className="ml-6 space-y-2 pt-2">
-                    <Label className="text-gray-900">Select an unpublished course</Label>
-                    <Select value={selectedCourseId} onValueChange={setSelectedCourseId}>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Choose a course" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {unpublishedCourses.map(c => (
-                          <SelectItem key={c.id} value={c.id}>
-                            {c.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <div className="space-y-2 pt-2">
-                      <Label className="text-gray-900">Description</Label>
-                      <Textarea
-                        value={description}
-                        onChange={e => {
-                          const val = e.target.value
-                          if (val.length <= 200) setDescription(val)
-                        }}
-                        placeholder="Describe what this demo will cover"
-                        rows={2}
-                        maxLength={200}
-                        className="resize-none"
-                      />
-                      <p className="text-right text-xs text-gray-500">{description.length}/200</p>
-                    </div>
-                  </div>
-                )}
-              {sessionType === 'teaching' &&
-                unpublishedCourses &&
-                unpublishedCourses.length === 0 && (
-                  <div className="ml-6 pt-2 text-sm text-gray-500">
-                    No unpublished courses available.
-                  </div>
-                )}
-            </DialogPanel>
-            <DialogPanel
-              className="flex cursor-pointer flex-col space-y-2 hover:bg-gray-50"
-              onClick={() => setSessionType('training')}
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="training" id="training" />
-                <Label htmlFor="training" className="flex-1 cursor-pointer">
-                  <div className="text-base font-semibold text-gray-900">
-                    Create a Scheduled Class
-                  </div>
-                  <div className="mt-1 text-sm font-normal text-gray-600">
-                    Schedule a single session for single topic classes, practice papers, and other
-                    specialized lessons.
-                  </div>
-                </Label>
+
+              <div className="space-y-2">
+                <Label className="text-gray-900">Description</Label>
+                <Textarea
+                  value={description}
+                  onChange={e => {
+                    const val = e.target.value
+                    if (val.length <= 200) setDescription(val)
+                  }}
+                  placeholder="Describe what this demo will cover"
+                  rows={2}
+                  maxLength={200}
+                  className="resize-none"
+                />
+                <p className="text-right text-xs text-gray-500">{description.length}/200</p>
               </div>
-              {sessionType === 'training' && (
-                <div className="ml-6 space-y-3 pt-2">
-                  <div className="space-y-2">
-                    <Label className="text-gray-900">Special Access Token</Label>
-                    <Input
-                      type="password"
-                      placeholder="Enter the landing page token"
-                      value={token}
-                      onChange={e => setToken(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="text-gray-900">Target Audience</Label>
-                    <Select value={targetAudience} onValueChange={setTargetAudience}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all">All Tutors</SelectItem>
-                        <SelectItem value="new">New (Never attended training)</SelectItem>
-                        <SelectItem value="math">Math Tutors</SelectItem>
-                        <SelectItem value="science">Science Tutors</SelectItem>
-                        <SelectItem value="language">Language Tutors</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="text-gray-900">Training Category</Label>
-                    <Select value={category} onValueChange={setCategory}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="orientation">Orientation</SelectItem>
-                        <SelectItem value="features">Features Explanation</SelectItem>
-                        <SelectItem value="subject_specific">Subject Specific</SelectItem>
-                        <SelectItem value="emergency">Emergency Update</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              )}
-            </DialogPanel>
-          </RadioGroup>
+            </div>
+          )}
+
+          {unpublishedCourses && unpublishedCourses.length === 0 && (
+            <div className="text-sm text-gray-500">No unpublished courses available.</div>
+          )}
         </div>
 
         <DialogFooter className="gap-3">

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/components/ModernHeroSection.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/components/ModernHeroSection.tsx
@@ -410,7 +410,7 @@ export function ModernHeroSection({
           <div className="flex flex-1 items-center justify-start gap-2">
             <Button
               size="sm"
-              className="border border-white bg-[#65A30D] text-white hover:translate-y-0 hover:bg-[#65A30D]/90"
+              className="border border-white bg-[#65A30D] text-white hover:border-[#65A30D] hover:bg-white hover:text-[#65A30D]"
               onClick={handleGoLiveClick}
               disabled={goLiveLoading}
             >

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -11,7 +11,7 @@ import {
   groupIntoSeries,
 } from '@/components/one-on-one/one-on-one-request-card'
 import { resolveOneOnOneSession, joinableRequestId } from '@/lib/one-on-one/enter-classroom'
-import { Card, CardContent, CardTitle } from '@/components/ui/card'
+import { CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TabsContent } from '@/components/ui/tabs'
 import {
@@ -794,7 +794,7 @@ function TutorDashboardContent() {
               { value: 'availability', label: 'My Availability' },
               { value: 'oneOnOne', label: '1-on-1 Requests' },
               { value: 'groupSessions', label: 'Group Sessions' },
-              { value: 'liveDemos', label: 'My Live Demos' },
+              { value: 'liveDemos', label: 'Classes' },
             ]}
             showCalendarControls={activeTab === 'calendar' || activeTab === 'availability'}
             calendarView={calendarView}
@@ -1158,7 +1158,7 @@ function TutorDashboardContent() {
             >
               <div className="h-full overflow-y-auto">
                 <CardTitle className="text-card-foreground mb-4 flex items-center gap-2">
-                  My Live Demos
+                  Classes
                   <span className="text-muted-foreground text-sm font-normal">
                     Demo classes you have created
                   </span>
@@ -1171,54 +1171,55 @@ function TutorDashboardContent() {
                   </div>
                 ) : liveDemos.length === 0 ? (
                   <div className="text-muted-foreground border-border/30 rounded-lg border border-dashed p-6 text-center text-sm">
-                    No live demos yet. Click <strong>Create Class</strong> to start one.
+                    No classes yet. Click <strong>Create Class</strong> to start one.
                   </div>
                 ) : (
                   <div className="space-y-3">
                     {liveDemos.map(demo => (
-                      <Card
+                      <div
                         key={demo.id}
-                        className="border-border/30 bg-card hover:border-border/50 transition-all duration-200 hover:bg-white"
+                        className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-400/30 bg-emerald-500 p-4 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition-all duration-200 hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
                       >
-                        <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="min-w-0 flex-1 space-y-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <p className="truncate font-medium text-gray-900">{demo.title}</p>
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  'text-[10px] uppercase tracking-wide',
-                                  demo.status === 'active'
-                                    ? 'bg-success/15 text-success border-success/25'
-                                    : demo.status === 'ended'
-                                      ? 'bg-muted text-muted-foreground border-border/30'
-                                      : 'bg-info/15 text-info border-info/25'
-                                )}
-                              >
-                                {demo.status}
-                              </Badge>
-                            </div>
-                            <p className="text-muted-foreground text-xs">{demo.subject}</p>
-                            {demo.description && (
-                              <p className="text-muted-foreground truncate text-xs">
-                                {demo.description}
-                              </p>
-                            )}
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Button
-                              size="sm"
-                              onClick={() =>
-                                router.push(withLocalePath(`/tutor/classroom?sessionId=${demo.id}`))
-                              }
-                              className="bg-emerald-500 text-white hover:bg-emerald-600"
+                        <div className="min-w-0 flex-1 space-y-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="truncate font-semibold text-white">{demo.title}</p>
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                'text-[10px] uppercase tracking-wide',
+                                demo.status === 'active'
+                                  ? 'border-white/40 bg-white/20 text-white'
+                                  : demo.status === 'ended'
+                                    ? 'border-black/20 bg-black/20 text-white/80'
+                                    : 'border-white/30 bg-white/15 text-white'
+                              )}
                             >
-                              <Video className="mr-1 h-3 w-3" />
-                              Enter
-                            </Button>
+                              {demo.status}
+                            </Badge>
                           </div>
-                        </CardContent>
-                      </Card>
+                          <div className="flex flex-wrap items-center gap-2 text-xs text-emerald-50">
+                            <span>{demo.subject}</span>
+                          </div>
+                          {demo.description && (
+                            <p className="truncate text-xs text-emerald-100/80">
+                              {demo.description}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              router.push(withLocalePath(`/tutor/classroom?sessionId=${demo.id}`))
+                            }
+                            className="border-transparent bg-white text-emerald-600 transition-all duration-200 hover:border-transparent hover:bg-emerald-50 hover:text-emerald-700"
+                          >
+                            <Video className="mr-1 h-3 w-3" />
+                            Enter
+                          </Button>
+                        </div>
+                      </div>
                     ))}
                   </div>
                 )}


### PR DESCRIPTION
- Rename dashboard tab and panel title from My Live Demos to Classes
- Update empty-state copy to reference Classes
- Restyle demo cards with emerald background to match requested design
- Use white Enter button for contrast on emerald cards
- Remove unused Card/CardContent imports