### PR TITLE
fix(communications, dashboard): rounded chat panel, notifications deep-link, compact class cards

### DIFF
--- a/tutorme-app/src/app/[locale]/student/dashboard-details/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/dashboard-details/page.tsx
@@ -201,7 +201,7 @@ export default function StudentDashboardDetails() {
               </Link>
             </div>
             <div className="flex items-center gap-4">
-              <NotificationBell />
+              <NotificationBell viewAllHref="/student/communications?tab=notifications" />
               <Link href="/student/settings">
                 <Button variant="ghost" size="icon">
                   <Settings className="h-5 w-5" />

--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1205,9 +1205,9 @@ function TutorDashboardContent() {
                     {liveDemos.map(demo => (
                       <div
                         key={demo.id}
-                        className="grid h-40 grid-cols-[1fr_auto_1fr] items-center gap-4 rounded-lg border border-white/20 bg-[#65A30D] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition-all duration-200 hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
+                        className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 rounded-lg border border-white/20 bg-[#65A30D] p-4 shadow-[0_8px_30px_rgba(0,0,0,0.35)] transition-all duration-200 hover:shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
                       >
-                        <div className="flex min-w-0 flex-col justify-between self-stretch py-1">
+                        <div className="flex min-w-0 flex-col justify-center gap-1">
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="truncate font-semibold text-white">{demo.title}</p>
                             <Badge
@@ -1228,12 +1228,12 @@ function TutorDashboardContent() {
                             <span>{demo.subject}</span>
                           </div>
                         </div>
-                        <div className="h-16 w-full max-w-[420px] self-center rounded-md bg-white px-3 py-2">
-                          <p className="line-clamp-3 text-xs text-gray-700">
+                        <div className="h-14 w-full max-w-[420px] self-center rounded-md bg-white px-3 py-2">
+                          <p className="line-clamp-2 text-xs text-gray-700">
                             {demo.description || 'No description'}
                           </p>
                         </div>
-                        <div className="flex flex-col items-end justify-center gap-2 self-stretch">
+                        <div className="flex flex-col items-end justify-center gap-2">
                           <Button
                             variant="outline"
                             size="sm"

--- a/tutorme-app/src/app/[locale]/tutor/layout.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/layout.tsx
@@ -230,7 +230,7 @@ export default function TutorLayout({ children }: { children: React.ReactNode })
               </div>
               <div className="flex items-center gap-2">
                 <div onClick={e => e.stopPropagation()}>
-                  <NotificationBell viewAllHref="/tutor/communications" />
+                  <NotificationBell viewAllHref="/tutor/communications?tab=notifications" />
                 </div>
               </div>
             </div>

--- a/tutorme-app/src/components/communications/communications-page.tsx
+++ b/tutorme-app/src/components/communications/communications-page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { toast } from 'sonner'
 import { Loader2, MessageSquare, Bell, CalendarClock } from 'lucide-react'
 import { TabsContent } from '@/components/ui/tabs'
@@ -17,7 +18,9 @@ interface CommunicationsPageProps {
 }
 
 export default function CommunicationsPage({ role }: CommunicationsPageProps) {
-  const [activeTab, setActiveTab] = useState('messaging')
+  const searchParams = useSearchParams()
+  const initialTab = searchParams?.get('tab') === 'notifications' ? 'notifications' : 'messaging'
+  const [activeTab, setActiveTab] = useState(initialTab)
   const [activeSection, setActiveSection] = useState<CommSection>('chats')
 
   // Notifications state
@@ -228,7 +231,6 @@ export default function CommunicationsPage({ role }: CommunicationsPageProps) {
               icon={<MessageSquare className="h-5 w-5 text-slate-900" />}
               defaultOpen
               collapsible={false}
-              flush
               fillHeight
               className="flex-1"
             >


### PR DESCRIPTION
## Changes\n\n1. **Chat panel corners** — Removed the `flush` prop from the Chat `CollapsibleCard` so all four corners are rounded-[16px], matching the Notifications panel.\n\n2. **Notifications deep-link** — The tutor and student notification bells now link to `/{role}/communications?tab=notifications`. The Communications page reads that query param and opens the Notifications tab by default; Messaging remains the default when no param is present.\n\n3. **Tutor dashboard class cards** — Reduced class cards from a fixed `h-40` to a compact, content-height layout similar to the session card, with a centered white description container (`h-14`, `max-w-[420px]`, `line-clamp-2`).\n\n## Verification\n\n- `npm run typecheck` passes.\n- Prettier formatting applied.\n- ESLint shows only pre-existing warnings.