### PR TITLE
fix(signup): 'Nationality is required' despite selecting region + country

### DIFF
--- a/tutorme-app/src/app/[locale]/register/tutor/page.tsx
+++ b/tutorme-app/src/app/[locale]/register/tutor/page.tsx
@@ -640,7 +640,7 @@ export default function TutorRegistrationPage() {
         profileData: {
           timezone: formData.timezone,
           preferredLanguage: formData.preferredLanguage,
-          nationality: formData.nationality,
+          nationality: formData.nationality || selectedCountryName,
           tutorNationalities: selectedRegions.includes('global')
             ? ['Global']
             : tutoringCountryNames,
@@ -651,7 +651,7 @@ export default function TutorRegistrationPage() {
           middleName: formData.middleName,
           lastName: formData.lastName,
           legalName: formData.legalName,
-          nationality: formData.nationality,
+          nationality: formData.nationality || selectedCountryName,
           phoneCountryCode: '+1',
           phoneNumber: '0000000000',
           educationLevel: 'Bachelor',
@@ -922,6 +922,12 @@ export default function TutorRegistrationPage() {
                             onValueChange={v => {
                               setRegion(v)
                               setCountryCode('')
+                              // Country (and the nationality derived from it) resets with the region.
+                              setFormData(prev => ({
+                                ...prev,
+                                nationality: '',
+                                countryOfResidence: '',
+                              }))
                               clearError('region')
                             }}
                           >
@@ -960,6 +966,15 @@ export default function TutorRegistrationPage() {
                             onValueChange={v => {
                               setCountryCode(v)
                               clearError('countryCode')
+                              // Derive nationality/residence from the chosen country — the schema
+                              // requires nationality and there is no separate input for it.
+                              const countryName =
+                                availableCountries.find(c => c.code === v)?.name ?? ''
+                              setFormData(prev => ({
+                                ...prev,
+                                nationality: countryName,
+                                countryOfResidence: countryName,
+                              }))
                             }}
                             disabled={!region}
                           >


### PR DESCRIPTION
## Problem
On **tutor signup**, submitting failed with **"Nationality is required"** even after selecting a region and country.

Root cause: the "Where do you live?" country dropdown (`onValueChange`) set `countryCode` but **never wrote `formData.nationality`** — it's initialized to `''` and updated nowhere. The submit payload sends `nationality: formData.nationality` (always `''`), and the server schema rejects it via `z.string().min(2, 'Nationality is required')`. There is no separate nationality input in the form; the app models "nationality" as the country name (used that way for tutor markets elsewhere).

## Fix
- Derive `nationality` (and `countryOfResidence`) from the chosen country in the country `onChange`.
- Clear them when the region changes (country resets too).
- Fall back to the resolved country name at submit (`formData.nationality || selectedCountryName`) as a second, independent guarantee.

## Verification
Tested the real `tutorAdditionalDataSchema` at the failing boundary:
- `nationality: ''` → `success=false`, error **`"Nationality is required"`** (reproduces the report)
- `nationality: 'United States'` → **`success=true`**

`tsc` / prettier clean; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)