### PR TITLE
fix(landing): show Demo Classes cards by fixing role enum query and polish class-card layout

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1205,9 +1205,9 @@ function TutorDashboardContent() {
                     {liveDemos.map(demo => (
                       <div
                         key={demo.id}
-                        className="flex h-40 items-stretch justify-between gap-4 rounded-lg border border-white/20 bg-[#65A30D] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition-all duration-200 hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
+                        className="grid h-40 grid-cols-[1fr_auto_1fr] items-center gap-4 rounded-lg border border-white/20 bg-[#65A30D] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition-all duration-200 hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
                       >
-                        <div className="flex min-w-0 flex-1 flex-col justify-between">
+                        <div className="flex min-w-0 flex-col justify-between self-stretch py-1">
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="truncate font-semibold text-white">{demo.title}</p>
                             <Badge
@@ -1224,16 +1224,16 @@ function TutorDashboardContent() {
                               {demo.status}
                             </Badge>
                           </div>
-                          <div className="h-16 w-full max-w-sm self-center rounded-md bg-white px-3 py-2">
-                            <p className="line-clamp-3 text-xs text-gray-700">
-                              {demo.description || 'No description'}
-                            </p>
-                          </div>
                           <div className="flex flex-wrap items-center gap-2 text-xs text-white/90">
                             <span>{demo.subject}</span>
                           </div>
                         </div>
-                        <div className="flex flex-col items-center justify-center gap-2">
+                        <div className="h-16 w-full max-w-[420px] self-center rounded-md bg-white px-3 py-2">
+                          <p className="line-clamp-3 text-xs text-gray-700">
+                            {demo.description || 'No description'}
+                          </p>
+                        </div>
+                        <div className="flex flex-col items-end justify-center gap-2 self-stretch">
                           <Button
                             variant="outline"
                             size="sm"

--- a/tutorme-app/src/app/api/public/live-sessions/route.ts
+++ b/tutorme-app/src/app/api/public/live-sessions/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { drizzleDb } from '@/lib/db/drizzle'
 import { liveSession, user, profile, course } from '@/lib/db/schema'
-import type { LiveSessionStatus } from '@/lib/db/schema/enums'
+import type { LiveSessionStatus, Role } from '@/lib/db/schema/enums'
 import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 
 export const dynamic = 'force-dynamic'
@@ -79,7 +79,7 @@ export async function GET(request: NextRequest) {
         and(
           eq(liveSession.sessionType, sessionType),
           inArray(liveSession.status, statuses as LiveSessionStatus[]),
-          sql`LOWER(${user.role}) = 'tutor'`
+          eq(user.role, 'TUTOR' as Role)
         )
       )
       .orderBy(desc(liveSession.scheduledAt))


### PR DESCRIPTION
## Problem\n- Demo Class cards never appeared on the landing page despite three prior edits.\n- The public live-sessions API returned a 500 because it used `LOWER(User.role)` on a PostgreSQL enum, which PostgreSQL does not support.\n- The tutor dashboard class-card description box was left-aligned instead of horizontally centered.\n\n## Changes\n- Compare `User.role` directly against `'TUTOR'` in the public live-sessions query.\n- Center the white description container horizontally and cap its width for ~150 characters.\n\n## Verification\n- Started local Postgres/Redis, seeded an active GO_LIVE_DEMO session, and confirmed `/api/public/live-sessions?type=GO_LIVE_DEMO&status=active` now returns the session.\n- `npm run typecheck` passes.\n- Prettier formatting applied.