### PR TITLE
fix(communications): non-collapsible Chat/Notifications panels + class card polish

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1224,8 +1224,8 @@ function TutorDashboardContent() {
                               {demo.status}
                             </Badge>
                           </div>
-                          <div className="h-[72px] rounded-md bg-white px-3 py-2">
-                            <p className="line-clamp-4 text-xs text-gray-700">
+                          <div className="h-16 w-full max-w-sm self-center rounded-md bg-white px-3 py-2">
+                            <p className="line-clamp-3 text-xs text-gray-700">
                               {demo.description || 'No description'}
                             </p>
                           </div>

--- a/tutorme-app/src/app/globals.css
+++ b/tutorme-app/src/app/globals.css
@@ -75,6 +75,12 @@
       inset 0 1px 0 rgba(255, 255, 255, 0.08);
   }
 
+  .panel-header-no-hover,
+  .panel-header-no-hover:hover {
+    transform: none !important;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08) !important;
+  }
+
   .course-top-header {
     border-radius: 16px;
   }

--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -10,6 +10,7 @@ export interface CollapsibleCardProps {
   description?: string
   icon?: React.ReactNode
   defaultOpen?: boolean
+  collapsible?: boolean
   className?: string
   contentClassName?: string
   flush?: boolean
@@ -22,6 +23,7 @@ export function CollapsibleCard({
   description,
   icon,
   defaultOpen = false,
+  collapsible = true,
   className,
   contentClassName,
   flush = false,
@@ -30,6 +32,9 @@ export function CollapsibleCard({
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen)
   const cardRef = useAutoScrollOnExpand(open, { delay: 400, margin: 16, block: 'start' })
+
+  const HeaderTag = collapsible ? 'button' : 'div'
+  const headerBaseClass = flush ? 'panel-header-metallic-flush' : 'panel-header-metallic'
 
   return (
     <div ref={cardRef} className={cn('flex flex-col', fillHeight && 'h-full')}>
@@ -46,12 +51,13 @@ export function CollapsibleCard({
       >
         {/* Inner wrapper with overflow hidden for animation */}
         <div className={cn('flex flex-col overflow-hidden p-0', fillHeight && 'h-full')}>
-          <button
-            type="button"
-            onClick={() => setOpen(o => !o)}
+          <HeaderTag
+            type={collapsible ? 'button' : undefined}
+            onClick={collapsible ? () => setOpen(o => !o) : undefined}
             className={cn(
               'panel-header w-full text-left',
-              flush ? 'panel-header-metallic-flush' : 'panel-header-metallic'
+              headerBaseClass,
+              !collapsible && 'panel-header-no-hover'
             )}
           >
             <div className="flex items-center justify-between gap-3">
@@ -62,15 +68,21 @@ export function CollapsibleCard({
                   {description && <span className="panel-header-subtext">{description}</span>}
                 </div>
               </div>
-              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
-                {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
-              </div>
+              {collapsible && (
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white">
+                  {open ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
+                </div>
+              )}
             </div>
-          </button>
+          </HeaderTag>
           <div
             className={cn(
               'overflow-hidden transition-all duration-300 ease-in-out',
-              open ? 'flex-1 opacity-100' : 'h-0 flex-none opacity-0'
+              collapsible
+                ? open
+                  ? 'flex-1 opacity-100'
+                  : 'h-0 flex-none opacity-0'
+                : 'flex-1 opacity-100'
             )}
           >
             <div className={cn('h-full overflow-hidden', contentClassName)}>{children}</div>

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -227,6 +227,8 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               title="Chat"
               icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
               defaultOpen
+              collapsible={false}
+              flush
               fillHeight
               className="flex-1"
             >
@@ -254,6 +256,7 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               title="Notifications"
               icon={<Bell className="h-5 w-5 text-slate-900" />}
               defaultOpen
+              collapsible={false}
               fillHeight
               className="flex-1"
             >


### PR DESCRIPTION
UI polish for the Communications page and tutor dashboard class cards.

## Changes

### Communications page
- **Chat panel:** no longer collapsible; bottom corners rounded (flush style) to match other panels; header hover effect removed.
- **Notifications panel:** no longer collapsible; header hover effect removed.
- Added a `collapsible` prop to `CollapsibleCard` and a `.panel-header-no-hover` CSS utility to support these states.

### Tutor dashboard class cards
- Centered the white description box horizontally within the card.
- Sized it for ~150-character descriptions (`max-w-sm`, `h-16`, `line-clamp-3`).

## Verification

- `npx tsc --noEmit` passes.
- Prettier formatting applied.
