### PR TITLE
fix(landing): wire up signup/contact submissions + hide broken demo cards

### DIFF
--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -28,7 +28,9 @@ const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || 'http://localhost:3003
 const HOW_IT_WORKS_VIDEOS: Record<string, { id: string; title: string; description: string }[]> = {
   Promo: [
     {
-      id: '_U8FwciBJxg',
+      // Previous id '_U8FwciBJxg' is no longer a live YouTube video. Put a real id here to
+      // surface the promo — placeholder ids stay hidden until then (see isRealVideo below).
+      id: 'PLACEHOLDER_PROMO',
       title: 'Promo',
       description: 'Watch the platform promo.',
     },
@@ -83,6 +85,18 @@ const HOW_IT_WORKS_DOCUMENTS = [
     filename: 'solocorn-course-builder-guide.pdf',
   },
 ];
+
+// Only surface entries that point at real, published assets. Placeholder YouTube ids and
+// unconfigured storage buckets are hidden so the "How It Works" panel never shows dead
+// cards — drop in real ids/URLs above and they appear automatically.
+const isRealVideo = (v: { id: string }) => !!v.id && !v.id.startsWith('PLACEHOLDER');
+const isRealDoc = (d: { url: string }) => !!d.url && !d.url.includes('YOUR_BUCKET');
+
+const VISIBLE_HOW_IT_WORKS_VIDEOS = Object.entries(HOW_IT_WORKS_VIDEOS)
+  .map(([section, videos]) => [section, videos.filter(isRealVideo)] as const)
+  .filter(([, videos]) => videos.length > 0);
+
+const VISIBLE_HOW_IT_WORKS_DOCUMENTS = HOW_IT_WORKS_DOCUMENTS.filter(isRealDoc);
 
 function HowItWorksVideoCard({ video }: { video: { id: string; title: string; description: string } }) {
   return (
@@ -449,26 +463,36 @@ export default function App() {
 
                   {/* Scrollable rows */}
                   <div className="scrollbar-hide w-full flex-1 overflow-y-auto px-1 py-1" style={{ overscrollBehaviorY: 'contain' }}>
-                    {Object.entries(HOW_IT_WORKS_VIDEOS).map(([section, videos], sectionIndex, sections) => (
-                      <div key={section}>
-                        <HowItWorksRow
-                          title={section}
-                          items={videos}
-                          renderItem={video => <HowItWorksVideoCard video={video} />}
-                        />
-                        {sectionIndex < sections.length - 1 && (
-                          <div className="mx-2 my-2 h-px bg-white/20" />
-                        )}
+                    {VISIBLE_HOW_IT_WORKS_VIDEOS.length === 0 &&
+                    VISIBLE_HOW_IT_WORKS_DOCUMENTS.length === 0 ? (
+                      <div className="flex h-40 items-center justify-center px-6 text-center text-sm text-white/70">
+                        Walkthroughs and resources are coming soon.
                       </div>
-                    ))}
+                    ) : (
+                      <>
+                        {VISIBLE_HOW_IT_WORKS_VIDEOS.map(([section, videos], sectionIndex) => (
+                          <div key={section}>
+                            <HowItWorksRow
+                              title={section}
+                              items={videos}
+                              renderItem={video => <HowItWorksVideoCard video={video} />}
+                            />
+                            {(sectionIndex < VISIBLE_HOW_IT_WORKS_VIDEOS.length - 1 ||
+                              VISIBLE_HOW_IT_WORKS_DOCUMENTS.length > 0) && (
+                              <div className="mx-2 my-2 h-px bg-white/20" />
+                            )}
+                          </div>
+                        ))}
 
-                    <div className="mx-2 my-2 h-px bg-white/20" />
-
-                    <HowItWorksRow
-                      title="Documents"
-                      items={HOW_IT_WORKS_DOCUMENTS}
-                      renderItem={doc => <HowItWorksDocumentCard doc={doc} />}
-                    />
+                        {VISIBLE_HOW_IT_WORKS_DOCUMENTS.length > 0 && (
+                          <HowItWorksRow
+                            title="Documents"
+                            items={VISIBLE_HOW_IT_WORKS_DOCUMENTS}
+                            renderItem={doc => <HowItWorksDocumentCard doc={doc} />}
+                          />
+                        )}
+                      </>
+                    )}
                   </div>
                 </div>
               </motion.div>

--- a/landing-page/src/components/ContactModal.tsx
+++ b/landing-page/src/components/ContactModal.tsx
@@ -15,7 +15,10 @@ export const ContactModal = ({ isOpen, onClose }: { isOpen: boolean, onClose: ()
     setIsSubmitting(true);
     setStatusMsg('');
     try {
-      const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || 'http://localhost:3003';
+      // Empty default → same-origin relative URL. In production the landing is served by
+      // the main app, so `/api/landing/message` reaches it directly. For a separate local
+      // dev server (vite on :3000), set VITE_MAIN_APP_URL=http://localhost:3003.
+      const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || '';
       const res = await fetch(`${MAIN_APP_URL}/api/landing/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/landing-page/src/components/Layout.tsx
+++ b/landing-page/src/components/Layout.tsx
@@ -146,7 +146,9 @@ export const ActionCard = ({ title, copy, buttonText, icon: Icon, onClick }: any
 );
 
 // Main App URL configuration
-const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || 'http://localhost:3003';
+// Empty default → same-origin. In production the landing is served by the main app, so
+// `/login` reaches it. For a separate local dev server, set VITE_MAIN_APP_URL=http://localhost:3003.
+const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || '';
 
 export const Navbar = ({ setView }: { setView: (v: View) => void }) => (
   <nav className="fixed top-0 left-0 right-0 z-50 px-6 py-4">
@@ -170,7 +172,7 @@ export const Navbar = ({ setView }: { setView: (v: View) => void }) => (
           JOIN
         </button>
         <a
-          href={MAIN_APP_URL}
+          href={`${MAIN_APP_URL}/login`}
           className="px-5 py-2 bg-white text-blue-700 rounded-full text-sm font-semibold hover:bg-white/90 transition-colors"
         >
           Sign In

--- a/landing-page/src/components/RegistrationPage.tsx
+++ b/landing-page/src/components/RegistrationPage.tsx
@@ -19,7 +19,10 @@ export const RegistrationPage = ({ onSubmit }: { onSubmit: (data: any) => void }
     setIsSubmitting(true);
     setErrorMsg('');
     try {
-      const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || 'http://localhost:3003';
+      // Empty default → same-origin relative URL. In production the landing is served by
+      // the main app, so `/api/landing/signup` reaches it directly. For a separate local
+      // dev server (vite on :3000), set VITE_MAIN_APP_URL=http://localhost:3003.
+      const MAIN_APP_URL = import.meta.env.VITE_MAIN_APP_URL || '';
       const res = await fetch(`${MAIN_APP_URL}/api/landing/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/tutorme-app/src/app/api/landing/message/route.ts
+++ b/tutorme-app/src/app/api/landing/message/route.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/landing/message — public contact/inquiry form on the marketing landing page.
+ * Stores the message in `landing_inquiries` (read by the admin "landing submissions" view).
+ * Public + unauthenticated, so it is rate-limited and length-capped.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { landingInquiry } from '@/lib/db/schema'
+import { withRateLimitPreset } from '@/lib/api/middleware'
+
+const MAX = { name: 200, email: 320, message: 5000 }
+
+export async function POST(req: NextRequest) {
+  try {
+    const { response: rateLimited } = await withRateLimitPreset(req, 'contact')
+    if (rateLimited) return rateLimited
+
+    const body = await req.json().catch(() => null)
+    const name = typeof body?.name === 'string' ? body.name.trim() : ''
+    const email = typeof body?.email === 'string' ? body.email.trim() : ''
+    const message = typeof body?.message === 'string' ? body.message.trim() : ''
+
+    if (!name || !email || !message) {
+      return NextResponse.json({ error: 'Name, email and message are required.' }, { status: 400 })
+    }
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+      return NextResponse.json({ error: 'Please enter a valid email address.' }, { status: 400 })
+    }
+
+    await drizzleDb.insert(landingInquiry).values({
+      id: crypto.randomUUID(),
+      name: name.slice(0, MAX.name),
+      email: email.slice(0, MAX.email),
+      message: message.slice(0, MAX.message),
+    })
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (err) {
+    console.error('landing message failed:', err)
+    return NextResponse.json({ error: 'Failed to send message.' }, { status: 500 })
+  }
+}

--- a/tutorme-app/src/app/api/landing/signup/route.ts
+++ b/tutorme-app/src/app/api/landing/signup/route.ts
@@ -1,0 +1,45 @@
+/**
+ * POST /api/landing/signup — public early-access signup on the marketing landing page.
+ * Stores the signup in `landing_signups` (read by the admin "landing submissions" view).
+ * Public + unauthenticated, so it is rate-limited and length-capped.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import { drizzleDb } from '@/lib/db/drizzle'
+import { landingSignup } from '@/lib/db/schema'
+import { withRateLimitPreset } from '@/lib/api/middleware'
+
+const MAX = { username: 100, bio: 2000, country: 100, photo: 2000 }
+
+export async function POST(req: NextRequest) {
+  try {
+    const { response: rateLimited } = await withRateLimitPreset(req, 'register')
+    if (rateLimited) return rateLimited
+
+    const body = await req.json().catch(() => null)
+    const username = typeof body?.username === 'string' ? body.username.trim() : ''
+    const bio = typeof body?.bio === 'string' ? body.bio.trim() : ''
+    const country = typeof body?.country === 'string' ? body.country.trim() : ''
+    const photo = typeof body?.photo === 'string' ? body.photo.trim() : ''
+
+    if (!username) {
+      return NextResponse.json({ error: 'A username is required.' }, { status: 400 })
+    }
+    // Only store a photo value if it is an http(s) URL — ignore anything else.
+    const safePhoto = /^https?:\/\//.test(photo) ? photo.slice(0, MAX.photo) : null
+
+    await drizzleDb.insert(landingSignup).values({
+      id: crypto.randomUUID(),
+      username: username.slice(0, MAX.username),
+      bio: bio ? bio.slice(0, MAX.bio) : null,
+      country: country ? country.slice(0, MAX.country) : null,
+      photo: safePhoto,
+    })
+
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (err) {
+    console.error('landing signup failed:', err)
+    return NextResponse.json({ error: 'Failed to submit signup.' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
Investigated the landing page's "demo classes" (the **How It Works** modal) and found it — and the landing's signup/contact forms — not wired.

## What was broken
- **Signup & contact forms** posted to `/api/landing/signup` and `/api/landing/message`, which **didn't exist** (no route, no rewrite, no catch-all). Every submission failed with "An error occurred", and the admin *landing-submissions* view — which reads `landing_signups` / `landing_inquiries` — was permanently empty because nothing wrote to those tables.
- Forms + the "Sign In" link defaulted `MAIN_APP_URL` to `http://localhost:3003`. The deployed landing is built **without** `VITE_MAIN_APP_URL`, so in production submissions were aimed at the *visitor's own machine*.
- **Demo content** was all placeholders: 6 videos with `PLACEHOLDER_1..6` ids, a promo whose YouTube id is now dead, and two PDFs pointing at an unconfigured `YOUR_BUCKET` — every thumbnail/link broken.

## Fix
- **New routes** `POST /api/landing/message` and `POST /api/landing/signup` — insert into the existing tables; rate-limited (`contact`/`register` presets), validated, length-capped; signup stores only `http(s)` photo URLs (rejects e.g. `javascript:`).
- **Same-origin URLs** — forms and Sign In now default to relative (`/api/landing/*`, `/login`), so the deployed landing (served by the main app) reaches them. Local split dev still works via `VITE_MAIN_APP_URL`.
- **Demo cleanup** — placeholder videos/docs are filtered out so only real assets render, with a "coming soon" empty state. Drop in real YouTube ids / PDF URLs and they appear automatically (no code change).

## Verification
- Both routes tested against an ephemeral Postgres: valid → **201 + row stored**; invalid → **400, no row**; malicious `javascript:` photo → stored as `null`.
- Landing `tsc` + `vite build` clean; built bundle now references relative `/api/landing/message`, `/api/landing/signup`, `/login` — **no `localhost:3003`**.

## Not included (needs content, not code)
Real promo/walkthrough YouTube ids and the actual pitch-deck / course-builder-guide PDF URLs (+ bucket). Once provided, they render automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)