### PR TITLE
fix(tutor-dashboard): shorten Classes card description container and add session date

### DIFF
--- a/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/dashboard/page.tsx
@@ -1226,10 +1226,22 @@ function TutorDashboardContent() {
                           </div>
                           <div className="flex flex-wrap items-center gap-2 text-xs text-white/90">
                             <span>{demo.subject}</span>
+                            {demo.scheduledAt && (
+                              <>
+                                <span className="text-white/50">•</span>
+                                <span className="text-white/70">
+                                  {new Date(demo.scheduledAt).toLocaleDateString('en-US', {
+                                    month: 'short',
+                                    day: 'numeric',
+                                    year: 'numeric',
+                                  })}
+                                </span>
+                              </>
+                            )}
                           </div>
                         </div>
-                        <div className="h-20 w-[320px] self-center rounded-md bg-white px-3 py-2">
-                          <p className="line-clamp-4 text-xs text-gray-700">
+                        <div className="h-16 w-[480px] self-center rounded-md bg-white px-3 py-2">
+                          <p className="line-clamp-3 text-xs text-gray-700">
                             {demo.description || 'No description'}
                           </p>
                         </div>


### PR DESCRIPTION
## What changed\n- Shortened the Classes card description container to 480×64 px with a 3-line clamp.\n- Added the scheduled session date next to the category badge.\n\n## Why\nPR #1318 (the Classes card layout alignment) has already merged. These are follow-up tweaks to make the card shorter and show the session date.\n\n## Verification\n- 
> solocorn-app@0.1.0 typecheck
> tsc --noEmit passed.