### PR TITLE
fix(account): release username on deletion so it can be reused

### DIFF
--- a/tutorme-app/src/app/api/user/gdpr/delete/route.ts
+++ b/tutorme-app/src/app/api/user/gdpr/delete/route.ts
@@ -47,6 +47,9 @@ export const POST = withCsrf(
           password: null,
           image: null,
           emailVerified: null,
+          // Release the handle (queried by the username-availability check) so the
+          // username can be reused by a new account after deletion.
+          handle: null,
         })
         .where(eq(user.userId, userId))
 
@@ -64,6 +67,8 @@ export const POST = withCsrf(
             bio: null,
             avatarUrl: null,
             dateOfBirth: null,
+            // Release the unique profile username so it can be reused.
+            username: null,
           })
           .where(eq(profile.userId, userId))
       }


### PR DESCRIPTION
## Problem
After deleting an account and creating a new one with the **same username**, signup failed with **"username already taken."**

GDPR account deletion (`POST /api/user/gdpr/delete`) anonymized email/name/etc. but **never released the username**:
- `user.handle` — what the username-availability check queries (`eq(user.handle, …)`) — was left intact, so the name still read as taken.
- `profile.username` is `.unique()`, so even past the check, the new account's profile insert would hit the unique constraint.

(`TutorApplication.username` was already fine — that row is deleted on account deletion.)

## Fix
Clear `user.handle` and `profile.username` (both nullable) inside the deletion transaction, releasing the username for reuse.

## Verification
Against an ephemeral Postgres, using the **real** `username-availability` GET handler:
- before delete → `available("reuseme")` = **false**
- after delete → **true**
- new account re-claims the username in **both** columns with no unique violation

`tsc` / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)