### PR TITLE
fix(account): Delete Account hit a non-existent endpoint (server error)

### DIFF
--- a/tutorme-app/src/app/[locale]/student/account/page.tsx
+++ b/tutorme-app/src/app/[locale]/student/account/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -239,8 +240,10 @@ export default function StudentAccount() {
       return
     }
     try {
-      const response = await fetch('/api/user/account', {
-        method: 'DELETE',
+      const response = await fetchWithCsrf('/api/user/gdpr/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: true }),
       })
       if (response.ok) {
         toast.success('Account deleted. Redirecting...')

--- a/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
+++ b/tutorme-app/src/app/[locale]/tutor/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
 import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { fetchWithCsrf } from '@/lib/api/fetch-csrf'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -653,8 +654,10 @@ export default function TutorSettings() {
       return
     }
     try {
-      const response = await fetch('/api/user/account', {
-        method: 'DELETE',
+      const response = await fetchWithCsrf('/api/user/gdpr/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: true }),
       })
       if (response.ok) {
         toast.success('Account deleted. Redirecting...')


### PR DESCRIPTION
## Problem
A user reported a **server error when deleting their account**. Root cause: the "Delete Account" button (on both **student → Account** and **tutor → Settings**) does `fetch('/api/user/account', { method: 'DELETE' })`, but **`/api/user/account` was never implemented** (no route, no rewrite, no catch-all). The request falls through to a dead 307 redirect → `response.ok` is false → users can never delete their account.

## Fix
Repoint both `handleDeleteAccount` handlers to the existing, already-deployed **`POST /api/user/gdpr/delete`** (immediate anonymization), using `fetchWithCsrf` so the CSRF token is attached. No new endpoint or duplicated deletion logic — reuses the tested GDPR path (and inherits the recording-purge improvement from #1314 once that merges).

## Verification (ran it)
Booted the app against an ephemeral Postgres, minted a session, and ran the exact sequence the fixed UI performs:
- `GET /api/csrf` → token
- `POST /api/user/gdpr/delete` `{confirm:true}` + `X-CSRF-Token` → **HTTP 200**, `{"message":"Account data anonymized…"}`
- DB after: user row anonymized — `email → deleted-*@deleted.local`, `password` & `emailVerified` nulled (account can no longer log in).
- Confirmed the old `DELETE /api/user/account` path returns a dead **307** (the "server error").

`tsc` / prettier / eslint clean on both files.

## Related (not in this PR)
The sibling **"Deactivate Account"** button posts to `POST /api/user/account/deactivate`, which is **also unimplemented** — same class of bug. Happy to fix in a follow-up (needs a decision on what "deactivate" should do — soft-disable vs. hide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)