### PR TITLE
fix(communications): round bottom corners of Chat and Notifications p…

### DIFF
--- a/tutorme-app/src/components/collapsible-card.tsx
+++ b/tutorme-app/src/components/collapsible-card.tsx
@@ -50,7 +50,13 @@ export function CollapsibleCard({
         )}
       >
         {/* Inner wrapper with overflow hidden for animation */}
-        <div className={cn('flex flex-col overflow-hidden p-0', fillHeight && 'h-full')}>
+        <div
+          className={cn(
+            'flex flex-col overflow-hidden p-0',
+            fillHeight && 'h-full',
+            flush ? 'rounded-b-[16px]' : 'rounded-[16px]'
+          )}
+        >
           <HeaderTag
             type={collapsible ? 'button' : undefined}
             onClick={collapsible ? () => setOpen(o => !o) : undefined}


### PR DESCRIPTION
…anels

The CollapsibleCard outer wrapper already rounded all four corners, but its inner overflow-hidden wrapper had no matching border-radius. The white content background clipped to a rectangle, making the bottom corners look square on the Communications Chat and Notifications panels.

Add the same border-radius to the inner wrapper so content is clipped to the outer wrapper's rounded shape.