### PR TITLE
fix(tutor-dashboard): align Classes card buttons and description container with Courses card

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1228,12 +1228,12 @@ function TutorDashboardContent() {
                             <span>{demo.subject}</span>
                           </div>
                         </div>
-                        <div className="h-14 w-full max-w-[420px] self-center rounded-md bg-white px-3 py-2">
-                          <p className="line-clamp-2 text-xs text-gray-700">
+                        <div className="h-20 w-[320px] self-center rounded-md bg-white px-3 py-2">
+                          <p className="line-clamp-4 text-xs text-gray-700">
                             {demo.description || 'No description'}
                           </p>
                         </div>
-                        <div className="flex flex-col items-end justify-center gap-2">
+                        <div className="flex flex-row items-center justify-end gap-2">
                           <Button
                             variant="outline"
                             size="sm"


### PR DESCRIPTION
## What changed\n- Fixed the Classes card description container to a 320×80 px box centered horizontally.\n- Changed the right-side buttons from stacked to a horizontal row, matching the adjacent-button layout of the Courses card.\n\n## Why\nThe description container previously varied in width and height depending on its content, and the Enter / Delete buttons were stacked vertically. The Courses card uses a compact horizontal row of buttons, so the Classes card now follows the same pattern.\n\n## Verification\n- 
> solocorn-app@0.1.0 typecheck
> tsc --noEmit passed.