### PR TITLE
fix(landing): show ended GO_LIVE_DEMO sessions in Demo Classes panel

### DIFF
--- a/tutorme-app/src/app/[locale]/page.tsx
+++ b/tutorme-app/src/app/[locale]/page.tsx
@@ -1940,7 +1940,7 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
           fetchTiered('courses', q, selectedCountryCode),
           fetchTiered('tutors', q, selectedCountryCode),
           fetchWithTimeout(
-            `/api/public/live-sessions?type=GO_LIVE_DEMO&status=active&_t=${Date.now()}`,
+            `/api/public/live-sessions?type=GO_LIVE_DEMO&status=active,ended&_t=${Date.now()}`,
             {
               signal: controller.signal,
               cache: 'no-store',
@@ -2204,10 +2204,27 @@ const Panel2SearchResults = ({ query, onClearAll }: { query: string; onClearAll:
               </div>
             </div>
             <div className="flex shrink-0 flex-col items-end gap-2">
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/20 px-2 py-0.5 text-[10px] font-semibold text-emerald-200 ring-1 ring-emerald-400/30">
-                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" />
-                Live
-              </span>
+              {(() => {
+                const isActive = !item?.status || item.status !== 'ended'
+                return (
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1',
+                      isActive
+                        ? 'bg-emerald-500/20 text-emerald-200 ring-emerald-400/30'
+                        : 'bg-slate-500/20 text-slate-200 ring-slate-400/30'
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'h-1.5 w-1.5 rounded-full',
+                        isActive ? 'animate-pulse bg-emerald-400' : 'bg-slate-400'
+                      )}
+                    />
+                    {isActive ? 'Live' : 'Ended'}
+                  </span>
+                )
+              })()}
               <div className="h-[52px] w-[52px] overflow-hidden rounded-[12px] border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.03)] shadow-[0_6px_16px_rgba(0,0,0,0.24)]">
                 {item?.tutor?.avatarUrl ? (
                   <img


### PR DESCRIPTION
The landing page Demo Classes panel only fetched active statuses, so tutors saw their cards disappear from the landing page as soon as a class ended.

This PR includes 'ended' in the public live-sessions query and updates the status badge to reflect 'Live' vs 'Ended' instead of always showing a green 'Live' indicator.

- Changes the landing-page fetch to query active and ended demo classes
- Makes the GoLiveSlot badge show 'Ended' for ended sessions while keeping the 'Live' pulse for active ones
